### PR TITLE
Added missing localization for 2.12

### DIFF
--- a/Resources/de.lproj/Push.strings
+++ b/Resources/de.lproj/Push.strings
@@ -14,7 +14,7 @@
 // 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
+//
 
 
 "push.notification.default" = "Neue Nachricht";

--- a/Resources/de.lproj/Push.strings
+++ b/Resources/de.lproj/Push.strings
@@ -14,7 +14,7 @@
 // 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-//
+// 
 
 
 "push.notification.default" = "Neue Nachricht";

--- a/Resources/de.lproj/Push.stringsdict
+++ b/Resources/de.lproj/Push.stringsdict
@@ -79,7 +79,7 @@
                 <key>one</key>
                 <string></string>
                 <key>other</key>
-                <string> %2$@ mal </string>
+                <string>%2$@ mal </string>
             </dict>
         </dict>
         <key>push.notification.call.missed.oneonone.nousername</key>
@@ -95,7 +95,7 @@
                 <key>one</key>
                 <string></string>
                 <key>other</key>
-                <string> %1$@ mal </string>
+                <string>%1$@ mal </string>
             </dict>
         </dict>
         <key>push.notification.call.missed.group</key>
@@ -111,7 +111,7 @@
                 <key>one</key>
                 <string></string>
                 <key>other</key>
-                <string> %3$@ mal </string>
+                <string>%3$@ mal </string>
             </dict>
         </dict>
         <key>push.notification.call.missed.group.nousername</key>
@@ -127,7 +127,7 @@
                 <key>one</key>
                 <string></string>
                 <key>other</key>
-                <string> %2$@ mal </string>
+                <string>%2$@ mal </string>
             </dict>
         </dict>
         <key>push.notification.call.missed.group.nousername.noconversationname</key>
@@ -143,7 +143,7 @@
                 <key>one</key>
                 <string></string>
                 <key>other</key>
-                <string> %1$@ mal </string>
+                <string>%1$@ mal </string>
             </dict>
         </dict>
         <key>push.notification.call.missed.group.noconversationname</key>
@@ -159,7 +159,7 @@
                 <key>one</key>
                 <string></string>
                 <key>other</key>
-                <string> %2$@ mal </string>
+                <string>%2$@ mal </string>
             </dict>
         </dict>
         <key>push.notification.call.missed.many</key>
@@ -221,9 +221,9 @@
                 <key>NSStringFormatValueTypeKey</key>
                 <string>@</string>
                 <key>one</key>
-                <string> </string>
+                <string></string>
                 <key>other</key>
-                <string> %2$@ mal </string>
+                <string>%2$@ mal </string>
             </dict>
         </dict>
         <key>push.notification.knock.group.nousername</key>
@@ -269,9 +269,9 @@
                 <key>NSStringFormatValueTypeKey</key>
                 <string>@</string>
                 <key>one</key>
-                <string> </string>
+                <string></string>
                 <key>other</key>
-                <string>  %3$@ mal</string>
+                <string> %3$@ mal</string>
             </dict>
         </dict>
         <key>push.notification.knock.oneonone.nousername</key>

--- a/Resources/de.lproj/Push.stringsdict
+++ b/Resources/de.lproj/Push.stringsdict
@@ -79,7 +79,7 @@
                 <key>one</key>
                 <string></string>
                 <key>other</key>
-                <string>%2$@ mal </string>
+                <string> %2$@ mal </string>
             </dict>
         </dict>
         <key>push.notification.call.missed.oneonone.nousername</key>
@@ -95,7 +95,7 @@
                 <key>one</key>
                 <string></string>
                 <key>other</key>
-                <string>%1$@ mal </string>
+                <string> %1$@ mal </string>
             </dict>
         </dict>
         <key>push.notification.call.missed.group</key>
@@ -111,7 +111,7 @@
                 <key>one</key>
                 <string></string>
                 <key>other</key>
-                <string>%3$@ mal </string>
+                <string> %3$@ mal </string>
             </dict>
         </dict>
         <key>push.notification.call.missed.group.nousername</key>
@@ -127,7 +127,7 @@
                 <key>one</key>
                 <string></string>
                 <key>other</key>
-                <string>%2$@ mal </string>
+                <string> %2$@ mal </string>
             </dict>
         </dict>
         <key>push.notification.call.missed.group.nousername.noconversationname</key>
@@ -143,7 +143,7 @@
                 <key>one</key>
                 <string></string>
                 <key>other</key>
-                <string>%1$@ mal </string>
+                <string> %1$@ mal </string>
             </dict>
         </dict>
         <key>push.notification.call.missed.group.noconversationname</key>
@@ -159,7 +159,7 @@
                 <key>one</key>
                 <string></string>
                 <key>other</key>
-                <string>%2$@ mal </string>
+                <string> %2$@ mal </string>
             </dict>
         </dict>
         <key>push.notification.call.missed.many</key>
@@ -181,7 +181,7 @@
         <key>push.notification.call.missed.many.noconversationname</key>
         <dict>
             <key>NSStringLocalizedFormatKey</key>
-            <string>Du hast %1$#@new_calls@ in einer Unterhaltung</string>
+            <string>Du hast %1$#@new_calls@ verpasste Anrufe in einer Unterhaltung</string>
             <key>new_calls</key>
             <dict>
                 <key>NSStringFormatSpecTypeKey</key>
@@ -221,9 +221,9 @@
                 <key>NSStringFormatValueTypeKey</key>
                 <string>@</string>
                 <key>one</key>
-                <string></string>
+                <string> </string>
                 <key>other</key>
-                <string>%2$@ mal </string>
+                <string> %2$@ mal </string>
             </dict>
         </dict>
         <key>push.notification.knock.group.nousername</key>
@@ -269,9 +269,9 @@
                 <key>NSStringFormatValueTypeKey</key>
                 <string>@</string>
                 <key>one</key>
-                <string></string>
+                <string> </string>
                 <key>other</key>
-                <string> %3$@ mal</string>
+                <string>  %3$@ mal</string>
             </dict>
         </dict>
         <key>push.notification.knock.oneonone.nousername</key>

--- a/Resources/pt-BR.lproj/Push.strings
+++ b/Resources/pt-BR.lproj/Push.strings
@@ -14,7 +14,7 @@
 // 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-//
+// 
 
 
 "push.notification.default" = "Nova mensagem";

--- a/Resources/pt-BR.lproj/Push.strings
+++ b/Resources/pt-BR.lproj/Push.strings
@@ -14,7 +14,7 @@
 // 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
+//
 
 
 "push.notification.default" = "Nova mensagem";
@@ -157,5 +157,5 @@
 "push.notification.action.call.accept" = "Aceitar";
 "push.notification.action.call.ignore" = "Rejeitar";
 "push.notification.action.call.message" = "Mensagem";
-"push.notification.action.call.callback" = "Call Back";
+"push.notification.action.call.callback" = "Ligue de volta";
 "push.notification.action.connection.accept" = "Aceitar";


### PR DESCRIPTION
In this PR:
- Added Brazilian Portuguese translation for push notifcation quick action for call back
- Changed German translation for the push notification for missed call in a conversation without a name
