### PR TITLE
Fix failing tests in ConversationTests+OTR

### DIFF
--- a/Source/Synchronization/ZMSyncStrategy.m
+++ b/Source/Synchronization/ZMSyncStrategy.m
@@ -609,7 +609,7 @@ ZM_EMPTY_ASSERTING_INIT()
     ZM_WEAK(self);
     [self.eventDecoder processEvents:events block:^(NSArray<ZMUpdateEvent *> * decryptedEvents) {
         ZM_STRONG(self);
-        if (self  == nil){
+        if (self == nil){
             return;
         }
         


### PR DESCRIPTION
# What's in this PR?

Fixes multiple failing tests in `ConversationTests+OTR`, which all where related to inserting a failed to decrypt system message.

### _Why were these tests failing?_

There were multiple issues with the tests, the first one being that a 💣 has been inserted as (plain) text, which is normally done when the sender can not establish a session with the receiver but still needs to send the message. On the receiving side messages with this string are discarded and no system message is inserted (which is another issue that can be discussed). 

Another issue was a missing save after the system message has been inserted. If only one update event is processed and that one can not be decrypted, the system message is appended from a call made inside the `EventDecoder`, the event decoder then does not have any events to propagate to the `ZMSyncStrategy` and thus will not call the consume block, which lead to no save being enqueued. ~~There are multiple solution to this issue, we now manually enqueue a save when inserting the can not decrypt system message.~~

**The behavior of the `EventDecoder` has been changed to make sure the passed in consume block is always called at least one, in case there was only one event and that event could not be decrypted it will now be called with an empty array.**