### PR TITLE
Fetch *some* contacts when searching the AB for an empty query

### DIFF
--- a/Source/Registration/AddressBook.swift
+++ b/Source/Registration/AddressBook.swift
@@ -131,6 +131,19 @@ extension AddressBookAccessor {
         
         return contacts
     }
+    
+    /// Returns the first X raw contacts from the address book
+    func firstRawContacts(number: Int) -> [ContactRecord] {
+        var contacts = Array<ContactRecord>()
+        contacts.reserveCapacity(number)
+        var count = 0
+        self.enumerateRawContacts { record in
+            contacts.append(record)
+            count += 1
+            return count < number
+        }
+        return contacts
+    }
 }
 
 /// Common base class between iOS 8 (AddressBook framework) and iOS 9+ (Contacts framework)
@@ -250,6 +263,9 @@ extension String {
 }
 
 // MARK: - Utilities
+
+let addressBookContactsSearchLimit = 2000
+
 extension String {
     
     /// Returns the base64 encoded string of the SHA hash of the string

--- a/Source/Registration/AddressBookIOS8.swift
+++ b/Source/Registration/AddressBookIOS8.swift
@@ -73,7 +73,7 @@ extension AddressBookIOS8 : AddressBookAccessor {
             guard !matchingQuery.isEmpty else {
                 return true
             }
-            return $0.displayName.lowercased().contains(matchingQuery)
+            return $0.displayName.range(of: matchingQuery, options: .caseInsensitive) != .none
         }
     }
 

--- a/Source/Registration/AddressBookIOS8.swift
+++ b/Source/Registration/AddressBookIOS8.swift
@@ -60,6 +60,7 @@ extension AddressBookIOS8 : CustomStringConvertible {
 // MARK: - Iterating contacts
 
 extension AddressBookIOS8 : AddressBookAccessor {
+    
     /// Gets a specific address book user by the local address book indentifier
     internal func contact(identifier: String) -> ContactRecord? {
         return nil
@@ -68,7 +69,12 @@ extension AddressBookIOS8 : AddressBookAccessor {
     
     /// Returns contacts matching search query
     func rawContacts(matchingQuery: String) -> [ContactRecord] {
-        return []
+        return self.firstRawContacts(number: addressBookContactsSearchLimit).filter {
+            guard !matchingQuery.isEmpty else {
+                return true
+            }
+            return $0.displayName.lowercased().contains(matchingQuery)
+        }
     }
 
     /// Enumerates the contacts, invoking the block for each contact.

--- a/Source/Registration/AddressBookIOS9.swift
+++ b/Source/Registration/AddressBookIOS9.swift
@@ -43,17 +43,21 @@ extension AddressBookIOS9 : AddressBookAccessor {
     }
     
     func rawContacts(matchingQuery query: String) -> [ContactRecord] {
-        if !AddressBook.accessGranted() {
+        guard AddressBook.accessGranted() else {
             return []
         }
+        
+        guard !query.isEmpty else {
+            return self.firstRawContacts(number: addressBookContactsSearchLimit)
+        }
+        
         let predicate: NSPredicate = CNContact.predicateForContacts(matchingName: query.lowercased())
         guard let foundContacts = try? CNContactStore().unifiedContacts(matching: predicate, keysToFetch: AddressBookIOS9.keysToFetch) else {
             return []
         }
         return foundContacts
     }
-
-
+    
     /// Enumerates the contacts, invoking the block for each contact.
     /// If the block returns false, it will stop enumerating them.
     internal func enumerateRawContacts(block: @escaping (ContactRecord) -> (Bool)) {


### PR DESCRIPTION
# Reason for this pull request
When searching with an empty query in the AB, we would get an empty result. We should have gotten the entire AB.

# Changes
Returns a part of the AB (max 2000 contacts)

# Testing
We don't yet have a system in place to test address book searches