### PR TITLE
Remove `dispatch_async` in favour or `performGroupedBlock` where possible

### DIFF
--- a/Source/Calling/ZMVoiceChannel+CallFlow.m
+++ b/Source/Calling/ZMVoiceChannel+CallFlow.m
@@ -68,15 +68,15 @@
     ZMConversation *conv = self.conversation;
     
     if ([self hasOngoingGSMCall]) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+        [conv.managedObjectContext.zm_userInterfaceContext performGroupedBlock: ^{
                 [CallingInitialisationNotification notifyCallingFailedWithErrorCode:ZMVoiceChannelErrorCodeOngoingGSMCall];
-            });
+            }];
         return;
     }
    
-    dispatch_async(dispatch_get_main_queue(), ^{
+    [conv.managedObjectContext.zm_userInterfaceContext performGroupedBlock: ^{
         [[NSNotificationCenter defaultCenter] postNotificationName:ZMTransportSessionShouldKeepWebsocketOpenNotificationName object:self userInfo:@{ZMTransportSessionShouldKeepWebsocketOpenKey: @YES}];
-    });
+    }];
     
     if(!conv.callDeviceIsActive) {
         [ZMUserSession appendAVSLogMessageForConversation:conv withMessage:@"Self user wants to join voice channel"];

--- a/Source/Notifications/ZMNotifications+UserSession.m
+++ b/Source/Notifications/ZMNotifications+UserSession.m
@@ -42,9 +42,7 @@ static NSString *const ZMInitialSyncCompletedNotificationName = @"ZMInitialSyncC
 
 + (void)notifyInitialSyncCompleted
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [[NSNotificationCenter defaultCenter] postNotificationName:ZMInitialSyncCompletedNotificationName object:nil];
-    });
+    [[NSNotificationCenter defaultCenter] postNotificationName:ZMInitialSyncCompletedNotificationName object:nil];
 }
 
 @end

--- a/Source/Notifications/ZMNotifications+UserSessionInternal.h
+++ b/Source/Notifications/ZMNotifications+UserSessionInternal.h
@@ -25,6 +25,7 @@
 
 @interface ZMUserSession (InternalNotifications)
 
+/// Notifies the UI that the initial sync is completed. This method should be called from the UI thread.
 + (void)notifyInitialSyncCompleted;
 
 @end

--- a/Source/Synchronization/Strategies/ProxiedRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/ProxiedRequestStrategy.swift
@@ -63,12 +63,9 @@ extension ProxiedRequestType {
                 request.doesNotFollowRedirects = true
             }
             request.expireAfterInterval(ProxiedRequestStrategy.RequestExpirationTime)
-            request.addCompletionHandler(ZMCompletionHandler(onGroupQueue: self.managedObjectContext, block: {
+            request.addCompletionHandler(ZMCompletionHandler(onGroupQueue: self.managedObjectContext.zm_userInterfaceContext, block: {
                 response in
-                dispatch_async(dispatch_get_main_queue(), {
                     callback?(response.rawData, response.rawResponse, response.transportSessionError)
-                    })
-                return
             }))
             return request
         }

--- a/Source/Synchronization/Sync States/ZMEventProcessingState.m
+++ b/Source/Synchronization/Sync States/ZMEventProcessingState.m
@@ -104,13 +104,16 @@
 
 - (void)didEnterState
 {
-    [self.objectStrategyDirectory processAllEventsInBuffer];
+    id<ZMObjectStrategyDirectory> directory = self.objectStrategyDirectory;
+    [directory processAllEventsInBuffer];
     [self.hotFix applyPatches];
 
     [[NSNotificationCenter defaultCenter] postNotificationName:ZMApplicationDidEnterEventProcessingStateNotificationName object:nil];
     [self.stateMachineDelegate didFinishSync];
 
-    [ZMUserSession notifyInitialSyncCompleted];
+    [directory.moc.zm_userInterfaceContext performBlock:^{
+        [ZMUserSession notifyInitialSyncCompleted];
+    }];
 }
 
 - (void)tearDown

--- a/Source/Synchronization/Transcoders/ZMConnectionTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMConnectionTranscoder.m
@@ -146,9 +146,10 @@ NSUInteger ZMConnectionTranscoderPageSize = 90;
                 }
             }
             
-            dispatch_async(dispatch_get_main_queue(), ^{
+            [self.managedObjectContext.zm_userInterfaceContext performGroupedBlock:^{
+
                 [[NSNotificationCenter defaultCenter] postNotification:[ZMConnectionLimitNotification connectionLimitNotification]];
-            });
+            }];
         }
     }];
 }

--- a/Source/Synchronization/ZMCallStateTranscoder.m
+++ b/Source/Synchronization/ZMCallStateTranscoder.m
@@ -730,11 +730,11 @@ _Pragma("clang diagnostic pop")
             
             isVoiceChannelFull = [NSError fullVoiceChannelErrorFromResponse:response] != nil;
             
-            dispatch_async(dispatch_get_main_queue(), ^{
+            [self.managedObjectContext.zm_userInterfaceContext performGroupedBlock:^{
                 [[NSNotificationCenter defaultCenter] postNotificationName:ZMConversationVoiceChannelJoinFailedNotification
                                                                     object:conversation.objectID
                                                                   userInfo:@{@"error": callbackError}];
-            });
+            }];
         }
         // the BE refused the request
         if (!conversation.callDeviceIsActive) {

--- a/Source/UserSession/ZMBlacklistDownloader.m
+++ b/Source/UserSession/ZMBlacklistDownloader.m
@@ -222,11 +222,13 @@ static NSString * const ExcludeVersionsKey = @"exclude";
         else {
             NSTimer *timer = [NSTimer timerWithTimeInterval:timeLeftSinceNextDownload target:self selector:@selector(timerDidFire) userInfo:nil repeats:NO];
             self.currentTimer = timer;
+            [self.workingGroup enter];
             dispatch_async(dispatch_get_main_queue(), ^{
                 ZM_STRONG(self);
                 if(self) {
                     [[NSRunLoop currentRunLoop] addTimer:timer forMode:NSRunLoopCommonModes];
                 }
+                [self.workingGroup leave];
             });
         }
         [self.workingGroup leave];
@@ -322,10 +324,10 @@ static NSString * const ExcludeVersionsKey = @"exclude";
         
         if (self.completionHandler) {
             void(^completionHandler)(NSString *, NSArray *) = self.completionHandler;
-//            [self.workingGroup enter];
+            [self.workingGroup enter];
             dispatch_async(dispatch_get_main_queue(), ^ void () {
                 completionHandler(minVersion, exclude);
-//                [self.workingGroup leave];
+                [self.workingGroup leave];
             });
         }
     }


### PR DESCRIPTION
Remove `dispatch_async` in favour or `performGroupedBlock` where possble

Where not possible, make sure to enter/leave groups.
Only using groups gives us the guarantee that tests will wait for the queue to be empty before moving to the next test. If we can't guarantee this, we will have a lot of flaky tests.