### PR TITLE
Load selfUser for syncMOC on syncMOC queue in UserImageTranscoder

### DIFF
--- a/Tests/Source/Synchronization/Transcoders/ZMUserImageTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMUserImageTranscoderTests.m
@@ -700,6 +700,8 @@
     ZMUserImageTranscoder __block *localSUT = [[ZMUserImageTranscoder alloc] initWithManagedObjectContext:self.syncMOC
                                                                                      imageProcessingQueue:self.queue];
     
+    XCTAssertTrue([self waitForAllGroupsToBeEmptyWithTimeout:0.5]);
+    
     // then
     
     [self.syncMOC performBlockAndWait:^{


### PR DESCRIPTION
- Another approach to fixing the crashes happening in current release
- Originally self user was created from syncMOC on main thread
- Idea is that the data gets corrupted because of loading happening on the incorrect thread