### PR TITLE
Correctly report end of the call; end all calls on startup

### DIFF
--- a/Source/Calling/ZMCallKitDelegate.h
+++ b/Source/Calling/ZMCallKitDelegate.h
@@ -31,6 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class CXCallUpdate;
 @class CXTransaction;
 @class CXHandle;
+@class CXCallObserver;
 
 /// Needed to unbound @c ZMCallKitDelegate from OS CallKit implementation (for testing).
 @protocol CallKitProviderType <NSObject>
@@ -47,6 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Needed to unbound @c ZMCallKitDelegate from OS CallKit implementation (for testing).
 @protocol CallKitCallController <NSObject>
 - (void)requestTransaction:(CXTransaction *)transaction completion:(void (^)(NSError *_Nullable error))completion;
+@property (nonatomic, readonly, strong) CXCallObserver *callObserver;
 @end
 
 @interface ZMUser (Handle)

--- a/Source/Calling/ZMCallKitDelegate.h
+++ b/Source/Calling/ZMCallKitDelegate.h
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Needed to unbound @c ZMCallKitDelegate from OS CallKit implementation (for testing).
 @protocol CallKitCallController <NSObject>
 - (void)requestTransaction:(CXTransaction *)transaction completion:(void (^)(NSError *_Nullable error))completion;
-@property (nonatomic, readonly, strong) CXCallObserver *callObserver;
+@property (nonatomic, readonly, strong, nullable) CXCallObserver *callObserver;
 @end
 
 @interface ZMUser (Handle)

--- a/Tests/Source/Calling/ZMCallKitDelegateTests.swift
+++ b/Tests/Source/Calling/ZMCallKitDelegateTests.swift
@@ -24,11 +24,6 @@ import Intents
 @available(iOS 10.0, *)
 class MockCallKitProvider: NSObject, CallKitProviderType {
 
-    public func reportCall(with UUID: UUID, endedAt dateEnded: Date?, reason endedReason: UInt) {
-        
-    }
-
-    
     required init(configuration: CXProviderConfiguration) {
         
     }
@@ -44,7 +39,7 @@ class MockCallKitProvider: NSObject, CallKitProviderType {
     }
     
     public var timesReportCallEndedAtCalled: Int = 0
-    func reportCall(with UUID: UUID, endedAt dateEnded: Date?, reason endedReason: CXCallEndedReason) {
+    public func reportCall(with UUID: UUID, endedAt dateEnded: Date?, reason endedReason: UInt) {
         timesReportCallEndedAtCalled = timesReportCallEndedAtCalled + 1
     }
     
@@ -61,9 +56,13 @@ class MockCallKitProvider: NSObject, CallKitProviderType {
 
 @available(iOS 10.0, *)
 class MockCallKitCallController: NSObject, CallKitCallController {
+    public var callObserver: CXCallObserver? {
+        return nil
+    }
     
     public var timesRequestTransactionCalled: Int = 0
     public var requestedTransaction: CXTransaction? = .none
+    
     
     @available(iOS 10.0, *)
     public func request(_ transaction: CXTransaction, completion: @escaping (Error?) -> Void) {
@@ -656,7 +655,7 @@ class ZMCallKitDelegateTest: MessagingTest {
         
         XCTAssertEqual(conversation.voiceChannel.state, .noActiveUsers)
         // then
-        XCTAssertEqual(self.callKitController.timesRequestTransactionCalled, 1)
+        XCTAssertEqual(self.callKitProvider.timesReportCallEndedAtCalled, 1)
     }
     
     func testThatItRequestsEndCall_Timeout() {
@@ -679,7 +678,7 @@ class ZMCallKitDelegateTest: MessagingTest {
         self.uiMOC.saveOrRollback()
         
         // then
-        XCTAssertEqual(self.callKitController.timesRequestTransactionCalled, 1)
+        XCTAssertEqual(self.callKitProvider.timesReportCallEndedAtCalled, 1)
     }
     
     func testThatItRequestsEndCall_OutgoingInGroupConversation() {


### PR DESCRIPTION
# Issue

Sometimes on CallKit version of the app, the call in one conversation is not possible to establish any more. Moreover, it is not possible to do so even after the app is restarted.

# Investigation

I found that in that case CallKit thinks that there is a not ended call going on in this conversation, and CallKit is rejecting to start another call there because "maximum amount of call groups is reached" (right now set to 1 in the app since we don't support the call grouping).

# Solution

It comes out that we where not using the API to report broken calls `-reportCallWithUUID:endedAtDate:reason:`. 

Also to be sure I added the code to end all ongoing CallKit calls on the startup, to make sure that the app is not blocked from calling after the restart.