### PR TITLE
Remove references to inactive participants

### DIFF
--- a/Source/Notifications/Push notifications/Notification Types/MessageNotifications/ZMLocalNotificationForSystemMessage.swift
+++ b/Source/Notifications/Push notifications/Notification Types/MessageNotifications/ZMLocalNotificationForSystemMessage.swift
@@ -70,7 +70,7 @@ final public class ZMLocalNotificationForSystemMessage : ZMLocalNotification, No
     func alertBodyForParticipantEvents(_ message: ZMSystemMessage) -> String {
         let isLeaveEvent = (message.systemMessageType == .participantsRemoved)
         let isCopy = (userCount != 0)
-        let users = (isLeaveEvent ? message.removedUsers : message.addedUsers) ?? Set()
+        let users = (isLeaveEvent ? message.removedUsers : message.addedUsers)
         
         userCount = userCount + users.count
         if isCopy {

--- a/Tests/Source/Data Model/ZMConversation+Testing.m
+++ b/Tests/Source/Data Model/ZMConversation+Testing.m
@@ -54,21 +54,6 @@
          [[mockActiveUsersUUID.allObjects valueForKey:@"transportString"] componentsJoinedByString:@", "]];
     }
 
-    NSMutableSet *inactiveUsersUUID = [NSMutableSet set];
-    for(ZMUser *user in self.otherInactiveParticipants) {
-        [inactiveUsersUUID addObject:user.remoteIdentifier];
-    }
-    NSMutableSet *mockInactiveUsersUUID = [NSMutableSet set];
-    for (MockUser *mockUser in conversation.inactiveUsers) {
-        [mockInactiveUsersUUID addObject:[mockUser.identifier UUID]];
-    }
-    [mockInactiveUsersUUID removeObject:conversation.selfIdentifier.UUID];
-    if (![inactiveUsersUUID isEqual:mockInactiveUsersUUID]) {
-        [failureRecorder recordFailure:@"Inactive users don't match {%@} != {%@}",
-         [[inactiveUsersUUID.allObjects valueForKey:@"transportString"] componentsJoinedByString:@", "],
-         [[mockInactiveUsersUUID.allObjects valueForKey:@"transportString"] componentsJoinedByString:@", "]];
-    }
-
     if (!((self.lastModifiedDate == conversation.lastEventTime
           || fabs([self.lastModifiedDate timeIntervalSinceDate:conversation.lastEventTime]) < 1))) {
         [failureRecorder recordFailure:@"Last modified date doesn't match '%@' != '%@'",

--- a/Tests/Source/Integration/ConversationsTests.m
+++ b/Tests/Source/Integration/ConversationsTests.m
@@ -223,7 +223,6 @@
         ZMUser *user = [self userForMockUser:self.user3];
 
         XCTAssertFalse([conversation.activeParticipants containsObject:user]);
-        XCTAssertTrue([conversation.inactiveParticipants containsObject:user]);
     }
     
 }
@@ -282,7 +281,6 @@
         ZMUser *user = [self userForMockUser:connectedUserNotInConv];
         
         XCTAssertTrue([conversation.activeParticipants containsObject:user]);
-        XCTAssertFalse([conversation.inactiveParticipants containsObject:user]);
     }
     
 }
@@ -346,7 +344,6 @@
     // then
     ZMUser *user4 = [self userForMockUser:self.user4];
     XCTAssertTrue([groupConversation.activeParticipants containsObject:user4]);
-    XCTAssertFalse([groupConversation.inactiveParticipants containsObject:user4]);
     XCTAssertEqual(groupConversation.keysThatHaveLocalModifications.count, 0u);
 }
 
@@ -369,7 +366,6 @@
     
     // then
     XCTAssertFalse([groupConversation.activeParticipants containsObject:user3]);
-    XCTAssertTrue([groupConversation.inactiveParticipants containsObject:user3]);
     XCTAssertEqual(groupConversation.keysThatHaveLocalModifications.count, 0u);
 }
 
@@ -608,7 +604,6 @@
     [self.userSession saveOrRollbackChanges];
     
     XCTAssertEqual(conversation.activeParticipants.count, 2u);
-    XCTAssertEqual(conversation.inactiveParticipants.count, 0u);
 }
 
 - (void)testThatActiveParticipantsInOneOnOneConversationWithABlockedUserAreAllParticipants
@@ -623,7 +618,6 @@
     [self.userSession saveOrRollbackChanges];
     
     XCTAssertEqual(conversation.activeParticipants.count, 2u);
-    XCTAssertEqual(conversation.inactiveParticipants.count, 0u);
     
     // when
     ZMUser *user1 = [self userForMockUser:self.user1];
@@ -635,7 +629,6 @@
     
     XCTAssertTrue(user1.isBlocked);
     XCTAssertEqual(conversation.activeParticipants.count, 2u);
-    XCTAssertEqual(conversation.inactiveParticipants.count, 0u);
 }
 
 - (NSArray *)movedIndexPairsForChangeSet:(ConversationListChangeInfo *)note
@@ -718,7 +711,7 @@
     ZMUser *user = [self userForMockUser:self.selfUser];
 
     XCTAssertEqualObjects(conversationList.firstObject, newConv);
-    XCTAssertTrue([[newConv allParticipants] containsObject:user]);
+    XCTAssertTrue([newConv.activeParticipants containsObject:user]);
 }
 
 

--- a/Tests/Source/Integration/SendAndReceiveMessagesTests.m
+++ b/Tests/Source/Integration/SendAndReceiveMessagesTests.m
@@ -1028,7 +1028,6 @@
     ZMUser *removedUser = [self userForMockUser:self.user1];
     
     // then
-    XCTAssertEqual(conversation.inactiveParticipants.count, 2lu); // because we removed user3 and user1
     XCTAssertEqual(conversation.activeParticipants.count, 3lu);
     XCTAssertEqual(systemMessage.users.count, 3lu);
     XCTAssertEqual(systemMessage.addedUsers.count, 1lu);

--- a/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.m
@@ -162,19 +162,13 @@ static NSString *const CONVERSATION_ID_REQUEST_PREFIX = @"/conversations?ids=";
         sameActiveUsers = sameActiveUsers && [activeParticipants containsObject:user.remoteIdentifier];
     }
     
-    BOOL sameInactiveUsers = inactiveParticipants.count == conversation.otherInactiveParticipants.count;
-    for(ZMUser *user in conversation.otherInactiveParticipants) {
-        sameInactiveUsers = sameInactiveUsers && [inactiveParticipants containsObject:user.remoteIdentifier];
-    }
-    
     return (sameLastEvent
             && sameRemoteIdentifier
             && sameModifiedDate
             && sameCreator
             && sameName
             && sameType
-            && sameActiveUsers
-            && sameInactiveUsers);
+            && sameActiveUsers);
 }
 
 
@@ -2337,9 +2331,7 @@ static NSString *const CONVERSATION_ID_REQUEST_PREFIX = @"/conversations?ids=";
     // then
     [self.syncMOC performGroupedBlockAndWait:^{
         XCTAssertEqual(conversation.otherActiveParticipants.count, 1u);
-        XCTAssertEqual(conversation.otherInactiveParticipants.count, 1u);
         XCTAssertEqualObjects(conversation.otherActiveParticipants.firstObject, nonRemovedUser);
-        XCTAssertEqualObjects(conversation.otherInactiveParticipants.firstObject, removedUser);
         
     }];
 }
@@ -2830,7 +2822,6 @@ static NSString *const CONVERSATION_ID_REQUEST_PREFIX = @"/conversations?ids=";
         
         // then
         XCTAssertEqual(conversation.otherActiveParticipants.count, 3u);
-        XCTAssertEqual(conversation.otherInactiveParticipants.count, 0u);
     }];
 }
 


### PR DESCRIPTION
# Reason for this pull request
We are removing `inactiveParticipants` from data model.

# Changes
Remove all reference to inactive participants and delete related tests