### PR TITLE
Create a user when receiving an AB match

### DIFF
--- a/Source/Synchronization/Strategies/AddressBookUploadRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/AddressBookUploadRequestStrategy.swift
@@ -177,9 +177,15 @@ extension AddressBookUploadRequestStrategy : RequestStrategy, ZMSingleRequestTra
         var missingIDs = Set(expectedContactIDs)
         cards.forEach {
             guard let userid = ($0["id"] as? String).flatMap({ UUID(uuidString: $0 )}),
-                let contactIds = $0["cards"] as? [String],
-                let user = idToUsers[userid]
+                let contactIds = $0["cards"] as? [String]
             else { return }
+            
+            let user : ZMUser = idToUsers[userid] ?? {
+                let newUser = ZMUser.insertNewObject(in: self.managedObjectContext)
+                newUser.remoteIdentifier = userid
+                newUser.needsToBeUpdatedFromBackend = true
+                return newUser
+            }()
 
             contactIds.forEach { contactId in
                 missingIDs.remove(contactId)


### PR DESCRIPTION
# Reason for this pull request
It an address book entry matches a result from the backend, we store the match only if we have a local user, otherwise we lose the information that this was a match.

# Changes
We create a local user every time there is a match, if such user did not exists