### PR TITLE
Do not filtering out conversation with @ in name

### DIFF
--- a/Source/UserSession/Search/Internal/ZMSearch.m
+++ b/Source/UserSession/Search/Internal/ZMSearch.m
@@ -155,15 +155,17 @@
 
 - (NSArray *)conversationsMatchingSearchString:(NSString *)searchString
 {
-    if([searchString hasPrefix:@"@"]) { // ignore group conversations if query is for usernames
-        return @[];
-    }
     NSFetchRequest *conversationFetchRequest = [ZMConversation sortedFetchRequestWithPredicate:[ZMConversation predicateForSearchString:searchString]];
-    
     NSSortDescriptor *sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:ZMNormalizedUserDefinedNameKey ascending:YES];
     conversationFetchRequest.sortDescriptors = @[sortDescriptor];
     
     NSArray *conversationResults = [self.searchContext executeFetchRequestOrAssert:conversationFetchRequest];
+    if([searchString hasPrefix:@"@"]) { // ignore group conversations if query is for usernames
+        conversationResults = [conversationResults filterWithBlock:^BOOL(ZMConversation *conversation) {
+            return [conversation.displayName containsString:@"@"];
+        }];
+    }
+    
     NSArray *sortedConversations = [self sortedConversationResults:conversationResults forSearchString:searchString];
     
     return sortedConversations;

--- a/Tests/Source/UserSession/Search/ZMSearchDirectoryTests.m
+++ b/Tests/Source/UserSession/Search/ZMSearchDirectoryTests.m
@@ -758,19 +758,19 @@
     XCTAssertEqualObjects(result.groupConversations, expectedResult);
 }
 
-- (void)testThatItFindsNoConversationWhenTheQueryStartsWithAtSymbol
+- (void)testThatItFiltersConversationWhenTheQueryStartsWithAtSymbol
 {
     // given
     [self createGroupConversationWithName:@"New Day Rising"];
-    [self createGroupConversationWithName:@"@Candy Apple Records"];
-    [self createGroupConversationWithName:@"Landspeed @Records"];
+    ZMConversation* conversation = [self createGroupConversationWithName:@"@Candy Apple Records"]; // this should be included because it has a @
+    [self createGroupConversationWithName:@"Landspeed Records"];
     
     // when
     ZMSearchToken token = [self.sut searchForUsersAndConversationsMatchingQueryString:@"@records"];
     [self waitForSearchResultsWithFailureRecorder:NewFailureRecorder() shouldFail:NO];
     
     // then
-    [self verifyThatResultWithToken:token containsConversations:@[] failureRecorder:NewFailureRecorder()];
+    [self verifyThatResultWithToken:token containsConversations:@[conversation] failureRecorder:NewFailureRecorder()];
 }
 
 @end


### PR DESCRIPTION
# Reason for this pull request
When filtering out conversation from a search result when the query was a username search (with starting with `@`), conversations that have `@` in the name should still be included

