### PR TITLE
Fix crashing/failing tests

### DIFF
--- a/Tests/Source/Synchronization/Transcoders/ZMAssetTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMAssetTranscoderTests.m
@@ -379,20 +379,19 @@ static NSString const *EventTypeAssetAdd = @"conversation.asset-add";
     XCTAssertNil(secondRequest);
 }
 
-// TODO MARCO
-- (void)DISABLED_testThatANewImageMessageIsCreatedFromAPushEventOfTheRightType
+- (void)testThatANewImageMessageIsCreatedFromAPushEventOfTheRightType
 {
     // given
     ZMUpdateEvent *event = [OCMockObject mockForClass:ZMUpdateEvent.class];
     (void)[(ZMUpdateEvent *)[[(id)event stub] andReturnValue:OCMOCK_VALUE(ZMUpdateEventConversationAssetAdd)] type];
 
-    ZMImageMessage *mockImageMessage = [OCMockObject mockForClass:ZMImageMessage.class];
     __block ZMImageMessage *imageMessage;
     [self.syncMOC performGroupedBlockAndWait:^{
         imageMessage = [ZMImageMessage insertNewObjectInManagedObjectContext:self.syncMOC];
     }];
     
     // expect
+    ZMImageMessage *mockImageMessage = [OCMockObject mockForClass:ZMImageMessage.class];
     [[[(id)mockImageMessage expect] andReturn:imageMessage] createOrUpdateMessageFromUpdateEvent:event inManagedObjectContext:self.syncMOC prefetchResult:nil];
     
     // when
@@ -400,25 +399,24 @@ static NSString const *EventTypeAssetAdd = @"conversation.asset-add";
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
+    [(id)event stopMocking];
     [(id)mockImageMessage verify];
     [(id)mockImageMessage stopMocking];
 }
 
-
-// TODO MARCO
-- (void)DISABLED_testThatANewImageMessageIsCreatedFromADownloadedEventOfTheRightType
+- (void)testThatANewImageMessageIsCreatedFromADownloadedEventOfTheRightType
 {
     // given
     ZMUpdateEvent *event = [OCMockObject mockForClass:ZMUpdateEvent.class];
     (void)[(ZMUpdateEvent *)[[(id)event stub] andReturnValue:OCMOCK_VALUE(ZMUpdateEventConversationAssetAdd)] type];
     
-    ZMImageMessage *mockImageMessage = [OCMockObject mockForClass:ZMImageMessage.class];
     __block ZMImageMessage *imageMessage;
     [self.syncMOC performGroupedBlockAndWait:^{
         imageMessage = [ZMImageMessage insertNewObjectInManagedObjectContext:self.syncMOC];
     }];
     
     // expect
+    ZMImageMessage *mockImageMessage = [OCMockObject mockForClass:ZMImageMessage.class];
     [[[(id)mockImageMessage expect] andReturn:imageMessage] createOrUpdateMessageFromUpdateEvent:event inManagedObjectContext:self.syncMOC prefetchResult:nil];
     
     // when
@@ -426,6 +424,7 @@ static NSString const *EventTypeAssetAdd = @"conversation.asset-add";
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
+    [(id)event stopMocking];
     [(id)mockImageMessage verify];
     [(id)mockImageMessage stopMocking];
 }

--- a/Tests/Source/Synchronization/Transcoders/ZMClientMessageTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMClientMessageTranscoderTests.m
@@ -61,7 +61,6 @@
 @end
 
 
-
 @implementation ZMClientMessageTranscoderTests
 
 - (void)setUp
@@ -1086,12 +1085,12 @@
     [self checkThatItCallsConfirmationStatus:NO whenReceivingAnEventThroughSource:ZMUpdateEventSourceDownload];
 }
 
-// TODO MARCO
-- (void)DISABLED_testThatItCallsConfirmationStatusWhenConfirmationMessageIsSentSuccessfully
+- (void)testThatItCallsConfirmationStatusWhenConfirmationMessageIsSentSuccessfully
 {
     if (BackgroundAPNSConfirmationStatus.sendDeliveryReceipts) {
         
         // given
+        [self createSelfClient];
         ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
         conversation.conversationType = ZMTConversationTypeOneOnOne;
         conversation.remoteIdentifier = [NSUUID createUUID];
@@ -1116,12 +1115,12 @@
     }
 }
 
-// TODO MARCO
-- (void)DISABLED_testThatItDeletesTheConfirmationMessageWhenSentSuccessfully
+- (void)testThatItDeletesTheConfirmationMessageWhenSentSuccessfully
 {
     if (BackgroundAPNSConfirmationStatus.sendDeliveryReceipts) {
         
         // given
+        [self createSelfClient];
         ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
         conversation.conversationType = ZMTConversationTypeOneOnOne;
         conversation.remoteIdentifier = [NSUUID createUUID];


### PR DESCRIPTION
## What is fixed?
Some tests where failing since they where crashing.

## What changed
- the `ZMClientMessageTranscoderTests` were failing since they didn't create requests since the self client was missing.
- the `ZMAssetTranscoderTests` were crashing since we were mocking the `ZMImageMessage` class and  creating  an instance of it. This led to a crash when the instances where being deallocated. To avoid the crash we create our instance before we start mocking the class.