### PR TITLE
Enable disabled test

### DIFF
--- a/Tests/Source/Calling/ZMFlowSyncTests.m
+++ b/Tests/Source/Calling/ZMFlowSyncTests.m
@@ -135,9 +135,7 @@ static NSString * const FlowEventName2 = @"conversation.member-join";
     }];
 }
 
-
-// TODO MARCO
-- (void)DISABLED_testThatItAcquiresTheFlowForCallDeviceIsActive_YES
+- (void)testThatItAcquiresTheFlowForCallDeviceIsActive_YES
 {
     [self.syncMOC performBlockAndWait:^{
         // given


### PR DESCRIPTION
## Why was this test failing
This test was not failing consistently. I actually could only make it fail one time out of ten. But I think the reason why it is sometimes failing, is that the `AVSFlowManager ` mock is accessed from two threads at the same time. This can happen since `[AVSFlowManager appendLogForConversation:message]:` gets called from the `avsLogQueue`.

If I look at the other `ZMFlowSync` tests many of them have the same issue, so I think we can try to enable this test for now.