### PR TITLE
Fix missing interval in AB search tracking

### DIFF
--- a/Source/Synchronization/Strategies/AddressBookUploadRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/AddressBookUploadRequestStrategy.swift
@@ -85,7 +85,7 @@ private let addressBookLastUploadedIndex = "ZMAddressBookTranscoderLastIndexUplo
         self.clientRegistrationStatus = clientRegistrationStatus
         self.managedObjectContext = managedObjectContext
         self.addressBookGenerator = addressBookGenerator
-        self.tracker = tracker ?? AddressBookAnalytics(analytics: managedObjectContext.analytics)
+        self.tracker = tracker ?? AddressBookAnalytics(analytics: managedObjectContext.analytics, managedObjectContext: managedObjectContext)
         super.init()
         self.requestSync = ZMSingleRequestSync(singleRequestTranscoder: self, managedObjectContext: managedObjectContext)
     }


### PR DESCRIPTION
# Reason for this pull request
Missing "interval" parameter in AB search tracking

# Changes
- Fixed not storing time of previous upload
- Also moved the "last uploaded" time from NSUserDefaults to the NSManagedObjectContext, so that in future deleting the context will reset the value

# Testing
Previous tests were not catching this error as they were injecting the time of the previous upload artificially. Added a test that just uploads twice without artificially injecting the value.
