### PR TITLE
Fix failing file transfer tests after changes in cache location

### DIFF
--- a/Tests/Source/Integration/FileTransferTests.m
+++ b/Tests/Source/Integration/FileTransferTests.m
@@ -3633,11 +3633,14 @@
         return nil;
     };
 
-    [self.userSession performChanges:^{
-        [message requestFileDownload];
-    }];
+    // We log an error when we fail to decrypt the received data
+    [self performIgnoringZMLogError:^{
+        [self.userSession performChanges:^{
+            [message requestFileDownload];
+        }];
 
-    WaitForAllGroupsToBeEmpty(0.5);
+        WaitForAllGroupsToBeEmpty(0.5);
+    }];
 
     // then
     ZMTransportRequest *lastRequest = self.mockTransportSession.receivedRequests.lastObject;

--- a/Tests/Source/Integration/FileTransferTests.m
+++ b/Tests/Source/Integration/FileTransferTests.m
@@ -1301,7 +1301,8 @@
     XCTAssertNotNil(message);
     XCTAssertNotNil(observer);
     XCTAssertNotNil(conversation);
-    
+
+    // when
     [self.userSession performChanges:^{
         [message requestImageDownload];
     }];
@@ -1489,6 +1490,7 @@
     WaitForAllGroupsToBeEmpty(0.5);
     
     // when
+    [self.mockTransportSession resetReceivedRequests];
     [self.userSession performChanges:^{
         [message requestFileDownload];
     }];
@@ -1499,6 +1501,7 @@
     ZMTransportRequest *lastRequest = self.mockTransportSession.receivedRequests.lastObject;
     NSString *expectedPath = [NSString stringWithFormat:@"/conversations/%@/otr/assets/%@", conversation.remoteIdentifier.transportString, message.assetId.transportString];
     XCTAssertEqualObjects(lastRequest.path, expectedPath);
+    XCTAssertEqualObjects(lastRequest.methodAsString, @"GET");
     XCTAssertEqual(message.transferState, ZMFileTransferStateDownloaded);
 }
 
@@ -3540,6 +3543,7 @@
     // given
     self.registeredOnThisDevice = YES;
     XCTAssertTrue([self logInAndWaitForSyncToBeComplete]);
+
     WaitForAllGroupsToBeEmpty(0.5);
 
     NSUUID *nonce = NSUUID.createUUID;
@@ -3577,6 +3581,8 @@
         return nil;
     };
 
+    // when we request the file download
+    [self.mockTransportSession resetReceivedRequests];
     [self.userSession performChanges:^{
         [message requestFileDownload];
     }];

--- a/Tests/Source/MessagingTest.m
+++ b/Tests/Source/MessagingTest.m
@@ -168,8 +168,17 @@
 
     [self resetState];
     [MessagingTest deleteAllFilesInCache];
+    [self removeCachesInSharedContainer];
     [super tearDown];
     Require([self waitForAllGroupsToBeEmptyWithTimeout:5]);
+}
+
+- (void)removeCachesInSharedContainer
+{
+    NSFileManager *fm = NSFileManager.defaultManager;
+    NSURL *sharedContainerURL = [fm containerURLForSecurityApplicationGroupIdentifier:self.groupIdentifier];
+    NSURL *cachesURL = [sharedContainerURL URLByAppendingPathComponent:@"Library/Caches"];
+    [fm removeItemAtURL:cachesURL error:nil];
 }
 
 - (void)resetState


### PR DESCRIPTION
# What's in this PR?

* The location of the caches was changed to be in the shared container, in our unit tests they are still located in the caches directory and only this one is cleared in `tearDown`. As the test host has the shared container entitlement the caches in integration tests are created in the shared container, but were never deleted in the `tearDown`.