### PR TITLE
Add hotfix marking all connected users to be updated from the backend

### DIFF
--- a/Source/Synchronization/ZMHotFixDirectory+Swift.swift
+++ b/Source/Synchronization/ZMHotFixDirectory+Swift.swift
@@ -59,8 +59,7 @@ extension ZMHotFixDirectory {
         context.enqueueDelayedSave()
     }
     
-    public static func insertNewConversationSystemMessage(_ context: NSManagedObjectContext)
-    {
+    public static func insertNewConversationSystemMessage(_ context: NSManagedObjectContext) {
         let fetchRequest = ZMConversation.sortedFetchRequest()
         guard let conversations = context.executeFetchRequestOrAssert(fetchRequest) as? [ZMConversation] else { return }
         
@@ -76,7 +75,7 @@ extension ZMHotFixDirectory {
         let filteredConversations =  conversations.filter{ $0.conversationType == .oneOnOne || $0.conversationType == .group }
         
         // update "you are using this device" message
-        filteredConversations.forEach{
+        filteredConversations.forEach {
             $0.replaceNewClientMessageIfNeededWithNewDeviceMesssage()
         }
     }
@@ -90,6 +89,17 @@ extension ZMHotFixDirectory {
             let cacheDirectory =  cachesDirectory.appendingPathComponent(PINCacheFolder, isDirectory: true)
             try? fileManager.removeItem(at: cacheDirectory)
         }
-    
+    }
+
+    /// We need to refetch all connected users as they might alreday have updated their username before we updated to
+    /// a version supporting them. Unconnected users are refreshed with a call to `refreshData` when information is displayed.
+    public static func refetchConnectedUsers(_ context: NSManagedObjectContext) {
+        let predicate = NSPredicate(format: "connection != nil")
+        let request = ZMUser.sortedFetchRequest(with: predicate)
+        let users = context.executeFetchRequestOrAssert(request) as? [ZMUser]
+
+        users?.lazy
+            .filter { $0.isConnected }
+            .forEach { $0.needsToBeUpdatedFromBackend = true }
     }
 }

--- a/Source/Synchronization/ZMHotFixDirectory.m
+++ b/Source/Synchronization/ZMHotFixDirectory.m
@@ -89,7 +89,12 @@ static NSString* ZMLogTag ZM_UNUSED = @"HotFix";
                      patchWithVersion:@"61.0.0"
                      patchCode:^(__unused NSManagedObjectContext *context) {
                         [ZMHotFixDirectory purgePINCachesInHostBundle];
-                    }]
+                    }],
+                    [ZMHotFixPatch
+                     patchWithVersion:@"62.0.0"
+                     patchCode:^(NSManagedObjectContext *context) {
+                         [ZMHotFixDirectory refetchConnectedUsers:context];
+                     }]
                     ]
                     ;
     });


### PR DESCRIPTION
# What's in this PR?

* Users updating from a non-username version might have missed the updates from users that previously set a username, which is why we now refetch all connected users in a hotfix.
* A refetch of unconnected users should already be initiated by the UI with a call to `refreshData`.