### PR TITLE
Notify Operationloop after preparing a client for delete

### DIFF
--- a/Source/E2EE/ZMUserSession+OTR.m
+++ b/Source/E2EE/ZMUserSession+OTR.m
@@ -37,6 +37,7 @@
     
     [self.syncManagedObjectContext performGroupedBlock:^{
         [self.clientUpdateStatus deleteClientsWithCredentials:self.clientRegistrationStatus.emailCredentials];
+        [ZMOperationLoop notifyNewRequestsAvailable: self];
     }];
 }
 
@@ -58,6 +59,7 @@
     
     [self.syncManagedObjectContext performGroupedBlock:^{
         [self.clientUpdateStatus deleteClientsWithCredentials:emailCredentials];
+        [ZMOperationLoop notifyNewRequestsAvailable: self];
     }];
 }
 


### PR DESCRIPTION
Seems like we were not sending the request immediately because the save on the UIMOC might happen before the changes on the syncMOC

Fix for `[ConversationTestsOTR  testThatItDoesNotSetAllConversationsToSecureWhenDeletingATrustedSelfUserClients]`