### PR TITLE
Fix missed call notification

### DIFF
--- a/Source/Notifications/Push notifications/ZMLocalNotificationForCallEvent.swift
+++ b/Source/Notifications/Push notifications/ZMLocalNotificationForCallEvent.swift
@@ -36,6 +36,18 @@ public class ZMLocalNotificationForCallEvent : ZMLocalNotificationForEvent {
     var lastJoinedSessionID : String?
     let unknownUUID = NSUUID(UUIDString: "cc6515c4-6d3e-48c2-b09d-43a6130c9333")!
     
+    override public func containsIdenticalEvent(event: ZMUpdateEvent) -> Bool {
+        guard super.containsIdenticalEvent(event) else { return false }
+        
+        guard let lastSequence = lastEvent?.payload["sequence"] as? Int,
+              let currentSequence = event.payload["sequence"] as? Int
+            where lastSequence == currentSequence else {
+                return false
+        }
+        
+        return true
+    }
+    
     override func canCreateNotification() -> Bool {
         if (!super.canCreateNotification()) { return false }
         let lastEvent = self.lastEvent!
@@ -92,9 +104,9 @@ public class ZMLocalNotificationForCallEvent : ZMLocalNotificationForEvent {
         super.prepareForCopy(note)
         if let note = note as? ZMLocalNotificationForCallEvent {
             lastSessionIDToSenderID = note.lastSessionIDToSenderID
-            lastJoinedSessionID = note.lastJoinedSessionID
+            lastJoinedSessionID     = note.lastJoinedSessionID
             callStartedEventsByUser = note.callStartedEventsByUser
-            currentCallType = note.currentCallType
+            currentCallType         = note.currentCallType
         }
     }
     

--- a/Source/Synchronization/Transcoders/ZMConversationTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMConversationTranscoder.m
@@ -342,10 +342,10 @@ static NSString *const ConversationInfoArchivedValueKey = @"archived";
     BOOL eventIsCompletedVoiceCall = NO;
     if (event.type == ZMUpdateEventConversationVoiceChannelDeactivate) {
         NSString *reason = [[event.payload optionalDictionaryForKey:@"data"] optionalStringForKey:@"reason"];
-        eventIsCompletedVoiceCall = ! [reason isEqualToString:@"missed"];
+        eventIsCompletedVoiceCall = ![reason isEqualToString:@"missed"];
     }
     
-    if ((! [ZMMessage doesEventTypeGenerateMessage:event.type]) || eventIsCompletedVoiceCall) {
+    if (eventIsCompletedVoiceCall) {
         [self updateLastReadForInvisibleEventInConversation:conversation
                                                   timeStamp:timeStamp
                                            oldLastTimeStamp:oldLastTimeStamp

--- a/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.m
@@ -4404,26 +4404,20 @@ static NSString *const CONVERSATION_ID_REQUEST_PREFIX = @"/conversations?ids=";
         
         NSDictionary *payload = @{
                                   @"conversation" : conversation.remoteIdentifier.transportString,
-                                  @"data" : @{},
+                                  @"data" : @{@"reason": @"completed"},
                                   @"from" : @"08316f5e-3c0a-4847-a235-2b4d93f291a4",
                                   @"time" : newDate.transportString,
-                                  @"type" : @"conversation.voice-channel-activate",
+                                  @"type" : @"conversation.voice-channel-deactivate",
                                   @"id"   : newEventID.transportString
                                   };
         
         ZMUpdateEvent *updateEvent = [ZMUpdateEvent eventFromEventStreamPayload:payload uuid:nil];
         XCTAssertNotNil(updateEvent);
         
-        // expect
-        id messageMock = [OCMockObject mockForClass:ZMMessage.class];
-        [[[[messageMock expect] andReturnValue:OCMOCK_VALUE(NO)] classMethod] doesEventTypeGenerateMessage:ZMUpdateEventConversationVoiceChannelActivate];
-        
         // when
         [self.sut processEvents:@[updateEvent] liveEvents:YES prefetchResult:nil];
         
         // then
-        [messageMock verify];
-        [messageMock stopMocking];
         XCTAssertEqualObjects(conversation.lastReadEventID, newEventID);
         XCTAssertEqualWithAccuracy(conversation.lastReadServerTimeStamp.timeIntervalSinceReferenceDate, newDate.timeIntervalSinceReferenceDate, 0.1);
     }];
@@ -4448,13 +4442,13 @@ static NSString *const CONVERSATION_ID_REQUEST_PREFIX = @"/conversations?ids=";
 
         NSDictionary *payload = @{
                                   @"conversation" : conversation.remoteIdentifier.transportString,
-                                  @"data" : @{},
+                                  @"data" : @{@"reason": @"completed"},
                                   @"from" : @"08316f5e-3c0a-4847-a235-2b4d93f291a4",
                                   @"time" : newDate.transportString,
-                                  @"type" : @"conversation.voice-channel-activate",
+                                  @"type" : @"conversation.voice-channel-deactivate",
                                   @"id"   : newEventID.transportString
                                   };
-        
+
         ZMUpdateEvent *updateEvent = [ZMUpdateEvent eventFromEventStreamPayload:payload uuid:nil];
         XCTAssertNotNil(updateEvent);
         
@@ -4489,7 +4483,7 @@ static NSString *const CONVERSATION_ID_REQUEST_PREFIX = @"/conversations?ids=";
         
         NSDictionary *payload = @{
                                   @"conversation" : conversation.remoteIdentifier.transportString,
-                                  @"data" : @{},
+                                  @"data" : @{@"reason": @"completed"},
                                   @"from" : @"08316f5e-3c0a-4847-a235-2b4d93f291a4",
                                   @"time" : newDate.transportString,
                                   @"type" : @"conversation.voice-channel-activate",
@@ -4568,28 +4562,24 @@ static NSString *const CONVERSATION_ID_REQUEST_PREFIX = @"/conversations?ids=";
         ZMEventID *newEventID = [ZMEventID eventIDWithMajor:(conversation.lastReadEventID.major+1) minor:0xbb];
         NSDate *newDate = [NSDate dateWithTimeInterval:10 sinceDate:conversation.lastServerTimeStamp];
         
+        
         NSDictionary *payload = @{
                                   @"conversation" : conversation.remoteIdentifier.transportString,
-                                  @"data" : @{},
+                                  @"data" : @{@"reason": @"completed"},
                                   @"from" : @"08316f5e-3c0a-4847-a235-2b4d93f291a4",
                                   @"time" : newDate.transportString,
-                                  @"type" : @"conversation.voice-channel-activate",
+                                  @"type" : @"conversation.voice-channel-deactivate",
                                   @"id"   : newEventID.transportString
                                   };
         
         ZMUpdateEvent *updateEvent = [ZMUpdateEvent eventFromEventStreamPayload:payload uuid:nil];
         XCTAssertNotNil(updateEvent);
         
-        // expect
-        id messageMock = [OCMockObject mockForClass:ZMMessage.class];
-        [[[[messageMock expect] andReturnValue:OCMOCK_VALUE(NO)] classMethod] doesEventTypeGenerateMessage:ZMUpdateEventConversationVoiceChannelActivate];
         
         // when
         [self.sut processEvents:@[updateEvent] liveEvents:NO prefetchResult:nil];
         
         // then
-        [messageMock verify];
-        [messageMock stopMocking];
         XCTAssertEqualObjects(conversation.lastReadEventID, newEventID);
         XCTAssertEqualWithAccuracy(conversation.lastReadServerTimeStamp.timeIntervalSinceReferenceDate, newDate.timeIntervalSinceReferenceDate, 0.1);
     }];


### PR DESCRIPTION
**What's in this PR**
This PR fixes an issue where the user would not see notification when he/she missed a call.

This was due to the fact that we would update the last read timestamp of the conversation for event like `VoiceChannelActivate`, or any other event that does not generate a message or system message. This would lead to the clearing of notification, leaving us unable to update the call notification to a missed call. 
With this changed, the only kind of event that would update the conversation timestamp are successful call termination.

Additionally, we would wrongfully consider equivalent 2 call state events with the same ID and type, even though they might have a different sequence number. The sequence number is what identify in which order call state event happens, so 2 distinct events can't have the same sequence number. This is corrected by now also checking if the sequence numbers are the same.