### PR TITLE
Do not ignore call when leaving

### DIFF
--- a/Source/Calling/ZMCallKitDelegate.m
+++ b/Source/Calling/ZMCallKitDelegate.m
@@ -607,14 +607,16 @@ NS_ASSUME_NONNULL_END
     ZMUserSession *userSession = self.userSession;
 
     ZMConversation *callConversation = [action conversationInContext:userSession.managedObjectContext];
-    [userSession performChanges:^{
-        if (callConversation.voiceChannel.selfUserConnectionState == ZMVoiceChannelConnectionStateNotConnected) {
-            [callConversation.voiceChannel ignoreIncomingCall];
-        }
-        else {
-            [callConversation.voiceChannel leave];
-        }
-    }];
+    if (callConversation.voiceChannel.state != ZMVoiceChannelStateNoActiveUsers) {
+        [userSession performChanges:^{
+            if (callConversation.voiceChannel.selfUserConnectionState == ZMVoiceChannelConnectionStateNotConnected) {
+                [callConversation.voiceChannel ignoreIncomingCall];
+            }
+            else {
+                [callConversation.voiceChannel leave];
+            }
+        }];
+    }
     [action fulfill];
 }
 


### PR DESCRIPTION
# Issue

When we used to leave the call, CallKit code additionally called `-[voiceChannel ignoreIncomingCall]` that made the next call ignored. Now we can check if ignoring call is necessary.