### PR TITLE
Revert notification stream changes

### DIFF
--- a/Source/Synchronization/Transcoders/Helper/ZMSimpleListRequestPaginator.h
+++ b/Source/Synchronization/Transcoders/Helper/ZMSimpleListRequestPaginator.h
@@ -19,18 +19,15 @@
 
 @import Foundation;
 @import ZMTransport;
-#import "ZMSingleRequestSync.h"
 
 @protocol ZMSimpleListRequestPaginatorSync;
+
 
 
 @interface ZMSimpleListRequestPaginator : NSObject
 
 /// YES if more requests should be made before to fetch the full list
 @property (nonatomic, readonly) BOOL hasMoreToFetch;
-
-/// Status of the underlying singleRequestTranscoder
-@property (nonatomic, readonly) ZMSingleRequestProgress status;
 
 - (instancetype)initWithBasePath:(NSString *)basePath
                         startKey:(NSString *)startKey
@@ -61,10 +58,5 @@
 /// Returns YES, if the error response for a specific statusCode should be parsed (e.g. if the payload contains content that needs to be processed)
 @optional
 - (BOOL)shouldParseErrorResponseForStatusCode:(NSInteger)statusCode;
-
-
-/// Returns additional query parameters in the from [parameter : value]
-@optional
-- (NSDictionary <NSString *, NSString*>*)additionalQueryParameters;
 
 @end

--- a/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.h
+++ b/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.h
@@ -19,27 +19,17 @@
 
 @import Foundation;
 #import <zmessaging/ZMObjectSyncStrategy.h>
-#import "ZMRequestGenerator.h"
 
-@class BackgroundAPNSPingBackStatus;
-@class ZMQuickSyncStatus;
-
-@protocol ZMMissingUpdateEventTranscoderDelegate;
-
-@interface ZMMissingUpdateEventsTranscoder : ZMObjectSyncStrategy <ZMObjectStrategy, ZMRequestGenerator>
+@interface ZMMissingUpdateEventsTranscoder : ZMObjectSyncStrategy <ZMObjectStrategy>
 
 @property (nonatomic, readonly) BOOL hasLastUpdateEventID;
 @property (nonatomic, readonly) BOOL isDownloadingMissingNotifications;
 @property (nonatomic, readonly) NSUUID *lastUpdateEventID;
 
-- (instancetype)initWithSyncStrategy:(ZMSyncStrategy *)strategy
-                  apnsPingBackStatus:(BackgroundAPNSPingBackStatus *)pingBackStatus;
+- (instancetype)initWithSyncStrategy:(ZMSyncStrategy *)strategy;
 - (void)startDownloadingMissingNotifications;
 
-- (NSArray <ZMUpdateEvent*> *)processAndReturnUpdateEventsFromPayload:(id<ZMTransportData>)payload;
++ (NSUUID *)processUpdateEventsAndReturnLastNotificationIDFromPayload:(id<ZMTransportData>)payload syncStrategy:(ZMSyncStrategy *)syncStrategy;
 
 
 @end
-
-
-

--- a/Source/Synchronization/Transcoders/ZMSelfTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMSelfTranscoder.m
@@ -134,7 +134,7 @@ NSTimeInterval ZMSelfTranscoderPendingValidationRequestInterval = 5;
 
 - (BOOL)isSlowSyncDone;
 {
-    return (self.downstreamSelfUserSync.status != ZMSingleRequestInProgress && self.downstreamSelfUserSync.status != ZMSingleRequestReady);
+    return (self.downstreamSelfUserSync.status != ZMSingleRequestInProgress);
 }
 
 - (void)setNeedsSlowSync

--- a/Source/Synchronization/ZMSingleRequestSync.h
+++ b/Source/Synchronization/ZMSingleRequestSync.h
@@ -33,7 +33,6 @@
 
 typedef NS_ENUM(int, ZMSingleRequestProgress) {
     ZMSingleRequestIdle = 0,
-    ZMSingleRequestReady,
     ZMSingleRequestInProgress,
     ZMSingleRequestCompleted
 };

--- a/Source/Synchronization/ZMSingleRequestSync.m
+++ b/Source/Synchronization/ZMSingleRequestSync.m
@@ -21,7 +21,6 @@
 @import ZMTransport;
 
 #import "ZMSingleRequestSync.h"
-#import "ZMOperationLoop.h"
 
 @interface ZMSingleRequestSync ()
 
@@ -62,7 +61,7 @@
 {
     ++self.requestUniqueCounter;
     self.currentRequest = nil;
-    self.status = ZMSingleRequestReady;
+    self.status = ZMSingleRequestInProgress;
 }
 
 - (void)readyForNextRequestIfNotBusy
@@ -75,15 +74,13 @@
 - (ZMTransportRequest *)nextRequest
 {
     id<ZMSingleRequestTranscoder> transcoder = self.transcoder;
-    if(self.currentRequest == nil && self.status == ZMSingleRequestReady) {
+    if(self.currentRequest == nil && self.status == ZMSingleRequestInProgress) {
         ZMTransportRequest *request = [transcoder requestForSingleRequestSync:self];
         [request setDebugInformationTranscoder:transcoder];
 
         self.currentRequest = request;
         if(request == nil) {
             self.status = ZMSingleRequestCompleted;
-        } else {
-            self.status = ZMSingleRequestInProgress;
         }
         const int currentCounter = self.requestUniqueCounter;
         ZM_WEAK(self);
@@ -119,7 +116,7 @@
             break;
         }
         case ZMTransportResponseStatusTemporaryError: {
-            self.status = ZMSingleRequestReady;
+            self.status = ZMSingleRequestInProgress;
             break;
         }
     }

--- a/Source/Synchronization/ZMSyncStrategy.m
+++ b/Source/Synchronization/ZMSyncStrategy.m
@@ -184,7 +184,6 @@ ZM_EMPTY_ASSERTING_INIT()
                                    self.pingBackRequestStrategy,
                                    self.pushNoticeFetchStrategy,
                                    self.fileUploadRequestStrategy,
-                                   self.missingUpdateEventsTranscoder,
                                    self.linkPreviewAssetDownloadRequestStrategy,
                                    self.linkPreviewAssetUploadRequestStrategy
                                    ];
@@ -223,7 +222,7 @@ ZM_EMPTY_ASSERTING_INIT()
     self.clientMessageTranscoder = [[ZMClientMessageTranscoder alloc ] initWithManagedObjectContext:self.syncMOC localNotificationDispatcher:localNotificationsDispatcher clientRegistrationStatus:clientRegistrationStatus];
     self.knockTranscoder = [[ZMKnockTranscoder alloc] initWithManagedObjectContext:self.syncMOC];
     self.registrationTranscoder = [[ZMRegistrationTranscoder alloc] initWithManagedObjectContext:self.syncMOC authenticationStatus:authenticationStatus];
-    self.missingUpdateEventsTranscoder = [[ZMMissingUpdateEventsTranscoder alloc] initWithSyncStrategy:self apnsPingBackStatus:backgroundAPNSPingBackStatus];
+    self.missingUpdateEventsTranscoder = [[ZMMissingUpdateEventsTranscoder alloc] initWithSyncStrategy:self];
     self.lastUpdateEventIDTranscoder = [[ZMLastUpdateEventIDTranscoder alloc] initWithManagedObjectContext:self.syncMOC objectDirectory:self];
     self.flowTranscoder = [[ZMFlowSync alloc] initWithMediaManager:mediaManager onDemandFlowManager:onDemandFlowManager syncManagedObjectContext:self.syncMOC uiManagedObjectContext:uiMOC];
     self.addressBookTranscoder = [[ZMAddressBookTranscoder alloc] initWithManagedObjectContext:self.syncMOC];

--- a/Tests/Source/Integration/CallingTests+PushNotifications.m
+++ b/Tests/Source/Integration/CallingTests+PushNotifications.m
@@ -58,8 +58,8 @@
     
     // (1) when we recieve a push notification
     {
-        [self simulateReceivePushNotification:@{@"data": @{@"payload": @[payload], 
-                                                           @"id": [NSUUID timeBasedUUID].transportString
+        [self simulateReceivePushNotification:@{@"data": @{@"payload": @[payload],
+                                                           @"id": [NSUUID createUUID].transportString
                                                            }
                                                 }];
         WaitForAllGroupsToBeEmpty(0.5);
@@ -117,7 +117,7 @@
     // (1) when we recieve a push notification
     {
         [self simulateReceivePushNotification:@{@"data": @{@"payload": @[payload],
-                                                           @"id": [NSUUID timeBasedUUID].transportString
+                                                           @"id": [NSUUID createUUID].transportString
                                                            }
                                                 }];
         WaitForAllGroupsToBeEmpty(0.5);
@@ -215,7 +215,7 @@
     // (1) when we recieve a push notification
     {
         [self simulateReceivePushNotification:@{@"data": @{@"payload": @[payload],
-                                                           @"id": [NSUUID timeBasedUUID].transportString
+                                                           @"id": [NSUUID createUUID].transportString
                                                            }
                                                 }];
         

--- a/Tests/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoderTests.m
@@ -27,8 +27,6 @@
 #import "ZMSingleRequestSync.h"
 #import "ZMSyncStrategy.h"
 #import "ZMSimpleListRequestPaginator.h"
-#import <zmessaging/zmessaging-Swift.h>
-
 
 static NSString * const LastUpdateEventIDStoreKey = @"LastUpdateEventID";
 
@@ -37,7 +35,6 @@ static NSString * const LastUpdateEventIDStoreKey = @"LastUpdateEventID";
 @property (nonatomic, readonly) ZMMissingUpdateEventsTranscoder *sut;
 @property (nonatomic, readonly) id lastUpdateEventIDTranscoder;
 @property (nonatomic, readonly) ZMSyncStrategy *syncStrategy;
-@property (nonatomic, readonly) id mockPingBackStatus;
 
 @end
 
@@ -45,12 +42,12 @@ static NSString * const LastUpdateEventIDStoreKey = @"LastUpdateEventID";
 
 - (void)setUp {
     [super setUp];
-    _mockPingBackStatus = [OCMockObject niceMockForClass:[BackgroundAPNSPingBackStatus class]];
+    
     _syncStrategy = [OCMockObject niceMockForClass:ZMSyncStrategy.class];
-    [[[(id) self.syncStrategy stub] andReturn:self.syncMOC] syncMOC];
+    [[[(id) self.syncStrategy stub] andReturn:self.uiMOC] syncMOC];
     [self verifyMockLater:self.syncStrategy];
     
-    _sut = [[ZMMissingUpdateEventsTranscoder alloc] initWithSyncStrategy:self.syncStrategy apnsPingBackStatus:self.mockPingBackStatus];
+    _sut = [[ZMMissingUpdateEventsTranscoder alloc] initWithSyncStrategy:self.syncStrategy];
 }
 
 - (void)tearDown {
@@ -61,11 +58,10 @@ static NSString * const LastUpdateEventIDStoreKey = @"LastUpdateEventID";
     [super tearDown];
 }
 
-
 - (void)testThatItCreatesAListPaginatorSync
 {
     // when
-    ZMMissingUpdateEventsTranscoder *sut = [[ZMMissingUpdateEventsTranscoder alloc] initWithSyncStrategy:self.syncStrategy apnsPingBackStatus:self.mockPingBackStatus];
+    ZMMissingUpdateEventsTranscoder *sut = [[ZMMissingUpdateEventsTranscoder alloc] initWithSyncStrategy:self.syncStrategy];
     
     // then
     XCTAssertNotNil(sut.listPaginator);
@@ -79,7 +75,7 @@ static NSString * const LastUpdateEventIDStoreKey = @"LastUpdateEventID";
     
     // then
     XCTAssertEqual(generators.count, 1u);
-    XCTAssertTrue([generators.lastObject isKindOfClass:ZMSimpleListRequestPaginator.class]);
+    XCTAssertTrue([generators.firstObject isKindOfClass:ZMSimpleListRequestPaginator.class]);
 }
 
 - (void)testThatItDoesNotReturnAContextChangeTracker;
@@ -474,7 +470,7 @@ static NSString * const LastUpdateEventIDStoreKey = @"LastUpdateEventID";
     WaitForAllGroupsToBeEmpty(0.5);
     
     // when
-    ZMMissingUpdateEventsTranscoder *sut = [[ZMMissingUpdateEventsTranscoder alloc] initWithSyncStrategy:self.syncStrategy apnsPingBackStatus:self.mockPingBackStatus ];
+    ZMMissingUpdateEventsTranscoder *sut = [[ZMMissingUpdateEventsTranscoder alloc] initWithSyncStrategy:self.syncStrategy];
     WaitForAllGroupsToBeEmpty(0.5);
     [sut.listPaginator resetFetching];
     ZMTransportRequest *request = [sut.listPaginator nextRequest];
@@ -509,7 +505,8 @@ static NSString * const LastUpdateEventIDStoreKey = @"LastUpdateEventID";
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
-    XCTAssertEqualObjects(self.syncMOC.zm_lastNotificationID, expectedLastUpdateEventID);
+    NSUUID *lastUpdateEventID = [[self.uiMOC persistentStoreMetadataForKey:LastUpdateEventIDStoreKey] UUID];
+    XCTAssertEqualObjects(lastUpdateEventID, expectedLastUpdateEventID);
 }
 
 - (void)testThatItStoresTheLastUpdateEventIDWhenItIsAMoreRecentType1
@@ -521,7 +518,8 @@ static NSString * const LastUpdateEventIDStoreKey = @"LastUpdateEventID";
     [self setLastUpdateEventID:[self newNotificationID] hasMore:NO];
     
     // then
-    XCTAssertEqualObjects(self.syncMOC.zm_lastNotificationID, [self newNotificationID]);
+    NSUUID *lastUpdateEventID = [[self.uiMOC persistentStoreMetadataForKey:LastUpdateEventIDStoreKey] UUID];
+    XCTAssertEqualObjects(lastUpdateEventID, [self newNotificationID]);
 }
 
 - (void)testThatItDoesNotStoreTheLastUpdateEventIDWhenItIsNotAMoreRecentType1
@@ -533,7 +531,8 @@ static NSString * const LastUpdateEventIDStoreKey = @"LastUpdateEventID";
     [self setLastUpdateEventID:[self olderNotificationID] hasMore:NO];
     
     // then
-    XCTAssertEqualObjects(self.syncMOC.zm_lastNotificationID, [self newNotificationID]);
+    NSUUID *lastUpdateEventID = [[self.uiMOC persistentStoreMetadataForKey:LastUpdateEventIDStoreKey] UUID];
+    XCTAssertEqualObjects(lastUpdateEventID, [self newNotificationID]);
 }
 
 - (void)testThatItStoresTheLastUpdateEventIDWhenItIsNotAType1
@@ -546,7 +545,8 @@ static NSString * const LastUpdateEventIDStoreKey = @"LastUpdateEventID";
     [self setLastUpdateEventID:secondUUID hasMore:NO];
     
     // then
-    XCTAssertEqualObjects(self.syncMOC.zm_lastNotificationID, secondUUID);
+    NSUUID *lastUpdateEventID = [[self.uiMOC persistentStoreMetadataForKey:LastUpdateEventIDStoreKey] UUID];
+    XCTAssertEqualObjects(lastUpdateEventID, secondUUID);
 }
 
 - (void)testThatItStoresTheLastUpdateEventIDWhenThePreviousOneIsNotAType1
@@ -559,7 +559,8 @@ static NSString * const LastUpdateEventIDStoreKey = @"LastUpdateEventID";
     [self setLastUpdateEventID:[self newNotificationID] hasMore:NO];
     
     // then
-    XCTAssertEqualObjects(self.syncMOC.zm_lastNotificationID, [self newNotificationID]);
+    NSUUID *lastUpdateEventID = [[self.uiMOC persistentStoreMetadataForKey:LastUpdateEventIDStoreKey] UUID];
+    XCTAssertEqualObjects(lastUpdateEventID, [self newNotificationID]);
 }
 
 - (void)testThatItStoresTheLastUpdateEventIDWhenReceivingNonTransientUpdateEvents
@@ -573,7 +574,8 @@ static NSString * const LastUpdateEventIDStoreKey = @"LastUpdateEventID";
     [self.sut processEvents:@[event] liveEvents:YES prefetchResult:nil];
     
     // then
-    XCTAssertEqualObjects(self.syncMOC.zm_lastNotificationID, expectedLastUpdateEventID);
+    NSUUID *lastUpdateEventID = [[self.uiMOC persistentStoreMetadataForKey:LastUpdateEventIDStoreKey] UUID];
+    XCTAssertEqualObjects(lastUpdateEventID, expectedLastUpdateEventID);
 }
 
 - (void)testThatItDoesStoreTheLastUpdateEventIDWhenEventIDSourceIsWebsocketOrDownload
@@ -591,20 +593,23 @@ static NSString * const LastUpdateEventIDStoreKey = @"LastUpdateEventID";
     [self.sut processEvents:@[websocketEvent] liveEvents:YES prefetchResult:nil];
     
     // then
-    XCTAssertEqualObjects(self.syncMOC.zm_lastNotificationID, websocketUpdateEventID);
+    NSUUID *lastUpdateEventID = [[self.uiMOC persistentStoreMetadataForKey:LastUpdateEventIDStoreKey] UUID];
+    XCTAssertEqualObjects(lastUpdateEventID, websocketUpdateEventID);
     
     // when
     [self.sut processEvents:@[downloadedEvent] liveEvents:YES prefetchResult:nil];
     
     // then
-    XCTAssertEqualObjects(self.syncMOC.zm_lastNotificationID, downstreamUpdateEventID);
+    lastUpdateEventID = [[self.uiMOC persistentStoreMetadataForKey:LastUpdateEventIDStoreKey] UUID];
+    XCTAssertEqualObjects(lastUpdateEventID, downstreamUpdateEventID);
     
     // when
     [self.sut processEvents:@[pushNotificationEvent] liveEvents:YES prefetchResult:nil];
     
     // then
-    XCTAssertNotEqualObjects(self.syncMOC.zm_lastNotificationID, notificationUpdateEventID);
-    XCTAssertEqualObjects(self.syncMOC.zm_lastNotificationID, downstreamUpdateEventID);
+    lastUpdateEventID = [[self.uiMOC persistentStoreMetadataForKey:LastUpdateEventIDStoreKey] UUID];
+    XCTAssertNotEqualObjects(lastUpdateEventID, notificationUpdateEventID);
+    XCTAssertEqualObjects(lastUpdateEventID, downstreamUpdateEventID);
 }
 
 - (void)testThatItDoesNotStoreTheLastUpdateEventIDWhenReceivingTransientUpdateEvents
@@ -622,7 +627,8 @@ static NSString * const LastUpdateEventIDStoreKey = @"LastUpdateEventID";
     [self.sut processEvents:@[event] liveEvents:YES prefetchResult:nil];
     
     // then
-    XCTAssertEqualObjects(self.syncMOC.zm_lastNotificationID, initialLastUpdateEventID);
+    NSUUID *lastUpdateEventID = [[self.uiMOC persistentStoreMetadataForKey:LastUpdateEventIDStoreKey] UUID];
+    XCTAssertEqualObjects(lastUpdateEventID, initialLastUpdateEventID);
 }
 
 - (ZMUpdateEvent *)updateEventWithIdentifier:(NSUUID *)identifier source:(ZMUpdateEventSource)source
@@ -691,186 +697,6 @@ static NSString * const LastUpdateEventIDStoreKey = @"LastUpdateEventID";
     XCTAssertNotNil(request3);
     NSURLComponents *components3 = [NSURLComponents componentsWithString:request3.path];
     XCTAssertTrue([components3.queryItems containsObject:[NSURLQueryItem queryItemWithName:@"since" value:lastUpdateEventID2.transportString]]);
-}
-
-@end
-
-
-@implementation ZMMissingUpdateEventsTranscoderTests (APNSPingBack)
-
-- (void)testThatItDoesNotReturnARequestWhenThereIsNoAPNSToFetch
-{
-    // given
-    [(BackgroundAPNSPingBackStatus*)[[self.mockPingBackStatus expect] andReturnValue:OCMOCK_VALUE(PingBackStatusDone)] status];
-    
-    // when
-    ZMTransportRequest *request = [self.sut nextRequest];
-    
-    // then
-    XCTAssertNil(request);
-}
-
-- (void)testThatItReturnsARequestWhenThereIsAnAPNSToFetch
-{
-    // given
-    self.syncMOC.zm_lastNotificationID = [NSUUID timeBasedUUID];
-    
-    EventsWithIdentifier *event = [[EventsWithIdentifier alloc] initWithEvents:@[] identifier:[NSUUID timeBasedUUID] isNotice:YES];
-    [(BackgroundAPNSPingBackStatus*)[[self.mockPingBackStatus expect] andReturnValue:OCMOCK_VALUE(PingBackStatusFetchingNotificationStream)] status];
-    [(BackgroundAPNSPingBackStatus*)[[self.mockPingBackStatus expect] andReturnValue:OCMOCK_VALUE(YES)] hasNoticeNotificationIDs];
-    [(BackgroundAPNSPingBackStatus*)[[self.mockPingBackStatus expect] andReturn:event] nextNoticeNotificationEventsWithID];
-
-    // when
-    ZMTransportRequest *request = [self.sut nextRequest];
-    
-    // then
-    XCTAssertNotNil(request);
-    NSString *expectedPath = [NSString stringWithFormat:@"/notifications?size=500&since=%@&cancel_fallback=%@", self.syncMOC.zm_lastNotificationID.transportString, event.identifier.transportString];
-    XCTAssertEqualObjects(request.path, expectedPath);
-}
-
-- (void)testThatItCallsBackPingBackStatusWhenRequestFinishes
-{
-    // given
-    self.syncMOC.zm_lastNotificationID = [NSUUID timeBasedUUID];
-    
-    EventsWithIdentifier *event = [[EventsWithIdentifier alloc] initWithEvents:@[] identifier:[NSUUID timeBasedUUID] isNotice:YES];
-    [(BackgroundAPNSPingBackStatus*)[[self.mockPingBackStatus stub] andReturnValue:OCMOCK_VALUE(PingBackStatusFetchingNotificationStream)] status];
-    [(BackgroundAPNSPingBackStatus*)[[self.mockPingBackStatus expect] andReturnValue:OCMOCK_VALUE(YES)] hasNoticeNotificationIDs];
-    [(BackgroundAPNSPingBackStatus*)[[self.mockPingBackStatus expect] andReturn:event] nextNoticeNotificationEventsWithID];
-    ZMTransportRequest *request = [self.sut nextRequest];
-    XCTAssertNotNil(request);
-
-    // expect
-    // it returns the events and hasMore No
-    [[self.mockPingBackStatus expect] missingUpdateEventTranscoderWithDidReceiveEvents:@[] originalEvents:event hasMore:NO];
-    
-    // when
-    [request completeWithResponse:[ZMTransportResponse responseWithPayload:@{@"notifications" : @[]} HTTPstatus:200 transportSessionError:nil]];
-    WaitForAllGroupsToBeEmpty(0.5);
-    
-    // and expect
-    // when we call nextRequest again, it does not create a request, because the event to fetch should be cleared
-    [(BackgroundAPNSPingBackStatus*)[[self.mockPingBackStatus expect] andReturnValue:OCMOCK_VALUE(NO)] hasNoticeNotificationIDs];
-    
-    // when
-    ZMTransportRequest *nextRequest1 = [self.sut nextRequest];
-    
-    // then
-    XCTAssertNil(nextRequest1);
-    [self.mockPingBackStatus verify];
-    
-    // and when
-    // when we do a normal quicksync it does not include the pingback parameter anymore
-    [self.sut startDownloadingMissingNotifications];
-    ZMTransportRequest *nextRequest2  = [[self.sut requestGenerators] nextRequest];
-    
-    // then
-    XCTAssertNotNil(nextRequest2);
-    NSString *expectedPath = [NSString stringWithFormat:@"/notifications?size=500&since=%@", self.syncMOC.zm_lastNotificationID.transportString];
-    XCTAssertEqualObjects(nextRequest2.path, expectedPath);
-}
-
-- (void)testThatItCallsBackPingBackStatusWhenRequestFinishes_HasMore
-{
-    // given
-    self.syncMOC.zm_lastNotificationID = [NSUUID timeBasedUUID];
-    
-    EventsWithIdentifier *event = [[EventsWithIdentifier alloc] initWithEvents:@[] identifier:[NSUUID timeBasedUUID] isNotice:YES];
-    [(BackgroundAPNSPingBackStatus*)[[self.mockPingBackStatus stub] andReturnValue:OCMOCK_VALUE(PingBackStatusFetchingNotificationStream)] status];
-    [(BackgroundAPNSPingBackStatus*)[[self.mockPingBackStatus expect] andReturnValue:OCMOCK_VALUE(YES)] hasNoticeNotificationIDs];
-    [(BackgroundAPNSPingBackStatus*)[[self.mockPingBackStatus expect] andReturn:event] nextNoticeNotificationEventsWithID];
-    ZMTransportRequest *request = [self.sut nextRequest];
-    XCTAssertNotNil(request);
-    
-    // expect
-    [[self.mockPingBackStatus expect] missingUpdateEventTranscoderWithDidReceiveEvents:@[] originalEvents:event hasMore:YES];
-    
-    // when
-    [request completeWithResponse:[ZMTransportResponse responseWithPayload:@{@"notifications" : @[], @"has_more" : @1} HTTPstatus:200 transportSessionError:nil]];
-    WaitForAllGroupsToBeEmpty(0.5);
-    
-    // and expect
-    // when we ask for the nextRequest it still has the event to fetch
-    [(BackgroundAPNSPingBackStatus*)[[self.mockPingBackStatus expect] andReturnValue:OCMOCK_VALUE(NO)] hasNoticeNotificationIDs];
-
-    // and when
-    ZMTransportRequest *nextRequest  = [self.sut nextRequest];
-    
-    // then
-    XCTAssertNotNil(nextRequest);
-    NSString *expectedPath = [NSString stringWithFormat:@"/notifications?size=500&since=%@&cancel_fallback=%@", self.syncMOC.zm_lastNotificationID.transportString, event.identifier.transportString];
-    XCTAssertEqualObjects(nextRequest.path, expectedPath);
-    
-    [self.mockPingBackStatus verify];
-}
-
-- (void)testThatWeCanPingBackTwiceInARow
-{
-    // given
-    self.syncMOC.zm_lastNotificationID = [NSUUID timeBasedUUID];
-    
-    EventsWithIdentifier *event1 = [[EventsWithIdentifier alloc] initWithEvents:@[] identifier:[NSUUID timeBasedUUID] isNotice:YES];
-    EventsWithIdentifier *event2 = [[EventsWithIdentifier alloc] initWithEvents:@[] identifier:[NSUUID timeBasedUUID] isNotice:YES];
-
-    [(BackgroundAPNSPingBackStatus*)[[self.mockPingBackStatus stub] andReturnValue:OCMOCK_VALUE(PingBackStatusFetchingNotificationStream)] status];
-    [(BackgroundAPNSPingBackStatus*)[[self.mockPingBackStatus expect] andReturnValue:OCMOCK_VALUE(YES)] hasNoticeNotificationIDs];
-    [(BackgroundAPNSPingBackStatus*)[[self.mockPingBackStatus expect] andReturn:event1] nextNoticeNotificationEventsWithID];
-    ZMTransportRequest *request = [self.sut nextRequest];
-    XCTAssertNotNil(request);
-    
-    // expect
-    [[self.mockPingBackStatus expect] missingUpdateEventTranscoderWithDidReceiveEvents:@[] originalEvents:event1 hasMore:NO];
-    
-    // when
-    [request completeWithResponse:[ZMTransportResponse responseWithPayload:@{@"notifications" : @[]} HTTPstatus:200 transportSessionError:nil]];
-    WaitForAllGroupsToBeEmpty(0.5);
-    
-    // expect
-    [(BackgroundAPNSPingBackStatus*)[[self.mockPingBackStatus expect] andReturnValue:OCMOCK_VALUE(YES)] hasNoticeNotificationIDs];
-    [(BackgroundAPNSPingBackStatus*)[[self.mockPingBackStatus expect] andReturn:event2] nextNoticeNotificationEventsWithID];
-    
-    // when
-    ZMTransportRequest *nextRequest = [self.sut nextRequest];
-    
-    // then
-    XCTAssertNotNil(request);
-    NSString *expectedPath = [NSString stringWithFormat:@"/notifications?size=500&since=%@&cancel_fallback=%@", self.syncMOC.zm_lastNotificationID.transportString, event2.identifier.transportString];
-    XCTAssertEqualObjects(nextRequest.path, expectedPath);
-    
-    [self.mockPingBackStatus verify];
-}
-
-- (void)testThatItNotifiesPingBackStatusWhenRequestFailsPermanently
-{
-    // given
-    self.syncMOC.zm_lastNotificationID = [NSUUID timeBasedUUID];
-    
-    EventsWithIdentifier *event = [[EventsWithIdentifier alloc] initWithEvents:@[] identifier:[NSUUID timeBasedUUID] isNotice:YES];
-    [(BackgroundAPNSPingBackStatus*)[[self.mockPingBackStatus stub] andReturnValue:OCMOCK_VALUE(PingBackStatusFetchingNotificationStream)] status];
-    [(BackgroundAPNSPingBackStatus*)[[self.mockPingBackStatus expect] andReturnValue:OCMOCK_VALUE(YES)] hasNoticeNotificationIDs];
-    [(BackgroundAPNSPingBackStatus*)[[self.mockPingBackStatus expect] andReturn:event] nextNoticeNotificationEventsWithID];
-    ZMTransportRequest *request = [self.sut nextRequest];
-    XCTAssertNotNil(request);
-    
-    // expect
-    [[self.mockPingBackStatus expect] missingUpdateEventTranscoderFailedDownloadingEvents:event];
-    
-    // when
-    [request completeWithResponse:[ZMTransportResponse responseWithPayload:nil HTTPstatus:400 transportSessionError:nil]];
-    WaitForAllGroupsToBeEmpty(0.5);
-    
-    [self.mockPingBackStatus verify];
-
-    // and when
-    // when we do a normal quicksync it does not include the pingback parameter anymore
-    [self.sut startDownloadingMissingNotifications];
-    ZMTransportRequest *nextRequest2  = [[self.sut requestGenerators] nextRequest];
-    
-    // then
-    XCTAssertNotNil(nextRequest2);
-    NSString *expectedPath = [NSString stringWithFormat:@"/notifications?size=500&since=%@", self.syncMOC.zm_lastNotificationID.transportString];
-    XCTAssertEqualObjects(nextRequest2.path, expectedPath);
 }
 
 @end

--- a/Tests/Source/Synchronization/ZMSingleRequestSyncTests.m
+++ b/Tests/Source/Synchronization/ZMSingleRequestSyncTests.m
@@ -58,8 +58,6 @@
     [self.sut readyForNextRequest];
     [[[self.transcoder stub] andReturn:expectedRequest] requestForSingleRequestSync:self.sut];
     ZMTransportRequest *request = [self.sut nextRequest];
-    XCTAssertEqual(self.sut.status, ZMSingleRequestInProgress);
-
     [request completeWithResponse:response];
     WaitForAllGroupsToBeEmpty(0.5);
 }
@@ -82,7 +80,7 @@
     XCTAssertEqual(self.sut.moc, self.uiMOC);
 }
 
-- (void)testThatItReturnsReadyWhenAskedToRequest
+- (void)testThatItReturnsInProgressWhenAskedToRequest
 {
     // given
     XCTAssertEqual(self.sut.status, ZMSingleRequestIdle);
@@ -92,24 +90,10 @@
     [self.sut readyForNextRequest];
     
     // then
-    XCTAssertEqual(self.sut.status, ZMSingleRequestReady);
-}
-
-- (void)testThatItReturnsInProgressWhenRequestIsCreated
-{
-    // given
-    XCTAssertEqual(self.sut.status, ZMSingleRequestIdle);
-    [[[self.transcoder stub] andReturn:[ZMTransportRequest requestGetFromPath:@"/foo"]] requestForSingleRequestSync:self.sut];
-    
-    // when
-    [self.sut readyForNextRequest];
-    [self.sut nextRequest];
-    
-    // then
     XCTAssertEqual(self.sut.status, ZMSingleRequestInProgress);
 }
 
-- (void)testThatItReturnsReadyWhenAskedToPrepareForNextRequest
+- (void)testThatItReturnsInProgressWhenAskedToPrepareForNextRequest
 {
     // given
     XCTAssertEqual(self.sut.status, ZMSingleRequestIdle);
@@ -119,7 +103,7 @@
     [self.sut readyForNextRequestIfNotBusy];
     
     // then
-    XCTAssertEqual(self.sut.status, ZMSingleRequestReady);
+    XCTAssertEqual(self.sut.status, ZMSingleRequestInProgress);
 }
 
 - (void)testThatItReturnsNoRequestWhenIdle
@@ -235,7 +219,7 @@
     [[self.transcoder reject] didReceiveResponse:OCMOCK_ANY forSingleRequest:OCMOCK_ANY];
     
     // then
-    XCTAssertEqual(self.sut.status, ZMSingleRequestReady);
+    XCTAssertEqual(self.sut.status, ZMSingleRequestInProgress);
     ZMTransportRequest *secondRequest = [self.sut nextRequest];
     XCTAssertNotNil(secondRequest);
 }
@@ -251,7 +235,7 @@
     [[self.transcoder reject] didReceiveResponse:OCMOCK_ANY forSingleRequest:OCMOCK_ANY];
     
     // then
-    XCTAssertEqual(self.sut.status, ZMSingleRequestReady);
+    XCTAssertEqual(self.sut.status, ZMSingleRequestInProgress);
     ZMTransportRequest *secondRequest = [self.sut nextRequest];
     XCTAssertNotNil(secondRequest);
 }
@@ -274,7 +258,7 @@
     XCTAssertEqual(self.sut.status, ZMSingleRequestIdle);
 }
 
-- (void)testThatItReturnsReadyWhenAskedToPrepareForNextRequest_WheItWasCompleted
+- (void)testThatItReturnsInProgressWhenAskedToPrepareForNextRequest_WheItWasCompleted
 {
     // expect
     [[self.transcoder stub] didReceiveResponse:OCMOCK_ANY forSingleRequest:self.sut];
@@ -287,15 +271,15 @@
     [self.sut readyForNextRequestIfNotBusy];
     
     // then
-    XCTAssertEqual(self.sut.status, ZMSingleRequestReady);
+    XCTAssertEqual(self.sut.status, ZMSingleRequestInProgress);
 }
 
 
-- (void)testThatResetCompletionStateDoesNotDoAnythingIfTheRequestIsReady
+- (void)testThatResetCompletionStateDoesNotDoAnythingIfTheRequestIsInProgress
 {
     // given
     [self.sut readyForNextRequest];
-    XCTAssertEqual(self.sut.status, ZMSingleRequestReady);
+    XCTAssertEqual(self.sut.status, ZMSingleRequestInProgress);
     
     // when
     [self performIgnoringZMLogError:^{
@@ -303,7 +287,7 @@
     }];
     
     // then
-    XCTAssertEqual(self.sut.status, ZMSingleRequestReady);
+    XCTAssertEqual(self.sut.status, ZMSingleRequestInProgress);
 }
 
 - (void)testThatItCreatesAnotherRequestWhenNeedDonwloadIsCalledWhileInProgress

--- a/Tests/Source/Synchronization/ZMSyncStrategyTests.m
+++ b/Tests/Source/Synchronization/ZMSyncStrategyTests.m
@@ -64,7 +64,6 @@
 #import "ZMMessageTranscoder+Internal.h"
 #import "ZMClientMessageTranscoder.h"
 #import "BadgeApplication.h"
-#import <zmessaging/zmessaging-Swift.h>
 
 
 @interface ZMSyncStrategyTests : MessagingTest
@@ -156,9 +155,9 @@
     [[[[registrationTranscoder expect] andReturn:registrationTranscoder] classMethod] alloc];
     (void) [[[registrationTranscoder expect] andReturn:registrationTranscoder] initWithManagedObjectContext:self.syncMOC authenticationStatus:self.authenticationStatus];
 
-    id missingUpdateEventsTranscoder = [OCMockObject niceMockForClass:ZMMissingUpdateEventsTranscoder.class];
+    id missingUpdateEventsTranscoder = [OCMockObject mockForClass:ZMMissingUpdateEventsTranscoder.class];
     [[[[missingUpdateEventsTranscoder expect] andReturn:missingUpdateEventsTranscoder] classMethod] alloc];
-    (void) [[[missingUpdateEventsTranscoder expect] andReturn:missingUpdateEventsTranscoder] initWithSyncStrategy:OCMOCK_ANY apnsPingBackStatus:OCMOCK_ANY];
+    (void) [[[missingUpdateEventsTranscoder expect] andReturn:missingUpdateEventsTranscoder] initWithSyncStrategy:OCMOCK_ANY];
 
     id mediaManager = [OCMockObject niceMockForClass:NSObject.class];
     


### PR DESCRIPTION
It seems like the new notification stream strategy is causing crashes on the application that are not easily debuggable. The crash are random and sometime causing the phone to reboot.
This commit reverts the notification stream processing to the previous state.
We will continue the work on the new notification stream strategy on a separate branch and merge it back to develop only when stable enough.