### PR TITLE
Fix/initial observer state

### DIFF
--- a/Source/Synchronization/Decoding/EventDecoder.swift
+++ b/Source/Synchronization/Decoding/EventDecoder.swift
@@ -19,6 +19,7 @@
 import Foundation
 import Cryptobox
 import ZMCDataModel
+import WireMessageStrategy
 
 private let zmLog = ZMSLog(tag: "EventDecoder")
 

--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -322,6 +322,8 @@ ZM_EMPTY_ASSERTING_INIT()
         [self registerForRequestToOpenConversationNotification];
         [self enablePushNotifications];
         [self enableBackgroundFetch];
+        
+        self.managedObjectContext.globalManagedObjectContextObserver.propagateChanges = self.application.applicationState != UIApplicationStateBackground;
         ZM_ALLOW_MISSING_SELECTOR([[NSNotificationCenter defaultCenter] addObserver:self
                                                                            selector:@selector(didEnterEventProcessingState:)
                                                                                name:ZMApplicationDidEnterEventProcessingStateNotificationName


### PR DESCRIPTION
# What's in this PR?

* Fixes the build as it was broken due to an missing import after extracting the strategies into their own framework (`wire-ios-message-strategy`).
* Enable change propagation when the user session is initialized according to the current application state.