### PR TITLE
Reset audio device when ending a callkit call

### DIFF
--- a/Source/Calling/ZMCallKitDelegate.m
+++ b/Source/Calling/ZMCallKitDelegate.m
@@ -713,6 +713,7 @@ NS_ASSUME_NONNULL_END
 - (void)providerDidReset:(CXProvider *)provider
 {
     [self logInfoForConversation:nil line:__LINE__ format:@"CXProvider %@ didReset", provider];
+    [self.mediaManager resetAudioDevice];
     [self leaveAllActiveCalls];
 }
 
@@ -756,6 +757,8 @@ NS_ASSUME_NONNULL_END
 
 - (void)provider:(CXProvider *)provider performEndCallAction:(nonnull CXEndCallAction *)action
 {
+    [self.mediaManager resetAudioDevice];
+    
     ZMUserSession *userSession = self.userSession;
 
     ZMConversation *callConversation = [action conversationInContext:userSession.managedObjectContext];


### PR DESCRIPTION
As requested by AVS we need to call `resetAudioDevice` when a Callkit call is over in order to restore the audio session. This should fix a bug where a ringtone would not play for the second call.

https://wearezeta.atlassian.net/browse/ZIOS-7823