### PR TITLE
Fix for crash in user image transcoder

### DIFF
--- a/Source/Synchronization/Transcoders/ZMUserImageTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMUserImageTranscoder.m
@@ -76,40 +76,43 @@ static NSString * const RequestUserProfileSmallAssetNotificationName = @"ZMReque
     self = [super initWithManagedObjectContext:moc];
     if (self != nil) {
         
-        [self recoverFromInconsistentUserImageStatus];
-                
-        _imageProcessingQueue = imageProcessingQueue;
-        
-        // Small profiles
-        NSPredicate *filterForSmallImage = [NSCompoundPredicate andPredicateWithSubpredicates:@[
-                                            [ZMUser predicateForSmallImageNeedingToBeUpdatedFromBackend],
-                                            [ZMUser predicateForSmallImageDownloadFilter]
-                                            ]];
-        self.smallProfileDownstreamSync = [[ZMDownstreamObjectSyncWithWhitelist alloc] initWithTranscoder:self
-                                                                                               entityName:ZMUser.entityName
-                                                                            predicateForObjectsToDownload:filterForSmallImage
-                                                                                     managedObjectContext:self.managedObjectContext];
-        [self.smallProfileDownstreamSync whiteListObject:[ZMUser selfUserInContext:moc]];
-        
-        // Medium profile
-        NSPredicate *filterForMediumImage = [NSCompoundPredicate andPredicateWithSubpredicates:@[
-                                                                                                 [ZMUser predicateForMediumImageNeedingToBeUpdatedFromBackend],
-                                                                                                 [ZMUser predicateForMediumImageDownloadFilter]
-                                                                                                 ]];
-        self.mediumDownstreamSync = [[ZMDownstreamObjectSyncWithWhitelist alloc] initWithTranscoder:self
-                                                                                         entityName:ZMUser.entityName
-                                                                      predicateForObjectsToDownload:filterForMediumImage
-                                                                               managedObjectContext:self.managedObjectContext];
-        [self.mediumDownstreamSync whiteListObject:[ZMUser selfUserInContext:moc]];
-        
-        // Self user upstream
-        self.upstreamSync = [[ZMUpstreamAssetSync alloc] initWithTranscoder:self entityName:ZMUser.entityName keysToSync:@[ImageSmallProfileDataKey, ImageMediumDataKey] managedObjectContext:self.managedObjectContext];
-        
-        _assetPreprocessingTracker = [self createAssetPreprocessingTracker];
-        
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(requestAssetForNotification:) name:RequestUserProfileAssetNotificationName object:nil];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(requestSmallAssetForNotification:) name:RequestUserProfileSmallAssetNotificationName object:nil];
-        
+        [self.managedObjectContext performBlockAndWait:^{
+            [self recoverFromInconsistentUserImageStatus];
+            
+            self->_imageProcessingQueue = imageProcessingQueue;
+            
+            // Small profiles
+            NSPredicate *filterForSmallImage = [NSCompoundPredicate andPredicateWithSubpredicates:@[
+                                                                                                    [ZMUser predicateForSmallImageNeedingToBeUpdatedFromBackend],
+                                                                                                    [ZMUser predicateForSmallImageDownloadFilter]
+                                                                                                    ]];
+            self.smallProfileDownstreamSync = [[ZMDownstreamObjectSyncWithWhitelist alloc] initWithTranscoder:self
+                                                                                                   entityName:ZMUser.entityName
+                                                                                predicateForObjectsToDownload:filterForSmallImage
+                                                                                         managedObjectContext:self.managedObjectContext];
+            [self.smallProfileDownstreamSync whiteListObject:[ZMUser selfUserInContext:moc]];
+            
+            // Medium profile
+            NSPredicate *filterForMediumImage = [NSCompoundPredicate andPredicateWithSubpredicates:@[
+                                                                                                     [ZMUser predicateForMediumImageNeedingToBeUpdatedFromBackend],
+                                                                                                     [ZMUser predicateForMediumImageDownloadFilter]
+                                                                                                     ]];
+            self.mediumDownstreamSync = [[ZMDownstreamObjectSyncWithWhitelist alloc] initWithTranscoder:self
+                                                                                             entityName:ZMUser.entityName
+                                                                          predicateForObjectsToDownload:filterForMediumImage
+                                                                                   managedObjectContext:self.managedObjectContext];
+            [self.mediumDownstreamSync whiteListObject:[ZMUser selfUserInContext:moc]];
+            
+            // Self user upstream
+            self.upstreamSync = [[ZMUpstreamAssetSync alloc] initWithTranscoder:self entityName:ZMUser.entityName keysToSync:@[ImageSmallProfileDataKey, ImageMediumDataKey] managedObjectContext:self.managedObjectContext];
+            
+            self->_assetPreprocessingTracker = [self createAssetPreprocessingTracker];
+            
+            [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(requestAssetForNotification:) name:RequestUserProfileAssetNotificationName object:nil];
+            [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(requestSmallAssetForNotification:) name:RequestUserProfileSmallAssetNotificationName object:nil];
+            
+        }];
+       
         
     }
     return self;
@@ -117,13 +120,13 @@ static NSString * const RequestUserProfileSmallAssetNotificationName = @"ZMReque
 
 - (void)recoverFromInconsistentUserImageStatus;
 {
-    [self.managedObjectContext performGroupedBlock:^{
-        NSFetchRequest *request = [ZMUser sortedFetchRequestWithPredicateFormat:@"(modifiedDataFields != 0) AND (%K == NULL OR %K == NULL)", ImageMediumDataKey, ImageSmallProfileDataKey];
-        NSArray *corruptUsers = [self.managedObjectContext executeFetchRequestOrAssert:request];
-        for (ZMUser *user in corruptUsers) {
-            [user resetLocallyModifiedKeys:[NSSet setWithArray:@[ImageMediumDataKey,ImageSmallProfileDataKey]]];
-        }
-    }];
+    NSSet *imageMediumKeys = [NSSet setWithArray:@[ImageMediumDataKey,ImageSmallProfileDataKey]];
+    
+    ZMUser *selfUser = [ZMUser selfUserInContext:self.managedObjectContext];
+    
+    if ([selfUser hasLocalModificationsForKeys:imageMediumKeys] && (selfUser.imageMediumData == nil || selfUser.imageSmallProfileData == nil)) {
+        [selfUser resetLocallyModifiedKeys:imageMediumKeys];
+    }
 }
 
 - (ZMImagePreprocessingTracker *)createAssetPreprocessingTracker

--- a/Tests/Source/Synchronization/Transcoders/ZMUserImageTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMUserImageTranscoderTests.m
@@ -680,6 +680,36 @@
 }
 
 
+- (void)testThatItRecoverFromInconsistenUserImageState
+{
+    // given
+    NSSet *modifiedKeys = [NSSet setWithArray:@[@"imageMediumData", @"imageSmallProfileData"]];
+    ZMUser *selfUser;
+    NSUUID *selfUserAndSelfConversationID = [NSUUID createUUID];
+    [self setUpSelfUser:&selfUser
+           withRemoteID:selfUserAndSelfConversationID
+                formats:@[@(ZMImageFormatProfile), @(ZMImageFormatMedium)]
+    locallyModifiedKeys:modifiedKeys.allObjects];
+    selfUser.imageMediumData = nil;
+    selfUser.imageSmallProfileData = nil;
+    
+    XCTAssertTrue([selfUser hasLocalModificationsForKeys:modifiedKeys]);
+
+    // when
+    
+    ZMUserImageTranscoder __block *localSUT = [[ZMUserImageTranscoder alloc] initWithManagedObjectContext:self.syncMOC
+                                                                                     imageProcessingQueue:self.queue];
+    
+    // then
+    
+    [self.syncMOC performBlockAndWait:^{
+        
+        XCTAssertFalse([selfUser hasLocalModificationsForKeys:modifiedKeys]);
+        localSUT = nil;
+    }];
+    
+}
+
 - (void)testThatItDoesNotUpdateTheImageIfTheCorrelationIDFromTheBackendResponseDiffersFromTheUserImageCorrelationID
 {
     // given


### PR DESCRIPTION
- Issue happens in code that is needed to solve problem with some old issue when user has no image data, but his locally modified flags are indicating that the upload must be initiated
- Uploading images is supported only for self user for logical reasons
- I changed the code to check only self user if it needs to be fixed
- Originally doing this made the tests crashing, but it looks like there was a race condition while `init` is also loading self user in same context, so I decided to load in once and pass it in
- There is no way to verify if code change really fixes the issue, but we'll see from tracking. I think that root of the issue was loading self user in `init` and in grouped block on sync MOC (which was happening indirectly if predicate was really matching it).