### PR TITLE
Fix for occasional failure to connect audio with CallKit (ZIOS-7624)

### DIFF
--- a/Source/Calling/ZMCallKitDelegate.m
+++ b/Source/Calling/ZMCallKitDelegate.m
@@ -512,26 +512,7 @@ NS_ASSUME_NONNULL_END
 
 - (void)configureAudioSession
 {
-    AVAudioSession *sessionInstance = [AVAudioSession sharedInstance];
-    
-    // we are going to play and record so we pick that category
-    NSError *error = nil;
-    [sessionInstance setCategory:AVAudioSessionCategoryPlayAndRecord error:&error];
-    if (error.code != 0) {
-        [self logErrorForConversation:nil line:__LINE__ format:@"couldn't set session's audio category: %ld", (long)error.code];
-    }
-    
-    // set the mode to voice chat
-    [sessionInstance setMode:AVAudioSessionModeVoiceChat error:&error];
-    if (error.code != 0) {
-        [self logErrorForConversation:nil line:__LINE__ format:@"couldn't set session's audio mode: %ld", (long)error.code];
-    }
-    
-    // set the session's sample rate
-    [sessionInstance setPreferredSampleRate:16000 error:&error];
-    if (error.code != 0) {
-        [self logErrorForConversation:nil line:__LINE__ format:@"couldn't set session's preferred sample rate: %ld", (long)error.code];
-    }
+	[self.mediaManager setupAudioDevice];
 }
 
 - (BOOL)continueUserActivity:(NSUserActivity *)userActivity


### PR DESCRIPTION
As of AVS 2.9.18 we have added a new function `setupAudioDevice` to `AVSMediaManager` that allows us to enter call state early, that appears to fix ZIOS-7624. I have tested 50 calls on an iPhone 6 and not seen the issue, but due to the nature of the bug more extensive testing by QA and affected users would be nice. This PR is a simple change to use the function.

