### PR TITLE
don’t create a notification for user leaving conversation

### DIFF
--- a/Source/Notifications/Push notifications/Notification Types/MessageNotifications/ZMLocalNotificationForSystemMessage.swift
+++ b/Source/Notifications/Push notifications/Notification Types/MessageNotifications/ZMLocalNotificationForSystemMessage.swift
@@ -41,6 +41,11 @@ final public class ZMLocalNotificationForSystemMessage : ZMLocalNotification, No
               let sender = message.sender
         else {return nil}
         
+        // We don't want to create notifications when a user leaves the conversation
+        if message.systemMessageType == .participantsRemoved, let removedUser = message.removedUsers.first, message.sender == removedUser {
+            return nil
+        }
+        
         self.senderUUID = sender.remoteIdentifier!
         self.application = application ?? UIApplication.shared
         super.init(conversationID: message.conversation?.remoteIdentifier)

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationForSystemMessageTests.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationForSystemMessageTests.swift
@@ -94,6 +94,21 @@ class ZMLocalNotificationForSystemMessageTests : ZMLocalNotificationForEventTest
         return uiNote.alertBody
     }
     
+    func testThatItDoesNotCreateANotificationWhenTheUserLeaves(){
+        // given
+        let systemMessage = ZMSystemMessage.insertNewObject(in: syncMOC)
+        systemMessage.systemMessageType = .participantsRemoved
+        systemMessage.removedUsers = [otherUser]
+        systemMessage.sender = otherUser
+        systemMessage.visibleInConversation = groupConversation
+        
+        // when
+        let note = ZMLocalNotificationForSystemMessage(message: systemMessage, application: application)
+
+        // then
+        XCTAssertNil(note)
+    }
+    
     func testThatItCreatesANotificationForParticipantRemoved(){
         
         //    "push.notification.member.leave.self" = "%1$@ removed you from %2$@";
@@ -110,9 +125,6 @@ class ZMLocalNotificationForSystemMessageTests : ZMLocalNotificationForEventTest
         //
         //    "push.notification.member.leave.many.nootherusername" = "%1$@ removed people from %2$@";
         //    "push.notification.member.leave.many.nootherusername.noconversationname" = "%1$@ removed people from a conversation";
-        
-        XCTAssertEqual(alertBodyForParticipantRemoved(groupConversation, aSender: sender, otherUsers: Set(arrayLiteral: sender)), "Super User left Super Conversation")
-        XCTAssertEqual(alertBodyForParticipantRemoved(groupConversationWithoutName, aSender: sender, otherUsers: Set(arrayLiteral: sender)), "Super User left a conversation")
         
         XCTAssertEqual(alertBodyForParticipantRemoved(groupConversation, aSender: sender, otherUsers: Set(arrayLiteral: otherUser)), "Super User removed Other User from Super Conversation")
         XCTAssertEqual(alertBodyForParticipantRemoved(groupConversation, aSender: sender, otherUsers: Set(arrayLiteral: selfUser)), "Super User removed you from Super Conversation")


### PR DESCRIPTION
**In this PR**
In case a user leaves a conversation, we don't want to send out a notification.