### PR TITLE
Add support for canceling proxy requests

### DIFF
--- a/Source/Public/ZMUserSession.h
+++ b/Source/Public/ZMUserSession.h
@@ -30,6 +30,7 @@
 @class ZMMessage;
 @class ZMConversation;
 @class UserClient;
+@class ZMProxyRequest;
 
 @protocol AnalyticsType;
 @protocol AVSMediaManager;
@@ -183,7 +184,8 @@ typedef NS_ENUM (NSInteger, ProxiedRequestType){
 
 @interface ZMUserSession (Proxy)
 
-- (void)proxiedRequestWithPath:(NSString *)path method:(ZMTransportRequestMethod)method type:(ProxiedRequestType)type callback:(void (^)(NSData *, NSHTTPURLResponse *, NSError *))callback;
+- (ZMProxyRequest *)proxiedRequestWithPath:(NSString *)path method:(ZMTransportRequestMethod)method type:(ProxiedRequestType)type callback:(void (^)(NSData *, NSHTTPURLResponse *, NSError *))callback;
+- (void)cancelProxiedRequest:(ZMProxyRequest *)proxyRequest;
 
 @end
 

--- a/Source/Synchronization/Strategies/ProxiedRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/ProxiedRequestStrategy.swift
@@ -55,8 +55,7 @@ extension ProxiedRequestType {
         
         guard let status = self.requestsStatus else { return nil }
         
-        if(status.pendingRequests.count > 0) {
-            let proxyRequest = status.pendingRequests.remove(at: 0)
+        if let proxyRequest = status.pendingRequests.popFirst() {
             let fullPath = ProxiedRequestStrategy.BasePath + proxyRequest.type.basePath + proxyRequest.path
             let request = ZMTransportRequest(path: fullPath, method: proxyRequest.method, payload: nil)
             if proxyRequest.type == .soundcloud {
@@ -68,7 +67,7 @@ extension ProxiedRequestType {
                     proxyRequest.callback?(response.rawData, response.rawResponse, response.transportSessionError as NSError?)
             }))
             request.add(ZMTaskCreatedHandler(on: self.managedObjectContext, block: { taskIdentifier in
-               self.requestsStatus?.executedRequests.append((proxyRequest, taskIdentifier))
+                self.requestsStatus?.executedRequests[proxyRequest] = taskIdentifier
             }))
             
             return request

--- a/Source/Synchronization/Strategies/ProxiedRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/ProxiedRequestStrategy.swift
@@ -56,29 +56,25 @@ extension ProxiedRequestType {
         guard let status = self.requestsStatus else { return nil }
         
         if(status.pendingRequests.count > 0) {
-            let (type, path, method, callback) = status.pendingRequests.remove(at: 0)
-            let fullPath = ProxiedRequestStrategy.BasePath + type.basePath + path
-            let request = ZMTransportRequest(path: fullPath, method: method, payload: nil)
-            if type == .soundcloud {
+            let proxyRequest = status.pendingRequests.remove(at: 0)
+            let fullPath = ProxiedRequestStrategy.BasePath + proxyRequest.type.basePath + proxyRequest.path
+            let request = ZMTransportRequest(path: fullPath, method: proxyRequest.method, payload: nil)
+            if proxyRequest.type == .soundcloud {
                 request.doesNotFollowRedirects = true
             }
             request.expire(afterInterval: ProxiedRequestStrategy.RequestExpirationTime)
             request.add(ZMCompletionHandler(on: self.managedObjectContext.zm_userInterface, block: {
                 response in
-                    callback?(response.rawData, response.rawResponse, response.transportSessionError as NSError?)
+                    proxyRequest.callback?(response.rawData, response.rawResponse, response.transportSessionError as NSError?)
             }))
+            request.add(ZMTaskCreatedHandler(on: self.managedObjectContext, block: { taskIdentifier in
+               self.requestsStatus?.executedRequests.append((proxyRequest, taskIdentifier))
+            }))
+            
             return request
         }
         
         return nil
     }
     
-    /**
-    Schedules a request to be sent to the backend.
-    
-    - parameter timeout: If it is not completed in the given interval, the request is completed with error
-    */
-    public func scheduleAuthenticatedRequestWithCompletionHandler(_ relativeUrl: URL, completionHandler: ((Data?, URLResponse?, NSError?) -> Void), timeout: TimeInterval) {
-        
-    }
 }

--- a/Source/UserSession/ProxiedRequestsStatus.swift
+++ b/Source/UserSession/ProxiedRequestsStatus.swift
@@ -46,8 +46,8 @@ public final class ProxiedRequestsStatus: NSObject {
     private let requestCancellation : ZMRequestCancellation
 
     /// List of requests to be sent to backend
-    public var pendingRequests : [ProxyRequest] = []
-    public var executedRequests : [(ProxyRequest, ZMTaskIdentifier)] = []
+    public var pendingRequests : Set<ProxyRequest> = Set()
+    public var executedRequests : [ProxyRequest : ZMTaskIdentifier] = [:]
     
     public init(requestCancellation: ZMRequestCancellation) {
         self.requestCancellation = requestCancellation
@@ -55,17 +55,14 @@ public final class ProxiedRequestsStatus: NSObject {
     
     @objc(addRequest:)
     public func add(request: ProxyRequest) {
-        pendingRequests.append(request)
+        pendingRequests.insert(request)
     }
     
     @objc(cancelRequest:)
     public func cancel(request: ProxyRequest) {
-        if let index = pendingRequests.index(of: request) {
-            pendingRequests.remove(at: index)
-        }
+        pendingRequests.remove(request)
         
-        if let index = executedRequests.index(where: {$0.0 == request }) {
-            let (_, taskIdentifier) = executedRequests.remove(at: index)
+        if let taskIdentifier = executedRequests[request] {
             requestCancellation.cancelTask(with: taskIdentifier)
         }
     }

--- a/Source/UserSession/ProxiedRequestsStatus.swift
+++ b/Source/UserSession/ProxiedRequestsStatus.swift
@@ -62,8 +62,9 @@ public final class ProxiedRequestsStatus: NSObject {
     public func cancel(request: ProxyRequest) {
         pendingRequests.remove(request)
         
-        if let taskIdentifier = executedRequests[request] {
+        if let taskIdentifier = executedRequests.removeValue(forKey: request) {
             requestCancellation.cancelTask(with: taskIdentifier)
+            
         }
     }
 }

--- a/Source/UserSession/ZMUserSession+Proxy.m
+++ b/Source/UserSession/ZMUserSession+Proxy.m
@@ -23,11 +23,21 @@
 
 @implementation ZMUserSession (Proxy)
 
-- (void)proxiedRequestWithPath:(NSString * __nonnull)path method:(ZMTransportRequestMethod)method type:(ProxiedRequestType)type callback:(void (^__nullable)(NSData * __nullable, NSHTTPURLResponse * __nonnull, NSError * __nullable))callback;
+- (ZMProxyRequest *)proxiedRequestWithPath:(NSString * __nonnull)path method:(ZMTransportRequestMethod)method type:(ProxiedRequestType)type callback:(void (^__nullable)(NSData * __nullable, NSHTTPURLResponse * __nonnull, NSError * __nullable))callback;
 {
+    ZMProxyRequest *request = [[ZMProxyRequest alloc] initWithType:type path:path method:method callback:callback];
+    
     [self.syncManagedObjectContext performGroupedBlock:^{
-        [self.proxiedRequestStatus addRequest:type path:path method:method callback:callback];
+        [self.proxiedRequestStatus addRequest:request];
         [ZMRequestAvailableNotification notifyNewRequestsAvailable:self];
+    }];
+    
+    return request;
+}
+
+- (void)cancelProxiedRequest:(ZMProxyRequest *)proxyRequest {
+    [self.syncManagedObjectContext performGroupedBlock:^{
+        [self.proxiedRequestStatus cancelRequest:proxyRequest];
     }];
 }
 

--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -270,7 +270,7 @@ ZM_EMPTY_ASSERTING_INIT()
                                                                               registrationStatusDelegate:self];
         self.accountStatus = [[ZMAccountStatus alloc] initWithManagedObjectContext: syncManagedObjectContext cookieStorage: session.cookieStorage];
         
-        self.proxiedRequestStatus = [[ProxiedRequestsStatus alloc] init];
+        
 
         self.localNotificationDispatcher =
         [[ZMLocalNotificationDispatcher alloc] initWithManagedObjectContext:syncManagedObjectContext sharedApplication:application];
@@ -284,6 +284,7 @@ ZM_EMPTY_ASSERTING_INIT()
         self.mediaManager = mediaManager;
         
         self.onDemandFlowManager = [[ZMOnDemandFlowManager alloc] initWithMediaManager:mediaManager];
+        self.proxiedRequestStatus = [[ProxiedRequestsStatus alloc] initWithRequestCancellation:self.transportSession];
         
         _application = application;
         

--- a/Tests/Source/Synchronization/Strategies/ProxiedRequestStrategyTests.swift
+++ b/Tests/Source/Synchronization/Strategies/ProxiedRequestStrategyTests.swift
@@ -80,32 +80,6 @@ class ProxiedRequestStrategyTests: MessagingTest {
         }
     }
     
-    func testThatItGeneratesTwoRequestsInOrder() {
-        
-        // given
-        
-        requestsStatus.add(request: ProxyRequest(type: .giphy, path: "/foo/bar1", method:.methodGET, callback: { (_,_,_) -> Void in return}))
-        requestsStatus.add(request: ProxyRequest(type: .giphy, path: "/foo/bar2", method:.methodGET, callback: { (_,_,_) -> Void in return}))
-        
-        // when
-        let request1 : ZMTransportRequest? = self.sut.nextRequest()
-        
-        // then
-        if let request1 = request1 {
-            XCTAssertEqual(request1.path, "/proxy/giphy/foo/bar1")
-        } else {
-            XCTFail("Empty request")
-        }
-        
-        // and when
-        let request2 : ZMTransportRequest? = self.sut.nextRequest()
-        
-        // then
-        if let request2 = request2 {
-            XCTAssertEqual(request2.path, "/proxy/giphy/foo/bar2")
-        }
-    }
-
     func testThatItGeneratesARequestOnlyOnce() {
         
         // given

--- a/Tests/Source/UserSession/ProxiedRequestStatusTests.swift
+++ b/Tests/Source/UserSession/ProxiedRequestStatusTests.swift
@@ -52,7 +52,7 @@ class ProxiedRequestsStatusTests: MessagingTest {
         self.sut.add(request: request)
         
         //then
-        let pendingRequest = self.sut.pendingRequests.last
+        let pendingRequest = self.sut.pendingRequests.first
         XCTAssertEqual(pendingRequest, request)
     }
     
@@ -72,7 +72,7 @@ class ProxiedRequestsStatusTests: MessagingTest {
         // given
         let request = ProxyRequest(type: .giphy, path: "foo/bar", method: .methodGET, callback: nil)
         let taskIdentifier = ZMTaskIdentifier(identifier: 0, sessionIdentifier: "123")!
-        sut.executedRequests.append((request, taskIdentifier))
+        sut.executedRequests[request] = taskIdentifier
 
         // when
         sut.cancel(request: request)

--- a/Tests/Source/UserSession/ProxiedRequestStatusTests.swift
+++ b/Tests/Source/UserSession/ProxiedRequestStatusTests.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
 // 
@@ -19,13 +19,25 @@
 
 import XCTest
 
+
+class MockRequestCancellation : NSObject, ZMRequestCancellation {
+    
+    var canceledTasks : [ZMTaskIdentifier] = []
+    
+    func cancelTask(with taskIdentifier: ZMTaskIdentifier) {
+        canceledTasks.append(taskIdentifier)
+    }
+}
+
 class ProxiedRequestsStatusTests: MessagingTest {
     
     fileprivate var sut: ProxiedRequestsStatus!
+    fileprivate var mockRequestCancellation : MockRequestCancellation!
     
     override func setUp() {
         super.setUp()
-        self.sut = ProxiedRequestsStatus()
+        self.mockRequestCancellation = MockRequestCancellation()
+        self.sut = ProxiedRequestsStatus(requestCancellation: mockRequestCancellation)
     }
     
     override func tearDown() {
@@ -33,32 +45,40 @@ class ProxiedRequestsStatusTests: MessagingTest {
     }
     
     func testThatRequestIsAddedToPendingRequest() {
-
-        let exp = self.expectation(description: "expected callback")
-
         //given
-        let path = "foo/bar"
-        let url = URL(string: path, relativeTo: nil)!
-        
-        let callback: (Data?, HTTPURLResponse?, Error?) -> Void = { (_, _, _) -> Void in
-            exp.fulfill()
-        }
+        let request = ProxyRequest(type: .giphy, path: "foo/bar", method: .methodGET, callback: nil)
         
         //when
-        self.sut.addRequest(.giphy, path:url.relativeString, method:.methodGET, callback: callback)
+        self.sut.add(request: request)
         
         //then
-        let request = self.sut.pendingRequests.last
-        XCTAssert(request != nil)
-        XCTAssertEqual(request!.path, path)
-        XCTAssert(request!.callback != nil)
-        if let receivedCallback = request!.callback {
-            receivedCallback(nil, HTTPURLResponse(), nil)
-        }
-        else {
-            XCTFail("No callback")
-        }
-        XCTAssertTrue(self.waitForCustomExpectations(withTimeout: 0.5))
+        let pendingRequest = self.sut.pendingRequests.last
+        XCTAssertEqual(pendingRequest, request)
+    }
+    
+    func testCancelRemovesRequestFromPendingRequests() {
+        // given
+        let request = ProxyRequest(type: .giphy, path: "foo/bar", method: .methodGET, callback: nil)
+        sut.add(request: request)
+        
+        // when
+        sut.cancel(request: request)
+        
+        // then
+        XCTAssertTrue(sut.pendingRequests.isEmpty)
+    }
+    
+    func testCancelCancelsAssociatedDataTask() {
+        // given
+        let request = ProxyRequest(type: .giphy, path: "foo/bar", method: .methodGET, callback: nil)
+        let taskIdentifier = ZMTaskIdentifier(identifier: 0, sessionIdentifier: "123")!
+        sut.executedRequests.append((request, taskIdentifier))
+
+        // when
+        sut.cancel(request: request)
+        
+        // then
+        XCTAssertEqual(mockRequestCancellation.canceledTasks.first, taskIdentifier)
     }
     
 }

--- a/Tests/Source/UserSession/UserSessionGiphyRequestStateTests.swift
+++ b/Tests/Source/UserSession/UserSessionGiphyRequestStateTests.swift
@@ -47,7 +47,7 @@ class UserSessionGiphyRequestStateTests: ZMUserSessionTestsBase {
         
         //then
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        let request = self.sut.proxiedRequestStatus.pendingRequests.last
+        let request = self.sut.proxiedRequestStatus.pendingRequests.first
         XCTAssert(request != nil)
         XCTAssertEqual(request!.path, path)
         XCTAssert(request!.callback != nil)
@@ -92,7 +92,7 @@ class UserSessionGiphyRequestStateTests: ZMUserSessionTestsBase {
         self.sut.proxiedRequest(withPath: url.absoluteString, method:.methodGET, type:.giphy, callback: callback)
         
         //then
-        var request = self.sut.proxiedRequestStatus.pendingRequests.last
+        var request = self.sut.proxiedRequestStatus.pendingRequests.first
         XCTAssertTrue(request == nil)
 
         //when
@@ -101,7 +101,7 @@ class UserSessionGiphyRequestStateTests: ZMUserSessionTestsBase {
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         //then
-        request = self.sut.proxiedRequestStatus.pendingRequests.last
+        request = self.sut.proxiedRequestStatus.pendingRequests.first
         XCTAssert(request != nil)
         
     }


### PR DESCRIPTION
## Why these changes?
For the updated giphy feature we allow searching for gifs as you type. For this this work correctly we need to be able to cancel previous searches.

## What Changed
- `ZMUserSession.proxiedRequestWithPath:` now returns a `ProxyRequest` object.
- added `ZMUserSession.cancelProxiedRequest:`