### PR TITLE
Fix non passing tests due to change in DataModel

### DIFF
--- a/Tests/Source/MessagingTest.h
+++ b/Tests/Source/MessagingTest.h
@@ -132,6 +132,7 @@ typedef BOOL (^SaveExpectationHandler)(ZMManagedObject *);
 
 - (NSData *)encryptedMessage:(ZMGenericMessage *)message recipient:(UserClient *)recipient;
 
+- (UserClient *)setupSelfClientInMoc:(NSManagedObjectContext *)moc;
 - (UserClient *)createSelfClient;
 - (UserClient *)createClientForUser:(ZMUser *)user createSessionWithSelfUser:(BOOL)createSessionWithSeflUser;
 - (UserClient *)createClientForMockUser:(MockUser *)mockUser createSessionWithSelfUser:(BOOL)createSessionWithSeflUser;

--- a/Tests/Source/MessagingTest.m
+++ b/Tests/Source/MessagingTest.m
@@ -659,6 +659,20 @@ static int32_t eventIdCounter;
     XCTAssertNil(error, @"Error establishing session: %@", error);
 }
 
+- (UserClient *)setupSelfClientInMoc:(NSManagedObjectContext *)moc;
+{
+    ZMUser *selfUser = [ZMUser selfUserInContext:moc];
+    
+    UserClient *client = [UserClient insertNewObjectInManagedObjectContext:moc];
+    client.remoteIdentifier = @"identifier";
+    client.user = selfUser;
+    
+    [moc setPersistentStoreMetadata:client.remoteIdentifier forKey:ZMPersistedClientIdKey];
+    [moc saveOrRollback];
+    
+    return client;
+}
+
 - (UserClient *)createSelfClient
 {
     ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];

--- a/Tests/Source/MessagingTest.m
+++ b/Tests/Source/MessagingTest.m
@@ -662,9 +662,12 @@ static int32_t eventIdCounter;
 - (UserClient *)setupSelfClientInMoc:(NSManagedObjectContext *)moc;
 {
     ZMUser *selfUser = [ZMUser selfUserInContext:moc];
+    if (selfUser.remoteIdentifier == nil) {
+        selfUser.remoteIdentifier = [NSUUID createUUID];
+    }
     
     UserClient *client = [UserClient insertNewObjectInManagedObjectContext:moc];
-    client.remoteIdentifier = @"identifier";
+    client.remoteIdentifier = [NSString createAlphanumericalString];
     client.user = selfUser;
     
     [moc setPersistentStoreMetadata:client.remoteIdentifier forKey:ZMPersistedClientIdKey];
@@ -675,15 +678,7 @@ static int32_t eventIdCounter;
 
 - (UserClient *)createSelfClient
 {
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
-    selfUser.remoteIdentifier = selfUser.remoteIdentifier ?: [NSUUID createUUID];
-    
-    UserClient *selfClient = [UserClient insertNewObjectInManagedObjectContext:self.syncMOC];
-    selfClient.remoteIdentifier = [NSString createAlphanumericalString];
-    selfClient.user = selfUser;
-    
-    [self.syncMOC setPersistentStoreMetadata:selfClient.remoteIdentifier forKey:ZMPersistedClientIdKey];
-    
+    UserClient *selfClient = [self setupSelfClientInMoc:self.syncMOC];
     [UserClient createOrUpdateClient:@{@"id": selfClient.remoteIdentifier, @"type": @"permanent", @"time": [[NSDate date] transportString]} context:self.syncMOC];
     [self.syncMOC saveOrRollback];
     

--- a/Tests/Source/Synchronization/Transcoders/ZMLastUpdateEventIDTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMLastUpdateEventIDTranscoderTests.m
@@ -273,7 +273,7 @@
 - (void)testThatItEncodesTheRightRequestWithClient
 {
     // given
-    UserClient *selfClient = self.createSelfClient;
+    UserClient *selfClient = [self setupSelfClientInMoc:self.uiMOC];
     XCTAssertNotNil(selfClient);
     
     // when

--- a/Tests/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoderTests.m
@@ -473,7 +473,7 @@ static NSString * const LastUpdateEventIDStoreKey = @"LastUpdateEventID";
 - (void)testThatTheClientIDFromTheUserClientIsIncludedInRequest
 {
     // Given
-    UserClient *userClient = [self createSelfClient];
+    UserClient *userClient = [self setupSelfClientInMoc:self.uiMOC];
     [self.sut startDownloadingMissingNotifications];
     
     // when

--- a/Tests/Source/UserSession/ZMAccountStatusTests.swift
+++ b/Tests/Source/UserSession/ZMAccountStatusTests.swift
@@ -156,7 +156,7 @@ class ZMAccountStatusTests : MessagingTest {
     
     func testThatItAppendsANewDeviceMessageWhenSyncCompletes_NewDevice() {
         // given
-        createSelfClient()
+        setupSelfClient(inMoc: self.uiMOC)
         
         let cookieStorage = MockCookieStorage()
         cookieStorage.shouldReturnCookie = false
@@ -197,7 +197,7 @@ class ZMAccountStatusTests : MessagingTest {
     
     func testThatItAppendsAReactivedDeviceMessageWhenSyncCompletes_ReactivatedDevice() {
         // given
-        createSelfClient()
+        setupSelfClient(inMoc: self.uiMOC)
         
         let cookieStorage = MockCookieStorage()
         cookieStorage.shouldReturnCookie = false

--- a/Tests/Source/UserSession/ZMClientRegistrationStatusTests.m
+++ b/Tests/Source/UserSession/ZMClientRegistrationStatusTests.m
@@ -207,15 +207,15 @@
     }];
     
     [self performPretendingUiMocIsSyncMoc:^{
-        ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
+        ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
         selfUser.remoteIdentifier = NSUUID.createUUID;
         
-        UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.syncMOC];
+        UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.uiMOC];
         client.remoteIdentifier = @"identifier";
         client.user = selfUser;
         
-        [self.syncMOC setPersistentStoreMetadata:client.remoteIdentifier forKey:ZMPersistedClientIdKey];
-        [self.syncMOC saveOrRollback];
+        [self.uiMOC setPersistentStoreMetadata:client.remoteIdentifier forKey:ZMPersistedClientIdKey];
+        [self.uiMOC saveOrRollback];
         
         // when
         [self.sut didDetectCurrentClientDeletion];


### PR DESCRIPTION
**What's in this PR**
This PR fixes tests that were broke changing the way contexts are initialized.