### PR TITLE
Mark self user as needing update from the backend in username hotfix

### DIFF
--- a/Source/Synchronization/ZMHotFixDirectory+Swift.swift
+++ b/Source/Synchronization/ZMHotFixDirectory+Swift.swift
@@ -101,5 +101,8 @@ extension ZMHotFixDirectory {
         users?.lazy
             .filter { $0.isConnected }
             .forEach { $0.needsToBeUpdatedFromBackend = true }
+
+        ZMUser.selfUser(in: context).needsToBeUpdatedFromBackend = true
+        context.enqueueDelayedSave()
     }
 }

--- a/Source/Synchronization/ZMHotFixDirectory.m
+++ b/Source/Synchronization/ZMHotFixDirectory.m
@@ -91,7 +91,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"HotFix";
                         [ZMHotFixDirectory purgePINCachesInHostBundle];
                     }],
                     [ZMHotFixPatch
-                     patchWithVersion:@"62.0.0"
+                     patchWithVersion:@"62.3.1"
                      patchCode:^(NSManagedObjectContext *context) {
                          [ZMHotFixDirectory refetchConnectedUsers:context];
                      }]

--- a/Tests/Source/Synchronization/ZMHotFixTests.m
+++ b/Tests/Source/Synchronization/ZMHotFixTests.m
@@ -580,6 +580,9 @@
     connectedUser.connection.status = ZMConnectionStatusAccepted;
     connectedUser.needsToBeUpdatedFromBackend = NO;
 
+    ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
+    selfUser.needsToBeUpdatedFromBackend = NO;
+
     ZMUser *unconnectedUser = [ZMUser insertNewObjectInManagedObjectContext:self.syncMOC];
     unconnectedUser.needsToBeUpdatedFromBackend = NO;
 
@@ -589,6 +592,7 @@
     XCTAssertFalse(unconnectedUser.isConnected);
     XCTAssertFalse(connectedUser.needsToBeUpdatedFromBackend);
     XCTAssertFalse(unconnectedUser.needsToBeUpdatedFromBackend);
+    XCTAssertFalse(selfUser.needsToBeUpdatedFromBackend);
 
     // when
     self.sut = [[ZMHotFix alloc] initWithSyncMOC:self.syncMOC];
@@ -600,6 +604,7 @@
     // then
     XCTAssertTrue(connectedUser.needsToBeUpdatedFromBackend);
     XCTAssertFalse(unconnectedUser.needsToBeUpdatedFromBackend);
+    XCTAssertTrue(selfUser.needsToBeUpdatedFromBackend);
 }
 
 @end


### PR DESCRIPTION
# What's in this PR?

* The previous hot fix missed the case in which the secondary client receives and discards the update event when setting the username on the primary one. As we are not refetching the self user by default we need to mark it to be fetched.