### PR TITLE
Strip initial @-symbol from the search query

### DIFF
--- a/Source/UserSession/Search/Internal/ZMSearchRequestCodec.m
+++ b/Source/UserSession/Search/Internal/ZMSearchRequestCodec.m
@@ -36,7 +36,11 @@ static NSString * const ZMSuggestedSearchEndPoint = @"/search/suggestions";
 + (ZMTransportRequest *)searchRequestForQueryString:(NSString *)queryString levels:(int)levels fetchLimit:(int)fetchLimit;
 {
     VerifyAction(queryString != nil, queryString = @"");
-
+    
+    if ([queryString hasPrefix:@"@"]) {
+        queryString = [queryString substringFromIndex:1];
+    }
+    
     NSMutableCharacterSet *set = [[NSCharacterSet URLQueryAllowedCharacterSet] mutableCopy];
     [set removeCharactersInString:@"=&+"];
     NSString *urlEncodedQuery = [queryString stringByAddingPercentEncodingWithAllowedCharacters:set];

--- a/Tests/Source/UserSession/Search/ZMSearchRequestCodecTests.m
+++ b/Tests/Source/UserSession/Search/ZMSearchRequestCodecTests.m
@@ -100,6 +100,30 @@
     XCTAssertEqualObjects(request.path, @"/search/contacts?q=search%20me&l=1&size=9");
 }
 
+- (void)testThatItRemovesInitialAtSymbol
+{
+    // given
+    NSString *queryString = @"@foo";
+    
+    // when
+    ZMTransportRequest *request = [ZMSearchRequestCodec searchRequestForQueryString:queryString levels:1 fetchLimit:9];
+    
+    // then
+    XCTAssertEqualObjects(request.path, @"/search/contacts?q=foo&l=1&size=9");
+}
+
+- (void)testThatItDoesNotRemovesNonInitialAtSymbol
+{
+    // given
+    NSString *queryString = @"boo@foo";
+    
+    // when
+    ZMTransportRequest *request = [ZMSearchRequestCodec searchRequestForQueryString:queryString levels:1 fetchLimit:9];
+    
+    // then
+    XCTAssertEqualObjects(request.path, @"/search/contacts?q=boo@foo&l=1&size=9");
+}
+
 - (void)testThatItAddsConnectedUsersToSearchResults_UsersInContact
 {
     XCTAssertTrue([self logInAndWaitForSyncToBeComplete]);


### PR DESCRIPTION
# Reason for this pull request
This will allow us to search by username on the backend, where usernames have no @ 