### PR TITLE
Do not offer phone and email calling with CallKit

### DIFF
--- a/Source/Calling/ZMCallKitDelegate.m
+++ b/Source/Calling/ZMCallKitDelegate.m
@@ -299,8 +299,6 @@ NS_ASSUME_NONNULL_END
     providerConfiguration.maximumCallGroups = 1;
     providerConfiguration.maximumCallsPerCallGroup = 1;
     providerConfiguration.supportedHandleTypes = [NSSet setWithObjects:
-                                                  @(CXHandleTypePhoneNumber),
-                                                  @(CXHandleTypeEmailAddress),
                                                   @(CXHandleTypeGeneric), nil];
     
     providerConfiguration.iconTemplateImageData = UIImagePNGRepresentation([UIImage imageNamed:@"logo"]);

--- a/Tests/Source/Calling/ZMCallKitDelegateTests.swift
+++ b/Tests/Source/Calling/ZMCallKitDelegateTests.swift
@@ -146,8 +146,6 @@ class ZMCallKitDelegateTest: MessagingTest {
         // then
         XCTAssertEqual(configuration.supportsVideo, true)
         XCTAssertEqual(configuration.localizedName, "zmessaging Test Host")
-        XCTAssertTrue(configuration.supportedHandleTypes.contains(.phoneNumber))
-        XCTAssertTrue(configuration.supportedHandleTypes.contains(.emailAddress))
         XCTAssertTrue(configuration.supportedHandleTypes.contains(.generic))
     }
     
@@ -685,7 +683,6 @@ class ZMCallKitDelegateTest: MessagingTest {
     }
     
     func testThatItRequestsEndCall_OutgoingInGroupConversation() {
-        // given
         // given
         let conversation = self.conversation(type: .group)
         conversation.callDeviceIsActive = true


### PR DESCRIPTION
# Issue

We used to offer the calling with Wire from address book using any phone or email.

# Fix

Exclude phone and email handle types from supported list.

# Going forward

The plan is to add back the handles and offer SiriKit handling, so iOS can check with Wire which number it can dial. Alternatively, we can offer sending invites to users not on wire who current user would like to call.