### PR TITLE
Fix failing ZMClientMessageTranscoder ZMLocalNotificationDispatcher tests

### DIFF
--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationDispatcherTest.m
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationDispatcherTest.m
@@ -173,7 +173,7 @@
     // then
     XCTAssertEqual(self.application.scheduledLocalNotifications.count, 2u);
     UILocalNotification *notification1 = self.application.scheduledLocalNotifications.firstObject;
-    UILocalNotification *notification2 = self.application.scheduledLocalNotifications.firstObject;
+    UILocalNotification *notification2 = self.application.scheduledLocalNotifications.lastObject;
     XCTAssertNotNil(notification1);
     XCTAssertNotNil(notification2);
     XCTAssertEqualObjects([notification1 conversationInManagedObjectContext:self.syncMOC], self.conversation1);

--- a/Tests/Source/Synchronization/Transcoders/ZMClientMessageTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMClientMessageTranscoderTests.m
@@ -1286,6 +1286,7 @@
         selfUser.remoteIdentifier = [NSUUID createUUID];
         ZMConversation *selfConversation = [ZMConversation conversationWithRemoteID:selfUser.remoteIdentifier createIfNeeded:YES inContext:self.syncMOC];
         selfConversation.conversationType = ZMConversationTypeSelf;
+        [self createSelfClient];
         
         NSDate *lastRead = [NSDate date];
         ZMConversation *updatedConversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];


### PR DESCRIPTION
## what was fixed

`ZMLocalNotificationDispatcherTest` failed because of a typo 

`ZMClientMessageTranscoderTests` did not return a request since it couldn't encrypt the payload because the self client wasn't created.