### PR TITLE
Adding translations for CallKit strings

### DIFF
--- a/Resources/da.lproj/Push.strings
+++ b/Resources/da.lproj/Push.strings
@@ -168,3 +168,8 @@
 "push.notification.action.call.message" = "Besked";
 "push.notification.action.call.callback" = "Ring tilbage";
 "push.notification.action.connection.accept" = "Besvar";
+
+"push.notification.callkit.call.started.group" = "%1$@ in %2$@";
+"push.notification.callkit.call.started.group.nousername.noconversationname" = "Someone calling in a conversation";
+"push.notification.callkit.call.started.group.nousername" = "Someone calling in %1$@";
+"push.notification.callkit.call.started.group.noconversationname" = "%@ calling in a conversation";

--- a/Resources/de.lproj/Push.strings
+++ b/Resources/de.lproj/Push.strings
@@ -168,3 +168,8 @@
 "push.notification.action.call.message" = "Nachricht";
 "push.notification.action.call.callback" = "Rückruf";
 "push.notification.action.connection.accept" = "Annehmen";
+
+"push.notification.callkit.call.started.group" = "%1$@ in %2$@";
+"push.notification.callkit.call.started.group.nousername.noconversationname" = "Someone calling in a conversation";
+"push.notification.callkit.call.started.group.nousername" = "Someone calling in %1$@";
+"push.notification.callkit.call.started.group.noconversationname" = "%@ calling in a conversation";

--- a/Resources/de.lproj/Push.strings
+++ b/Resources/de.lproj/Push.strings
@@ -170,6 +170,6 @@
 "push.notification.action.connection.accept" = "Annehmen";
 
 "push.notification.callkit.call.started.group" = "%1$@ in %2$@";
-"push.notification.callkit.call.started.group.nousername.noconversationname" = "Someone calling in a conversation";
-"push.notification.callkit.call.started.group.nousername" = "Someone calling in %1$@";
-"push.notification.callkit.call.started.group.noconversationname" = "%@ calling in a conversation";
+"push.notification.callkit.call.started.group.nousername.noconversationname" = "Jemand ruft in einer Unterhaltung an";
+"push.notification.callkit.call.started.group.nousername" = "Jemand ruft in %1$@ an";
+"push.notification.callkit.call.started.group.noconversationname" = "%@ ruft in einer Unterhaltung an";

--- a/Resources/es.lproj/Push.strings
+++ b/Resources/es.lproj/Push.strings
@@ -168,3 +168,8 @@
 "push.notification.action.call.message" = "Mensaje";
 "push.notification.action.call.callback" = "Devolver la llamada";
 "push.notification.action.connection.accept" = "Aceptar";
+
+"push.notification.callkit.call.started.group" = "%1$@ in %2$@";
+"push.notification.callkit.call.started.group.nousername.noconversationname" = "Someone calling in a conversation";
+"push.notification.callkit.call.started.group.nousername" = "Someone calling in %1$@";
+"push.notification.callkit.call.started.group.noconversationname" = "%@ calling in a conversation";

--- a/Resources/fr.lproj/Push.strings
+++ b/Resources/fr.lproj/Push.strings
@@ -168,3 +168,8 @@
 "push.notification.action.call.message" = "Message";
 "push.notification.action.call.callback" = "Rappeler";
 "push.notification.action.connection.accept" = "Accepter";
+
+"push.notification.callkit.call.started.group" = "%1$@ dans %2$@";
+"push.notification.callkit.call.started.group.nousername.noconversationname" = "Quelqu'un appelle dans une conversation";
+"push.notification.callkit.call.started.group.nousername" = "Quelqu'un appelle dans %1$@";
+"push.notification.callkit.call.started.group.noconversationname" = "%@ appelle dans une conversation";

--- a/Resources/it.lproj/Push.strings
+++ b/Resources/it.lproj/Push.strings
@@ -168,3 +168,8 @@
 "push.notification.action.call.message" = "Messaggio";
 "push.notification.action.call.callback" = "Richiama";
 "push.notification.action.connection.accept" = "Accetta";
+
+"push.notification.callkit.call.started.group" = "%1$@ in %2$@";
+"push.notification.callkit.call.started.group.nousername.noconversationname" = "Qualcuno sta chiamando in una conversazione";
+"push.notification.callkit.call.started.group.nousername" = "Qualcuno sta chiamando in %1$@";
+"push.notification.callkit.call.started.group.noconversationname" = "%@ sta chiamando in una conversazione";

--- a/Resources/ja.lproj/Push.strings
+++ b/Resources/ja.lproj/Push.strings
@@ -168,3 +168,8 @@
 "push.notification.action.call.message" = "メッセージ";
 "push.notification.action.call.callback" = "電話をかけ直す";
 "push.notification.action.connection.accept" = "承諾";
+
+"push.notification.callkit.call.started.group" = "%1$@ in %2$@";
+"push.notification.callkit.call.started.group.nousername.noconversationname" = "Someone calling in a conversation";
+"push.notification.callkit.call.started.group.nousername" = "Someone calling in %1$@";
+"push.notification.callkit.call.started.group.noconversationname" = "%@ calling in a conversation";

--- a/Resources/nl.lproj/Push.strings
+++ b/Resources/nl.lproj/Push.strings
@@ -168,3 +168,8 @@
 "push.notification.action.call.message" = "Stuur bericht";
 "push.notification.action.call.callback" = "Bel terug";
 "push.notification.action.connection.accept" = "Neem op";
+
+"push.notification.callkit.call.started.group" = "%1$@ in %2$@";
+"push.notification.callkit.call.started.group.nousername.noconversationname" = "Iemand belt in een gesprek";
+"push.notification.callkit.call.started.group.nousername" = "Iemand belt in %1$@";
+"push.notification.callkit.call.started.group.noconversationname" = "%@ belt in een gesprek";

--- a/Resources/pt-BR.lproj/Push.strings
+++ b/Resources/pt-BR.lproj/Push.strings
@@ -168,3 +168,8 @@
 "push.notification.action.call.message" = "Mensagem";
 "push.notification.action.call.callback" = "Ligue de volta";
 "push.notification.action.connection.accept" = "Aceitar";
+
+"push.notification.callkit.call.started.group" = "%1$@ in %2$@";
+"push.notification.callkit.call.started.group.nousername.noconversationname" = "Someone calling in a conversation";
+"push.notification.callkit.call.started.group.nousername" = "Someone calling in %1$@";
+"push.notification.callkit.call.started.group.noconversationname" = "%@ calling in a conversation";

--- a/Resources/ru.lproj/Push.strings
+++ b/Resources/ru.lproj/Push.strings
@@ -168,3 +168,8 @@
 "push.notification.action.call.message" = "Сообщение";
 "push.notification.action.call.callback" = "Перезвонить";
 "push.notification.action.connection.accept" = "Принять";
+
+"push.notification.callkit.call.started.group" = "%1$@ в %2$@";
+"push.notification.callkit.call.started.group.nousername.noconversationname" = "Звонок";
+"push.notification.callkit.call.started.group.nousername" = "Звонок в %1$@";
+"push.notification.callkit.call.started.group.noconversationname" = "%1$@ звонит";

--- a/Resources/tr.lproj/Push.strings
+++ b/Resources/tr.lproj/Push.strings
@@ -168,3 +168,8 @@
 "push.notification.action.call.message" = "Mesaj";
 "push.notification.action.call.callback" = "Geri Ara";
 "push.notification.action.connection.accept" = "Kabul et";
+
+"push.notification.callkit.call.started.group" = "%1$@ in %2$@";
+"push.notification.callkit.call.started.group.nousername.noconversationname" = "Someone calling in a conversation";
+"push.notification.callkit.call.started.group.nousername" = "Someone calling in %1$@";
+"push.notification.callkit.call.started.group.noconversationname" = "%@ calling in a conversation";

--- a/Resources/uk.lproj/Push.strings
+++ b/Resources/uk.lproj/Push.strings
@@ -168,3 +168,8 @@
 "push.notification.action.call.message" = "Повідомлення";
 "push.notification.action.call.callback" = "Передзвонити";
 "push.notification.action.connection.accept" = "Прийняти";
+
+"push.notification.callkit.call.started.group" = "%1$@ в %2$@";
+"push.notification.callkit.call.started.group.nousername.noconversationname" = "Хтось дзвонить у розмові";
+"push.notification.callkit.call.started.group.nousername" = "Хтось дзвонить в %1$@";
+"push.notification.callkit.call.started.group.noconversationname" = "%@ дзвонить у розмові";

--- a/Resources/zh-Hans.lproj/Push.strings
+++ b/Resources/zh-Hans.lproj/Push.strings
@@ -168,3 +168,8 @@
 "push.notification.action.call.message" = "信息";
 "push.notification.action.call.callback" = "回拨电话";
 "push.notification.action.connection.accept" = "接听";
+
+"push.notification.callkit.call.started.group" = "%1$@ 在 %2$@";
+"push.notification.callkit.call.started.group.nousername.noconversationname" = "在对话中联系人来电";
+"push.notification.callkit.call.started.group.nousername" = "在%1$@中联系人来电";
+"push.notification.callkit.call.started.group.noconversationname" = "在对话中%@来电";


### PR DESCRIPTION
What's in this PR:

- Added translation (or English placeholders) for CallKit strings
