### PR TITLE
Determine handle from the original request's url instead of the header

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
-github "wireapp/wire-ios-mocktransport" ~> 11.1
+github "wireapp/wire-ios-mocktransport" ~> 11.2
 github "wireapp/wire-ios-testing" ~> 8.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -12,7 +12,7 @@ github "wireapp/wire-ios-testing" "8.0.1"
 github "wireapp/wire-ios-transport" "15.0.0"
 github "wireapp/wire-ios-protos" "9.1.0"
 github "wireapp/wire-ios-data-model" "30.1.0"
-github "wireapp/wire-ios-mocktransport" "11.2.1"
+github "wireapp/wire-ios-mocktransport" "11.2.2"
 github "wireapp/wire-ios-request-strategy" "10.1.0"
 github "wireapp/wire-ios-message-strategy" "7.1.0"
 

--- a/Source/Synchronization/Strategies/UserProfileUpdateRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/UserProfileUpdateRequestStrategy.swift
@@ -187,7 +187,7 @@ extension UserProfileRequestStrategy : ZMSingleRequestTranscoder {
             }
             
         case self.handleCheckSync:
-            let handle = (response.headers?["Location"] as? NSString)?.lastPathComponent ?? ""
+            let handle = response.rawResponse?.url?.lastPathComponent ?? ""
             if response.result == .success {
                 self.userProfileUpdateStatus.didFetchHandle(handle: handle)
             } else {

--- a/Tests/Source/Synchronization/Transcoders/UserProfileUpdateRequestStrategyTests.swift
+++ b/Tests/Source/Synchronization/Transcoders/UserProfileUpdateRequestStrategyTests.swift
@@ -479,7 +479,7 @@ extension UserProfileUpdateRequestStrategyTests {
 extension UserProfileUpdateRequestStrategyTests {
     
     func errorResponse(path: String? = nil) -> ZMTransportResponse {
-        if let url = path.flatMap ({ URL(string: $0) }) {
+        if let url = path.flatMap(URL.init) {
             return ZMTransportResponse(originalUrl: url, httpStatus: 400, error: nil)
         }
 
@@ -521,7 +521,7 @@ extension UserProfileUpdateRequestStrategyTests {
     }
     
     func successResponse(path: String? = nil) -> ZMTransportResponse {
-        if let url = path.flatMap ({ URL(string: $0) }) {
+        if let url = path.flatMap(URL.init) {
             return ZMTransportResponse(originalUrl: url, httpStatus: 200, error: nil)
         }
         return ZMTransportResponse(
@@ -540,7 +540,8 @@ extension UserProfileUpdateRequestStrategyTests {
 extension ZMTransportResponse {
 
     convenience init(originalUrl: URL, httpStatus: Int, error: Error?) {
-        let httpResponse = HTTPURLResponse(url: originalUrl, statusCode: httpStatus, httpVersion: nil, headerFields: ["content-type": "json"])
+        let headers = ["Content-Type": "application/json"]
+        let httpResponse = HTTPURLResponse(url: originalUrl, statusCode: httpStatus, httpVersion: nil, headerFields: headers)
         self.init(httpurlResponse: httpResponse!, data: nil, error: error)
     }
 

--- a/Tests/Source/Synchronization/Transcoders/UserProfileUpdateRequestStrategyTests.swift
+++ b/Tests/Source/Synchronization/Transcoders/UserProfileUpdateRequestStrategyTests.swift
@@ -392,7 +392,7 @@ extension UserProfileUpdateRequestStrategyTests {
         
         // WHEN
         let request = self.sut.nextRequest()
-        request?.complete(with: self.successResponse(location: request?.path))
+        request?.complete(with: self.successResponse(path: request?.path))
         
         // THEN
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
@@ -407,7 +407,7 @@ extension UserProfileUpdateRequestStrategyTests {
         
         // WHEN
         let request = self.sut.nextRequest()
-        request?.complete(with: self.notFoundResponse(location: request?.path))
+        request?.complete(with: self.notFoundResponse(path: request!.path))
         
         // THEN
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
@@ -422,7 +422,7 @@ extension UserProfileUpdateRequestStrategyTests {
         
         // WHEN
         let request = self.sut.nextRequest()
-        request?.complete(with: self.errorResponse(location: request?.path))
+        request?.complete(with: self.errorResponse(path: request?.path))
         
         // THEN
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
@@ -478,11 +478,15 @@ extension UserProfileUpdateRequestStrategyTests {
 // MARK: - Helpers
 extension UserProfileUpdateRequestStrategyTests {
     
-    func errorResponse(location: String? = nil) -> ZMTransportResponse {
+    func errorResponse(path: String? = nil) -> ZMTransportResponse {
+        if let url = path.flatMap ({ URL(string: $0) }) {
+            return ZMTransportResponse(originalUrl: url, httpStatus: 400, error: nil)
+        }
+
         return ZMTransportResponse(payload: nil,
                                    httpStatus: 400,
                                    transportSessionError: nil,
-                                   headers: ["Location" : location ?? ""]
+                                   headers: nil
         )
     }
     
@@ -516,21 +520,30 @@ extension UserProfileUpdateRequestStrategyTests {
                                    transportSessionError: nil)
     }
     
-    func successResponse(location: String? = nil) -> ZMTransportResponse {
-        return ZMTransportResponse(payload: nil,
-                                   httpStatus: 200,
-                                   transportSessionError: nil,
-                                   headers: ["Location" : location ?? ""]
+    func successResponse(path: String? = nil) -> ZMTransportResponse {
+        if let url = path.flatMap ({ URL(string: $0) }) {
+            return ZMTransportResponse(originalUrl: url, httpStatus: 200, error: nil)
+        }
+        return ZMTransportResponse(
+            payload: nil,
+            httpStatus: 200,
+            transportSessionError: nil,
+            headers: nil
         )
     }
-    
-    func notFoundResponse(location: String? = nil) -> ZMTransportResponse {
-        return ZMTransportResponse(payload: nil,
-                                   httpStatus: 404,
-                                   transportSessionError: nil,
-                                   headers: ["Location" : location ?? ""]
-        )
+
+    func notFoundResponse(path: String) -> ZMTransportResponse {
+        return ZMTransportResponse(originalUrl: URL(string: path)!, httpStatus: 404, error: nil)
     }
+}
+
+extension ZMTransportResponse {
+
+    convenience init(originalUrl: URL, httpStatus: Int, error: Error?) {
+        let httpResponse = HTTPURLResponse(url: originalUrl, statusCode: httpStatus, httpVersion: nil, headerFields: ["content-type": "json"])
+        self.init(httpurlResponse: httpResponse!, data: nil, error: error)
+    }
+
 }
 
 class TestUserProfileUpdateStatus : UserProfileUpdateStatus {

--- a/Tests/Source/UserSession/Search/ZMSearchUserTests.m
+++ b/Tests/Source/UserSession/Search/ZMSearchUserTests.m
@@ -153,7 +153,7 @@
                                                            handle:@"foo"
                                                       accentColor:ZMAccentColorStrongLimeGreen
                                                          remoteID:[NSUUID createUUID]
-                                                             user:nil
+                                                             user:user
                                          syncManagedObjectContext:self.syncMOC
                                            uiManagedObjectContext:self.uiMOC];
 


### PR DESCRIPTION
# What's in this PR?

* The `Location` header will not be set in the response we receive when checking handle availability. We thus need to determine the handle we checked the availability of using the url of the response's underlying `HTTPURLResponse`.
* Another way would have been to add a completion handler to the request and capture the handle, but this would clutter the `UserProfileUpdateRequestStrategy` and how the response parsing is done for the other update requests.

- [x] This PR depends on a new release of `wire-ios-mocktransport` after https://github.com/wireapp/wire-ios-mocktransport/pull/14 has been released.