### PR TITLE
Fix of a crash on failed decryption

### DIFF
--- a/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
@@ -140,12 +140,14 @@ NSUInteger const ZMMissingUpdateEventsTranscoderListPageSize = 500;
             [event appendDebugInformation:@"From missing update events transcoder, processUpdateEventsAndReturnLastNotificationIDFromPayload"];
             
             ZMUpdateEvent *decryptedEvent = [self.managedObjectContext.zm_cryptKeyStore.box decryptUpdateEventAndAddClient:event managedObjectContext:self.managedObjectContext];
-            [decryptedEvents addObject:decryptedEvent];
-            if (decryptedEvent.type == ZMUpdateEventCallState) {
-                lastCallStateEvents[event.conversationUUID] = decryptedEvent;
-            }
-            else {
-                [parsedEvents addObject:decryptedEvent];
+            if (nil != decryptedEvent) {
+                [decryptedEvents addObject:decryptedEvent];
+                if (decryptedEvent.type == ZMUpdateEventCallState) {
+                    lastCallStateEvents[event.conversationUUID] = decryptedEvent;
+                }
+                else {
+                    [parsedEvents addObject:decryptedEvent];
+                }
             }
         }
     }


### PR DESCRIPTION
It is possible for the decryption of an event to fail, returning a nil decrypted event.
We were not guarding for that eventuality, leading to a crash.

This PR fixes that.