### PR TITLE
Fix restart address book search from first batch

### DIFF
--- a/Source/Registration/AddressBook+Encoding.swift
+++ b/Source/Registration/AddressBook+Encoding.swift
@@ -33,12 +33,15 @@ extension AddressBook {
 
             let range = startingContactIndex..<(startingContactIndex+maxNumberOfContacts)
             let cards = self.generateContactCards(range)
-            guard cards.count > 0 else {
+            
+            guard cards.count > 0 || startingContactIndex > 0 else {
+                // this should happen if I have zero contacts
                 groupQueue.performGroupedBlock({
                     completion(nil)
                 })
                 return
             }
+            
             let cardsRange = startingContactIndex..<(startingContactIndex+UInt(cards.count))
             let encodedAB = EncodedAddressBookChunk(numberOfTotalContacts: self.numberOfContacts,
                                                     otherContactsHashes: cards,

--- a/Tests/Source/Registration/AddressBookTests.swift
+++ b/Tests/Source/Registration/AddressBookTests.swift
@@ -439,7 +439,13 @@ extension AddressBookTests {
         sut.encodeWithCompletionHandler(queue, startingContactIndex: 20, maxNumberOfContacts: 20) { chunk in
             
             // then
-            XCTAssertNil(chunk)
+            if let chunk = chunk {
+                XCTAssertEqual(chunk.numberOfTotalContacts, 3)
+                XCTAssertEqual(chunk.includedContacts, UInt(20)..<UInt(20))
+                XCTAssertEqual(chunk.otherContactsHashes, [])
+            } else {
+                XCTFail()
+            }
             expectation.fulfill()
         }
         


### PR DESCRIPTION
# Reason for this pull request
Address book search was stopping when it reaches the end of the AB. It should have restarted from the beginning.

# Changes
Return empty chunk when we tried to generate a chunk past the 0 starting position and there were no more contacts. This will be interpreted as "I reached the end" and trigger the restart.