### PR TITLE
move notification creation and add sound

### DIFF
--- a/Source/Notifications/Push notifications/Notification Types/ZMLocalNotificationForEvent.swift
+++ b/Source/Notifications/Push notifications/Notification Types/ZMLocalNotificationForEvent.swift
@@ -167,9 +167,15 @@ public class ZMLocalNotificationForEvent : ZMLocalNotification {
     
     func configureNotification() -> UILocalNotification {
         let notification = UILocalNotification()
-        notification.alertBody = configureAlertBody().stringByEscapingPercentageSymbols()
-        notification.soundName = soundName
-        notification.category = category
+        let shouldHideContent = managedObjectContext.valueForKey(ZMShouldHideNotificationContentKey)
+        if let shouldHideContent = shouldHideContent as? NSNumber where shouldHideContent.boolValue == true {
+            notification.alertBody = ZMPushStringDefault.localizedString()
+            notification.soundName = ZMLocalNotificationNewMessageSoundName()
+        } else {
+            notification.alertBody = configureAlertBody().stringByEscapingPercentageSymbols()
+            notification.soundName = soundName
+            notification.category = category
+        }
         notification.setupUserInfo(conversation, forEvent: lastEvent)
         return notification
     }

--- a/Source/Notifications/Push notifications/ZMLocalNotificationDispatcher.m
+++ b/Source/Notifications/Push notifications/ZMLocalNotificationDispatcher.m
@@ -34,24 +34,6 @@ NSString * const ZMConversationCancelNotificationForIncomingCallNotificationName
 NSString * _Null_unspecified const ZMShouldHideNotificationContentKey = @"ZMShouldHideNotificationContentKey";
 
 
-@interface UILocalNotification (Default)
-
-+ (instancetype)defaultNotification;
-
-@end
-
-@implementation UILocalNotification (Default)
-
-+ (instancetype)defaultNotification;
-{
-    UILocalNotification *notification = [[UILocalNotification alloc] init];
-    notification.alertBody = [ZMPushStringDefault localizedString];
-    return notification;
-}
-
-@end
-
-
 @interface ZMLocalNotificationDispatcher ()
 
 @property (nonatomic) NSManagedObjectContext *syncMOC;
@@ -192,7 +174,7 @@ ZM_EMPTY_ASSERTING_INIT();
     for (ZMUpdateEvent *event in events) {
         ZMLocalNotificationForEvent *note = [self notificationForEvent:event];
         if (note != nil && note.uiNotifications.count > 0) {
-            UILocalNotification *localNote = [[self.syncMOC persistentStoreMetadataForKey:ZMShouldHideNotificationContentKey] boolValue] ? [UILocalNotification defaultNotification] : note.uiNotifications.lastObject;
+            UILocalNotification *localNote = note.uiNotifications.lastObject;
             ZMLogPushKit(@"Scheduling local notification <%@: %p> '%@'", localNote.class, localNote, localNote.alertBody);
             [self.sharedApplication scheduleLocalNotification:localNote];
             if (notificationID != nil) {

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationDispatcherTest.m
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationDispatcherTest.m
@@ -393,7 +393,7 @@
 
 - (void)testThatItSchedulesADefaultNotificationIfContentShouldNotBeVisible;
 {
-    [self.syncMOC setPersistentStoreMetadata:@(YES) forKey:@"ZMShouldHideNotificationContentKey"];
+    [self.syncMOC setPersistentStoreMetadata:@(YES) forKey:ZMShouldHideNotificationContentKey];
     [self.syncMOC saveOrRollback];
     // given
     NSDictionary *data = @{@"content" : @"hallo", @"nonce": [NSUUID UUID].transportString };
@@ -401,8 +401,8 @@
     
     // expect
     [[self.mockUISharedApplication stub] scheduleLocalNotification:[OCMArg checkWithBlock:^BOOL(UILocalNotification *localNotification) {
-        
-        return [localNotification.alertBody isEqualToString:[ZMPushStringDefault localizedString]];
+        return ([localNotification.alertBody isEqualToString:[ZMPushStringDefault localizedString]] &&
+                [localNotification.soundName isEqualToString:@"new_message_apns.caf"]);
     }]];
     
     //when


### PR DESCRIPTION
**What's in this PR**

(1) Moved notification creation for notifications with hidden content into `ZMLocalNotificationForEvent`. Previously we were creating a new `UILocalNotification` which we were not able to cancel (e.g. when opening the conversation) because we did  not keep a reference to it.

(2) Added notification sound