### PR TITLE
Use correct user collection for member join / leave notifications

### DIFF
--- a/Source/Notifications/Push notifications/Notification Types/MessageNotifications/ZMLocalNotificationForSystemMessage.swift
+++ b/Source/Notifications/Push notifications/Notification Types/MessageNotifications/ZMLocalNotificationForSystemMessage.swift
@@ -42,7 +42,7 @@ final public class ZMLocalNotificationForSystemMessage : ZMLocalNotification, No
         else {return nil}
         
         // We don't want to create notifications when a user leaves the conversation
-        if message.systemMessageType == .participantsRemoved, let removedUser = message.removedUsers.first, message.sender == removedUser {
+        if message.systemMessageType == .participantsRemoved, let removedUser = message.users.first, message.sender == removedUser {
             return nil
         }
         
@@ -70,9 +70,8 @@ final public class ZMLocalNotificationForSystemMessage : ZMLocalNotification, No
     func alertBodyForParticipantEvents(_ message: ZMSystemMessage) -> String {
         let isLeaveEvent = (message.systemMessageType == .participantsRemoved)
         let isCopy = (userCount != 0)
-        let users = isLeaveEvent ? message.removedUsers : message.addedUsers
         
-        userCount = userCount + users.count
+        userCount = userCount + message.users.count
         if isCopy {
             let key = isLeaveEvent ? ZMPushStringMemberLeaveMany : ZMPushStringMemberJoinMany
             return key.localizedString(with: nil, conversation: message.conversation, otherUser: nil)
@@ -81,12 +80,8 @@ final public class ZMLocalNotificationForSystemMessage : ZMLocalNotification, No
         var user: ZMUser?
         var key : NSString = (isLeaveEvent ? ZMPushStringMemberLeaveMany : ZMPushStringMemberJoinMany) as NSString
         if userCount == 1 {
-            if (users.first == message.sender) {
-                key = ZMPushStringMemberLeaveSender as NSString
-            } else {
-                user = users.first
-                key = (isLeaveEvent ? ZMPushStringMemberLeave : ZMPushStringMemberJoin) as NSString
-            }
+            user = message.users.first
+            key = (isLeaveEvent ? ZMPushStringMemberLeave : ZMPushStringMemberJoin) as NSString
         }
         return key.localizedString(with: message.sender, conversation: message.conversation, otherUser: user)
     }

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationForSystemMessageTests.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationForSystemMessageTests.swift
@@ -43,7 +43,7 @@ class ZMLocalNotificationForSystemMessageTests : ZMLocalNotificationForEventTest
         // given
         let systemMessage = ZMSystemMessage.insertNewObject(in: syncMOC)
         systemMessage.systemMessageType = .participantsAdded
-        systemMessage.addedUsers = otherUsers
+        systemMessage.users = otherUsers
         systemMessage.sender = aSender
         systemMessage.visibleInConversation = conversation
         
@@ -82,7 +82,7 @@ class ZMLocalNotificationForSystemMessageTests : ZMLocalNotificationForEventTest
         // given
         let systemMessage = ZMSystemMessage.insertNewObject(in: syncMOC)
         systemMessage.systemMessageType = .participantsRemoved
-        systemMessage.removedUsers = otherUsers
+        systemMessage.users = otherUsers
         systemMessage.sender = aSender
         systemMessage.visibleInConversation = conversation
         
@@ -98,7 +98,7 @@ class ZMLocalNotificationForSystemMessageTests : ZMLocalNotificationForEventTest
         // given
         let systemMessage = ZMSystemMessage.insertNewObject(in: syncMOC)
         systemMessage.systemMessageType = .participantsRemoved
-        systemMessage.removedUsers = [otherUser]
+        systemMessage.users = [otherUser]
         systemMessage.sender = otherUser
         systemMessage.visibleInConversation = groupConversation
         


### PR DESCRIPTION
We were using the wrong property (removedUsers / addedUsers instead of users) on ZMSystemMessage to create the push notification.