### PR TITLE
Move configureAudioSession to reportNewIncomingCallWithUUID when receiving a call

### DIFF
--- a/Source/Calling/ZMCallKitDelegate.m
+++ b/Source/Calling/ZMCallKitDelegate.m
@@ -490,6 +490,8 @@ NS_ASSUME_NONNULL_END
                                           if (nil != error) {
                                               [conversation.voiceChannel leave];
                                               [self logErrorForConversation:conversation.remoteIdentifier.transportString line:__LINE__ format:@"Cannot report incoming call: %@", error];
+                                          } else {
+                                              [self configureAudioSession];
                                           }
                                       }];
 }
@@ -759,8 +761,6 @@ NS_ASSUME_NONNULL_END
 - (void)provider:(CXProvider *)provider performAnswerCallAction:(CXAnswerCallAction *)action
 {
     [self.userSession performChanges:^{
-        [self configureAudioSession];
-
         ZMConversation *callConversation = [action conversationInContext:self.userSession.managedObjectContext];
         [self logInfoForConversation:callConversation.remoteIdentifier.transportString line:__LINE__ format:@"CXProvider %@ performAnswerCallAction", provider];
         if (callConversation.isVideoCall) {


### PR DESCRIPTION
Sometimes calls gets stuck in connecting when answering via Callkit on the lock screen. According to this thread on the apple forums it could be a race condition and they propose this change as a workaround.

https://forums.developer.apple.com/thread/60336

ticket: https://wearezeta.atlassian.net/browse/ZIOS-7624