### PR TITLE
Fix failing tests due to wrong test setup

### DIFF
--- a/Tests/Source/UserSession/BackgroundAPNSConfirmationStatusTests.swift
+++ b/Tests/Source/UserSession/BackgroundAPNSConfirmationStatusTests.swift
@@ -48,9 +48,10 @@ class BackgroundAPNSConfirmationStatusTests : MessagingTest {
 
     override func setUp() {
         super.setUp()
+        application.setBackground()
         fakeBGActivityFactory = FakeBackgroundActivityFactory()
         fakeBGActivityFactory.mainGroupQueue = uiMOC // this mimics the real BackgroundActivityFactory
-        sut = BackgroundAPNSConfirmationStatus(application: self.application, managedObjectContext: syncMOC, backgroundActivityFactory: fakeBGActivityFactory)
+        sut = BackgroundAPNSConfirmationStatus(application: application, managedObjectContext: syncMOC, backgroundActivityFactory: fakeBGActivityFactory)
     }
     
     override func tearDown() {


### PR DESCRIPTION
## Why were the tests failing?
The test were failing since they expected the application to be in the background state.

## What changed?
Change the mock UIApplication into background state during `setUp`