### PR TITLE
Set absolute string instead of non plist url in persistent store metadata

### DIFF
--- a/Source/UserSession/Search/TopConversationsDirectory.swift
+++ b/Source/UserSession/Search/TopConversationsDirectory.swift
@@ -63,17 +63,17 @@ extension TopConversationsDirectory {
     
     /// Persist list of conversations to persistent store
     private func persistList() {
-        let valueToSave = self.topConversations.map { $0.objectID.uriRepresentation() }
+        let valueToSave = self.topConversations.map { $0.objectID.uriRepresentation().absoluteString }
         self.managedObjectContext.setPersistentStoreMetadata(valueToSave, forKey: topConversationsObjectIDKey)
         TopConversationsDirectoryNotification.post()
     }
 
     /// Load list from persistent store
     fileprivate func loadList() {
-        guard let ids = self.managedObjectContext.persistentStoreMetadata(forKey: topConversationsObjectIDKey) as? [URL] else {
+        guard let ids = self.managedObjectContext.persistentStoreMetadata(forKey: topConversationsObjectIDKey) as? [String] else {
             return
         }
-        let managedObjectIDs = ids.flatMap { self.managedObjectContext.persistentStoreCoordinator?.managedObjectID(forURIRepresentation: $0) }
+        let managedObjectIDs = ids.flatMap(URL.init).flatMap { self.managedObjectContext.persistentStoreCoordinator?.managedObjectID(forURIRepresentation: $0) }
         self.topConversationsCache = managedObjectIDs.flatMap { self.managedObjectContext.object(with: $0) as? ZMConversation }
     }
 }


### PR DESCRIPTION
# What's in this PR?

* We tried to set a `URL` instance as value in the persistent store metadata which not a valid plist type.