### PR TITLE
The Missing OTR Folder Mystery

### DIFF
--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -180,6 +180,11 @@ ZM_EMPTY_ASSERTING_INIT()
     return nil;
 }
 
++ (NSURL *)keyStoreURLForAppGroupIdentifier:(NSString *)appGroupIdentifier
+{
+    return [self sharedContainerDirectoryForApplicationGroup:appGroupIdentifier];
+}
+
 + (NSURL *)storeURLForAppGroupIdentifier:(NSString *)appGroupIdentifier
 {
     return [[[self sharedContainerDirectoryForApplicationGroup:appGroupIdentifier]
@@ -227,7 +232,7 @@ ZM_EMPTY_ASSERTING_INIT()
     ZMAPNSEnvironment *apnsEnvironment = [[ZMAPNSEnvironment alloc] init];
     
     self.storeURL = [self.class storeURLForAppGroupIdentifier:appGroupIdentifier];
-    self.keyStoreURL = [self.storeURL URLByDeletingLastPathComponent];
+    self.keyStoreURL = [self.class keyStoreURLForAppGroupIdentifier:appGroupIdentifier];
     RequireString(nil != self.storeURL, "Unable to get a store URL using group identifier: %s", appGroupIdentifier.UTF8String);
     NSManagedObjectContext *userInterfaceContext = [NSManagedObjectContext createUserInterfaceContextWithStoreAtURL:self.storeURL];
     NSManagedObjectContext *syncMOC = [NSManagedObjectContext createSyncContextWithStoreAtURL:self.storeURL keyStoreURL:self.keyStoreURL];

--- a/Tests/Source/MessagingTest.m
+++ b/Tests/Source/MessagingTest.m
@@ -112,7 +112,7 @@
     
     NSURL *sharedContainerURL = [fm containerURLForSecurityApplicationGroupIdentifier:self.groupIdentifier];
     self.storeURL = [[sharedContainerURL URLByAppendingPathComponent:bundleIdentifier] URLByAppendingPathComponent:@"store.wiredatabase"];
-    self.keyStoreURL = [self.storeURL URLByDeletingLastPathComponent];
+    self.keyStoreURL = sharedContainerURL;
     
     _application = [[ApplicationMock alloc] init];
     


### PR DESCRIPTION
# Mystery

It was a sunny beautiful day, the chilly second one of Berlin winter. @mikeger was rushing to the office: he was thinking about by the fresh and soft croissant that was waiting for him.

As he walked up the stairs, he noticed that something is not quite right that day. Everyone seemed to be worried; no one was enjoying the croissants and looked onto the screens of their mobile phones; it was perfectly clear that something happened.

-- Look! I also got that message! Did someone replaced your key information. I see the message "Identity changed" in your conversation!

Could that really be that someone was trying to break Wire's encryption for everyone in the office? No, there is no time for croissants now, we need to solve that mystery immediately!


# Issue report

It comes out that we merged the changes that did not took in account the old folder structure in "Library" folder. The files used to reside in the following structure:

```
- /Library:
    - otr
        - <necessary key and session information>
    - com.wearezeta.zclient-alpha
        - store.wiredatabase
```

Now for some reason otr folder moved to `com.wearezeta.zclient-alpha`:

```
- /Library:
    - com.wearezeta.zclient-alpha
        - store.wiredatabase
        - otr
            - <necessary key and session information>

```

# Solution

Put the folder back. This should make the old identity be used again, so the client would be repaired.
