### PR TITLE
Fix crash when deviceToken is nil

### DIFF
--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -503,7 +503,7 @@ ZM_EMPTY_ASSERTING_INIT()
     [self.managedObjectContext performGroupedBlock:^{
         // Refresh the Voip token if needed
         NSData *actualToken = self.pushRegistrant.pushToken;
-        if (actualToken != nil && ![actualToken isEqualToData:self.managedObjectContext.pushKitToken.deviceToken]){
+        if (actualToken != nil && ![actualToken isEqual:self.managedObjectContext.pushKitToken.deviceToken]){
             self.managedObjectContext.pushKitToken = nil;
             [self setPushKitToken:actualToken];
         }


### PR DESCRIPTION
## What was causing the crash
After the swift 3 migration this call to `isEqualToData:` crashes if we pass in nil.

## Fixing it
We can replace the call with `isEqual:` where nil is a valid input.
