### PR TITLE
Do not crash when creating the group conversation

### DIFF
--- a/Source/Calling/ZMCallKitDelegate.m
+++ b/Source/Calling/ZMCallKitDelegate.m
@@ -487,6 +487,10 @@ NS_ASSUME_NONNULL_END
 
 - (void)updateConversationIfNeeded:(ZMConversation *)conversation
 {
+    if (conversation.remoteIdentifier == nil) {
+        return;
+    }
+    
     ZMVoiceChannelState newState = conversation.voiceChannel.state;
     NSNumber *knownStateNumber = self.lastConversationsState[conversation.remoteIdentifier.transportString];
     ZMVoiceChannelState knownState = (ZMVoiceChannelState)[knownStateNumber integerValue];
@@ -503,7 +507,7 @@ NS_ASSUME_NONNULL_END
     
     switch (conversation.voiceChannel.state) {
     case ZMVoiceChannelStateIncomingCall:
-            [self indicateIncomingCallInConversation:conversation];
+        [self indicateIncomingCallInConversation:conversation];
         break;
     case ZMVoiceChannelStateSelfIsJoiningActiveChannel:
             [self.provider reportOutgoingCallWithUUID:conversation.remoteIdentifier

--- a/Tests/Source/Calling/ZMCallKitDelegateTests.swift
+++ b/Tests/Source/Calling/ZMCallKitDelegateTests.swift
@@ -434,23 +434,48 @@ class ZMCallKitDelegateTest: MessagingTest {
     
     // Observer API - report incoming call
     
+    func testThatItIgnoresConversationsWithoutRemoteId() {
+        // given
+        let conversation = self.conversation()
+        conversation.remoteIdentifier = nil
+
+        conversation.callDeviceIsActive = true
+        
+        // when
+        let mutableCallParticipants = conversation.mutableOrderedSetValue(forKey: ZMConversationCallParticipantsKey)
+        mutableCallParticipants.add(self.otherUser(moc: self.uiMOC))
+        mutableCallParticipants.add(ZMUser.selfUser(in: self.uiMOC))
+        self.uiMOC.saveOrRollback()
+        
+        XCTAssertEqual(conversation.voiceChannel.state, .selfIsJoiningActiveChannel)
+        // when
+        
+        self.uiMOC.saveOrRollback()
+        
+        // then
+        XCTAssertEqual(self.callKitProvider.timesReportNewIncomingCallCalled, 0)
+        XCTAssertEqual(self.callKitProvider.timesReportOutgoingCallConnectedAtCalled, 0)
+        XCTAssertEqual(self.callKitProvider.timesReportOutgoingCallStartedConnectingCalled, 0)
+        XCTAssertEqual(self.callKitProvider.timesReportCallEndedAtCalled, 0)
+    }
+    
     func testThatItDoesNotRequestCallStart_Outgoing() {
-//        // given
-//        let conversation = self.conversation()
-//        
-//        // when
-//        conversation.isOutgoingCall = true
-//        let mutableCallParticipants = conversation.mutableOrderedSetValue(forKey: ZMConversationCallParticipantsKey)
-//        mutableCallParticipants.add(ZMUser.selfUser(in: self.uiMOC))
-//        self.uiMOC.saveOrRollback()
-//        XCTAssertEqual(conversation.voiceChannel.state, .outgoingCall)
-//
-//        // then
-//        XCTAssertEqual(self.callKitProvider.timesReportNewIncomingCallCalled, 0)
-//        
-//        XCTAssertEqual(self.callKitProvider.timesReportOutgoingCallConnectedAtCalled, 0)
-//        XCTAssertEqual(self.callKitProvider.timesReportOutgoingCallStartedConnectingCalled, 0)
-//        XCTAssertEqual(self.callKitProvider.timesReportCallEndedAtCalled, 0)
+        // given
+        let conversation = self.conversation()
+        
+        // when
+        conversation.isOutgoingCall = true
+        let mutableCallParticipants = conversation.mutableOrderedSetValue(forKey: ZMConversationCallParticipantsKey)
+        mutableCallParticipants.add(ZMUser.selfUser(in: self.uiMOC))
+        self.uiMOC.saveOrRollback()
+        XCTAssertEqual(conversation.voiceChannel.state, .outgoingCall)
+
+        // then
+        XCTAssertEqual(self.callKitProvider.timesReportNewIncomingCallCalled, 0)
+        
+        XCTAssertEqual(self.callKitProvider.timesReportOutgoingCallConnectedAtCalled, 0)
+        XCTAssertEqual(self.callKitProvider.timesReportOutgoingCallStartedConnectingCalled, 0)
+        XCTAssertEqual(self.callKitProvider.timesReportCallEndedAtCalled, 0)
     }
     
     func testThatItRequestsCallStart_Incoming() {


### PR DESCRIPTION
# Issue

Managed object context observer in CallKit used to observe also the conversations that are just created locally, those don't have the remoteIdentifier yet.