### PR TITLE
Return first suggested handle when receiving 404 checking available handles

### DIFF
--- a/Source/Synchronization/Strategies/UserProfileUpdateRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/UserProfileUpdateRequestStrategy.swift
@@ -225,6 +225,12 @@ extension UserProfileRequestStrategy : ZMSingleRequestTranscoder {
         case self.handleSuggestionSearchSync:
             if response.result == .success, let missingHandle = self.findMissingHandleInResponse(response: response) {
                 self.userProfileUpdateStatus.didFindHandleSuggestion(handle: missingHandle)
+            } else if response.httpStatus == 404 {
+                if let handle = self.userProfileUpdateStatus.suggestedHandlesToCheck?.first {
+                    self.userProfileUpdateStatus.didFindHandleSuggestion(handle: handle)
+                } else {
+                    self.userProfileUpdateStatus.didFailToFindHandleSuggestion()
+                }
             } else {
                 self.userProfileUpdateStatus.didFailToFindHandleSuggestion()
             }


### PR DESCRIPTION
# What's in this PR?

When bulk checking handle availabilities we were only acknowledging a 200 response as potentially available (parsing the response to check for which handles we did not receive a payload).
As the used endpoint is not a specific search endpoint but the usual endpoint to get user profiles we also need handle a 404 where all handles are available.
If none of the handles belongs to an existing user the endpoint returns a 404 NOT FOUND and we now use the first suggested handle.