### PR TITLE
Ignore transient events for lastEventId

### DIFF
--- a/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
@@ -141,7 +141,10 @@ NSUInteger const ZMMissingUpdateEventsTranscoderListPageSize = 500;
             else {
                 [parsedEvents addObject:event];
             }
-            latestEventId = event.uuid;
+            
+            if (!event.isTransient) {
+                latestEventId = event.uuid;
+            }
         }
     }
     


### PR DESCRIPTION
# Issue

Users started to see the message "you haven't used this device in a while" in the random circumstances.

# Investigation

The above mentioned message is inserted only when `/notifications` call return 404. This means that either from backend we had an issue, or on our side we create the incorrect request.
The request has several parameters. One of them is last known to client notification ID. Thanks to help from @basine and @tiago-loureiro we figured out that the request also returns 404 if the last notification ID passed by client is not known to the backend.

We are having a concept of transient events, those are used for realtime call setup (I think). The client can receive events in two ways: with push channel or using sync via `/notifications`. Transient events are delivered via push channel, but they can be also delivered for a limited time via `/notifications`.

# Bug

We missed to check if the last event received from `/notifications` is transient. Therefore there was a chance that last event is transient and we save it's id as last one known to us. So we where sending this id back to backend next time the client needed to sync with `/notifications` (presumably on bad networks -- two syncs in a row), and backend responded with 404.

# Solution

Add the missing check.