### PR TITLE
Fix searching with address book when some contacts do not have valid …

### DIFF
--- a/Source/Synchronization/Strategies/AddressBookUploadRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/AddressBookUploadRequestStrategy.swift
@@ -183,7 +183,7 @@ extension AddressBookUploadRequestStrategy : RequestStrategy, ZMSingleRequestTra
 
 extension EncodedAddressBookChunk {
     
-    /// Whether another address book chunk needs to be uploaded after this one
+    /// Whether this is the last chunk and no following chunk needs to be uploaded after this one
     var isLast : Bool {
         return UInt(self.otherContactsHashes.count) < maxEntriesInAddressBookChunk
     }

--- a/Source/Synchronization/Strategies/AddressBookUploadRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/AddressBookUploadRequestStrategy.swift
@@ -49,7 +49,7 @@ private let addressBookLastUploadedIndex = "ZMAddressBookTranscoderLastIndexUplo
     private var requestSync : ZMSingleRequestSync!
     
     /// Encoded address book chunk
-    private var encodedAddressBookChunk : EncodedAddressBookChunk? = nil
+    private var encodedAddressBookChunkToUpload : EncodedAddressBookChunk? = nil
     
     /// Is the payload being generated? This is an async operation
     private var isGeneratingPayload : Bool = false
@@ -92,7 +92,7 @@ extension AddressBookUploadRequestStrategy : RequestStrategy, ZMSingleRequestTra
         }
         
         // already encoded? just send it
-        if self.encodedAddressBookChunk != nil {
+        if self.encodedAddressBookChunkToUpload != nil {
             return self.requestSync.nextRequest()
         }
         
@@ -101,7 +101,7 @@ extension AddressBookUploadRequestStrategy : RequestStrategy, ZMSingleRequestTra
     }
     
     func requestForSingleRequestSync(sync: ZMSingleRequestSync!) -> ZMTransportRequest! {
-        guard sync == self.requestSync, let encodedChunk = self.encodedAddressBookChunk else {
+        guard sync == self.requestSync, let encodedChunk = self.encodedAddressBookChunkToUpload else {
             return nil
         }
         let contactCards = encodedChunk.otherContactsHashes
@@ -122,7 +122,7 @@ extension AddressBookUploadRequestStrategy : RequestStrategy, ZMSingleRequestTra
             self.managedObjectContext.suggestedUsersForUser = NSOrderedSet()
             self.managedObjectContext.commonConnectionsForUsers = [:]
             self.addressBookNeedsToBeUploaded = false
-            self.encodedAddressBookChunk = nil
+            self.encodedAddressBookChunkToUpload = nil
         }
     }
     
@@ -148,15 +148,54 @@ extension AddressBookUploadRequestStrategy : RequestStrategy, ZMSingleRequestTra
             }
             strongSelf.isGeneratingPayload = false
             if let encodedChunk = encodedChunk {
-                let lastIndex = encodedChunk.includedContacts.endIndex
-                let isEndOfCards = lastIndex >= encodedChunk.numberOfTotalContacts - 1
-                // is this the last card? if it is, reset to 0 so it will restart
-                strongSelf.lastUploadedCardIndex = isEndOfCards ? 0 : lastIndex
-                strongSelf.encodedAddressBookChunk = encodedChunk
-                strongSelf.requestSync.readyForNextRequest()
-                ZMOperationLoop.notifyNewRequestsAvailable(strongSelf)
+                strongSelf.checkIfShouldUpload(encodedChunk)
             }
         }
+    }
+    
+    private func checkIfShouldUpload(encodedChunk: EncodedAddressBookChunk) {
+        
+        if !encodedChunk.isEmpty {
+            // not empty? we are uploading it!
+            self.startUpload(encodedChunk)
+        }
+        
+        // reached the end, I had 1000 contacts and I was trying to encode 1001st ?
+        let shouldEncodeFirstChunkInstead = encodedChunk.isEmpty && !encodedChunk.isFirst
+        
+        if shouldEncodeFirstChunkInstead {
+            self.lastUploadedCardIndex = 0
+            self.generateAddressBookPayloadIfNeeded()
+        } else if encodedChunk.isLast {
+            self.lastUploadedCardIndex = 0
+        } else {
+            self.lastUploadedCardIndex = encodedChunk.includedContacts.endIndex
+        }
+    }
+    
+    /// Start uploading a given chunk
+    private func startUpload(encodedChunk: EncodedAddressBookChunk) {
+        self.encodedAddressBookChunkToUpload = encodedChunk
+        self.requestSync.readyForNextRequest()
+        ZMOperationLoop.notifyNewRequestsAvailable(self)
+    }
+}
+
+extension EncodedAddressBookChunk {
+    
+    /// Whether another address book chunk needs to be uploaded after this one
+    var isLast : Bool {
+        return UInt(self.otherContactsHashes.count) < maxEntriesInAddressBookChunk
+    }
+    
+    /// Whether this is the first chunk
+    var isFirst : Bool {
+        return self.includedContacts.startIndex == 0
+    }
+    
+    /// Whether the chunk is empty
+    var isEmpty : Bool {
+        return self.otherContactsHashes.isEmpty
     }
 }
 

--- a/Tests/Source/Synchronization/Strategies/AddressBookUploadRequestStrategyTest.swift
+++ b/Tests/Source/Synchronization/Strategies/AddressBookUploadRequestStrategyTest.swift
@@ -308,7 +308,6 @@ extension AddressBookUploadRequestStrategyTest {
         let request3 = self.getNextUploadingRequest()
         
         // then
-        // then
         XCTAssertNotNil(request1)
         XCTAssertNotNil(request2)
         XCTAssertNotNil(request3)

--- a/Tests/Source/Synchronization/Strategies/AddressBookUploadRequestStrategyTest.swift
+++ b/Tests/Source/Synchronization/Strategies/AddressBookUploadRequestStrategyTest.swift
@@ -222,6 +222,8 @@ extension AddressBookUploadRequestStrategyTest {
         // given
         let cardsNumber = Int(Double(maxEntriesInAddressBookChunk) * 1.5)
         self.addressBook.fillWithContacts(UInt(cardsNumber))
+        
+        // when
         let request1 = self.getNextUploadingRequest()
         let request2 = self.getNextUploadingRequest()
         let request3 = self.getNextUploadingRequest()
@@ -288,6 +290,51 @@ extension AddressBookUploadRequestStrategyTest {
             XCTFail()
         }
     }
+    
+    func testThatItUploadsInBatchesAndRestartWhenItReachedTheEnd_WithDiscrepancyOnTheNumberOfContacts() {
+        // It could happen that we have 2000 contacts in the AB, but only 1500 of them have valid emails
+        // or phone numbers that we can upload. So we can never upload more than 1500. This test checks 
+        // that we correcly detect that we reached the end of the "uploadable" contacts and restart from
+        // the first, even if we did not yet upload as many "raw" contacts as we have in the AB
+        
+        // given
+        let cardsNumber = Int(Double(maxEntriesInAddressBookChunk) * 1.5)
+        self.addressBook.fillWithContacts(UInt(cardsNumber))
+        self.addressBook.numberOfContactsOverride = UInt(maxEntriesInAddressBookChunk * 5)
+        
+        // when
+        let request1 = self.getNextUploadingRequest()
+        let request2 = self.getNextUploadingRequest()
+        let request3 = self.getNextUploadingRequest()
+        
+        // then
+        // then
+        XCTAssertNotNil(request1)
+        XCTAssertNotNil(request2)
+        XCTAssertNotNil(request3)
+        if let cards1 = (request1?.payload as? [String:AnyObject])?["cards"] as? [[String:AnyObject]] {
+            XCTAssertEqual(cards1.count, maxEntriesInAddressBookChunk)
+            XCTAssertTrue(self.checkCard(cards1.first, expectedIndex: 0))
+            XCTAssertTrue(self.checkCard(cards1.last, expectedIndex: maxEntriesInAddressBookChunk - 1))
+        } else {
+            XCTFail()
+        }
+        if let cards2 = (request2?.payload as? [String:AnyObject])?["cards"] as? [[String:AnyObject]] {
+            XCTAssertEqual(cards2.count, cardsNumber - maxEntriesInAddressBookChunk)
+            XCTAssertTrue(self.checkCard(cards2.first, expectedIndex: maxEntriesInAddressBookChunk))
+            XCTAssertTrue(self.checkCard(cards2.last, expectedIndex: cardsNumber-1))
+        } else {
+            XCTFail()
+        }
+        if let cards3 = (request3?.payload as? [String:AnyObject])?["cards"] as? [[String:AnyObject]] {
+            XCTAssertEqual(cards3.count, maxEntriesInAddressBookChunk)
+            XCTAssertTrue(self.checkCard(cards3.first, expectedIndex: 0))
+            XCTAssertTrue(self.checkCard(cards3.last, expectedIndex: maxEntriesInAddressBookChunk - 1))
+        } else {
+            XCTFail()
+        }
+        
+    }
 }
 
 // MARK: - Helpers
@@ -324,9 +371,15 @@ extension AddressBookUploadRequestStrategyTest {
 /// Fake to supply predefined AB hashes
 class AddressBookFake : zmessaging.AddressBookAccessor {
     
+    /// Number of contacts to return. If not set, it will count
+    /// the actual number of contact hashes
+    var numberOfContactsOverride : UInt? = nil
+    
     var numberOfContacts : UInt {
-        return UInt(contactHashes.count)
+        return self.numberOfContactsOverride ?? UInt(contactHashes.count)
     }
+    
+    /// Hashes to upload
     var contactHashes : [[String]] = []
     
     func iterate() -> LazySequence<AnyGenerator<ZMAddressBookContact>> {
@@ -340,7 +393,7 @@ class AddressBookFake : zmessaging.AddressBookAccessor {
             })
             return
         }
-        let range = startingContactIndex..<(min(numberOfContacts, startingContactIndex+maxNumberOfContacts))
+        let range = startingContactIndex..<(min(UInt(self.contactHashes.count), startingContactIndex+maxNumberOfContacts))
         let contactsInRange = Array(self.contactHashes[Int(range.startIndex)..<Int(range.endIndex)])
         let chunk = zmessaging.EncodedAddressBookChunk(numberOfTotalContacts: self.numberOfContacts,
                                                        otherContactsHashes: contactsInRange,
@@ -350,13 +403,14 @@ class AddressBookFake : zmessaging.AddressBookAccessor {
         }
     }
     
+    /// Replace the content with a given number of random hashes
     func fillWithContacts(number: UInt) {
         contactHashes = (0..<number).map {
             self.hashesForCard($0)
         }
     }
     
-    func hashesForCard(number: UInt) -> [String] {
+    private func hashesForCard(number: UInt) -> [String] {
         return ["hash-\(number)_0", "hash-\(number)_1"]
     }
 }


### PR DESCRIPTION
# Reason for this pull request
Uploading the address book in batches would get stuck trying to upload the last batch

We get the information on how many AB contacts are available directly from the AB (because we don't want to parse/normalize ALL of them just to know how many there are, it might take a long time). However some of these contacts might actually have invalid email or phone number, so the actually number of contacts that we can upload might be lower. This was causing the last batch to be empty, but we thought it was not the last batch, so we kept trying to upload the next (also empty).

# Changes
Before this PR, we were relying on the number of contacts in the AB, and not the number of "uploadable" contacts, to know if we reached the last batch of the search and we should restart from the first. But in case of non valid contacts, we would think that we never reach the end.
Now we correctly check if we reached the last "upload able" contact by checking if we have less contacts in the batch that we could have, and if that's the case, reset the batch counter so that we reupload the first one the next time.

Also, when trying to upload a new batch, it could be that the computed batch is empty - because the previous batch stopped exactly at the last "uploadable" contact. If this is the case, and we are trying to upload this (empty) batch, immediately reupload the first one instead.
