### PR TITLE
Use new address book upload endpoint

### DIFF
--- a/Source/Synchronization/ZMAddressBookSync.m
+++ b/Source/Synchronization/ZMAddressBookSync.m
@@ -31,7 +31,7 @@
 #import "zmessaging/zmessaging-Swift.h"
 
 static NSString * const ZMAddressBookTranscoderNeedsToBeUploadedKey = @"ZMAddressBookTranscoderNeedsToBeUploaded";
-static NSString * const ZMOnboardingEndpoint = @"/onboarding/v2";
+static NSString * const ZMOnboardingEndpoint = @"/onboarding/v3";
 
 
 @interface ZMAddressBookSync ()
@@ -149,13 +149,11 @@ static NSString * const ZMOnboardingEndpoint = @"/onboarding/v2";
 - (void)didReceiveResponse:(ZMTransportResponse *)response forSingleRequest:(ZMSingleRequestSync * __unused)sync
 {
     if (response.result == ZMTransportResponseStatusSuccess) {
-        NSArray *remoteIdentifiersAsStrings = [[response.payload asDictionary] arrayForKey:@"results"];
-        NSArray *remoteIdentifiers = [remoteIdentifiersAsStrings mapWithBlock:^id(NSString *s) {
-            return s.UUID;
-        }];
-        
-        self.managedObjectContext.suggestedUsersForUser = [NSOrderedSet orderedSetWithArray:remoteIdentifiers];
         self.managedObjectContext.commonConnectionsForUsers = @{};
+        // This is a momentary workaround until we decide whether suggestions should be displayed or not
+        // At the moment they are not displayed anywhere, so I can safely set it to an empty set
+        self.managedObjectContext.suggestedUsersForUser = [NSOrderedSet orderedSet];
+
     }
     self.uploadedAddressBookDigest = self.encodedAddressBook.digest;
     self.encodedAddressBook = nil;

--- a/Tests/Source/Integration/UserProfileTests.m
+++ b/Tests/Source/Integration/UserProfileTests.m
@@ -148,7 +148,7 @@
     __block ZMTransportRequest *onboardingRequest;
     XCTAssertTrue([self waitOnMainLoopUntilBlock:^BOOL{
         for(ZMTransportRequest *request in self.mockTransportSession.receivedRequests) {
-            if([request.path isEqual:@"/onboarding/v2"]) {
+            if([request.path isEqual:@"/onboarding/v3"]) {
                 onboardingRequest = request;
                 return YES;
             }

--- a/Tests/Source/Synchronization/Transcoders/ZMAddressBookSyncTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMAddressBookSyncTests.m
@@ -140,7 +140,7 @@
     XCTAssertNotNil(request);
     XCTAssertEqual(request.method, ZMMethodPOST);
     XCTAssertTrue(request.shouldCompress);
-    XCTAssertEqualObjects(request.path, @"/onboarding/v2");
+    XCTAssertEqualObjects(request.path, @"/onboarding/v3");
     XCTAssertNotNil(request.payload);
     XCTAssertTrue([request.payload isKindOfClass:[NSDictionary class]]);
     NSDictionary *payload = [request.payload asDictionary];
@@ -261,7 +261,7 @@
 
 @implementation ZMAddressBookSyncTests (SuggestedContacts)
 
-- (void)testThatItUpdatesTheSuggestedContacts;
+- (void)testThatItDoesNotUpdatesTheSuggestedContacts;
 {
     // given
     [ZMAddressBookSync markAddressBookAsNeedingToBeUploadedInContext:self.uiMOC];
@@ -279,7 +279,7 @@
     XCTAssert([self waitForCustomExpectationsWithTimeout:0.5]);
     
     // then
-    XCTAssertEqualObjects(self.uiMOC.suggestedUsersForUser.array, remoteIdentifiers);
+    XCTAssertEqualObjects(self.uiMOC.suggestedUsersForUser.array, @[]);
 }
 
 @end


### PR DESCRIPTION
The new address book upload endpoint does not return suggestions of people you might know. However, we do not display people you might know anywhere in the client anymore, so we can safely set it to an empty set.
The code to handle people you might know is not being removed completely yet because we are still debating whether it will come back soon.