### PR TITLE
Feature/failing integration tests

### DIFF
--- a/Source/Synchronization/ZMSyncStrategy.m
+++ b/Source/Synchronization/ZMSyncStrategy.m
@@ -622,6 +622,7 @@ ZM_EMPTY_ASSERTING_INIT()
         }
         [self.localNotificationDispatcher processEvents:decryptedEvents liveEvents:YES prefetchResult:nil];
         [self.syncMOC saveIfTooManyChanges];
+        [self.syncMOC enqueueDelayedSave];
     }];
 }
 

--- a/Source/Synchronization/ZMSyncStrategy.m
+++ b/Source/Synchronization/ZMSyncStrategy.m
@@ -535,7 +535,6 @@ ZM_EMPTY_ASSERTING_INIT()
 {
     if(ignoreBuffer) {
         [self consumeUpdateEvents:events];
-        [self.syncMOC enqueueDelayedSave]; // make sure we save at least once
         return;
     }
     
@@ -572,7 +571,6 @@ ZM_EMPTY_ASSERTING_INIT()
             break;
         }
     }
-    [self.syncMOC enqueueDelayedSave]; // make sure we save at least once
 }
 
 - (ZMFetchRequestBatch *)fetchRequestBatchForEvents:(NSArray<ZMUpdateEvent *> *)events

--- a/Source/Synchronization/ZMSyncStrategy.m
+++ b/Source/Synchronization/ZMSyncStrategy.m
@@ -619,7 +619,6 @@ ZM_EMPTY_ASSERTING_INIT()
             }
         }
         [self.localNotificationDispatcher processEvents:decryptedEvents liveEvents:YES prefetchResult:nil];
-        [self.syncMOC saveIfTooManyChanges];
         [self.syncMOC enqueueDelayedSave];
     }];
 }


### PR DESCRIPTION
## What was failing
Since the event decoder now operates asynchronously when processing events, the call to `consumeUpdateEvents:` is no longer blocking. This has the side affect that the calls to `enqueueDelayedSave` in `processUpdateEvents:` are executed before the any update events has been processed and there by causing the sync context not be saved in some cases.

## The fix
Move `enqueueDelayedSave` calls into the event coder's processing block.