### PR TITLE
Fix testThatItSendsAConfirmationWhenReceivingAMessageInAOneOnOneConve…

### DIFF
--- a/Tests/Source/Integration/ConversationTests+Confirmation.swift
+++ b/Tests/Source/Integration/ConversationTests+Confirmation.swift
@@ -30,7 +30,7 @@ class ConversationTests_Confirmation: ConversationTestsBase {
             let textMessage = ZMGenericMessage(text: "Hello", nonce: NSUUID.createUUID().transportString())
             let conversation = conversationForMockConversation(selfToUser1Conversation)
             
-            let requestPath = "/conversations/\(conversation.remoteIdentifier.transportString())/otr/messages"
+            let requestPath = "/conversations/\(conversation.remoteIdentifier.transportString())/otr/messages?report_missing=\(user1.identifier)"
             
             // expect
             mockTransportSession.responseGeneratorBlock = { request in


### PR DESCRIPTION
# Reason for this pull request
The test `testThatItSendsAConfirmationWhenReceivingAMessageInAOneOnOneConversation` was failing

# Changes
Expect the `report_missing` parameter