### PR TITLE
Do not abort AB processing on invalid entry

### DIFF
--- a/Source/Registration/AddressBook.swift
+++ b/Source/Registration/AddressBook.swift
@@ -47,7 +47,7 @@ extension AddressBookAccessor {
     
     /// Enumerates the contacts, normalized and validated, invoking the block for each contact.
     /// Non valid contacts (no email nor phone) will be excluded from the enumeration.
-    /// If the block returns true, it will stop enumerating them.
+    /// If the block returns false, it will stop enumerating them.
     func enumerateValidContacts(block: @escaping (ZMAddressBookContact)->(Bool)) {
         self.enumerateRawContacts {
             guard let parsed = ZMAddressBookContact(contact: $0, phoneNumberNormalizer: self.phoneNumberNormalizer) else {

--- a/Source/Registration/AddressBook.swift
+++ b/Source/Registration/AddressBook.swift
@@ -51,7 +51,7 @@ extension AddressBookAccessor {
     func enumerateValidContacts(block: @escaping (ZMAddressBookContact)->(Bool)) {
         self.enumerateRawContacts {
             guard let parsed = ZMAddressBookContact(contact: $0, phoneNumberNormalizer: self.phoneNumberNormalizer) else {
-                return false
+                return true
             }
             return block(parsed)
         }


### PR DESCRIPTION
# Reason for this pull request
The AB iteration was aborting in case of invalid entry (no valid email or password). It should continue to the next contact instead.