### PR TITLE
Fix address book search not working

### DIFF
--- a/Source/Registration/AddressBook+Encoding.swift
+++ b/Source/Registration/AddressBook+Encoding.swift
@@ -27,13 +27,12 @@ extension AddressBook {
                                      maxNumberOfContacts: UInt,
                                      completion: (EncodedAddressBookChunk?)->()
         ) {
-        groupQueue.dispatchGroup.asyncOnQueue(addressBookProcessingQueue) { [weak self] in
-            guard let strongSelf = self else {
-                return
-            }
-            
+        // here we are explicitly capturing self, this is executed on a queue that is
+        // never blocked indefinitely as this is the only function using it
+        groupQueue.dispatchGroup.asyncOnQueue(addressBookProcessingQueue) {
+
             let range = startingContactIndex..<(startingContactIndex+maxNumberOfContacts)
-            let cards = strongSelf.generateContactCards(range)
+            let cards = self.generateContactCards(range)
             guard cards.count > 0 else {
                 groupQueue.performGroupedBlock({
                     completion(nil)
@@ -41,7 +40,7 @@ extension AddressBook {
                 return
             }
             let cardsRange = startingContactIndex..<(startingContactIndex+UInt(cards.count))
-            let encodedAB = EncodedAddressBookChunk(numberOfTotalContacts: strongSelf.numberOfContacts,
+            let encodedAB = EncodedAddressBookChunk(numberOfTotalContacts: self.numberOfContacts,
                                                     otherContactsHashes: cards,
                                                     includedContacts: cardsRange)
             groupQueue.performGroupedBlock({ 

--- a/Source/Synchronization/ZMSyncStrategy.m
+++ b/Source/Synchronization/ZMSyncStrategy.m
@@ -178,6 +178,9 @@ ZM_EMPTY_ASSERTING_INIT()
                                    [[AssetDownloadRequestStrategy alloc] initWithAuthStatus:authenticationStatus
                                                                    taskCancellationProvider:taskCancellationProvider
                                                                        managedObjectContext:self.syncMOC],
+                                   [[AddressBookUploadRequestStrategy alloc] initWithAuthenticationStatus:authenticationStatus
+                                                                                 clientRegistrationStatus:clientRegistrationStatus
+                                                                                                      moc:self.syncMOC],
                                    self.pingBackRequestStrategy,
                                    self.pushNoticeFetchStrategy,
                                    self.fileUploadRequestStrategy,

--- a/Tests/Source/Synchronization/Strategies/AddressBookUploadRequestStrategyTest.swift
+++ b/Tests/Source/Synchronization/Strategies/AddressBookUploadRequestStrategyTest.swift
@@ -96,6 +96,9 @@ extension AddressBookUploadRequestStrategyTest {
                 XCTFail("No parsed cards")
             }
             XCTAssertTrue(request.shouldCompress)
+            let selfArray = (request.payload as? [String : AnyObject])?["self"] as? [String]
+            XCTAssertNotNil(selfArray)
+            XCTAssertEqual(selfArray?.count, 0)
         }
     }
     


### PR DESCRIPTION
# Reason for this pull request
Address book search was not working

# Changes
This bug was caused by a number of factors, all fixed in this PR:
- AddressBookUploadRequestStrategy not being added to list of strategies
- Backend returning 400 in case "self" key was missing in payload, even if it's ignored
- Async completion handler not being executed because the AddressBook instance was released in the meanwhile

# Testing
Given the kind of issues that were found, it seems like this feature is missing proper component testing.  We will address that in future PR.
