### PR TITLE
Fix multithreading violation in EventDecoder

### DIFF
--- a/Source/Synchronization/Decoding/EventDecoder.swift
+++ b/Source/Synchronization/Decoding/EventDecoder.swift
@@ -119,6 +119,8 @@ extension NSManagedObjectContext {
     let syncMOC: NSManagedObjectContext
     weak var encryptionContext : EncryptionContext?
     
+    private typealias EventsWithStoredEvents = (storedEvents: [StoredUpdateEvent], updateEvents: [ZMUpdateEvent])
+    
     public init(eventMOC: NSManagedObjectContext, syncMOC: NSManagedObjectContext) {
         self.eventMOC = eventMOC
         self.syncMOC = syncMOC
@@ -131,11 +133,11 @@ extension NSManagedObjectContext {
     /// If the app crashes while processing the events, they can be recovered from the database
     /// Recovered events are processed before the passed in events to reflect event history
     public func processEvents(events: [ZMUpdateEvent], block: ConsumeBlock) {
-
+        
         // fetch first batch of old events
         let batchSize = EventDecoder.BatchSize
         let oldStoredEvents = StoredUpdateEvent.nextEvents(eventMOC, batchSize: batchSize, stopAtIndex: nil)
-        let oldEvents = StoredUpdateEvent.eventsFromStoredEvents(oldStoredEvents)
+        let oldUpdateEvents = StoredUpdateEvent.eventsFromStoredEvents(oldStoredEvents)
         
         // get highest index of events in DB
         var lastIndex = oldStoredEvents.last?.sortIndex ?? 0
@@ -145,20 +147,20 @@ extension NSManagedObjectContext {
 
         // decryptEvents and insert counting upwards from highest index in DB
         var newStoredEvents = [StoredUpdateEvent]()
-        var newEvents = [ZMUpdateEvent]()
+        var newUpdateEvents = [ZMUpdateEvent]()
         
         
         // We decrypt the events and store them in the event database
         encryptionContext?.perform({ [weak self] (sessionsDirectory) in
             guard let strongSelf = self else { return }
 
-            newEvents = events.flatMap { sessionsDirectory.decryptUpdateEventAndAddClient($0, managedObjectContext: strongSelf.syncMOC) }
+            newUpdateEvents = events.flatMap { sessionsDirectory.decryptUpdateEventAndAddClient($0, managedObjectContext: strongSelf.syncMOC) }
 
             // This call has to be synchronous to ensure that we close the
             // encryption context only if we stored all events in the database
             strongSelf.eventMOC.performGroupedBlockAndWait {
                 // decryptEvents and insert counting upwards from highest index in DB
-                for (idx, event) in newEvents.enumerate() {
+                for (idx, event) in newUpdateEvents.enumerate() {
                     if let storedEvent = StoredUpdateEvent.create(event, managedObjectContext: strongSelf.eventMOC, index: idx + lastIndex + 1) {
                         newStoredEvents.append(storedEvent)
                     }
@@ -168,28 +170,43 @@ extension NSManagedObjectContext {
             }
         })
         
-        // process old events
-        consumeStoredEvents(oldStoredEvents, someEvents: oldEvents, lastIndexToFetch: lastIndex, consumeBlock: block)
-        
-        // process new events
-        if newEvents.count > 0 {
-            processBatch(newEvents, storedEvents: newStoredEvents, block: block)
-        } else {
-            block([])
+        process(
+            oldEvents: (storedEvents: oldStoredEvents, updateEvents: oldUpdateEvents),
+            newEvents: (storedEvents: newStoredEvents, updateEvents: newUpdateEvents),
+            lastIndexToFetch: lastIndex,
+            consumeBlock: block
+        )
+    }
+    
+    // Processes first the old, then the new events
+    private func process(oldEvents oldEvents: EventsWithStoredEvents, newEvents: EventsWithStoredEvents, lastIndexToFetch: Int64, consumeBlock: ConsumeBlock) {
+        eventMOC.performGroupedBlock {
+            // process old events
+            self.consumeStoredEvents(oldEvents.storedEvents, someEvents: oldEvents.updateEvents, lastIndexToFetch: lastIndexToFetch, consumeBlock: consumeBlock)
+            
+            // process new events
+            if newEvents.updateEvents.count > 0 {
+                self.processBatch(newEvents.updateEvents, storedEvents: newEvents.storedEvents, block: consumeBlock)
+            } else {
+                consumeBlock([])
+            }
         }
     }
     
     /// calls the consuming block and deletes the respective stored events subsequently
-    private func processBatch(events:[ZMUpdateEvent], storedEvents:[StoredUpdateEvent], block: ConsumeBlock) {
-        block(events)
+    private func processBatch(events:[ZMUpdateEvent], storedEvents:[NSManagedObject], block: ConsumeBlock) {
         let strongEventMOC = eventMOC
 
-        eventMOC.performGroupedBlock {
-            storedEvents.forEach(strongEventMOC.deleteObject)
-            strongEventMOC.saveOrRollback()
+        // switch to the sync queue to call the passed in block with the update events
+        syncMOC.performGroupedBlock { 
+            block(events)
+            
+            strongEventMOC.performGroupedBlock {
+                storedEvents.forEach(strongEventMOC.deleteObject)
+                strongEventMOC.saveOrRollback()
+            }
         }
     }
-    
     
     /// consumes passed in stored events and fetches more events if the last passed in event is not the last event to fetch
     private func consumeStoredEvents(someStoredEvents: [StoredUpdateEvent], someEvents: [ZMUpdateEvent], lastIndexToFetch: Int64, consumeBlock: ConsumeBlock) {

--- a/Source/Synchronization/Decoding/EventDecoder.swift
+++ b/Source/Synchronization/Decoding/EventDecoder.swift
@@ -214,6 +214,7 @@ extension NSManagedObjectContext {
     /// Consumes passed in stored events and fetches more events if the last passed in event is not the last event to fetch
     /// Calls itself recursivly if there are multiple batches (of size `EventDecoder.BatchSize`) to fetch. The completion closure is called
     /// when there are no more stored events to fetch (respecting the `lastIndexToFetch`)
+    /// In this method it is __crucial__ to call the completion closure in every possibe termination condition.
     private func consumeStoredEvents(someStoredEvents: [StoredUpdateEvent], someEvents: [ZMUpdateEvent], lastIndexToFetch: Int64, consumeBlock: ConsumeBlock, completion: () -> Void) {
 
         guard someEvents.count > 0 else { return completion() }

--- a/Source/Synchronization/Decoding/EventDecoder.swift
+++ b/Source/Synchronization/Decoding/EventDecoder.swift
@@ -134,69 +134,68 @@ extension NSManagedObjectContext {
     /// Recovered events are processed before the passed in events to reflect event history
     public func processEvents(events: [ZMUpdateEvent], block: ConsumeBlock) {
         
-        // fetch first batch of old events
-        let batchSize = EventDecoder.BatchSize
-        let oldStoredEvents = StoredUpdateEvent.nextEvents(eventMOC, batchSize: batchSize, stopAtIndex: nil)
-        let oldUpdateEvents = StoredUpdateEvent.eventsFromStoredEvents(oldStoredEvents)
-        
-        // get highest index of events in DB
-        var lastIndex = oldStoredEvents.last?.sortIndex ?? 0
-        if oldStoredEvents.count == batchSize {
-            lastIndex = StoredUpdateEvent.highestIndex(eventMOC)
+        eventMOC.performGroupedBlock {
+            // Get the highest index of events in the DB
+            let lastIndex = StoredUpdateEvent.highestIndex(self.eventMOC)
+            
+            // Store the new events
+            self.storeEvents(events, startingAtIndex: lastIndex) {
+                // Process all events in the database in batches
+                self.process(block)
+            }
         }
 
-        // decryptEvents and insert counting upwards from highest index in DB
-        var newStoredEvents = [StoredUpdateEvent]()
-        var newUpdateEvents = [ZMUpdateEvent]()
-        
-        
-        // We decrypt the events and store them in the event database
-        encryptionContext?.perform({ [weak self] (sessionsDirectory) in
-            guard let strongSelf = self else { return }
-
-            newUpdateEvents = events.flatMap { sessionsDirectory.decryptUpdateEventAndAddClient($0, managedObjectContext: strongSelf.syncMOC) }
-
-            // This call has to be synchronous to ensure that we close the
-            // encryption context only if we stored all events in the database
-            strongSelf.eventMOC.performGroupedBlockAndWait {
-                // decryptEvents and insert counting upwards from highest index in DB
-                for (idx, event) in newUpdateEvents.enumerate() {
-                    if let storedEvent = StoredUpdateEvent.create(event, managedObjectContext: strongSelf.eventMOC, index: idx + lastIndex + 1) {
-                        newStoredEvents.append(storedEvent)
-                    }
-                }
+    }
+    
+    /// Decrypts and stores the decrypted events as `StoreUpdateEvent` in the event database.
+    /// The encryption context is only closed after the events have been stored, which ensures 
+    /// they can be decrypted again in case of a crash.
+    /// - parameter events The new events that should be decrypted and stored in the database.
+    /// - parameter completion The startIndex to be used for the incrementing sortIndex of the stored events.
+    /// - parameter completion The completion closure to be called after the events have been stored and decrypted, called on the eventMOC queue.
+    private func storeEvents(events: [ZMUpdateEvent], startingAtIndex startIndex: Int64, completion: () -> Void) {
+        syncMOC.performGroupedBlock {
+            self.encryptionContext?.perform { [weak self] (sessionsDirectory) in
+                guard let strongSelf = self else { return }
                 
-                strongSelf.eventMOC.saveOrRollback()
+                let newUpdateEvents = events.flatMap { sessionsDirectory.decryptUpdateEventAndAddClient($0, managedObjectContext: strongSelf.syncMOC) }
+                
+                // This call has to be synchronous to ensure that we close the
+                // encryption context only if we stored all events in the database
+                strongSelf.eventMOC.performGroupedBlockAndWait {
+                    
+                    // Decrypt the events and insert them counting upwards from the highest index in the DB
+                    for (idx, event) in newUpdateEvents.enumerate() {
+                        _ = StoredUpdateEvent.create(event, managedObjectContext: strongSelf.eventMOC, index: idx + startIndex + 1)
+                    }
+                    
+                    strongSelf.eventMOC.saveOrRollback()
+                }
             }
-        })
-        
-        process(
-            oldEvents: (storedEvents: oldStoredEvents, updateEvents: oldUpdateEvents),
-            newEvents: (storedEvents: newStoredEvents, updateEvents: newUpdateEvents),
-            lastIndexToFetch: lastIndex,
-            consumeBlock: block
-        )
+            
+            self.eventMOC.performGroupedBlock {
+                completion()
+            }
+        }
     }
 
-    // Processes first the old, then the new events subsequently
-    private func process(oldEvents oldEvents: EventsWithStoredEvents, newEvents: EventsWithStoredEvents, lastIndexToFetch: Int64, consumeBlock: ConsumeBlock) {
-        eventMOC.performGroupedBlock {
-            // process old events
-            self.consumeStoredEvents(oldEvents.storedEvents, someEvents: oldEvents.updateEvents, lastIndexToFetch: lastIndexToFetch, consumeBlock: consumeBlock) {
-                // process new events
-                if newEvents.updateEvents.count > 0 {
-                    self.processBatch(newEvents.updateEvents, storedEvents: newEvents.storedEvents, block: consumeBlock, completion: nil)
-                } else {
-                    consumeBlock([])
-                }
+    // Processes the stored events in the database in batches of size EventDecoder.BatchSize` and calls the `consumeBlock` for each batch.
+    // After the `consumeBlock` has been called the stored events are deleted from the database.
+    // This method terminates when no more events are in the database.
+    private func process(consumeBlock: ConsumeBlock) {
+        fetchNextEventsBatch { events in
+            guard events.storedEvents.count > 0 else { return }
+
+            self.processBatch(events.updateEvents, storedEvents: events.storedEvents, block: consumeBlock) {
+                self.process(consumeBlock)
             }
         }
     }
     
     /// Calls the `ComsumeBlock` and deletes the respective stored events subsequently,
     /// The consume block is guaranteed to be called on the syncMOC's queue.
-    /// The completion closure is invokes after the `StoredEvent`'s have been deleted on the eventMOC.
-    private func processBatch(events:[ZMUpdateEvent], storedEvents:[NSManagedObject], block: ConsumeBlock, completion: (() -> Void)?) {
+    /// The completion closure is invoked after the `StoredEvent`'s have been deleted on the eventMOC.
+    private func processBatch(events: [ZMUpdateEvent], storedEvents: [NSManagedObject], block: ConsumeBlock, completion: () -> Void) {
         let strongEventMOC = eventMOC
 
         // switch to the sync queue to call the passed in block with the update events
@@ -206,38 +205,18 @@ extension NSManagedObjectContext {
             strongEventMOC.performGroupedBlock {
                 storedEvents.forEach(strongEventMOC.deleteObject)
                 strongEventMOC.saveOrRollback()
-                completion?()
+                completion()
             }
         }
     }
     
-    /// Consumes passed in stored events and fetches more events if the last passed in event is not the last event to fetch
-    /// Calls itself recursivly if there are multiple batches (of size `EventDecoder.BatchSize`) to fetch. The completion closure is called
-    /// when there are no more stored events to fetch (respecting the `lastIndexToFetch`)
-    /// In this method it is __crucial__ to call the completion closure in every possibe termination condition.
-    private func consumeStoredEvents(someStoredEvents: [StoredUpdateEvent], someEvents: [ZMUpdateEvent], lastIndexToFetch: Int64, consumeBlock: ConsumeBlock, completion: () -> Void) {
-
-        guard someEvents.count > 0 else { return completion() }
-        
-        var (storedEvents, events) = (someStoredEvents, someEvents)
-        let hasMore = storedEvents.last?.sortIndex != lastIndexToFetch
-
-        processBatch(events, storedEvents: storedEvents, block: consumeBlock) {
-            (storedEvents, events) = ([], [])
-            guard hasMore else { return completion() }
-            
-            self.eventMOC.performGroupedBlock {
-                storedEvents = StoredUpdateEvent.nextEvents(self.eventMOC, batchSize: EventDecoder.BatchSize, stopAtIndex: lastIndexToFetch)
-                
-                if storedEvents.count > 0 {
-                    events = StoredUpdateEvent.eventsFromStoredEvents(storedEvents)
-                    self.syncMOC.performGroupedBlock {
-                        self.consumeStoredEvents(storedEvents, someEvents: events, lastIndexToFetch: lastIndexToFetch, consumeBlock: consumeBlock, completion: completion)
-                    }
-                } else {
-                    return completion()
-                }
-            }
+    /// Fetches the next batch of of size `EventDecoder.BatchSize` and calls the completion handler
+    /// with the `StoredEvents` and `ZMUpdateEvent`'s in a `EventsWithStoredEvents` tuple.
+    private func fetchNextEventsBatch(completion: (EventsWithStoredEvents) -> Void) {
+        self.eventMOC.performGroupedBlock {
+            let storedEvents = StoredUpdateEvent.nextEvents(self.eventMOC, batchSize: EventDecoder.BatchSize)
+            let updateEvents = StoredUpdateEvent.eventsFromStoredEvents(storedEvents)
+            return completion((storedEvents: storedEvents, updateEvents: updateEvents))
         }
     }
     

--- a/Source/Synchronization/Decoding/StoreUpdateEvent.swift
+++ b/Source/Synchronization/Decoding/StoreUpdateEvent.swift
@@ -50,13 +50,11 @@ public class StoredUpdateEvent: NSManagedObject {
     
     /// Returns stored events sorted by and up until (including) the defined `stopIndex`
     /// Returns a maximum of `batchSize` events at a time
-    public static func nextEvents(context: NSManagedObjectContext, batchSize: Int, stopAtIndex: Int64?) -> [StoredUpdateEvent] {
+    public static func nextEvents(context: NSManagedObjectContext, batchSize: Int) -> [StoredUpdateEvent] {
         let fetchRequest = NSFetchRequest(entityName: self.entityName)
-        if let stopIndex = stopAtIndex {
-            fetchRequest.predicate = NSPredicate(format: "\(StoredUpdateEvent.SortIndexKey) <= \(stopIndex)")
-        }
         fetchRequest.sortDescriptors = [NSSortDescriptor(key: StoredUpdateEvent.SortIndexKey, ascending: true)]
         fetchRequest.fetchLimit = batchSize
+        fetchRequest.returnsObjectsAsFaults = false
         let result = context.executeFetchRequestOrAssert(fetchRequest)
         return result as? [StoredUpdateEvent] ?? []
     }

--- a/Source/Synchronization/ZMSyncStrategy.m
+++ b/Source/Synchronization/ZMSyncStrategy.m
@@ -157,6 +157,7 @@ ZM_EMPTY_ASSERTING_INIT()
         self.uiMOC = uiMOC;
         self.badge = badge;
         self.eventMOC = [NSManagedObjectContext createEventContextWithAppGroupIdentifier:appGroupIdentifier];
+        [self.eventMOC addGroup:self.syncMOC.dispatchGroup];
         self.apnsConfirmationStatus = [[BackgroundAPNSConfirmationStatus alloc] initWithApplication:application
                                                                                managedObjectContext:self.syncMOC
                                                                           backgroundActivityFactory:[BackgroundActivityFactory sharedInstance]];

--- a/Source/UserSession/BackgroundAPNSConfirmationStatus.swift
+++ b/Source/UserSession/BackgroundAPNSConfirmationStatus.swift
@@ -28,9 +28,9 @@ extension UIApplication : ApplicationStateOwner {}
 
 @objc
 public class BackgroundAPNSConfirmationStatus : NSObject {
-    
-    /// Switch for sending delivery receipts
-    public static let sendDeliveryReceipts : Bool = true
+
+    /// TODO: Switch sending delivery receipts back on
+    public static let sendDeliveryReceipts : Bool = false
 
     let backgroundTime : NSTimeInterval = 25
     private var tornDown = false

--- a/Source/UserSession/BackgroundAPNSConfirmationStatus.swift
+++ b/Source/UserSession/BackgroundAPNSConfirmationStatus.swift
@@ -28,9 +28,9 @@ extension UIApplication : ApplicationStateOwner {}
 
 @objc
 public class BackgroundAPNSConfirmationStatus : NSObject {
-
-    /// TODO: Switch sending delivery receipts back on
-    public static let sendDeliveryReceipts : Bool = false
+    
+    /// Switch for sending delivery receipts
+    public static let sendDeliveryReceipts : Bool = true
 
     let backgroundTime : NSTimeInterval = 25
     private var tornDown = false

--- a/Tests/Source/Synchronization/EventDecoderTests.swift
+++ b/Tests/Source/Synchronization/EventDecoderTests.swift
@@ -63,6 +63,9 @@ class EventDecoderTest: MessagingTest {
     
     func testThatItProcessesPreviouslyStoredEventsFirst() {
         // given
+        
+        EventDecoder.testingBatchSize = 1
+        
         let event1 = dummyEvent()
         let event2 = dummyEvent()
         let _ = StoredUpdateEvent.create(event1, managedObjectContext: eventMOC, index: 0)
@@ -78,7 +81,7 @@ class EventDecoderTest: MessagingTest {
             } else {
                 XCTFail("called too often")
             }
-            callCount = callCount+1
+            callCount += 1
         }
         XCTAssert(waitForAllGroupsToBeEmptyWithTimeout(0.5))
         
@@ -108,18 +111,17 @@ class EventDecoderTest: MessagingTest {
                 XCTAssertTrue(events.contains(event2))
             } else if callCount == 1 {
                 XCTAssertTrue(events.contains(event3))
-            } else if callCount == 2 {
                 XCTAssertTrue(events.contains(event4))
             }
             else {
                 XCTFail("called too often")
             }
-            callCount = callCount+1
+            callCount += 1
         }
         XCTAssert(waitForAllGroupsToBeEmptyWithTimeout(0.5))
         
         // then
-        XCTAssertEqual(callCount, 3)
+        XCTAssertEqual(callCount, 2)
     }
 
 }

--- a/Tests/Source/Synchronization/EventDecoderTests.swift
+++ b/Tests/Source/Synchronization/EventDecoderTests.swift
@@ -24,10 +24,11 @@ class EventDecoderTest: MessagingTest {
     
     var eventMOC = NSManagedObjectContext.createEventContext(withAppGroupIdentifier: nil)
     var sut : EventDecoder!
-    
+
     override func setUp() {
         super.setUp()
         sut = EventDecoder(eventMOC: eventMOC, syncMOC: syncMOC)
+        eventMOC.addGroup(self.dispatchGroup)
     }
     
     override func tearDown() {
@@ -53,13 +54,14 @@ class EventDecoderTest: MessagingTest {
             XCTAssertTrue(events.contains(event))
             didCallBlock = true
         }
+
         XCTAssert(waitForAllGroupsToBeEmptyWithTimeout(0.5))
         
         // then
         XCTAssertTrue(didCallBlock)
     }
     
-    func testThatItProcessesPreviouslyStoredEventsFirst(){
+    func testThatItProcessesPreviouslyStoredEventsFirst() {
         // given
         let event1 = dummyEvent()
         let event2 = dummyEvent()
@@ -84,7 +86,7 @@ class EventDecoderTest: MessagingTest {
         XCTAssertEqual(callCount, 2)
     }
     
-    func testThatItProcessesInBatches(){
+    func testThatItProcessesInBatches() {
         // given
         EventDecoder.testingBatchSize = 2
         


### PR DESCRIPTION
# What's in this PR?

There was a Core Data multithreading violation introduced in https://github.com/wireapp/wire-ios-sync-engine/pull/28 in which we fetched `StoredEvents` while still on the `syncMOC`'s queue in `consumeStoredEvents:someEvents:lastIndexToFetch:consumeBlock:`.

* This PR changes the event processing to be asynchronous and dispatches all processing onto the `eventMOC`'s queue. The `consumeBlock` is called on the `syncMOC` with the decrypted update events.
* `processBatch:storedEvents:block:` now takes an additional optional completion closure which is used in the `consumeStoredEvents` method to ensure the previously processed events have been deleted when the next batch is fetched.
