### PR TITLE
Fix image messages not depending on missing clients

### DIFF
--- a/Source/Synchronization/Strategies/ImageUploadRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/ImageUploadRequestStrategy.swift
@@ -66,13 +66,17 @@ public class ImageUploadRequestStrategy: ZMObjectSyncStrategy, RequestStrategy, 
         guard self.authenticationStatus.currentPhase == .Authenticated else { return nil }
         return self.upstreamSync.nextRequest()
     }
-    
 }
 
 extension ImageUploadRequestStrategy : ZMUpstreamTranscoder {
     
     public func requestForInsertingObject(managedObject: ZMManagedObject, forKeys keys: Set<NSObject>?) -> ZMUpstreamRequest? {
         return nil // no-op
+    }
+    
+    public func dependentObjectNeedingUpdateBeforeProcessingObject(dependant: ZMManagedObject) -> ZMManagedObject? {
+        guard let message = dependant as? ZMMessage else { return nil }
+        return message.dependendObjectNeedingUpdateBeforeProcessing()
     }
     
     private func update(message: ZMAssetClientMessage, withResponse response: ZMTransportResponse, updatedKeys keys: Set<NSObject>) {


### PR DESCRIPTION
# Reason for this pull request
Image messages were being sent even in case of missing session with remote client

# Changes
Make sure that message dependencies are considered by the transcoder

# Testing
Tests were already in place and failing (see `testThatItSendsFailedSessionOTRAssetMessageAfterMissingClientsAreFetchedButSessionIsNotCreated`)