### PR TITLE
Fix failed to decrypt when receiving messages in background

### DIFF
--- a/Source/Synchronization/Decoding/EventDecoder.swift
+++ b/Source/Synchronization/Decoding/EventDecoder.swift
@@ -58,7 +58,7 @@ private let previouslyReceivedEventIDsKey = "zm_previouslyReceivedEventIDsKey"
         self.eventMOC = eventMOC
         self.syncMOC = syncMOC
         super.init()
-        self.createReceivedPushEventIDsStore()
+        self.createReceivedPushEventIDsStoreIfNecessary()
     }
 }
 
@@ -156,7 +156,7 @@ extension EventDecoder {
 extension EventDecoder {
     
     /// create event ID store if needed
-    fileprivate func createReceivedPushEventIDsStore() {
+    fileprivate func createReceivedPushEventIDsStoreIfNecessary() {
         if self.eventMOC.persistentStoreMetadata(forKey: previouslyReceivedEventIDsKey) as? [String] == nil {
             self.eventMOC.setPersistentStoreMetadata(NSArray(), forKey: previouslyReceivedEventIDsKey)
         }

--- a/Source/Synchronization/Decoding/EventDecoder.swift
+++ b/Source/Synchronization/Decoding/EventDecoder.swift
@@ -23,112 +23,7 @@ import WireMessageStrategy
 
 private let zmLog = ZMSLog(tag: "EventDecoder")
 
-extension NSManagedObjectContext {
-    
-    fileprivate static var eventPersistentStoreCoordinator: NSPersistentStoreCoordinator?
-    
-    /// Creates and returns the `ManagedObjectContext` used for storing update events, ee `ZMEventModel`, `StorUpdateEvent` and `EventDecoder`.
-    /// - parameter appGroupIdentifier: Optional identifier for a shared container group to be used to store the database,
-    /// if `nil` is passed a default of `group. + bundleIdentifier` will be used (e.g. when testing)
-    public static func createEventContext(withAppGroupIdentifier appGroupIdentifier: String?) -> NSManagedObjectContext {
-        eventPersistentStoreCoordinator = createPersistentStoreCoordinator()
-        let managedObjectContext = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
-        managedObjectContext.persistentStoreCoordinator = eventPersistentStoreCoordinator
-        managedObjectContext.createDispatchGroups()
-        
-        addPersistentStore(eventPersistentStoreCoordinator!, appGroupIdentifier: appGroupIdentifier)
-        return managedObjectContext
-    }
-    
-    public func tearDown() {
-        if let store = persistentStoreCoordinator?.persistentStores.first {
-            try! persistentStoreCoordinator?.remove(store)
-        }
-        
-        type(of: self).eventPersistentStoreCoordinator = nil
-    }
-    
-    fileprivate static func createPersistentStoreCoordinator() -> NSPersistentStoreCoordinator {
-        guard let modelURL = Bundle(for: StoredUpdateEvent.self).url(forResource: "ZMEventModel", withExtension:"momd") else {
-            fatalError("Error loading model from bundle")
-        }
-        guard let mom = NSManagedObjectModel(contentsOf: modelURL) else {
-            fatalError("Error initializing mom from: \(modelURL)")
-        }
-        return NSPersistentStoreCoordinator(managedObjectModel: mom)
-    }
-    
-    fileprivate static func addPersistentStore(_ psc: NSPersistentStoreCoordinator, appGroupIdentifier: String?, isSecondTry: Bool = false) {
-        guard let storeURL = storeURL(forAppGroupIdentifier: appGroupIdentifier) else { return }
-        do {
-            let storeType = useInMemoryStore() ? NSInMemoryStoreType : NSSQLiteStoreType
-            try psc.addPersistentStore(ofType: storeType, configurationName: nil, at: storeURL, options: nil)
-        } catch {
-            if isSecondTry {
-                zmLog.error("Error adding persistent store \(error)")
-            } else {
-                let stores = psc.persistentStores
-                stores.forEach { try! psc.remove($0) }
-                addPersistentStore(psc, appGroupIdentifier: appGroupIdentifier, isSecondTry: true)
-            }
-        }
-    }
-    
-    fileprivate static func storeURL(forAppGroupIdentifier appGroupdIdentifier: String?) -> URL? {
-        let fileManager = FileManager.default
-        
-        guard let identifier = Bundle.main.bundleIdentifier ?? Bundle(for: ZMUser.self).bundleIdentifier else { return nil }
-        let groupIdentifier = appGroupdIdentifier ?? "group.\(identifier)"
-        let directoryInContainer = fileManager.containerURL(forSecurityApplicationGroupIdentifier: groupIdentifier)
-        
-        let directory: URL
-        
-        if directoryInContainer != .none {
-            directory = directoryInContainer!
-        }
-        else {
-            // Seems like the shared container is not available. This could happen for series of reasons:
-            // 1. The app is compiled with with incorrect provisioning profile (for example with 3rd parties)
-            // 2. App is running on simulator and there is no correct provisioning profile on the system
-            // 3. Bug with signing
-            //
-            // The app should allow not having a shared container in cases 1 and 2; in case 3 the app should crash
-            
-            let deploymentEnvironment = ZMDeploymentEnvironment().environmentType()
-            if TARGET_IPHONE_SIMULATOR == 0 && (deploymentEnvironment == ZMDeploymentEnvironmentType.appStore || deploymentEnvironment == ZMDeploymentEnvironmentType.internal) {
-                return nil
-            }
-            else {
-                directory = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
-                zmLog.error(String(format: "ERROR: self.databaseDirectoryURL == nil and deploymentEnvironment = %d", deploymentEnvironment.rawValue))
-                zmLog.error("================================WARNING================================")
-                zmLog.error("Wire is going to use APPLICATION SUPPORT directory to host the EventDecoder database")
-                zmLog.error("================================WARNING================================")
-            }
-        }
-        
-        var _storeURL = directory.appendingPathComponent(identifier)
-        
-        if !fileManager.fileExists(atPath: _storeURL.path) {
-            do {
-                try fileManager.createDirectory(at: _storeURL, withIntermediateDirectories: true, attributes: nil)
-            } catch {
-                assertionFailure("Failed to get or create directory \(error)")
-            }
-        }
-        
-        do {
-            var values = URLResourceValues()
-            values.isExcludedFromBackup = true
-            try _storeURL.setResourceValues(values)
-        } catch {
-            assertionFailure("Error excluding \(_storeURL.path) from backup: \(error)")
-        }
-        
-        let storeFileName = "ZMEventModel.sqlite"
-        return _storeURL.appendingPathComponent(storeFileName)
-    }
-}
+private let previouslyReceivedEventIDsKey = "zm_previouslyReceivedEventIDsKey"
 
 @objc public final class EventDecoder: NSObject {
     
@@ -153,13 +48,21 @@ extension NSManagedObjectContext {
         self.eventMOC = eventMOC
         self.syncMOC = syncMOC
         super.init()
+        self.createReceivedPushEventIDsStore()
     }
+
+}
+
+// MARK: - Process events
+extension EventDecoder {
     
     /// Decrypts passed in events and stores them in chronological order in a persisted database. It then saves the database and cryptobox
     /// It then calls the passed in block (multiple times if necessary), returning the decrypted events
     /// If the app crashes while processing the events, they can be recovered from the database
-    /// Recovered events are processed before the passed in events to reflect event history
     public func processEvents(_ events: [ZMUpdateEvent], block: ConsumeBlock) {
+     
+        self.storeReceivedPushEventIDs(from: events)
+        let filteredEvents = self.filterAlreadyReceivedEvents(from: events)
         
         var lastIndex: Int64?
         
@@ -170,7 +73,7 @@ extension NSManagedObjectContext {
         
         guard let index = lastIndex else { return }
 
-        storeEvents(events, startingAtIndex: index)
+        storeEvents(filteredEvents, startingAtIndex: index)
         process(block, firstCall: true)
     }
     
@@ -194,7 +97,7 @@ extension NSManagedObjectContext {
                 for (idx, event) in newUpdateEvents.enumerated() {
                     _ = StoredUpdateEvent.create(event, managedObjectContext: self.eventMOC, index: idx + startIndex + 1)
                 }
-                
+
                 self.eventMOC.saveOrRollback()
             }
         }
@@ -203,7 +106,7 @@ extension NSManagedObjectContext {
     // Processes the stored events in the database in batches of size EventDecoder.BatchSize` and calls the `consumeBlock` for each batch.
     // After the `consumeBlock` has been called the stored events are deleted from the database.
     // This method terminates when no more events are in the database.
-    fileprivate func process(_ consumeBlock: ConsumeBlock, firstCall: Bool) {
+    private func process(_ consumeBlock: ConsumeBlock, firstCall: Bool) {
         let events = fetchNextEventsBatch()
         guard events.storedEvents.count > 0 else {
             if firstCall {
@@ -217,7 +120,7 @@ extension NSManagedObjectContext {
     }
     
     /// Calls the `ComsumeBlock` and deletes the respective stored events subsequently.
-    fileprivate func processBatch(_ events: [ZMUpdateEvent], storedEvents: [NSManagedObject], block: ConsumeBlock) {
+    private func processBatch(_ events: [ZMUpdateEvent], storedEvents: [NSManagedObject], block: ConsumeBlock) {
         block(events)
         
         eventMOC.performGroupedBlockAndWait {
@@ -228,16 +131,65 @@ extension NSManagedObjectContext {
     
     /// Fetches and returns the next batch of size `EventDecoder.BatchSize` 
     /// of `StoredEvents` and `ZMUpdateEvent`'s in a `EventsWithStoredEvents` tuple.
-    fileprivate func fetchNextEventsBatch() -> EventsWithStoredEvents {
+    private func fetchNextEventsBatch() -> EventsWithStoredEvents {
         var (storedEvents, updateEvents)  = ([StoredUpdateEvent](), [ZMUpdateEvent]())
 
         eventMOC.performGroupedBlockAndWait {
             storedEvents = StoredUpdateEvent.nextEvents(self.eventMOC, batchSize: EventDecoder.BatchSize)
             updateEvents = StoredUpdateEvent.eventsFromStoredEvents(storedEvents)
         }
-        
         return (storedEvents: storedEvents, updateEvents: updateEvents)
     }
     
 }
 
+// MARK: - List of already received event IDs
+extension EventDecoder {
+    
+    /// create event ID store if needed
+    fileprivate func createReceivedPushEventIDsStore() {
+        if self.eventMOC.persistentStoreMetadata(forKey: previouslyReceivedEventIDsKey) as? [String] == nil {
+            self.eventMOC.setPersistentStoreMetadata(NSArray(), forKey: previouslyReceivedEventIDsKey)
+        }
+    }
+    
+    
+    /// List of already received event IDs
+    fileprivate var alreadyReceivedPushEventIDs : Set<UUID> {
+        let array = self.eventMOC.persistentStoreMetadata(forKey: previouslyReceivedEventIDsKey) as! [String]
+        return Set(array.flatMap { UUID(uuidString: $0) })
+    }
+    
+    /// List of already received event IDs as strings
+    fileprivate var alreadyReceivedPushEventIDsStrings : Set<String> {
+        return Set(self.eventMOC.persistentStoreMetadata(forKey: previouslyReceivedEventIDsKey) as! [String])
+    }
+    
+    /// Discards the list of already received events
+    public func discardListOfAlreadyReceivedPushEventIDs() {
+        self.eventMOC.setPersistentStoreMetadata(NSArray(), forKey: previouslyReceivedEventIDsKey)
+    }
+    
+    /// Store received event IDs 
+    fileprivate func storeReceivedPushEventIDs(from: [ZMUpdateEvent]) {
+        let uuidToAdd = from
+            .filter { $0.source == .pushNotification }
+            .flatMap { $0.uuid }
+            .map { $0.transportString() }
+        let allUuidStrings = self.alreadyReceivedPushEventIDsStrings.union(uuidToAdd)
+        
+        self.eventMOC.setPersistentStoreMetadata(Array(allUuidStrings), forKey: previouslyReceivedEventIDsKey)
+    }
+    
+    /// Filters out events that have been received before
+    fileprivate func filterAlreadyReceivedEvents(from: [ZMUpdateEvent]) -> [ZMUpdateEvent] {
+        let eventIDsToDiscard = self.alreadyReceivedPushEventIDs
+        return from.flatMap { event -> ZMUpdateEvent? in
+            if event.source != .pushNotification, let uuid = event.uuid {
+                return eventIDsToDiscard.contains(uuid) ? nil : event
+            } else {
+                return event
+            }
+        }
+    }
+}

--- a/Source/Synchronization/NSManagedObjectContext+EventDecoder.swift
+++ b/Source/Synchronization/NSManagedObjectContext+EventDecoder.swift
@@ -1,0 +1,130 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+import ZMCSystem
+
+private let zmLog = ZMSLog(tag: "EventDecoder")
+
+extension NSManagedObjectContext {
+    
+    fileprivate static var eventPersistentStoreCoordinator: NSPersistentStoreCoordinator?
+    
+    /// Creates and returns the `ManagedObjectContext` used for storing update events, ee `ZMEventModel`, `StorUpdateEvent` and `EventDecoder`.
+    /// - parameter appGroupIdentifier: Optional identifier for a shared container group to be used to store the database,
+    /// if `nil` is passed a default of `group. + bundleIdentifier` will be used (e.g. when testing)
+    public static func createEventContext(withAppGroupIdentifier appGroupIdentifier: String?) -> NSManagedObjectContext {
+        eventPersistentStoreCoordinator = createPersistentStoreCoordinator()
+        let managedObjectContext = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
+        managedObjectContext.persistentStoreCoordinator = eventPersistentStoreCoordinator
+        managedObjectContext.createDispatchGroups()
+        
+        addPersistentStore(eventPersistentStoreCoordinator!, appGroupIdentifier: appGroupIdentifier)
+        return managedObjectContext
+    }
+    
+    public func tearDown() {
+        if let store = persistentStoreCoordinator?.persistentStores.first {
+            try! persistentStoreCoordinator?.remove(store)
+        }
+        
+        type(of: self).eventPersistentStoreCoordinator = nil
+    }
+    
+    fileprivate static func createPersistentStoreCoordinator() -> NSPersistentStoreCoordinator {
+        guard let modelURL = Bundle(for: StoredUpdateEvent.self).url(forResource: "ZMEventModel", withExtension:"momd") else {
+            fatalError("Error loading model from bundle")
+        }
+        guard let mom = NSManagedObjectModel(contentsOf: modelURL) else {
+            fatalError("Error initializing mom from: \(modelURL)")
+        }
+        return NSPersistentStoreCoordinator(managedObjectModel: mom)
+    }
+    
+    fileprivate static func addPersistentStore(_ psc: NSPersistentStoreCoordinator, appGroupIdentifier: String?, isSecondTry: Bool = false) {
+        guard let storeURL = storeURL(forAppGroupIdentifier: appGroupIdentifier) else { return }
+        do {
+            let storeType = useInMemoryStore() ? NSInMemoryStoreType : NSSQLiteStoreType
+            try psc.addPersistentStore(ofType: storeType, configurationName: nil, at: storeURL, options: nil)
+        } catch {
+            if isSecondTry {
+                zmLog.error("Error adding persistent store \(error)")
+            } else {
+                let stores = psc.persistentStores
+                stores.forEach { try! psc.remove($0) }
+                addPersistentStore(psc, appGroupIdentifier: appGroupIdentifier, isSecondTry: true)
+            }
+        }
+    }
+    
+    fileprivate static func storeURL(forAppGroupIdentifier appGroupdIdentifier: String?) -> URL? {
+        let fileManager = FileManager.default
+        
+        guard let identifier = Bundle.main.bundleIdentifier ?? Bundle(for: ZMUser.self).bundleIdentifier else { return nil }
+        let groupIdentifier = appGroupdIdentifier ?? "group.\(identifier)"
+        let directoryInContainer = fileManager.containerURL(forSecurityApplicationGroupIdentifier: groupIdentifier)
+        
+        let directory: URL
+        
+        if directoryInContainer != .none {
+            directory = directoryInContainer!
+        }
+        else {
+            // Seems like the shared container is not available. This could happen for series of reasons:
+            // 1. The app is compiled with with incorrect provisioning profile (for example with 3rd parties)
+            // 2. App is running on simulator and there is no correct provisioning profile on the system
+            // 3. Bug with signing
+            //
+            // The app should allow not having a shared container in cases 1 and 2; in case 3 the app should crash
+            
+            let deploymentEnvironment = ZMDeploymentEnvironment().environmentType()
+            if TARGET_IPHONE_SIMULATOR == 0 && (deploymentEnvironment == ZMDeploymentEnvironmentType.appStore || deploymentEnvironment == ZMDeploymentEnvironmentType.internal) {
+                return nil
+            }
+            else {
+                directory = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
+                zmLog.error(String(format: "ERROR: self.databaseDirectoryURL == nil and deploymentEnvironment = %d", deploymentEnvironment.rawValue))
+                zmLog.error("================================WARNING================================")
+                zmLog.error("Wire is going to use APPLICATION SUPPORT directory to host the EventDecoder database")
+                zmLog.error("================================WARNING================================")
+            }
+        }
+        
+        var _storeURL = directory.appendingPathComponent(identifier)
+        
+        if !fileManager.fileExists(atPath: _storeURL.path) {
+            do {
+                try fileManager.createDirectory(at: _storeURL, withIntermediateDirectories: true, attributes: nil)
+            } catch {
+                assertionFailure("Failed to get or create directory \(error)")
+            }
+        }
+        
+        do {
+            var values = URLResourceValues()
+            values.isExcludedFromBackup = true
+            try _storeURL.setResourceValues(values)
+        } catch {
+            assertionFailure("Error excluding \(_storeURL.path) from backup: \(error)")
+        }
+        
+        let storeFileName = "ZMEventModel.sqlite"
+        return _storeURL.appendingPathComponent(storeFileName)
+    }
+}

--- a/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.h
+++ b/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.h
@@ -20,13 +20,15 @@
 @import Foundation;
 @import WireRequestStrategy;
 
+@protocol PreviouslyReceivedEventIDsCollection;
+
 @interface ZMMissingUpdateEventsTranscoder : ZMObjectSyncStrategy <ZMObjectStrategy>
 
 @property (nonatomic, readonly) BOOL hasLastUpdateEventID;
 @property (nonatomic, readonly) BOOL isDownloadingMissingNotifications;
 @property (nonatomic, readonly) NSUUID *lastUpdateEventID;
 
-- (instancetype)initWithSyncStrategy:(ZMSyncStrategy *)strategy;
+- (instancetype)initWithSyncStrategy:(ZMSyncStrategy *)strategy previouslyReceivedEventIDsCollection:(id<PreviouslyReceivedEventIDsCollection>)eventIDsCollection;
 - (void)startDownloadingMissingNotifications;
 
 + (NSUUID *)processUpdateEventsAndReturnLastNotificationIDFromPayload:(id<ZMTransportData>)payload syncStrategy:(ZMSyncStrategy *)syncStrategy;

--- a/Source/Synchronization/ZMSyncStrategy.m
+++ b/Source/Synchronization/ZMSyncStrategy.m
@@ -254,7 +254,7 @@ ZM_EMPTY_ASSERTING_INIT()
     self.clientMessageTranscoder = [[ZMClientMessageTranscoder alloc ] initWithManagedObjectContext:self.syncMOC localNotificationDispatcher:localNotificationsDispatcher clientRegistrationStatus:clientRegistrationStatus apnsConfirmationStatus: self.apnsConfirmationStatus];
     self.knockTranscoder = [[ZMKnockTranscoder alloc] initWithManagedObjectContext:self.syncMOC];
     self.registrationTranscoder = [[ZMRegistrationTranscoder alloc] initWithManagedObjectContext:self.syncMOC authenticationStatus:authenticationStatus];
-    self.missingUpdateEventsTranscoder = [[ZMMissingUpdateEventsTranscoder alloc] initWithSyncStrategy:self];
+    self.missingUpdateEventsTranscoder = [[ZMMissingUpdateEventsTranscoder alloc] initWithSyncStrategy:self previouslyReceivedEventIDsCollection:self.eventDecoder];
     self.lastUpdateEventIDTranscoder = [[ZMLastUpdateEventIDTranscoder alloc] initWithManagedObjectContext:self.syncMOC objectDirectory:self];
     self.flowTranscoder = [[ZMFlowSync alloc] initWithMediaManager:mediaManager onDemandFlowManager:onDemandFlowManager syncManagedObjectContext:self.syncMOC uiManagedObjectContext:uiMOC application:self.application];
     self.pushTokenTranscoder = [[ZMPushTokenTranscoder alloc] initWithManagedObjectContext:self.syncMOC clientRegistrationStatus:clientRegistrationStatus];

--- a/Tests/Source/Synchronization/ZMSyncStrategyTests.m
+++ b/Tests/Source/Synchronization/ZMSyncStrategyTests.m
@@ -144,7 +144,7 @@
 
     id missingUpdateEventsTranscoder = [OCMockObject mockForClass:ZMMissingUpdateEventsTranscoder.class];
     [[[[missingUpdateEventsTranscoder expect] andReturn:missingUpdateEventsTranscoder] classMethod] alloc];
-    (void) [[[missingUpdateEventsTranscoder expect] andReturn:missingUpdateEventsTranscoder] initWithSyncStrategy:OCMOCK_ANY];
+    (void) [[[missingUpdateEventsTranscoder expect] andReturn:missingUpdateEventsTranscoder] initWithSyncStrategy:OCMOCK_ANY previouslyReceivedEventIDsCollection:OCMOCK_ANY];
     
     id flowTranscoder = [OCMockObject mockForClass:ZMFlowSync.class];
     [[[[flowTranscoder expect] andReturn:flowTranscoder] classMethod] alloc];

--- a/zmessaging-cocoa.xcodeproj/project.pbxproj
+++ b/zmessaging-cocoa.xcodeproj/project.pbxproj
@@ -239,6 +239,7 @@
 		54A170691B300717001B41A5 /* ProxiedRequestStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54A170671B300717001B41A5 /* ProxiedRequestStrategyTests.swift */; };
 		54A1BE4519E6B79000B68A76 /* ZMCommonContactsSearchTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 54A1BE4319E6B79000B68A76 /* ZMCommonContactsSearchTests.m */; };
 		54A227D61D6604A5009414C0 /* SynchronizationMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54A227D51D6604A5009414C0 /* SynchronizationMocks.swift */; };
+		54A2C9F31DAFBA3300FFD2A0 /* NSManagedObjectContext+EventDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54A2C9F21DAFBA3300FFD2A0 /* NSManagedObjectContext+EventDecoder.swift */; };
 		54A2CADF1C0723A300ACDA0D /* IncompleteConversationsDownstreamSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54A2CADD1C07239500ACDA0D /* IncompleteConversationsDownstreamSyncTests.swift */; };
 		54A343471D6B589A004B65EA /* AddressBookSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54A343461D6B589A004B65EA /* AddressBookSearch.swift */; };
 		54A3ACC31A261603008AF8DF /* BackgroundTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 54A3ACC21A261603008AF8DF /* BackgroundTests.m */; };
@@ -719,6 +720,7 @@
 		54A1BE3A19E69A3400B68A76 /* ZMCommonContactsSearch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMCommonContactsSearch.m; sourceTree = "<group>"; };
 		54A1BE4319E6B79000B68A76 /* ZMCommonContactsSearchTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMCommonContactsSearchTests.m; sourceTree = "<group>"; };
 		54A227D51D6604A5009414C0 /* SynchronizationMocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SynchronizationMocks.swift; sourceTree = "<group>"; };
+		54A2C9F21DAFBA3300FFD2A0 /* NSManagedObjectContext+EventDecoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+EventDecoder.swift"; sourceTree = "<group>"; };
 		54A2CADD1C07239500ACDA0D /* IncompleteConversationsDownstreamSyncTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IncompleteConversationsDownstreamSyncTests.swift; sourceTree = "<group>"; };
 		54A343461D6B589A004B65EA /* AddressBookSearch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddressBookSearch.swift; sourceTree = "<group>"; };
 		54A3ACC21A261603008AF8DF /* BackgroundTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BackgroundTests.m; sourceTree = "<group>"; };
@@ -1991,6 +1993,7 @@
 				BF2A9D501D6B536E00FA7DBC /* EventDecoder.swift */,
 				BF2A9D5A1D6B63DB00FA7DBC /* StoreUpdateEvent.swift */,
 				BF2A9D5F1D6C70EA00FA7DBC /* ZMEventModel.xcdatamodeld */,
+				54A2C9F21DAFBA3300FFD2A0 /* NSManagedObjectContext+EventDecoder.swift */,
 			);
 			name = Decoding;
 			sourceTree = "<group>";
@@ -2595,6 +2598,7 @@
 				F98EDCF51D82B924001E65CB /* ZMSpellOutSmallNumbersFormatter.m in Sources */,
 				54B2A08C1DAE71F100BB40B1 /* Clusterizer+VOIP.swift in Sources */,
 				54A0A6311BCE9864001A3A4C /* ZMHotFix.m in Sources */,
+				54A2C9F31DAFBA3300FFD2A0 /* NSManagedObjectContext+EventDecoder.swift in Sources */,
 				54A0A6321BCE9867001A3A4C /* ZMHotFixDirectory.m in Sources */,
 				54F0A0951B3018D7003386BC /* ProxiedRequestsStatus.swift in Sources */,
 				549815D71A432BC700A7CE2E /* ZMCommonContactsSearch.m in Sources */,

--- a/zmessaging-cocoa.xcodeproj/xcshareddata/xcschemes/zmessaging-ios.xcscheme
+++ b/zmessaging-cocoa.xcodeproj/xcshareddata/xcschemes/zmessaging-ios.xcscheme
@@ -102,6 +102,11 @@
             isEnabled = "NO">
          </EnvironmentVariable>
          <EnvironmentVariable
+            key = "OS_ACTIVITY_MODE"
+            value = "disable"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
             key = "ZM_TESTING"
             value = "1"
             isEnabled = "YES">


### PR DESCRIPTION
# Reason for this pull request
When in background, APNS enabled, and receiving more than ~10 messages from the same user without opening the app, upon opening the app later some error messages ("failed to decrypt") will be inserted in the conversation, even if no message was missing.

This was causing by trying to decrypt the message twice (once, successfully, from APNS and once later, when coming back to foreground and fetching the notification stream). It is not expected to be able to decrypt the same message twice, but normally cryptobox will return a "duplicated message" error, which we expect and ignore. 

However, if the session with the sender had advanced the key enough times (and it does, because APNS cause a confirmation message to be sent back to the sender, which advance the session), the original key used for the first message is already gone outside of the history of the session and instead of "duplicated message" cryptobox will return "invalid message".

The solution is not to rely on cryptobox to tell us that the message is duplicated (i.e. previously received) but to keep track ourselves.

# Changes
Added a list of notification IDs that we already received through APNS. The list is used to filter out events from the notification stream, and then discarded (we will never fetch the same event from the notification stream twice, so we don't need to filter those events anymore).

# Known issues
This fixes the most common cause of event not being decrypted, but there are still some edge cases that were introduced with the delivery confirmation behavior.

- If APNS delivery is failing and some messages are not pushed, then it recovers later (causing delivery confirmations to be sent), when coming back online we might not be able to decrypt the messages that were missed for the same reason (the session key moved ahead too much).
- if there is a muted conversation (which does not cause APNS) with user B and there is a one-to-one conversation between A and B that is not silenced, if B user writes enough messages in the silenced conversation while A is in the background, A might not be able to decrypt messages from the muted conversation when fetching the notification stream

A better solution would be to have APNS cause a fetch of the entire notification stream. However we should investigate how this will affect APNS reliability as the app will use more data and battery and most likely be more penalized by the OS.
