### PR TITLE
Add support to send assets using /assets/v3

### DIFF
--- a/Source/Synchronization/ZMSyncStrategy.m
+++ b/Source/Synchronization/ZMSyncStrategy.m
@@ -199,10 +199,17 @@ ZM_EMPTY_ASSERTING_INIT()
                                                                    taskCancellationProvider:taskCancellationProvider
                                                                        managedObjectContext:self.syncMOC],
                                    [[AssetV3DownloadRequestStrategy alloc] initWithAuthStatus:clientRegistrationStatus
-                                                                   taskCancellationProvider:taskCancellationProvider
-                                                                       managedObjectContext:self.syncMOC],
+                                                                     taskCancellationProvider:taskCancellationProvider
+                                                                         managedObjectContext:self.syncMOC],
+                                   [[AssetClientMessageRequestStrategy alloc] initWithClientRegistrationStatus:clientRegistrationStatus
+                                                                                          managedObjectContext:self.syncMOC],
+                                   [[AssetV3ImageUploadRequestStrategy alloc] initWithClientRegistrationStatus:clientRegistrationStatus
+                                                                                          managedObjectContext:self.syncMOC],
                                    [[AssetV3PreviewDownloadRequestStrategy alloc] initWithAuthStatus:clientRegistrationStatus
                                                                                 managedObjectContext:self.syncMOC],
+                                   [[AssetV3FileUploadRequestStrategy alloc] initWithClientRegistrationStatus:clientRegistrationStatus
+                                                                       taskCancellationProvider:taskCancellationProvider
+                                                                           managedObjectContext:self.syncMOC],
                                    [[AddressBookUploadRequestStrategy alloc] initWithAuthenticationStatus:authenticationStatus
                                                                                  clientRegistrationStatus:clientRegistrationStatus
                                                                                                       moc:self.syncMOC],

--- a/Source/Synchronization/ZMSyncStrategy.m
+++ b/Source/Synchronization/ZMSyncStrategy.m
@@ -204,6 +204,7 @@ ZM_EMPTY_ASSERTING_INIT()
                                    [[AssetClientMessageRequestStrategy alloc] initWithClientRegistrationStatus:clientRegistrationStatus
                                                                                           managedObjectContext:self.syncMOC],
                                    [[AssetV3ImageUploadRequestStrategy alloc] initWithClientRegistrationStatus:clientRegistrationStatus
+                                                                                      taskCancellationProvider:taskCancellationProvider
                                                                                           managedObjectContext:self.syncMOC],
                                    [[AssetV3PreviewDownloadRequestStrategy alloc] initWithAuthStatus:clientRegistrationStatus
                                                                                 managedObjectContext:self.syncMOC],

--- a/Tests/Source/Integration/FileTransferTests.m
+++ b/Tests/Source/Integration/FileTransferTests.m
@@ -2003,7 +2003,7 @@
 
 
 #pragma mark - Asset V3
-#pragma mark Receiving
+#pragma mark - Receiving
 
 @implementation FileTransferTests (V3)
 
@@ -2180,62 +2180,7 @@
     XCTAssertEqual(message.transferState, ZMFileTransferStateUploaded);
 }
 
-- (void)testThatItSendsTheRequestToDownloadAFileWhenItHasTheAssetID_AndSetsTheStateTo_Downloaded_AfterSuccesfullDecryption_V3
-{
-    // given
-    self.registeredOnThisDevice = YES;
-    XCTAssertTrue([self logInAndWaitForSyncToBeComplete]);
-    WaitForAllGroupsToBeEmpty(0.5);
-
-    NSUUID *nonce = NSUUID.createUUID;
-    NSUUID *assetID = NSUUID.createUUID;
-    NSData *otrKey = NSData.randomEncryptionKey;
-
-    NSData *assetData = [NSData secureRandomDataOfLength:256];
-    NSData *encryptedAsset = [assetData zmEncryptPrefixingPlainTextIVWithKey:otrKey];
-    NSData *sha256 = encryptedAsset.zmSHA256Digest;
-
-    ZMGenericMessage *uploaded = [[ZMGenericMessage genericMessageWithUploadedOTRKey:otrKey sha256:sha256 messageID:nonce.transportString expiresAfter:nil] updatedUploadedWithAssetId:assetID.transportString token:nil];
-
-    // when
-    ZMAssetClientMessage *message = [self remotelyInsertAssetOriginalAndUpdate:uploaded insertBlock:
-                                     ^(__unused NSData *data, MockConversation *conversation, MockUserClient *from, MockUserClient *to) {
-                                         [conversation insertOTRMessageFromClient:from toClient:to data:data];
-                                     } nonce:nonce];
-    WaitForAllGroupsToBeEmpty(0.5);
-    __unused ZMConversation *conversation = [self conversationForMockConversation:self.selfToUser1Conversation];
-
-    // then
-    XCTAssertNotNil(message);
-    XCTAssertNil(message.assetId); // We do not store the asset ID in the DB for v3 assets
-    XCTAssertEqualObjects(message.nonce, nonce);
-    XCTAssertEqual(message.transferState, ZMFileTransferStateUploaded);
-    WaitForAllGroupsToBeEmpty(0.5);
-
-    // when
-    // Mock the asset/v3 request
-    self.mockTransportSession.responseGeneratorBlock = ^ZMTransportResponse *(ZMTransportRequest *request) {
-        NSString *expectedPath = [NSString stringWithFormat:@"/assets/v3/%@", assetID.transportString];
-        if ([request.path isEqualToString:expectedPath]) {
-            return [[ZMTransportResponse alloc] initWithImageData:encryptedAsset HTTPStatus:200 transportSessionError:nil headers:nil];
-        }
-        return nil;
-    };
-
-    [self.userSession performChanges:^{
-        [message requestFileDownload];
-    }];
-
-    WaitForAllGroupsToBeEmpty(0.5);
-
-    // then
-    ZMTransportRequest *lastRequest = self.mockTransportSession.receivedRequests.lastObject;
-    NSString *expectedPath = [NSString stringWithFormat:@"/assets/v3/%@", assetID.transportString];
-    XCTAssertEqualObjects(lastRequest.path, expectedPath);
-    XCTAssertEqual(message.transferState, ZMFileTransferStateDownloaded);
-}
-
-#pragma mark: Sending
+#pragma mark Sending
 
 - (void)testThatItSendsAFileMessage_V3
 {
@@ -2721,5 +2666,984 @@
     XCTAssertNil(message.imageMessageData);
 }
 
+
+#pragma mark Sending Video (Preview)
+
+- (void)testThatItSendsAFileMessage_WithVideo_V3
+{
+    // given
+    self.registeredOnThisDevice = YES;
+    XCTAssertTrue([self logInAndWaitForSyncToBeComplete]);
+    WaitForEverythingToBeDone();
+
+    ZMConversation *conversation = [self conversationForMockConversation:self.selfToUser1Conversation];
+    XCTAssertNotNil(conversation);
+    XCTAssertEqual(conversation.messages.count, 1lu);
+
+    [self prefetchRemoteClientByInsertingMessageInConversation:self.selfToUser1Conversation];
+    NSUInteger initialMessageCount = conversation.messages.count;
+
+    NSURL *fileURL = self.testVideoFileURL;
+    NSString *expectedMessageAddPath = [NSString stringWithFormat:@"/conversations/%@/otr/messages", conversation.remoteIdentifier.transportString];
+    // Used for uploading the thumbnail and the full asset
+    NSString *expectedAssetAddPath = @"/assets/v3";
+
+    // when
+    [self.mockTransportSession resetReceivedRequests];
+
+    __block ZMMessage *fileMessage;
+    [self.userSession performChanges:^{
+        ZMVideoMetadata *metadata = [[ZMVideoMetadata alloc] initWithFileURL:fileURL thumbnail:self.mediumJPEGData];
+        fileMessage = (id)[conversation appendMessageWithFileMetadata:metadata version3:YES];
+    }];
+    WaitForEverythingToBeDone();
+
+    // then
+    XCTAssertEqual(fileMessage.deliveryState, ZMDeliveryStateSent);
+    XCTAssertEqual(fileMessage.fileMessageData.transferState, ZMFileTransferStateDownloaded);
+
+    NSArray <ZMTransportRequest *> *requests = [self filterOutRequestsForLastRead:self.mockTransportSession.receivedRequests];
+
+    // Asset.Original, Asset.Preview upload, generic message, Asset.Uploaded upload, generic message
+    if (5 != requests.count) {
+        return XCTFail(@"Wrong number of requests");
+    }
+
+    XCTAssertEqualObjects(requests.firstObject.path, expectedMessageAddPath);
+
+    ZMTransportRequest *thumbnailRequest = requests[1];
+    XCTAssertEqualObjects(thumbnailRequest.path, expectedAssetAddPath);
+
+    ZMTransportRequest *thumbnailGenericMessageRequest = requests[2];
+    XCTAssertEqualObjects(thumbnailGenericMessageRequest.path, expectedMessageAddPath);
+
+    ZMTransportRequest *fullAssetRequest = requests[3];
+    XCTAssertEqualObjects(fullAssetRequest.path, expectedAssetAddPath);
+
+    ZMTransportRequest *fullAssetGenericMessageRequest = requests[4];
+    XCTAssertEqualObjects(fullAssetGenericMessageRequest.path, expectedMessageAddPath);
+
+    XCTAssertEqual(conversation.messages.count - initialMessageCount, 1lu);
+
+    ZMMessage *message = conversation.messages.lastObject;
+
+    XCTAssertNotNil(message.fileMessageData);
+    XCTAssertNil(message.imageMessageData);
+    XCTAssertEqualObjects(message.fileMessageData.filename.stringByDeletingPathExtension, @"video");
+    XCTAssertEqualObjects(message.fileMessageData.filename.pathExtension, @"mp4");
+
+    NSError *error = nil;
+    NSUInteger size = [NSFileManager.defaultManager attributesOfItemAtPath:fileURL.path error:&error].fileSize;
+
+    XCTAssertNil(error);
+    XCTAssertEqual(message.fileMessageData.size, size);
+}
+
+- (void)testThatItResendsAFailedFileMessage_WithVideo_V3
+{
+    //given
+    self.registeredOnThisDevice = YES;
+    XCTAssertTrue([self logInAndWaitForSyncToBeComplete]);
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    ZMConversation *conversation = [self conversationForMockConversation:self.selfToUser1Conversation];
+    XCTAssertNotNil(conversation);
+    XCTAssertEqual(conversation.messages.count, 1lu);
+
+    NSURL *fileURL = self.testVideoFileURL;
+
+    self.mockTransportSession.responseGeneratorBlock = ^ZMTransportResponse *(ZMTransportRequest *request) {
+        // We fail the thumbnail asset upload
+        if ([request.path isEqualToString:@"/assets/v3"]) {
+            return [ZMTransportResponse responseWithPayload:nil HTTPStatus:400 transportSessionError:nil];
+        }
+        return nil;
+    };
+
+    // when
+    __block ZMMessage *fileMessage;
+    [self.userSession performChanges:^{
+        ZMVideoMetadata *metadata = [[ZMVideoMetadata alloc] initWithFileURL:fileURL thumbnail:self.mediumJPEGData];
+        fileMessage = (id)[conversation appendMessageWithFileMetadata:metadata version3:YES];
+    }];
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    // then
+    XCTAssertEqual(fileMessage.deliveryState, ZMDeliveryStateFailedToSend);
+    XCTAssertEqual(fileMessage.fileMessageData.transferState, ZMFileTransferStateFailedUpload);
+
+    // and when
+    self.mockTransportSession.responseGeneratorBlock = nil;
+    [self.userSession performChanges:^{
+        [fileMessage resend];
+    }];
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    // then
+    XCTAssertEqual(fileMessage.deliveryState, ZMDeliveryStateSent);
+    XCTAssertEqual(fileMessage.fileMessageData.transferState, ZMFileTransferStateDownloaded);
+    XCTAssertEqualObjects(fileMessage.fileMessageData.filename.stringByDeletingPathExtension, @"video");
+    XCTAssertEqualObjects(fileMessage.fileMessageData.filename.pathExtension, @"mp4");
+
+    NSError *error = nil;
+    NSUInteger size = [NSFileManager.defaultManager attributesOfItemAtPath:fileURL.path error:&error].fileSize;
+
+    XCTAssertNil(error);
+    XCTAssertEqual(fileMessage.fileMessageData.size, size);
+}
+
+- (void)testThatItResendsAFailedFileMessage_WithVideo_ThumbnailGenericMessageUploadFailed_V3
+{
+    //given
+    self.registeredOnThisDevice = YES;
+    XCTAssertTrue([self logInAndWaitForSyncToBeComplete]);
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    ZMConversation *conversation = [self conversationForMockConversation:self.selfToUser1Conversation];
+    XCTAssertNotNil(conversation);
+    XCTAssertEqual(conversation.messages.count, 1lu);
+
+    NSURL *fileURL = self.testVideoFileURL;
+    NSString *genericMessagePath = [NSString stringWithFormat:@"/conversations/%@/otr/messages", conversation.remoteIdentifier.transportString];
+
+    __block NSUInteger genericMessageUploadCount = 0;
+
+    self.mockTransportSession.responseGeneratorBlock = ^ZMTransportResponse *(ZMTransportRequest *request) {
+        // We fail the thumbnail asset generic message, which is the second /otr/messages post
+        if ([request.path isEqualToString:genericMessagePath] && ++genericMessageUploadCount == 2) {
+            return [ZMTransportResponse responseWithPayload:nil HTTPStatus:400 transportSessionError:nil];
+        }
+        return nil;
+    };
+
+    // when
+    __block ZMMessage *fileMessage;
+    [self.userSession performChanges:^{
+        ZMVideoMetadata *metadata = [[ZMVideoMetadata alloc] initWithFileURL:fileURL thumbnail:self.mediumJPEGData];
+        fileMessage = (id)[conversation appendMessageWithFileMetadata:metadata version3:YES];
+    }];
+    WaitForAllGroupsToBeEmpty(0.5);
+    XCTAssertEqual(genericMessageUploadCount, 2lu);
+
+    // then
+    XCTAssertEqual(fileMessage.deliveryState, ZMDeliveryStateFailedToSend);
+    XCTAssertEqual(fileMessage.fileMessageData.transferState, ZMFileTransferStateFailedUpload);
+
+    // and when
+    self.mockTransportSession.responseGeneratorBlock = nil;
+    [self.userSession performChanges:^{
+        [fileMessage resend];
+    }];
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    // then
+    XCTAssertEqual(fileMessage.deliveryState, ZMDeliveryStateSent);
+    XCTAssertEqual(fileMessage.fileMessageData.transferState, ZMFileTransferStateDownloaded);
+    XCTAssertEqualObjects(fileMessage.fileMessageData.filename.stringByDeletingPathExtension, @"video");
+    XCTAssertEqualObjects(fileMessage.fileMessageData.filename.pathExtension, @"mp4");
+
+    NSError *error = nil;
+    NSUInteger size = [NSFileManager.defaultManager attributesOfItemAtPath:fileURL.path error:&error].fileSize;
+
+    XCTAssertNil(error);
+    XCTAssertEqual(fileMessage.fileMessageData.size, size);
+}
+
+- (void)testThatItResendsAFailedFileMessage_UploadingFullAssetFails_V3
+{
+    //given
+    self.registeredOnThisDevice = YES;
+    XCTAssertTrue([self logInAndWaitForSyncToBeComplete]);
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    ZMConversation *conversation = [self conversationForMockConversation:self.selfToUser1Conversation];
+    XCTAssertNotNil(conversation);
+    XCTAssertEqual(conversation.messages.count, 1lu);
+
+    NSURL *fileURL = self.testVideoFileURL;
+    __block NSUInteger assetUploadCounter = 0;
+
+    self.mockTransportSession.responseGeneratorBlock = ^ZMTransportResponse *(ZMTransportRequest *request) {
+        // We fail the second post to `/assets/v3`, which is the upload of the full asset
+        if ([request.path isEqualToString:@"/assets/v3"] && ++assetUploadCounter == 2) {
+            return [ZMTransportResponse responseWithPayload:nil HTTPStatus:400 transportSessionError:nil];
+        }
+        return nil;
+    };
+
+    // when
+    __block ZMMessage *fileMessage;
+    [self.userSession performChanges:^{
+        ZMVideoMetadata *metadata = [[ZMVideoMetadata alloc] initWithFileURL:fileURL thumbnail:self.mediumJPEGData];
+        fileMessage = (id)[conversation appendMessageWithFileMetadata:metadata version3:YES];
+    }];
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    // then
+    XCTAssertEqual(fileMessage.deliveryState, ZMDeliveryStateFailedToSend);
+    XCTAssertEqual(fileMessage.fileMessageData.transferState, ZMFileTransferStateFailedUpload);
+
+    // and when
+    self.mockTransportSession.responseGeneratorBlock = nil;
+    [self.userSession performChanges:^{
+        [fileMessage resend];
+    }];
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    //then
+    XCTAssertEqual(fileMessage.deliveryState, ZMDeliveryStateSent);
+    XCTAssertEqual(fileMessage.fileMessageData.transferState, ZMFileTransferStateDownloaded);
+    XCTAssertEqualObjects(fileMessage.fileMessageData.filename.stringByDeletingPathExtension, @"video");
+    XCTAssertEqualObjects(fileMessage.fileMessageData.filename.pathExtension, @"mp4");
+
+    NSError *error = nil;
+    NSUInteger size = [NSFileManager.defaultManager attributesOfItemAtPath:fileURL.path error:&error].fileSize;
+
+    XCTAssertNil(error);
+    XCTAssertEqual(fileMessage.fileMessageData.size, size);
+}
+
+- (void)testThatItResendsAFailedFileMessage_UploadingFullAssetGenericMessageFails_V3
+{
+    //given
+    self.registeredOnThisDevice = YES;
+    XCTAssertTrue([self logInAndWaitForSyncToBeComplete]);
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    ZMConversation *conversation = [self conversationForMockConversation:self.selfToUser1Conversation];
+    XCTAssertNotNil(conversation);
+    XCTAssertEqual(conversation.messages.count, 1lu);
+
+    NSURL *fileURL = self.testVideoFileURL;
+    NSString *genericMessagePath = [NSString stringWithFormat:@"/conversations/%@/otr/messages", conversation.remoteIdentifier.transportString];
+
+    __block NSUInteger genericMessageUploadCount = 0;
+
+    self.mockTransportSession.responseGeneratorBlock = ^ZMTransportResponse *(ZMTransportRequest *request) {
+        // We fail the third post to `/otr/messages`, which is the upload of the full asset generic message
+        if ([request.path isEqualToString:genericMessagePath] && ++genericMessageUploadCount == 3) {
+            return [ZMTransportResponse responseWithPayload:nil HTTPStatus:400 transportSessionError:nil];
+        }
+        return nil;
+    };
+
+    // when
+    __block ZMMessage *fileMessage;
+    [self.userSession performChanges:^{
+        ZMVideoMetadata *metadata = [[ZMVideoMetadata alloc] initWithFileURL:fileURL thumbnail:self.mediumJPEGData];
+        fileMessage = (id)[conversation appendMessageWithFileMetadata:metadata version3:YES];
+    }];
+    WaitForAllGroupsToBeEmpty(0.5);
+    // Asset.Original, Asset.Preview, Asset.Uploaded, Asset.NOTUploaded
+    XCTAssertEqual(genericMessageUploadCount, 4lu);
+
+    // then
+    XCTAssertEqual(fileMessage.deliveryState, ZMDeliveryStateFailedToSend);
+    XCTAssertEqual(fileMessage.fileMessageData.transferState, ZMFileTransferStateFailedUpload);
+
+    // and when
+    self.mockTransportSession.responseGeneratorBlock = nil;
+    [self.userSession performChanges:^{
+        [fileMessage resend];
+    }];
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    //then
+    XCTAssertEqual(fileMessage.deliveryState, ZMDeliveryStateSent);
+    XCTAssertEqual(fileMessage.fileMessageData.transferState, ZMFileTransferStateDownloaded);
+    XCTAssertEqualObjects(fileMessage.fileMessageData.filename.stringByDeletingPathExtension, @"video");
+    XCTAssertEqualObjects(fileMessage.fileMessageData.filename.pathExtension, @"mp4");
+
+    NSError *error = nil;
+    NSUInteger size = [NSFileManager.defaultManager attributesOfItemAtPath:fileURL.path error:&error].fileSize;
+
+    XCTAssertNil(error);
+    XCTAssertEqual(fileMessage.fileMessageData.size, size);
+}
+
+- (void)testThatItDoesNotSendAFileWhenTheOriginalRequestFails_WithVideo_V3
+{
+    //given
+    self.registeredOnThisDevice = YES;
+    XCTAssertTrue([self logInAndWaitForSyncToBeComplete]);
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    ZMConversation *conversation = [self conversationForMockConversation:self.selfToUser1Conversation];
+    XCTAssertNotNil(conversation);
+    XCTAssertEqual(conversation.messages.count, 1lu);
+
+    NSURL *fileURL = self.testVideoFileURL;
+    NSString *expectedMessageAddPath = [NSString stringWithFormat:@"/conversations/%@/otr/messages", conversation.remoteIdentifier.transportString];
+
+    self.mockTransportSession.responseGeneratorBlock = ^ZMTransportResponse *(ZMTransportRequest *request) {
+        if ([request.path isEqualToString:expectedMessageAddPath]) {
+            return [ZMTransportResponse responseWithPayload:nil HTTPStatus:401 transportSessionError:nil];
+        }
+        return nil;
+    };
+
+    // when
+    [self.mockTransportSession resetReceivedRequests];
+
+    __block ZMMessage *fileMessage;
+    [self.userSession performChanges:^{
+        ZMVideoMetadata *metadata = [[ZMVideoMetadata alloc] initWithFileURL:fileURL thumbnail:self.mediumJPEGData];
+        fileMessage = (id)[conversation appendMessageWithFileMetadata:metadata version3:YES];
+    }];
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    //then
+    XCTAssertEqual(fileMessage.deliveryState, ZMDeliveryStateFailedToSend);
+    XCTAssertEqual(fileMessage.fileMessageData.transferState, ZMFileTransferStateFailedUpload);
+
+    NSArray <ZMTransportRequest *> *requests = [self filterOutRequestsForLastRead:self.mockTransportSession.receivedRequests];
+    XCTAssertEqual(requests.count, 1lu); // Asset.Original
+    XCTAssertEqualObjects(requests.firstObject.path, expectedMessageAddPath);
+}
+
+- (void)testThatItDoesSendAFailedUploadMessageWhenTheThumbnailUploadFails_400_WithVideo_V3
+{
+    //given
+    self.registeredOnThisDevice = YES;
+    XCTAssertTrue([self logInAndWaitForSyncToBeComplete]);
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    ZMConversation *conversation = [self conversationForMockConversation:self.selfToUser1Conversation];
+    XCTAssertNotNil(conversation);
+    XCTAssertEqual(conversation.messages.count, 1lu);
+
+    [self prefetchRemoteClientByInsertingMessageInConversation:self.selfToUser1Conversation];
+    NSUInteger initialMessageCount = conversation.messages.count;
+
+    NSURL *fileURL = self.testVideoFileURL;
+    NSString *transportString = conversation.remoteIdentifier.transportString;
+    NSString *expectedMessageAddPath = [NSString stringWithFormat:@"/conversations/%@/otr/messages", transportString];
+    NSString *expectedAssetAddPath = @"/assets/v3";
+
+    self.mockTransportSession.responseGeneratorBlock = ^ZMTransportResponse *(ZMTransportRequest *request) {
+        if ([request.path isEqualToString:expectedAssetAddPath]) {
+            return [ZMTransportResponse responseWithPayload:nil HTTPStatus:401 transportSessionError:nil];
+        }
+        return nil;
+    };
+
+    // when
+    [self.mockTransportSession resetReceivedRequests];
+
+    __block ZMMessage *fileMessage;
+    [self.userSession performChanges:^{
+        ZMVideoMetadata *metadata = [[ZMVideoMetadata alloc] initWithFileURL:fileURL thumbnail:self.mediumJPEGData];
+        fileMessage = (id)[conversation appendMessageWithFileMetadata:metadata version3:YES];
+    }];
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    //then
+    XCTAssertEqual(fileMessage.deliveryState, ZMDeliveryStateFailedToSend);
+    XCTAssertEqual(fileMessage.fileMessageData.transferState, ZMFileTransferStateFailedUpload);
+
+    NSArray <ZMTransportRequest *> *requests = [self filterOutRequestsForLastRead:self.mockTransportSession.receivedRequests];
+    XCTAssertEqual(requests.count, 3lu);
+    XCTAssertEqualObjects(requests[0].path, expectedMessageAddPath);  // Asset.Original
+    XCTAssertEqualObjects(requests[1].path, expectedAssetAddPath);    // Asset.Preview Asset upload (v3)
+    XCTAssertEqualObjects(requests[2].path, expectedMessageAddPath);  // Asset.NotUploaded
+
+    XCTAssertEqual(conversation.messages.count - initialMessageCount, 1lu);
+
+    ZMMessage *message = conversation.messages.lastObject;
+    XCTAssertNotNil(message.fileMessageData);
+    XCTAssertNil(message.imageMessageData);
+}
+
+- (void)testThatItDoesSendAFailedUploadMessageWhenTheFullAssetUploadFails_400_WithVideo_V3
+{
+    //given
+    self.registeredOnThisDevice = YES;
+    XCTAssertTrue([self logInAndWaitForSyncToBeComplete]);
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    ZMConversation *conversation = [self conversationForMockConversation:self.selfToUser1Conversation];
+    XCTAssertNotNil(conversation);
+    XCTAssertEqual(conversation.messages.count, 1lu);
+
+    [self prefetchRemoteClientByInsertingMessageInConversation:self.selfToUser1Conversation];
+    NSUInteger initialMessageCount = conversation.messages.count;
+
+    NSURL *fileURL = self.testVideoFileURL;
+    NSString *expectedMessageAddPath = [NSString stringWithFormat:@"/conversations/%@/otr/messages", conversation.remoteIdentifier.transportString];
+    NSString *expectedAssetAddPath = @"/assets/v3";
+
+    __block NSUInteger assetCallCount = 0;
+    self.mockTransportSession.responseGeneratorBlock = ^ZMTransportResponse *(ZMTransportRequest *request) {
+        if ([request.path isEqualToString:expectedAssetAddPath]) {
+            if (++assetCallCount == 2) {
+                return [ZMTransportResponse responseWithPayload:nil HTTPStatus:401 transportSessionError:nil];
+            }
+        }
+        return nil;
+    };
+
+    // when
+    [self.mockTransportSession resetReceivedRequests];
+
+    __block ZMMessage *fileMessage;
+    [self.userSession performChanges:^{
+        ZMVideoMetadata *metadata = [[ZMVideoMetadata alloc] initWithFileURL:fileURL thumbnail:self.mediumJPEGData];
+        fileMessage = (id)[conversation appendMessageWithFileMetadata:metadata version3:YES];
+    }];
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    //then
+    XCTAssertEqual(assetCallCount, 2lu);
+    XCTAssertEqual(fileMessage.deliveryState, ZMDeliveryStateFailedToSend);
+    XCTAssertEqual(fileMessage.fileMessageData.transferState, ZMFileTransferStateFailedUpload);
+
+    NSArray <ZMTransportRequest *> *requests = [self filterOutRequestsForLastRead:self.mockTransportSession.receivedRequests];
+    XCTAssertEqual(requests.count, 5lu);
+    XCTAssertEqualObjects(requests[0].path, expectedMessageAddPath);  // Asset.Original    generic message
+    XCTAssertEqualObjects(requests[1].path, expectedAssetAddPath);    // Asset.Preview     asset upload
+    XCTAssertEqualObjects(requests[2].path, expectedMessageAddPath);  // Asset.Preview     generic message
+    XCTAssertEqualObjects(requests[3].path, expectedAssetAddPath);    // Asset.FullAsset   asset upload
+    XCTAssertEqualObjects(requests[4].path, expectedMessageAddPath);  // Asset.NotUploaded generic message
+
+    XCTAssertEqual(conversation.messages.count - initialMessageCount, 1lu);
+
+    ZMMessage *message = conversation.messages.lastObject;
+    XCTAssertNotNil(message.fileMessageData);
+    XCTAssertNil(message.imageMessageData);
+}
+
+- (void)testThatItDoesSendAFailedUploadMessageWhenTheThumbnailUploadFails_NetworkError_WithVideo_V3
+{
+    //given
+    self.registeredOnThisDevice = YES;
+    XCTAssertTrue([self logInAndWaitForSyncToBeComplete]);
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    ZMConversation *conversation = [self conversationForMockConversation:self.selfToUser1Conversation];
+    XCTAssertNotNil(conversation);
+    XCTAssertEqual(conversation.messages.count, 1lu);
+
+    [self prefetchRemoteClientByInsertingMessageInConversation:self.selfToUser1Conversation];
+    NSUInteger initialMessageCount = conversation.messages.count;
+
+    NSURL *fileURL = self.testVideoFileURL;
+    NSString *expectedMessageAddPath = [NSString stringWithFormat:@"/conversations/%@/otr/messages", conversation.remoteIdentifier.transportString];
+    NSString *expectedAssetAddPath = @"/assets/v3";
+    NSError *error = [NSError errorWithDomain:ZMTransportSessionErrorDomain code:ZMTransportSessionErrorCodeTryAgainLater userInfo:nil];
+    self.mockTransportSession.responseGeneratorBlock = ^ZMTransportResponse *(ZMTransportRequest *request) {
+        if ([request.path isEqualToString:expectedAssetAddPath]) {
+            return [ZMTransportResponse responseWithPayload:nil HTTPStatus:0 transportSessionError:error];
+        }
+        return nil;
+    };
+
+    // when
+    [self.mockTransportSession resetReceivedRequests];
+
+    __block ZMMessage *fileMessage;
+    [self.userSession performChanges:^{
+        ZMVideoMetadata *metadata = [[ZMVideoMetadata alloc] initWithFileURL:fileURL thumbnail:self.mediumJPEGData];
+        fileMessage = (id)[conversation appendMessageWithFileMetadata:metadata version3:YES];
+    }];
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    //then
+    XCTAssertEqual(fileMessage.deliveryState, ZMDeliveryStateFailedToSend);
+    XCTAssertEqual(fileMessage.fileMessageData.transferState, ZMFileTransferStateFailedUpload);
+
+    NSArray <ZMTransportRequest *> *requests = [self filterOutRequestsForLastRead:self.mockTransportSession.receivedRequests];
+    XCTAssertEqual(requests.count, 3lu);
+    XCTAssertEqualObjects(requests[0].path, expectedMessageAddPath);  // Asset.Original    generic message
+    XCTAssertEqualObjects(requests[1].path, expectedAssetAddPath);    // Asset.Preview     asset upload
+    XCTAssertEqualObjects(requests[2].path, expectedMessageAddPath);  // Asset.NotUploaded generic message
+
+    XCTAssertEqual(conversation.messages.count - initialMessageCount, 1lu);
+
+    ZMMessage *message = conversation.messages.lastObject;
+    XCTAssertNotNil(message.fileMessageData);
+    XCTAssertNil(message.imageMessageData);
+}
+
+- (void)testThatItDoesSendAFailedUploadMessageWhenTheFileDataUploadFails_NetworkError_WithVideo_V3
+{
+    //given
+    self.registeredOnThisDevice = YES;
+    XCTAssertTrue([self logInAndWaitForSyncToBeComplete]);
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    ZMConversation *conversation = [self conversationForMockConversation:self.selfToUser1Conversation];
+    XCTAssertNotNil(conversation);
+    XCTAssertEqual(conversation.messages.count, 1lu);
+
+    [self prefetchRemoteClientByInsertingMessageInConversation:self.selfToUser1Conversation];
+    NSUInteger initialMessageCount = conversation.messages.count;
+
+    NSURL *fileURL = self.testVideoFileURL;
+    NSString *expectedMessageAddPath = [NSString stringWithFormat:@"/conversations/%@/otr/messages", conversation.remoteIdentifier.transportString];
+    NSString *expectedAssetAddPath = @"/assets/v3";
+    __block NSUInteger assetCallCount = 0;
+    NSError *error = [NSError errorWithDomain:ZMTransportSessionErrorDomain code:ZMTransportSessionErrorCodeTryAgainLater userInfo:nil];
+    self.mockTransportSession.responseGeneratorBlock = ^ZMTransportResponse *(ZMTransportRequest *request) {
+        if ([request.path isEqualToString:expectedAssetAddPath]) {
+            if (++assetCallCount == 2) {
+                return [ZMTransportResponse responseWithPayload:nil HTTPStatus:0 transportSessionError:error];
+            }
+        }
+        return nil;
+    };
+
+    // when
+    [self.mockTransportSession resetReceivedRequests];
+
+    __block ZMMessage *fileMessage;
+    [self.userSession performChanges:^{
+        ZMVideoMetadata *metadata = [[ZMVideoMetadata alloc] initWithFileURL:fileURL thumbnail:self.mediumJPEGData];
+        fileMessage = (id)[conversation appendMessageWithFileMetadata:metadata version3:YES];
+    }];
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    //then
+    XCTAssertEqual(assetCallCount, 2lu);
+    XCTAssertEqual(fileMessage.deliveryState, ZMDeliveryStateFailedToSend);
+    XCTAssertEqual(fileMessage.fileMessageData.transferState, ZMFileTransferStateFailedUpload);
+
+    NSArray <ZMTransportRequest *> *requests = [self filterOutRequestsForLastRead:self.mockTransportSession.receivedRequests];
+    XCTAssertEqual(requests.count, 5lu);
+    XCTAssertEqualObjects(requests[0].path, expectedMessageAddPath);  // Asset.Original    generic message
+    XCTAssertEqualObjects(requests[1].path, expectedAssetAddPath);    // Asset.Preview     asset upload
+    XCTAssertEqualObjects(requests[2].path, expectedMessageAddPath);  // Asset.Preview     generic message
+    XCTAssertEqualObjects(requests[3].path, expectedAssetAddPath);    // Asset.FullAsset   asset upload
+    XCTAssertEqualObjects(requests[4].path, expectedMessageAddPath);  // Asset.NotUploaded generic message
+
+    XCTAssertEqual(conversation.messages.count - initialMessageCount, 1lu);
+
+    ZMMessage *message = conversation.messages.lastObject;
+    XCTAssertNotNil(message.fileMessageData);
+    XCTAssertNil(message.imageMessageData);
+}
+
+- (void)testThatItDoesSendACancelledUploadMessageWhenTheThumbnailDataUploadIsCancelled_WithVideo_V3
+{
+    //given
+    self.registeredOnThisDevice = YES;
+    XCTAssertTrue([self logInAndWaitForSyncToBeComplete]);
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    ZMConversation *conversation = [self conversationForMockConversation:self.selfToUser1Conversation];
+    XCTAssertNotNil(conversation);
+    XCTAssertEqual(conversation.messages.count, 1lu);
+
+    [self prefetchRemoteClientByInsertingMessageInConversation:self.selfToUser1Conversation];
+    NSUInteger initialMessageCount = conversation.messages.count;
+
+    NSURL *fileURL = self.testVideoFileURL;
+    NSString *expectedMessageAddPath = [NSString stringWithFormat:@"/conversations/%@/otr/messages", conversation.remoteIdentifier.transportString];
+    NSString *expectedAssetAddPath = @"/assets/v3";
+
+    __block ZMMessage *fileMessage;
+
+    self.mockTransportSession.responseGeneratorBlock = ^ZMTransportResponse *(ZMTransportRequest *request) {
+        if ([request.path isEqualToString:expectedAssetAddPath]) {
+            return ResponseGenerator.ResponseNotCompleted;
+        }
+        return nil;
+    };
+
+    // when
+    [self.mockTransportSession resetReceivedRequests];
+
+    [self.userSession performChanges:^{
+        ZMVideoMetadata *metadata = [[ZMVideoMetadata alloc] initWithFileURL:fileURL thumbnail:self.mediumJPEGData];
+        fileMessage = (id)[conversation appendMessageWithFileMetadata:metadata version3:YES];
+    }];
+    WaitForEverythingToBeDone();
+
+    [self.userSession performChanges:^{
+        [fileMessage.fileMessageData cancelTransfer];
+    }];
+    WaitForEverythingToBeDone();
+
+    //then
+    XCTAssertEqual(fileMessage.deliveryState, ZMDeliveryStateFailedToSend);
+    XCTAssertEqual(fileMessage.fileMessageData.transferState, ZMFileTransferStateCancelledUpload);
+
+    NSArray <ZMTransportRequest *> *requests = [self filterOutRequestsForLastRead:self.mockTransportSession.receivedRequests];
+    XCTAssertEqual(requests.count, 3lu);
+    XCTAssertEqualObjects(requests[0].path, expectedMessageAddPath);  // Asset.Original
+    XCTAssertEqualObjects(requests[1].path, expectedAssetAddPath);    // Asset.Preview upload
+    XCTAssertEqualObjects(requests[2].path, expectedMessageAddPath);  // Asset.NotUploaded
+
+    XCTAssertEqual(conversation.messages.count - initialMessageCount, 1lu);
+
+    ZMMessage *message = conversation.messages.lastObject;
+    XCTAssertNotNil(message.fileMessageData);
+    XCTAssertNil(message.imageMessageData);
+
+    XCTAssertEqualObjects(message.fileMessageData.filename.stringByDeletingPathExtension, @"video");
+    XCTAssertEqualObjects(message.fileMessageData.filename.pathExtension, @"mp4");
+
+    NSError *error = nil;
+    NSUInteger size = [NSFileManager.defaultManager attributesOfItemAtPath:fileURL.path error:&error].fileSize;
+
+    XCTAssertNil(error);
+    XCTAssertEqual(message.fileMessageData.size, size);
+}
+
+- (void)testThatItDoesSendACancelledUploadMessageWhenTheFileDataUploadIsCancelled_WithVideo_V3
+{
+    //given
+    self.registeredOnThisDevice = YES;
+    XCTAssertTrue([self logInAndWaitForSyncToBeComplete]);
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    ZMConversation *conversation = [self conversationForMockConversation:self.selfToUser1Conversation];
+    XCTAssertNotNil(conversation);
+    XCTAssertEqual(conversation.messages.count, 1lu);
+
+    [self prefetchRemoteClientByInsertingMessageInConversation:self.selfToUser1Conversation];
+
+    NSUInteger initialMessageCount = conversation.messages.count;
+    NSURL *fileURL = self.testVideoFileURL;
+    NSString *expectedMessageAddPath = [NSString stringWithFormat:@"/conversations/%@/otr/messages", conversation.remoteIdentifier.transportString];
+    NSString *expectedAssetAddPath = @"/assets/v3";
+
+    __block ZMMessage *fileMessage;
+    __block NSUInteger assetCallCount = 0;
+    self.mockTransportSession.responseGeneratorBlock = ^ZMTransportResponse *(ZMTransportRequest *request) {
+        if ([request.path isEqualToString:expectedAssetAddPath]) {
+            if (++assetCallCount == 2) {
+                return ResponseGenerator.ResponseNotCompleted;
+            }
+        }
+        return nil;
+    };
+
+    // when
+    [self.mockTransportSession resetReceivedRequests];
+
+    [self.userSession performChanges:^{
+        ZMVideoMetadata *metadata = [[ZMVideoMetadata alloc] initWithFileURL:fileURL thumbnail:self.mediumJPEGData];
+        fileMessage = (id)[conversation appendMessageWithFileMetadata:metadata version3:YES];
+    }];
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    [self.userSession performChanges:^{
+        [fileMessage.fileMessageData cancelTransfer];
+    }];
+    WaitForAllGroupsToBeEmpty(5);
+
+    //then
+    XCTAssertEqual(assetCallCount, 2lu);
+    XCTAssertEqual(fileMessage.deliveryState, ZMDeliveryStateFailedToSend);
+    XCTAssertEqual(fileMessage.fileMessageData.transferState, ZMFileTransferStateCancelledUpload);
+
+    NSArray <ZMTransportRequest *> *requests = [self filterOutRequestsForLastRead:self.mockTransportSession.receivedRequests];
+    XCTAssertEqual(requests.count, 5lu);
+    XCTAssertEqualObjects(requests[0].path, expectedMessageAddPath);  // Asset.Original     generic message
+    XCTAssertEqualObjects(requests[1].path, expectedAssetAddPath);    // Asset.Preview      upload (v3)
+    XCTAssertEqualObjects(requests[2].path, expectedMessageAddPath);  // Asset.Preview      generic message
+    XCTAssertEqualObjects(requests[3].path, expectedAssetAddPath);    // Asset.Uploaded     upload (v3)
+    XCTAssertEqualObjects(requests[4].path, expectedMessageAddPath);  // Asset.NotUploaded  generic message
+
+    XCTAssertEqual(conversation.messages.count - initialMessageCount, 1lu);
+
+    ZMMessage *message = conversation.messages.lastObject;
+    XCTAssertNotNil(message.fileMessageData);
+    XCTAssertNil(message.imageMessageData);
+
+    XCTAssertEqualObjects(message.fileMessageData.filename.stringByDeletingPathExtension, @"video");
+    XCTAssertEqualObjects(message.fileMessageData.filename.pathExtension, @"mp4");
+
+    NSError *error = nil;
+    NSUInteger size = [NSFileManager.defaultManager attributesOfItemAtPath:fileURL.path error:&error].fileSize;
+
+    XCTAssertNil(error);
+    XCTAssertEqual(message.fileMessageData.size, size);
+}
+
+- (void)testThatItDoesNotSendACancelledUploadMessageWhenThePlaceholderUploadFails_WithVideo_V3
+{
+    //given
+    self.registeredOnThisDevice = YES;
+    XCTAssertTrue([self logInAndWaitForSyncToBeComplete]);
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    ZMConversation *conversation = [self conversationForMockConversation:self.selfToUser1Conversation];
+    XCTAssertNotNil(conversation);
+    XCTAssertEqual(conversation.messages.count, 1lu);
+
+    NSURL *fileURL = self.testVideoFileURL;
+    NSString *expectedMessageAddPath = [NSString stringWithFormat:@"/conversations/%@/otr/messages", conversation.remoteIdentifier.transportString];
+
+    __block ZMMessage *fileMessage;
+
+    self.mockTransportSession.responseGeneratorBlock = ^ZMTransportResponse *(ZMTransportRequest *request) {
+        if ([request.path isEqualToString:expectedMessageAddPath]) {
+            return [ZMTransportResponse responseWithPayload:nil HTTPStatus:401 transportSessionError:nil];
+        }
+        return nil;
+    };
+
+    // when
+    [self.mockTransportSession resetReceivedRequests];
+
+    [self.userSession performChanges:^{
+        ZMVideoMetadata *metadata = [[ZMVideoMetadata alloc] initWithFileURL:fileURL thumbnail:self.mediumJPEGData];
+        fileMessage = (id)[conversation appendMessageWithFileMetadata:metadata version3:YES];
+    }];
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    //then
+    XCTAssertEqual(fileMessage.deliveryState, ZMDeliveryStateFailedToSend);
+    XCTAssertEqual(fileMessage.fileMessageData.transferState, ZMFileTransferStateFailedUpload);
+
+    NSArray <ZMTransportRequest *> *requests = [self filterOutRequestsForLastRead:self.mockTransportSession.receivedRequests];
+    XCTAssertEqual(requests.count, 1lu); // Asset.Original
+    XCTAssertEqualObjects(requests[0].path, expectedMessageAddPath);
+
+    XCTAssertEqual(conversation.messages.count, 2lu);
+    ZMMessage *message = conversation.messages.lastObject;
+    XCTAssertNotNil(message.fileMessageData);
+    XCTAssertNil(message.imageMessageData);
+}
+
+- (void)testThatItDoesReuploadTheAssetMetadataAfterReceivingA_412_MissingClients_WithVideo_V3
+{
+    //given
+    self.registeredOnThisDevice = YES;
+    XCTAssertTrue([self logInAndWaitForSyncToBeComplete]);
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    ZMConversation *conversation = [self conversationForMockConversation:self.selfToUser1Conversation];
+    XCTAssertEqual(conversation.messages.count, 1lu);
+
+    NSURL *fileURL = self.testVideoFileURL;
+    NSString *conversationIDString = conversation.remoteIdentifier.transportString;
+    NSString *expectedMessageAddPath = [NSString stringWithFormat:@"/conversations/%@/otr/messages", conversationIDString];
+
+    NSString *expectedAssetAddPath = @"/assets/v3";
+
+    // when
+    // register other users client
+    __unused EncryptionContext *user1Box = [self setupOTREnvironmentForUser:self.user1
+                                                               isSelfClient:NO
+                                                               numberOfKeys:1
+                                               establishSessionWithSelfUser:NO];
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    __block ZMMessage *fileMessage;
+
+    [self.mockTransportSession resetReceivedRequests];
+    [self.userSession performChanges:^{
+        ZMVideoMetadata *metadata = [[ZMVideoMetadata alloc] initWithFileURL:fileURL thumbnail:self.mediumJPEGData];
+        fileMessage = (id)[conversation appendMessageWithFileMetadata:metadata version3:YES];
+    }];
+
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    //then
+    XCTAssertEqual(fileMessage.deliveryState, ZMDeliveryStateSent);
+    XCTAssertEqual(fileMessage.fileMessageData.transferState, ZMFileTransferStateDownloaded);
+
+    NSArray <ZMTransportRequest *> *requests = [self filterOutRequestsForLastRead:self.mockTransportSession.receivedRequests];
+
+    // Asset.Original, Prekeys, Asset.Original reuploading, Asset.Preview upload, generic message, Asset.Uploaded upload, generic message
+    XCTAssertEqual(requests.count, 7lu);
+    if (requests.count < 7) {
+        return;
+    }
+
+    ZMTransportRequest *firstOriginalUploadRequest = requests[0];
+    ZMTransportRequest *missingPrekeysRequest = requests[1];
+    ZMTransportRequest *secondOriginalUploadRequest = requests[2];
+    ZMTransportRequest *thumbnailUploadRequest = requests[3];
+    ZMTransportRequest *thumbnailGenericMessageRequest = requests[4];
+    ZMTransportRequest *fullAssetUploadRequest = requests[5];
+    ZMTransportRequest *fullAssetGenericMessageRequest = requests[6];
+
+    XCTAssertEqualObjects(firstOriginalUploadRequest.path, expectedMessageAddPath);
+    XCTAssertEqualObjects(secondOriginalUploadRequest.path, expectedMessageAddPath);
+    XCTAssertEqualObjects(missingPrekeysRequest.path, @"/users/prekeys");
+    XCTAssertEqualObjects(thumbnailUploadRequest.path, expectedAssetAddPath);
+    XCTAssertEqualObjects(thumbnailGenericMessageRequest.path, expectedMessageAddPath);
+    XCTAssertEqualObjects(fullAssetUploadRequest.path, expectedAssetAddPath);
+    XCTAssertEqualObjects(fullAssetGenericMessageRequest.path, expectedMessageAddPath);
+    XCTAssertEqual(conversation.messages.count, 2lu);
+
+    ZMMessage *message = conversation.messages.lastObject;
+    XCTAssertNotNil(message.fileMessageData);
+    XCTAssertNil(message.imageMessageData);
+}
+
+- (void)testThatItSendsARegularFileMessageForAFileWithVideoButNilThumbnail_V3
+{
+    //given
+    self.registeredOnThisDevice = YES;
+    XCTAssertTrue([self logInAndWaitForSyncToBeComplete]);
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    ZMConversation *conversation = [self conversationForMockConversation:self.selfToUser1Conversation];
+    XCTAssertNotNil(conversation);
+    XCTAssertEqual(conversation.messages.count, 1lu);
+
+    [self prefetchRemoteClientByInsertingMessageInConversation:self.selfToUser1Conversation];
+    NSUInteger initialMessageCount = conversation.messages.count;
+
+    NSURL *fileURL = self.testVideoFileURL; // Video URL
+    NSString *expectedMessageAddPath = [NSString stringWithFormat:@"/conversations/%@/otr/messages", conversation.remoteIdentifier.transportString];
+    NSString *expectedAssetAddPath = @"/assets/v3";
+
+    // when
+    [self.mockTransportSession resetReceivedRequests];
+
+    __block ZMMessage *fileMessage;
+    [self.userSession performChanges:^{
+        ZMVideoMetadata *metadata = [[ZMVideoMetadata alloc] initWithFileURL:fileURL thumbnail:nil]; // No thumbnail
+        fileMessage = (id)[conversation appendMessageWithFileMetadata:metadata version3:YES];
+    }];
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    // then
+    XCTAssertEqual(fileMessage.deliveryState, ZMDeliveryStateSent);
+    XCTAssertEqual(fileMessage.fileMessageData.transferState, ZMFileTransferStateDownloaded);
+
+    NSArray <ZMTransportRequest *> *requests = [self filterOutRequestsForLastRead:self.mockTransportSession.receivedRequests];
+    XCTAssertEqual(requests.count, 3lu); // Asset.Original & Asset.Uploaded asset upload & Asset.Uploaded generic message
+
+    ZMTransportRequest *originalMessageRequest = requests[0];
+    ZMTransportRequest *uploadAssetRequest = requests[1];
+    ZMTransportRequest *uploadMessageRequest = requests[2];
+
+    XCTAssertEqualObjects(originalMessageRequest.path, expectedMessageAddPath);
+    XCTAssertEqualObjects(uploadAssetRequest.path, expectedAssetAddPath);
+    XCTAssertEqualObjects(uploadMessageRequest.path, expectedMessageAddPath);
+    XCTAssertEqual(conversation.messages.count - initialMessageCount, 1lu);
+
+    ZMMessage *message = conversation.messages.lastObject;
+
+    XCTAssertNotNil(message.fileMessageData);
+    XCTAssertNil(message.imageMessageData);
+    XCTAssertEqualObjects(message.fileMessageData.filename.stringByDeletingPathExtension, @"video");
+    XCTAssertEqualObjects(message.fileMessageData.filename.pathExtension, @"mp4");
+
+    NSError *error = nil;
+    NSUInteger size = [NSFileManager.defaultManager attributesOfItemAtPath:fileURL.path error:&error].fileSize;
+
+    XCTAssertNil(error);
+    XCTAssertEqual(message.fileMessageData.size, size);
+}
+
+#pragma mark Downloading
+
+- (void)testThatItSendsTheRequestToDownloadAFileWhenItHasTheAssetID_AndSetsTheStateTo_Downloaded_AfterSuccesfullDecryption_V3
+{
+    // given
+    self.registeredOnThisDevice = YES;
+    XCTAssertTrue([self logInAndWaitForSyncToBeComplete]);
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    NSUUID *nonce = NSUUID.createUUID;
+    NSUUID *assetID = NSUUID.createUUID;
+    NSData *otrKey = NSData.randomEncryptionKey;
+
+    NSData *assetData = [NSData secureRandomDataOfLength:256];
+    NSData *encryptedAsset = [assetData zmEncryptPrefixingPlainTextIVWithKey:otrKey];
+    NSData *sha256 = encryptedAsset.zmSHA256Digest;
+
+    ZMGenericMessage *uploaded = [[ZMGenericMessage genericMessageWithUploadedOTRKey:otrKey sha256:sha256 messageID:nonce.transportString expiresAfter:nil] updatedUploadedWithAssetId:assetID.transportString token:nil];
+
+    // when
+    ZMAssetClientMessage *message = [self remotelyInsertAssetOriginalAndUpdate:uploaded insertBlock:
+                                     ^(__unused NSData *data, MockConversation *conversation, MockUserClient *from, MockUserClient *to) {
+                                         [conversation insertOTRMessageFromClient:from toClient:to data:data];
+                                     } nonce:nonce];
+    WaitForAllGroupsToBeEmpty(0.5);
+    __unused ZMConversation *conversation = [self conversationForMockConversation:self.selfToUser1Conversation];
+
+    // then
+    XCTAssertNotNil(message);
+    XCTAssertNil(message.assetId); // We do not store the asset ID in the DB for v3 assets
+    XCTAssertEqualObjects(message.nonce, nonce);
+    XCTAssertEqual(message.transferState, ZMFileTransferStateUploaded);
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    // when
+    // Mock the asset/v3 request
+    self.mockTransportSession.responseGeneratorBlock = ^ZMTransportResponse *(ZMTransportRequest *request) {
+        NSString *expectedPath = [NSString stringWithFormat:@"/assets/v3/%@", assetID.transportString];
+        if ([request.path isEqualToString:expectedPath]) {
+            return [[ZMTransportResponse alloc] initWithImageData:encryptedAsset HTTPStatus:200 transportSessionError:nil headers:nil];
+        }
+        return nil;
+    };
+
+    [self.userSession performChanges:^{
+        [message requestFileDownload];
+    }];
+
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    // then
+    ZMTransportRequest *lastRequest = self.mockTransportSession.receivedRequests.lastObject;
+    NSString *expectedPath = [NSString stringWithFormat:@"/assets/v3/%@", assetID.transportString];
+    XCTAssertEqualObjects(lastRequest.path, expectedPath);
+    XCTAssertEqual(message.transferState, ZMFileTransferStateDownloaded);
+}
+
+- (void)testThatItSendsTheRequestToDownloadAFileWhenItHasTheAssetID_AndSetsTheStateTo_FailedDownload_AfterFailedDecryption_V3
+{
+    // given
+    self.registeredOnThisDevice = YES;
+    XCTAssertTrue([self logInAndWaitForSyncToBeComplete]);
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    NSUUID *nonce = NSUUID.createUUID;
+    NSUUID *assetID = NSUUID.createUUID;
+    NSData *otrKey = NSData.randomEncryptionKey;
+
+    NSData *assetData = [NSData secureRandomDataOfLength:256];
+    NSData *encryptedAsset = [assetData zmEncryptPrefixingPlainTextIVWithKey:otrKey];
+    NSData *sha256 = encryptedAsset.zmSHA256Digest;
+
+    ZMGenericMessage *uploaded = [[ZMGenericMessage genericMessageWithUploadedOTRKey:otrKey sha256:sha256 messageID:nonce.transportString expiresAfter:nil] updatedUploadedWithAssetId:assetID.transportString token:nil];
+
+    // when
+    ZMAssetClientMessage *message = [self remotelyInsertAssetOriginalAndUpdate:uploaded insertBlock:
+                                     ^(__unused NSData *data, MockConversation *conversation, MockUserClient *from, MockUserClient *to) {
+                                         [conversation insertOTRMessageFromClient:from toClient:to data:data];
+                                     } nonce:nonce];
+    WaitForAllGroupsToBeEmpty(0.5);
+    __unused ZMConversation *conversation = [self conversationForMockConversation:self.selfToUser1Conversation];
+
+    // then
+    XCTAssertNotNil(message);
+    XCTAssertNil(message.assetId); // We do not store the asset ID in the DB for v3 assets
+    XCTAssertEqualObjects(message.nonce, nonce);
+    XCTAssertEqual(message.transferState, ZMFileTransferStateUploaded);
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    // when
+    // Mock the asset/v3 request
+    self.mockTransportSession.responseGeneratorBlock = ^ZMTransportResponse *(ZMTransportRequest *request) {
+        NSString *expectedPath = [NSString stringWithFormat:@"/assets/v3/%@", assetID.transportString];
+        if ([request.path isEqualToString:expectedPath]) {
+            NSData *wrongData = [NSData secureRandomDataOfLength:128];
+            return [[ZMTransportResponse alloc] initWithImageData:wrongData HTTPStatus:200 transportSessionError:nil headers:nil];
+        }
+        return nil;
+    };
+
+    [self.userSession performChanges:^{
+        [message requestFileDownload];
+    }];
+
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    // then
+    ZMTransportRequest *lastRequest = self.mockTransportSession.receivedRequests.lastObject;
+    NSString *expectedPath = [NSString stringWithFormat:@"/assets/v3/%@", assetID.transportString];
+    XCTAssertEqualObjects(lastRequest.path, expectedPath);
+    XCTAssertEqual(message.transferState, ZMFileTransferStateFailedDownload);
+}
 
 @end


### PR DESCRIPTION
# What's in this PR?

* This adds the required strategies added in https://github.com/wireapp/wire-ios-message-strategy/pull/19 to the strategies array.
* Add integration tests for asset sending using the `/assets/v3` endpoint.

### This PR is dependent on:
- [x] A new release of `wire-ios-data-model` after https://github.com/wireapp/wire-ios-data-model/pull/84 has been merged.
- [x] A new release of `wire-ios-message-strategy` after https://github.com/wireapp/wire-ios-message-strategy/pull/19 has been merged.