### PR TITLE
Add tracking to address book search

### DIFF
--- a/Source/Synchronization/Strategies/AddressBookUploadRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/AddressBookUploadRequestStrategy.swift
@@ -18,8 +18,6 @@
 
 import Foundation
 
-// TODO MARCO: add tracking
-
 /// BE onboarding endpoint
 private let onboardingEndpoint = "/onboarding/v3"
 
@@ -76,7 +74,7 @@ private let addressBookLastUploadedIndex = "ZMAddressBookTranscoderLastIndexUplo
         self.clientRegistrationStatus = clientRegistrationStatus
         self.managedObjectContext = managedObjectContext
         self.addressBookGenerator = addressBookGenerator
-        self.tracker = tracker ?? AddressBookTracker(analytics: managedObjectContext.analytics)
+        self.tracker = tracker ?? AddressBookAnalytics(analytics: managedObjectContext.analytics)
         super.init()
         self.requestSync = ZMSingleRequestSync(singleRequestTranscoder: self, managedObjectContext: managedObjectContext)
     }
@@ -113,6 +111,7 @@ extension AddressBookUploadRequestStrategy : RequestStrategy, ZMSingleRequestTra
                 ]
         }
         let payload = ["cards" : contactCards]
+        self.tracker.tagAddressBookUploadStarted(encodedChunk.numberOfTotalContacts)
         return ZMTransportRequest(path: onboardingEndpoint, method: .MethodPOST, payload: payload, shouldCompress: true)
     }
     
@@ -123,6 +122,9 @@ extension AddressBookUploadRequestStrategy : RequestStrategy, ZMSingleRequestTra
             self.managedObjectContext.commonConnectionsForUsers = [:]
             self.addressBookNeedsToBeUploaded = false
             self.encodedAddressBookChunk = nil
+            
+            // tracking
+            self.tracker.tagAddressBookUploadSuccess()
         }
     }
     

--- a/Tests/Source/Synchronization/Strategies/AddressBookUploadRequestStrategyTest.swift
+++ b/Tests/Source/Synchronization/Strategies/AddressBookUploadRequestStrategyTest.swift
@@ -26,6 +26,7 @@ class AddressBookUploadRequestStrategyTest : MessagingTest {
     var authenticationStatus : MockAuthenticationStatus!
     var clientRegistrationStatus : ZMMockClientRegistrationStatus!
     var addressBook : AddressBookFake!
+    var trackerFake : AddressBookTrackerFake!
     
     override func setUp() {
         super.setUp()
@@ -33,14 +34,17 @@ class AddressBookUploadRequestStrategyTest : MessagingTest {
         self.clientRegistrationStatus = ZMMockClientRegistrationStatus()
         self.clientRegistrationStatus.mockPhase = .Registered
         self.addressBook = AddressBookFake()
+        self.trackerFake = AddressBookTrackerFake()
+        
         let ab = self.addressBook // I don't want to capture self in closure later
         ab.contactHashes = [
             ["1"], ["2a", "2b"], ["3"], ["4"]
         ]
         self.sut = zmessaging.AddressBookUploadRequestStrategy(authenticationStatus: self.authenticationStatus,
-                                                    clientRegistrationStatus: self.clientRegistrationStatus,
-                                                    managedObjectContext: self.syncMOC,
-                                                    addressBookGenerator: { return ab } )
+                                                               clientRegistrationStatus: self.clientRegistrationStatus,
+                                                               managedObjectContext: self.syncMOC,
+                                                               addressBookGenerator: { return ab },
+                                                               tracker: self.trackerFake)
     }
     
     override func tearDown() {
@@ -290,6 +294,63 @@ extension AddressBookUploadRequestStrategyTest {
     }
 }
 
+// MARK: - Tracking
+extension AddressBookUploadRequestStrategyTest {
+    
+    func testThatItTagsTheEventWhenStartingToUpload() {
+        
+        // given
+        zmessaging.AddressBook.markAddressBookAsNeedingToBeUploaded(self.syncMOC)
+        _ = sut.nextRequest() // this will return nil and start async processing
+        XCTAssertTrue(self.waitForAllGroupsToBeEmptyWithTimeout(0.5))
+        
+        // when
+        let request = sut.nextRequest()
+        XCTAssertNotNil(request)
+        XCTAssertTrue(self.waitForAllGroupsToBeEmptyWithTimeout(0.5))
+        
+        // then
+        XCTAssertEqual(self.trackerFake.taggedStartEventParameters, [self.addressBook.contactHashes.count])
+        XCTAssertEqual(self.trackerFake.taggedEndEventCount, 0)
+    }
+    
+    func testThatItTagsTheEventWhenUploadingSuccessfully() {
+        
+        // given
+        zmessaging.AddressBook.markAddressBookAsNeedingToBeUploaded(self.syncMOC)
+        _ = sut.nextRequest() // this will return nil and start async processing
+        XCTAssertTrue(self.waitForAllGroupsToBeEmptyWithTimeout(0.5))
+        let request = sut.nextRequest()
+        XCTAssertNotNil(request)
+        
+        // when
+        request?.completeWithResponse(ZMTransportResponse(payload: nil, HTTPstatus: 200, transportSessionError: nil))
+        XCTAssertTrue(self.waitForAllGroupsToBeEmptyWithTimeout(0.5))
+        
+        // then
+        XCTAssertEqual(self.trackerFake.taggedStartEventParameters, [self.addressBook.contactHashes.count])
+        XCTAssertEqual(self.trackerFake.taggedEndEventCount, 1)
+    }
+    
+    func testThatItDoesNotTagTheEventWhenUploadingUnsuccessfully() {
+        
+        // given
+        zmessaging.AddressBook.markAddressBookAsNeedingToBeUploaded(self.syncMOC)
+        _ = sut.nextRequest() // this will return nil and start async processing
+        XCTAssertTrue(self.waitForAllGroupsToBeEmptyWithTimeout(0.5))
+        let request = sut.nextRequest()
+        XCTAssertNotNil(request)
+        
+        // when
+        request?.completeWithResponse(ZMTransportResponse(payload: nil, HTTPstatus: 400, transportSessionError: nil))
+        XCTAssertTrue(self.waitForAllGroupsToBeEmptyWithTimeout(0.5))
+        
+        // then
+        XCTAssertEqual(self.trackerFake.taggedStartEventParameters, [self.addressBook.contactHashes.count])
+        XCTAssertEqual(self.trackerFake.taggedEndEventCount, 0)
+    }
+}
+
 // MARK: - Helpers
 extension AddressBookUploadRequestStrategyTest {
     
@@ -404,5 +465,21 @@ extension ZMTransportData {
         } catch {
             return nil
         }
+    }
+}
+
+/// Fake tracker to test upload tracking
+final class AddressBookTrackerFake : zmessaging.AddressBookTracker {
+    
+    var taggedStartEventParameters : [UInt] = []
+    
+    var taggedEndEventCount : UInt = 0
+    
+    func tagAddressBookUploadSuccess() {
+        self.taggedEndEventCount += 1
+    }
+    
+    func tagAddressBookUploadStarted(entireABsize: UInt) {
+        self.taggedStartEventParameters.append(entireABsize)
     }
 }


### PR DESCRIPTION
# Reason for this pull request
Address book search is missing analytics

# Changes
Add two separate events:
- begin of address book processing / search request
- end of address book search, when the backend returns a 200

We have two events because it's possible that we start the search, but if we are in the background we fail to process the address book / submit the request before we get suspended or killed. We can look at the difference between the # of start events and the # of end events to know how many times we tried a search but we failed to complete it.
