### PR TITLE
Fix for video call not sending video

### DIFF
--- a/Source/Calling/ZMCallKitDelegate.m
+++ b/Source/Calling/ZMCallKitDelegate.m
@@ -341,7 +341,7 @@ NS_ASSUME_NONNULL_END
 
 - (NSArray<ZMConversation *> *)nonIdleCallConversations
 {
-    ZMConversationList *nonIdleConversations = [ZMConversationList conversationsInUserSession:self.userSession];
+    ZMConversationList *nonIdleConversations = [ZMConversationList conversationsIncludingArchivedInUserSession:self.userSession];
     
     return [nonIdleConversations filterWithBlock:^BOOL(ZMConversation *conversation) {
         return conversation.voiceChannel.inNonIdleState;


### PR DESCRIPTION
# Issue

In the CallKit mode, the video call incoming must not send video until the app is in the foreground. When app comes to the foreground, `ZMCallKitDelegate` gets the notification in `-[ZMCallKitDelegate applicationDidBecomeActive]` and looks for current active call to check if it is video call.

The bug happened to be with `-[ZMCallKitDelegate nonIdleCallConversations]` method that was looking into `conversationsInUserSession` list for current active call, however this array explicitly excludes the current call.

# Solution

Use another array that contains all conversations: `conversationsIncludingArchivedInUserSession`.