### PR TITLE
Move statuses into ZMSyncStrategy

### DIFF
--- a/Source/Synchronization/Sync States/ZMStateMachineDelegate.h
+++ b/Source/Synchronization/Sync States/ZMStateMachineDelegate.h
@@ -25,7 +25,7 @@ extern NSString *const ZMApplicationDidEnterEventProcessingStateNotificationName
 
 @class ZMSyncState;
 
-@protocol ZMStateMachineDelegate <ZMSyncStateDelegate>
+@protocol ZMStateMachineDelegate <NSObject>
 
 @property (nonatomic, readonly) ZMSyncState *unauthenticatedState; ///< need to log in. Will sturtup timer to try to login while waiting for email verification.
 @property (nonatomic, readonly) ZMSyncState *unauthenticatedBackgroundState; ///< need to log in, but we are in the background. In background we don't keep trying to login on timer waiting for email verification.

--- a/Source/Synchronization/Sync States/ZMSyncStateMachine.m
+++ b/Source/Synchronization/Sync States/ZMSyncStateMachine.m
@@ -132,16 +132,6 @@ static NSString *ZMLogTag ZM_UNUSED = @"State machine";
     [self tearDown];
 }
 
-- (void)didStartSync
-{
-    [self.syncStateDelegate didStartSync];
-}
-
-- (void)didFinishSync
-{
-    [self.syncStateDelegate didFinishSync];
-}
-
 - (void)enterBackground;
 {
     [self.currentState didEnterBackground];
@@ -156,11 +146,6 @@ static NSString *ZMLogTag ZM_UNUSED = @"State machine";
 {
     // No-op
 }
-
-//- (void)startQuickSync
-//{
-//    [self goToState:self.updateEventsCatchUpPhaseOneState];
-//}
 
 - (void)startBackgroundFetchWithCompletionHandler:(ZMBackgroundFetchHandler)handler;
 {

--- a/Source/Synchronization/Transcoders/ZMConversationTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMConversationTranscoder.m
@@ -25,7 +25,7 @@
 
 #import "ZMConversationTranscoder.h"
 #import "ZMAuthenticationStatus.h"
-#import "ZMSyncStrategy.h"
+#import "ZMSyncStrategy+EventProcessing.h"
 #import "ZMSimpleListRequestPaginator.h"
 #import <zmessaging/zmessaging-Swift.h>
 

--- a/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
@@ -22,7 +22,7 @@
 @import WireRequestStrategy;
 
 #import "ZMMissingUpdateEventsTranscoder+Internal.h"
-#import "ZMSyncStrategy.h"
+#import "ZMSyncStrategy+EventProcessing.h"
 #import <zmessaging/zmessaging-Swift.h>
 #import "ZMSimpleListRequestPaginator.h"
 

--- a/Source/Synchronization/Transcoders/ZMSelfStrategy.m
+++ b/Source/Synchronization/Transcoders/ZMSelfStrategy.m
@@ -115,11 +115,11 @@ NSTimeInterval ZMSelfStrategyPendingValidationRequestInterval = 5;
     
     if (clientStatus.currentPhase == ZMClientRegistrationPhaseWaitingForSelfUser) {
         ZMUser *selfUser = [ZMUser selfUserInContext:self.managedObjectContext];
-        if (!self.isSelfUserComplete && !selfUser.needsToBeUpdatedFromBackend) {
+        if (! selfUser.needsToBeUpdatedFromBackend) {
             selfUser.needsToBeUpdatedFromBackend = YES;
             [self.downstreamSelfUserSync readyForNextRequestIfNotBusy];
         }
-        if (! self.isSlowSyncDone) {
+        if (selfUser.needsToBeUpdatedFromBackend) {
             return [self.downstreamSelfUserSync nextRequest];
         }
     }
@@ -138,11 +138,6 @@ NSTimeInterval ZMSelfStrategyPendingValidationRequestInterval = 5;
             [self.downstreamSelfUserSync readyForNextRequest];
         }
     });
-}
-
-- (BOOL)isSlowSyncDone;
-{
-    return ![ZMUser selfUserInContext:self.managedObjectContext].needsToBeUpdatedFromBackend;
 }
 
 - (BOOL)isSelfUserComplete

--- a/Source/Synchronization/ZMObjectStrategyDirectory.h
+++ b/Source/Synchronization/ZMObjectStrategyDirectory.h
@@ -60,6 +60,4 @@
 
 - (NSArray *)allTranscoders;
 
-- (NSArray *)conversationIdsThatHaveBufferedUpdatesForCallState;
-
 @end

--- a/Source/Synchronization/ZMOperationLoop+Background.m
+++ b/Source/Synchronization/ZMOperationLoop+Background.m
@@ -22,6 +22,7 @@
 
 #import "ZMOperationLoop+Background.h"
 #import "ZMOperationLoop+Private.h"
+#import "ZMSyncStrategy+EventProcessing.h"
 
 #import "ZMLocalNotificationDispatcher.h"
 #import "ZMSyncStrategy+Internal.h"

--- a/Source/Synchronization/ZMOperationLoop+Private.h
+++ b/Source/Synchronization/ZMOperationLoop+Private.h
@@ -29,7 +29,7 @@
 @property (nonatomic) EncryptionContext *encryptionContext;
 @property (nonatomic) ZMSyncStrategy *syncStrategy;
 @property (nonatomic) NSManagedObjectContext *syncMOC;
-@property (nonatomic) BackgroundAPNSPingBackStatus *backgroundAPNSPingBackStatus;
+@property (nonatomic, readonly) BackgroundAPNSPingBackStatus *backgroundAPNSPingBackStatus;
 @end
 
 
@@ -38,7 +38,6 @@
 - (instancetype)initWithTransportSession:(ZMTransportSession *)transportSession
                             syncStrategy:(ZMSyncStrategy *)syncStrategy
                                    uiMOC:(NSManagedObjectContext *)uiMOC
-                                 syncMOC:(NSManagedObjectContext *)syncMOC
-            backgroundAPNSPingBackStatus:(BackgroundAPNSPingBackStatus *)backgroundAPNSPingBackStatus;
+                                 syncMOC:(NSManagedObjectContext *)syncMOC;
 
 @end

--- a/Source/Synchronization/ZMOperationLoop.h
+++ b/Source/Synchronization/ZMOperationLoop.h
@@ -26,6 +26,7 @@
 @class ZMClientRegistrationStatus;
 @class NSManagedObjectContext;
 @class ZMLocalNotificationDispatcher;
+@class ZMCookie;
 
 @protocol ZMSyncStateDelegate;
 @protocol ZMTransportData;
@@ -52,13 +53,7 @@ extern NSString * const ZMPushChannelResponseStatusKey;
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithTransportSession:(ZMTransportSession *)transportSession
-                    authenticationStatus:(ZMAuthenticationStatus *)authenticationStatus
-                 userProfileUpdateStatus:(UserProfileUpdateStatus *)userProfileUpdateStatus
-                clientRegistrationStatus:(ZMClientRegistrationStatus *)clientRegistrationStatus
-                      clientUpdateStatus:(ClientUpdateStatus *)clientUpdateStatus
-                    proxiedRequestStatus:(ProxiedRequestsStatus *)proxiedRequestStatus
-                           accountStatus:(ZMAccountStatus *)accountStatus
-            backgroundAPNSPingBackStatus:(BackgroundAPNSPingBackStatus *)backgroundAPNSPingBackStatus
+                                  cookie:(ZMCookie *)cookie
                topConversationsDirectory:(TopConversationsDirectory *)topConversationsDirectory
              localNotificationdispatcher:(ZMLocalNotificationDispatcher *)dispatcher
                             mediaManager:(id<AVSMediaManager>)mediaManager

--- a/Source/Synchronization/ZMSyncStateDelegate.h
+++ b/Source/Synchronization/ZMSyncStateDelegate.h
@@ -16,12 +16,22 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
+@class UserClient;
 
-@protocol ZMSyncStateDelegate <NSObject>
+
+
+@protocol ZMClientRegistrationStatusDelegate <NSObject>
+
+- (void)didRegisterUserClient:(UserClient *)userClient;
+
+@end
+
+
+
+@protocol ZMSyncStateDelegate <ZMClientRegistrationStatusDelegate>
 
 - (void)didStartSync;
 - (void)didFinishSync;
-
 
 @end
 

--- a/Source/Synchronization/ZMSyncStrategy+EventProcessing.h
+++ b/Source/Synchronization/ZMSyncStrategy+EventProcessing.h
@@ -1,0 +1,22 @@
+//
+//  ZMSyncStrategy+EventProcessing.h
+//  zmessaging-cocoa
+//
+//  Created by Sabine Geithner on 08/12/16.
+//  Copyright © 2016 Zeta Project Gmbh. All rights reserved.
+//
+
+#import "ZMSyncStrategy.h"
+
+@interface ZMSyncStrategy (EventProcessing) <ZMUpdateEventConsumer>
+
+/// Process events that are recevied through the notification stream or the websocket
+- (void)processUpdateEvents:(NSArray <ZMUpdateEvent *>*)events ignoreBuffer:(BOOL)ignoreBuffer;
+
+/// Process events that were downloaded as part of the clinet history
+- (void)processDownloadedEvents:(NSArray <ZMUpdateEvent *>*)events;
+
+
+- (NSArray *)conversationIdsThatHaveBufferedUpdatesForCallState;
+
+@end

--- a/Source/Synchronization/ZMSyncStrategy+EventProcessing.m
+++ b/Source/Synchronization/ZMSyncStrategy+EventProcessing.m
@@ -1,0 +1,125 @@
+//
+//  ZMSyncStrategy+EventProcessing.m
+//  zmessaging-cocoa
+//
+//  Created by Sabine Geithner on 08/12/16.
+//  Copyright © 2016 Zeta Project Gmbh. All rights reserved.
+//
+
+#import "ZMSyncStrategy+EventProcessing.h"
+#import "ZMSyncStrategy+Internal.h"
+#import "ZMSyncStateMachine.h"
+
+
+@implementation ZMSyncStrategy (EventProcessing)
+
+- (void)processUpdateEvents:(NSArray *)events ignoreBuffer:(BOOL)ignoreBuffer;
+{
+    if(ignoreBuffer) {
+        [self consumeUpdateEvents:events];
+        return;
+    }
+    
+    NSArray *flowEvents = [events filterWithBlock:^BOOL(ZMUpdateEvent* event) {
+        return event.isFlowEvent;
+    }];
+    if(flowEvents.count > 0) {
+        [self consumeUpdateEvents:flowEvents];
+    }
+    NSArray *callstateEvents = [events filterWithBlock:^BOOL(ZMUpdateEvent* event) {
+        return event.type == ZMUpdateEventCallState;
+    }];
+    NSArray *notFlowEvents = [events filterWithBlock:^BOOL(ZMUpdateEvent* event) {
+        return !event.isFlowEvent;
+    }];
+    
+    if (self.syncStatus.isSyncing) {
+        for(ZMUpdateEvent *event in notFlowEvents) {
+            [self.eventsBuffer addUpdateEvent:event];
+        }
+    }
+    else {
+        switch(self.stateMachine.updateEventsPolicy) {
+            case ZMUpdateEventPolicyIgnore: {
+                if(callstateEvents.count > 0) {
+                    [self consumeUpdateEvents:callstateEvents];
+                }
+                break;
+            }
+            case ZMUpdateEventPolicyBuffer: {
+                for(ZMUpdateEvent *event in notFlowEvents) {
+                    [self.eventsBuffer addUpdateEvent:event];
+                }
+                break;
+            }
+            case ZMUpdateEventPolicyProcess: {
+                if(notFlowEvents.count > 0) {
+                    [self consumeUpdateEvents:notFlowEvents];
+                }
+                break;
+            }
+        }
+    }
+}
+
+- (void)consumeUpdateEvents:(NSArray<ZMUpdateEvent *>*)events
+{
+    ZM_WEAK(self);
+    [self.eventDecoder processEvents:events block:^(NSArray<ZMUpdateEvent *> * decryptedEvents) {
+        ZM_STRONG(self);
+        if (self == nil){
+            return;
+        }
+        
+        ZMFetchRequestBatch *fetchRequest = [self fetchRequestBatchForEvents:decryptedEvents];
+        ZMFetchRequestBatchResult *prefetchResult = [self.syncMOC executeFetchRequestBatchOrAssert:fetchRequest];
+        NSArray *allObjectStrategies = [self.allTranscoders arrayByAddingObjectsFromArray:self.requestStrategies];
+        
+        for(id obj in allObjectStrategies) {
+            @autoreleasepool {
+                if ([obj conformsToProtocol:@protocol(ZMEventConsumer)]) {
+                    [obj processEvents:decryptedEvents liveEvents:YES prefetchResult:prefetchResult];
+                }
+            }
+        }
+        [self.localNotificationDispatcher processEvents:decryptedEvents liveEvents:YES prefetchResult:nil];
+        [self.syncMOC enqueueDelayedSave];
+    }];
+}
+
+- (void)processDownloadedEvents:(NSArray <ZMUpdateEvent *>*)events;
+{
+    ZM_WEAK(self);
+    [self.eventDecoder processEvents:events block:^(NSArray<ZMUpdateEvent *> * decryptedEvents) {
+        ZM_STRONG(self);
+        if (self  == nil){
+            return;
+        }
+        
+        ZMFetchRequestBatch *fetchRequest = [self fetchRequestBatchForEvents:decryptedEvents];
+        ZMFetchRequestBatchResult *prefetchResult = [self.moc executeFetchRequestBatchOrAssert:fetchRequest];
+        
+        NSArray *allEventConsumers = [self.allTranscoders arrayByAddingObjectsFromArray:self.requestStrategies];
+        for(id<ZMEventConsumer> obj in allEventConsumers) {
+            @autoreleasepool {
+                if ([obj conformsToProtocol:@protocol(ZMEventConsumer)]) {
+                    ZMSTimePoint *tp = [ZMSTimePoint timePointWithInterval:5 label:[NSString stringWithFormat:@"Processing downloaded events in %@", [obj class]]];
+                    [obj processEvents:decryptedEvents liveEvents:NO prefetchResult:prefetchResult];
+                    [tp warnIfLongerThanInterval];
+                }
+            }
+        }
+    }];
+}
+
+- (NSArray *)conversationIdsThatHaveBufferedUpdatesForCallState;
+{
+    return [[self.eventsBuffer updateEvents] mapWithBlock:^id(ZMUpdateEvent *event) {
+        if (event.type == ZMUpdateEventCallState) {
+            return event.conversationUUID;
+        }
+        return nil;
+    }];
+}
+
+@end

--- a/Source/Synchronization/ZMSyncStrategy+Internal.h
+++ b/Source/Synchronization/ZMSyncStrategy+Internal.h
@@ -18,12 +18,29 @@
 
 
 #import "ZMSyncStrategy.h"
+@class ZMSyncStateMachine;
+
+@interface ZMSyncStrategy (Internal)
+
+@property (atomic, readonly) BOOL tornDown;
+@property (nonatomic, weak, readonly) NSManagedObjectContext *uiMOC;
+@property (nonatomic, readonly) EventDecoder *eventDecoder;
+@property (nonatomic, readonly) ZMSyncStateMachine *stateMachine;
+@property (nonatomic, readonly) ZMUpdateEventsBuffer *eventsBuffer;
+@property (nonatomic, weak, readonly) ZMLocalNotificationDispatcher *localNotificationDispatcher;
+
+@property (nonatomic, readonly) NSArray<ZMObjectSyncStrategy *> *requestStrategies;
+@property (nonatomic, readonly) NSArray<id<ZMContextChangeTracker>> *allChangeTrackers;
+
+@end
+
 
 @interface ZMSyncStrategy (Badge)
 
 - (void)updateBadgeCount;
 
 @end
+
 
 @interface ZMSyncStrategy (AppBackgroundForeground)
 
@@ -33,8 +50,6 @@
 @end
 
 
-
-
 @interface ZMSyncStrategy (Testing)
 
 @property (nonatomic) BOOL contextMergingDisabled;
@@ -42,3 +57,5 @@
 - (ZMFetchRequestBatch *)fetchRequestBatchForEvents:(NSArray<ZMUpdateEvent *> *)events;
 
 @end
+
+

--- a/Source/Synchronization/ZMSyncStrategy+ManagedObjectChanges.h
+++ b/Source/Synchronization/ZMSyncStrategy+ManagedObjectChanges.h
@@ -1,0 +1,16 @@
+//
+//  ZMSyncStrategy+ManagedObjectChanges.h
+//  zmessaging-cocoa
+//
+//  Created by Sabine Geithner on 08/12/16.
+//  Copyright © 2016 Zeta Project Gmbh. All rights reserved.
+//
+
+#import "ZMSyncStrategy.h"
+
+@interface ZMSyncStrategy (ManagedObjectChanges)
+
+- (void)managedObjectContextDidSave:(NSNotification *)note;
+- (BOOL)processSaveWithInsertedObjects:(NSSet *)insertedObjects updateObjects:(NSSet *)updatedObjects;
+
+@end

--- a/Source/Synchronization/ZMSyncStrategy+ManagedObjectChanges.m
+++ b/Source/Synchronization/ZMSyncStrategy+ManagedObjectChanges.m
@@ -1,0 +1,125 @@
+//
+//  ZMSyncStrategy+ManagedObjectChanges.m
+//  zmessaging-cocoa
+//
+//  Created by Sabine Geithner on 08/12/16.
+//  Copyright © 2016 Zeta Project Gmbh. All rights reserved.
+//
+
+#import "ZMSyncStrategy+Internal.h"
+#import "ZMSyncStrategy+ManagedObjectChanges.h"
+#import "ZMessagingLogs.h"
+
+@implementation ZMSyncStrategy (ManagedObjectChanges)
+
+
+- (void)managedObjectContextDidSave:(NSNotification *)note;
+{
+    if(self.tornDown || self.contextMergingDisabled) {
+        return;
+    }
+    
+    if([ZMSLog getLevelWithTag:ZMTAG_CORE_DATA] == ZMLogLevelDebug) {
+        [self logDidSaveNotification:note];
+    }
+    
+    NSManagedObjectContext *mocThatSaved = note.object;
+    NSManagedObjectContext *strongUiMoc = self.uiMOC;
+    ZMCallState *callStateChanges = mocThatSaved.zm_callState.createCopyAndResetHasChanges;
+    
+    if (mocThatSaved.zm_isUserInterfaceContext && strongUiMoc != nil) {
+        if(mocThatSaved != strongUiMoc) {
+            RequireString(mocThatSaved == strongUiMoc, "Not the right MOC!");
+        }
+        
+        NSSet *conversationsWithCallChanges = [callStateChanges allContainedConversationsInContext:strongUiMoc];
+        if (conversationsWithCallChanges != nil) {
+            [strongUiMoc.globalManagedObjectContextObserver notifyUpdatedCallState:conversationsWithCallChanges notifyDirectly:YES];
+        }
+        
+        ZM_WEAK(self);
+        [self.syncMOC performGroupedBlock:^{
+            ZM_STRONG(self);
+            if(self == nil || self.tornDown) {
+                return;
+            }
+            NSSet *changedConversations = [self.syncMOC mergeCallStateChanges:callStateChanges];
+            [self.syncMOC mergeChangesFromContextDidSaveNotification:note];
+            
+            [self processSaveWithInsertedObjects:[NSSet set] updateObjects:changedConversations];
+            [self.syncMOC processPendingChanges]; // We need this because merging sometimes leaves the MOC in a 'dirty' state
+        }];
+    } else if (mocThatSaved.zm_isSyncContext) {
+        RequireString(mocThatSaved == self.syncMOC, "Not the right MOC!");
+        
+        ZM_WEAK(self);
+        [strongUiMoc performGroupedBlock:^{
+            ZM_STRONG(self);
+            if(self == nil || self.tornDown) {
+                return;
+            }
+            
+            NSSet *changedConversations = [strongUiMoc mergeCallStateChanges:callStateChanges];
+            [strongUiMoc.globalManagedObjectContextObserver notifyUpdatedCallState:changedConversations notifyDirectly:[self shouldForwardCallStateChangeDirectlyForNote:note]];
+            
+            [strongUiMoc mergeChangesFromContextDidSaveNotification:note];
+            [strongUiMoc processPendingChanges]; // We need this because merging sometimes leaves the MOC in a 'dirty' state
+        }];
+    }
+}
+
+- (BOOL)processSaveWithInsertedObjects:(NSSet *)insertedObjects updateObjects:(NSSet *)updatedObjects
+{
+    NSSet *allObjects = [NSSet zmSetByCompiningSets:insertedObjects, updatedObjects, nil];
+    
+    for(id<ZMContextChangeTracker> tracker in self.allChangeTrackers)
+    {
+        [tracker objectsDidChange:allObjects];
+    }
+    
+    return YES;
+}
+
+- (BOOL)shouldForwardCallStateChangeDirectlyForNote:(NSNotification *)note
+{
+    if ([(NSSet *)note.userInfo[NSInsertedObjectsKey] count] == 0 &&
+        [(NSSet *)note.userInfo[NSDeletedObjectsKey] count] == 0 &&
+        [(NSSet *)note.userInfo[NSUpdatedObjectsKey] count] == 0 &&
+        [(NSSet *)note.userInfo[NSRefreshedObjectsKey] count] == 0) {
+        return YES;
+    }
+    return NO;
+}
+
+
+- (void)logDidSaveNotification:(NSNotification *)note;
+{
+    NSManagedObjectContext * ZM_UNUSED moc = note.object;
+    ZMLogWithLevelAndTag(ZMLogLevelDebug, ZMTAG_CORE_DATA, @"<%@: %p> did save. Context type = %@",
+                         moc.class, moc,
+                         moc.zm_isUserInterfaceContext ? @"UI" : moc.zm_isSyncContext ? @"Sync" : @"");
+    NSSet *inserted = note.userInfo[NSInsertedObjectsKey];
+    if (inserted.count > 0) {
+        NSString * ZM_UNUSED description = [[inserted.allObjects mapWithBlock:^id(NSManagedObject *mo) {
+            return mo.objectID.URIRepresentation;
+        }] componentsJoinedByString:@", "];
+        ZMLogWithLevelAndTag(ZMLogLevelDebug, ZMTAG_CORE_DATA, @"    Inserted: %@", description);
+    }
+    NSSet *updated = note.userInfo[NSUpdatedObjectsKey];
+    if (updated.count > 0) {
+        NSString * ZM_UNUSED description = [[updated.allObjects mapWithBlock:^id(NSManagedObject *mo) {
+            return mo.objectID.URIRepresentation;
+        }] componentsJoinedByString:@", "];
+        ZMLogWithLevelAndTag(ZMLogLevelDebug, ZMTAG_CORE_DATA, @"    Updated: %@", description);
+    }
+    NSSet *deleted = note.userInfo[NSDeletedObjectsKey];
+    if (deleted.count > 0) {
+        NSString * ZM_UNUSED description = [[deleted.allObjects mapWithBlock:^id(NSManagedObject *mo) {
+            return mo.objectID.URIRepresentation;
+        }] componentsJoinedByString:@", "];
+        ZMLogWithLevelAndTag(ZMLogLevelDebug, ZMTAG_CORE_DATA, @"    Deleted: %@", description);
+    }
+}
+
+
+@end

--- a/Source/Synchronization/ZMSyncStrategy.h
+++ b/Source/Synchronization/ZMSyncStrategy.h
@@ -46,26 +46,20 @@
 @protocol ApplicationStateOwner;
 
 
-@interface ZMSyncStrategy : NSObject <ZMObjectStrategyDirectory, ZMUpdateEventConsumer>
+@interface ZMSyncStrategy : NSObject <ZMObjectStrategyDirectory>
 
-- (instancetype)initWithAuthenticationCenter:(ZMAuthenticationStatus *)authenticationStatus
-                     userProfileUpdateStatus:(UserProfileUpdateStatus *)userProfileStatus
-                    clientRegistrationStatus:(ZMClientRegistrationStatus *)clientRegistrationStatus
-                          clientUpdateStatus:(ClientUpdateStatus *)clientUpdateStatus
-                        proxiedRequestStatus:(ProxiedRequestsStatus *)proxiedRequestStatus
-                               accountStatus:(ZMAccountStatus *)accountStatus
-                backgroundAPNSPingBackStatus:(BackgroundAPNSPingBackStatus *)backgroundAPNSPingBackStatus
-                   topConversationsDirectory:(TopConversationsDirectory *)topConversationsDirectory
-                                mediaManager:(id<AVSMediaManager>)mediaManager
-                         onDemandFlowManager:(ZMOnDemandFlowManager *)onDemandFlowManager
-                                     syncMOC:(NSManagedObjectContext *)syncMOC
-                                       uiMOC:(NSManagedObjectContext *)uiMOC
-                           syncStateDelegate:(id<ZMSyncStateDelegate>)syncStateDelegate
-                       backgroundableSession:(id<ZMBackgroundable>)backgroundableSession
-                localNotificationsDispatcher:(ZMLocalNotificationDispatcher *)localNotificationsDispatcher
-                    taskCancellationProvider:(id <ZMRequestCancellation>)taskCancellationProvider
-                          appGroupIdentifier:(NSString *)appGroupIdentifier
-                                 application:(id<ZMApplication>)application;
+- (instancetype)initWithSyncManagedObjectContextMOC:(NSManagedObjectContext *)syncMOC
+                             uiManagedObjectContext:(NSManagedObjectContext *)uiMOC
+                                             cookie:(ZMCookie *)cookie
+                          topConversationsDirectory:(TopConversationsDirectory *)topConversationsDirectory
+                                       mediaManager:(id<AVSMediaManager>)mediaManager
+                                onDemandFlowManager:(ZMOnDemandFlowManager *)onDemandFlowManager
+                                  syncStateDelegate:(id<ZMSyncStateDelegate>)syncStateDelegate
+                              backgroundableSession:(id<ZMBackgroundable>)backgroundableSession
+                       localNotificationsDispatcher:(ZMLocalNotificationDispatcher *)localNotificationsDispatcher
+                           taskCancellationProvider:(id <ZMRequestCancellation>)taskCancellationProvider
+                                 appGroupIdentifier:(NSString *)appGroupIdentifier
+                                        application:(id<ZMApplication>)application;
 
 - (void)didInterruptUpdateEventsStream;
 - (void)didEstablishUpdateEventsStream;
@@ -73,16 +67,18 @@
 - (ZMTransportRequest *)nextRequest;
 - (void)dataDidChange;
 
-/// Process events that are recevied through the notification stream or the websocket
-- (void)processUpdateEvents:(NSArray <ZMUpdateEvent *>*)events ignoreBuffer:(BOOL)ignoreBuffer;
-
-/// Process events that were downloaded as part of the clinet history
-- (void)processDownloadedEvents:(NSArray <ZMUpdateEvent *>*)events;
-
-- (BOOL)processSaveWithInsertedObjects:(NSSet *)insertedObjects updateObjects:(NSSet *)updatedObjects;
 - (void)tearDown;
 
 @property (nonatomic, readonly) NSManagedObjectContext *syncMOC;
+@property (nonatomic, readonly) BackgroundAPNSConfirmationStatus *apnsConfirmationStatus;
+@property (nonatomic, readonly) ZMAuthenticationStatus *authenticationStatus;
+@property (nonatomic, readonly) UserProfileUpdateStatus *userProfileUpdateStatus;
+@property (nonatomic, readonly) ZMClientRegistrationStatus *clientRegistrationStatus;
+@property (nonatomic, readonly) ClientUpdateStatus *clientUpdateStatus;
+@property (nonatomic, readonly) BackgroundAPNSPingBackStatus *pingBackStatus;
+@property (nonatomic, readonly) ZMAccountStatus *accountStatus;
+@property (nonatomic, readonly) ProxiedRequestsStatus *proxiedRequestStatus;
+@property (nonatomic, readonly) SyncStatus *syncStatus;
 
 - (void)startBackgroundFetchWithCompletionHandler:(ZMBackgroundFetchHandler)handler;
 

--- a/Source/Synchronization/ZMSyncStrategy.m
+++ b/Source/Synchronization/ZMSyncStrategy.m
@@ -26,8 +26,12 @@
 @import WireRequestStrategy;
 
 #import "ZMSyncStrategy+Internal.h"
-#import "ZMUserSession.h"
+#import "ZMSyncStrategy+ManagedObjectChanges.h"
+#import "ZMSyncStrategy+EventProcessing.h"
+
+
 #import "ZMUserSession+Internal.h"
+
 #import "ZMConnectionTranscoder.h"
 #import "ZMUserTranscoder.h"
 #import "ZMSelfStrategy.h"
@@ -42,7 +46,6 @@
 #import "ZMCallStateTranscoder.h"
 #import "ZMPhoneNumberVerificationTranscoder.h"
 #import "ZMLoginCodeRequestTranscoder.h"
-#import "ZMessagingLogs.h"
 #import "ZMClientRegistrationStatus.h"
 #import "ZMOnDemandFlowManager.h"
 #import "ZMLocalNotificationDispatcher.h"
@@ -92,7 +95,18 @@
 @property (nonatomic) NSManagedObjectContext *eventMOC;
 @property (nonatomic) EventDecoder *eventDecoder;
 @property (nonatomic, weak) ZMLocalNotificationDispatcher *localNotificationDispatcher;
+
+// Statuus
 @property (nonatomic) BackgroundAPNSConfirmationStatus *apnsConfirmationStatus;
+@property (nonatomic) ZMAuthenticationStatus *authenticationStatus;
+@property (nonatomic) UserProfileUpdateStatus *userProfileUpdateStatus;
+@property (nonatomic) ZMClientRegistrationStatus *clientRegistrationStatus;
+@property (nonatomic) ClientUpdateStatus *clientUpdateStatus;
+@property (nonatomic) BackgroundAPNSPingBackStatus *pingBackStatus;
+@property (nonatomic) ZMAccountStatus *accountStatus;
+@property (nonatomic) ProxiedRequestsStatus *proxiedRequestStatus;
+@property (nonatomic) SyncStatus *syncStatus;
+
 
 @property (nonatomic) NSArray *allChangeTrackers;
 
@@ -101,12 +115,14 @@
 @property (atomic) BOOL tornDown;
 @property (nonatomic) BOOL contextMergingDisabled;
 
-@property (nonatomic, weak) ZMAuthenticationStatus *authenticationStatus;
-@property (nonatomic, weak) ZMClientRegistrationStatus *clientRegistrationStatus;
-@property (nonatomic) SyncStatus *syncStatus;
+
 @property (nonatomic, weak) id<ZMSyncStateDelegate> syncStateDelegate;
 @property (nonatomic) ZMHotFix *hotFix;
 
+@end
+
+
+@interface ZMSyncStrategy (Registration) <ZMClientRegistrationStatusDelegate>
 @end
 
 @interface ZMLocalNotificationDispatcher (Push) <ZMPushMessageHandler>
@@ -116,32 +132,26 @@
 @end
 
 @interface ZMClientRegistrationStatus (Protocol) <ClientRegistrationDelegate>
-
 @end
+
 
 @implementation ZMSyncStrategy
 
 ZM_EMPTY_ASSERTING_INIT()
 
 
-- (instancetype)initWithAuthenticationCenter:(ZMAuthenticationStatus *)authenticationStatus
-                     userProfileUpdateStatus:(UserProfileUpdateStatus *)userProfileStatus
-                    clientRegistrationStatus:(ZMClientRegistrationStatus *)clientRegistrationStatus
-                          clientUpdateStatus:(ClientUpdateStatus *)clientUpdateStatus
-                        proxiedRequestStatus:(ProxiedRequestsStatus *)proxiedRequestStatus
-                               accountStatus:(ZMAccountStatus *)accountStatus
-                backgroundAPNSPingBackStatus:(BackgroundAPNSPingBackStatus *)backgroundAPNSPingBackStatus
-                   topConversationsDirectory:(TopConversationsDirectory *)topConversationsDirectory
-                                mediaManager:(id<AVSMediaManager>)mediaManager
-                         onDemandFlowManager:(ZMOnDemandFlowManager *)onDemandFlowManager
-                                     syncMOC:(NSManagedObjectContext *)syncMOC
-                                       uiMOC:(NSManagedObjectContext *)uiMOC
-                           syncStateDelegate:(id<ZMSyncStateDelegate>)syncStateDelegate
-                       backgroundableSession:(id<ZMBackgroundable>)backgroundableSession
-                localNotificationsDispatcher:(ZMLocalNotificationDispatcher *)localNotificationsDispatcher
-                    taskCancellationProvider:(id <ZMRequestCancellation>)taskCancellationProvider
-                          appGroupIdentifier:(NSString *)appGroupIdentifier
-                                 application:(id<ZMApplication>)application;
+- (instancetype)initWithSyncManagedObjectContextMOC:(NSManagedObjectContext *)syncMOC
+                             uiManagedObjectContext:(NSManagedObjectContext *)uiMOC
+                                             cookie:(ZMCookie *)cookie
+                          topConversationsDirectory:(TopConversationsDirectory *)topConversationsDirectory
+                                       mediaManager:(id<AVSMediaManager>)mediaManager
+                                onDemandFlowManager:(ZMOnDemandFlowManager *)onDemandFlowManager
+                                  syncStateDelegate:(id<ZMSyncStateDelegate>)syncStateDelegate
+                              backgroundableSession:(id<ZMBackgroundable>)backgroundableSession
+                       localNotificationsDispatcher:(ZMLocalNotificationDispatcher *)localNotificationsDispatcher
+                           taskCancellationProvider:(id <ZMRequestCancellation>)taskCancellationProvider
+                                 appGroupIdentifier:(NSString *)appGroupIdentifier
+                                        application:(id<ZMApplication>)application;
 
 {
     self = [super init];
@@ -149,30 +159,42 @@ ZM_EMPTY_ASSERTING_INIT()
         self.syncStateDelegate = syncStateDelegate;
         self.application = application;
         self.localNotificationDispatcher = localNotificationsDispatcher;
-        self.authenticationStatus = authenticationStatus;
-        self.clientRegistrationStatus = clientRegistrationStatus;
         self.syncMOC = syncMOC;
         self.uiMOC = uiMOC;
         self.hotFix = [[ZMHotFix alloc] initWithSyncMOC:self.syncMOC];
 
         self.eventMOC = [NSManagedObjectContext createEventContextWithAppGroupIdentifier:appGroupIdentifier];
         [self.eventMOC addGroup:self.syncMOC.dispatchGroup];
+        
+        // Statuus
         self.apnsConfirmationStatus = [[BackgroundAPNSConfirmationStatus alloc] initWithApplication:application
                                                                                managedObjectContext:self.syncMOC
                                                                           backgroundActivityFactory:[BackgroundActivityFactory sharedInstance]];
         self.syncStatus = [[SyncStatus alloc] initWithManagedObjectContext:self.syncMOC syncStateDelegate:self];
 
-        [self createTranscodersWithClientRegistrationStatus:clientRegistrationStatus
-                               localNotificationsDispatcher:localNotificationsDispatcher
-                                       authenticationStatus:authenticationStatus
-                               backgroundAPNSPingBackStatus:backgroundAPNSPingBackStatus
-                                              accountStatus:accountStatus
+        self.authenticationStatus = [[ZMAuthenticationStatus alloc] initWithManagedObjectContext:syncMOC cookie:cookie];
+        self.userProfileUpdateStatus = [[UserProfileUpdateStatus alloc] initWithManagedObjectContext:syncMOC];
+        self.clientUpdateStatus = [[ClientUpdateStatus alloc] initWithSyncManagedObjectContext:syncMOC];
+        
+        self.clientRegistrationStatus = [[ZMClientRegistrationStatus alloc] initWithManagedObjectContext:syncMOC
+                                                                                 loginCredentialProvider:self.authenticationStatus
+                                                                                updateCredentialProvider:self.userProfileUpdateStatus
+                                                                                                  cookie:cookie
+                                                                              registrationStatusDelegate:self];
+        
+        self.accountStatus = [[ZMAccountStatus alloc] initWithManagedObjectContext: syncMOC cookieStorage: cookie];
+        
+        self.pingBackStatus = [[BackgroundAPNSPingBackStatus alloc] initWithSyncManagedObjectContext:syncMOC
+                                                                              authenticationProvider:self.authenticationStatus];
+        self.proxiedRequestStatus = [[ProxiedRequestsStatus alloc] initWithRequestCancellation:taskCancellationProvider];
+        
+        [self createTranscodersWithLocalNotificationsDispatcher:localNotificationsDispatcher
                                                mediaManager:mediaManager
                                         onDemandFlowManager:onDemandFlowManager
                                    taskCancellationProvider:taskCancellationProvider];
         
-        self.stateMachine = [[ZMSyncStateMachine alloc] initWithAuthenticationStatus:authenticationStatus
-                                                            clientRegistrationStatus:clientRegistrationStatus
+        self.stateMachine = [[ZMSyncStateMachine alloc] initWithAuthenticationStatus:self.authenticationStatus
+                                                            clientRegistrationStatus:self.clientRegistrationStatus
                                                              objectStrategyDirectory:self
                                                                    syncStateDelegate:syncStateDelegate
                                                                backgroundableSession:backgroundableSession
@@ -180,65 +202,65 @@ ZM_EMPTY_ASSERTING_INIT()
                                                                        slowSynStatus:self.syncStatus];
 
         self.eventsBuffer = [[ZMUpdateEventsBuffer alloc] initWithUpdateEventConsumer:self];
-        self.userClientRequestStrategy = [[UserClientRequestStrategy alloc] initWithAuthenticationStatus:authenticationStatus
-                                                                                clientRegistrationStatus:clientRegistrationStatus
-                                                                                      clientUpdateStatus:clientUpdateStatus
+        self.userClientRequestStrategy = [[UserClientRequestStrategy alloc] initWithAuthenticationStatus:self.authenticationStatus
+                                                                                clientRegistrationStatus:self.clientRegistrationStatus
+                                                                                      clientUpdateStatus:self.clientUpdateStatus
                                                                                                  context:self.syncMOC];
-        self.missingClientsRequestStrategy = [[MissingClientsRequestStrategy alloc] initWithClientRegistrationStatus:clientRegistrationStatus apnsConfirmationStatus: self.apnsConfirmationStatus managedObjectContext:self.syncMOC];
+        self.missingClientsRequestStrategy = [[MissingClientsRequestStrategy alloc] initWithClientRegistrationStatus:self.clientRegistrationStatus apnsConfirmationStatus: self.apnsConfirmationStatus managedObjectContext:self.syncMOC];
         
         NSOperationQueue *imageProcessingQueue = [ZMImagePreprocessor createSuitableImagePreprocessingQueue];
         self.requestStrategies = @[
                                    self.userClientRequestStrategy,
                                    self.missingClientsRequestStrategy,
                                    self.missingUpdateEventsTranscoder,
-                                   [[ProxiedRequestStrategy alloc] initWithRequestsStatus:proxiedRequestStatus
+                                   [[ProxiedRequestStrategy alloc] initWithRequestsStatus:self.proxiedRequestStatus
                                                                      managedObjectContext:self.syncMOC],
-                                   [[DeleteAccountRequestStrategy alloc] initWithAuthStatus:authenticationStatus
+                                   [[DeleteAccountRequestStrategy alloc] initWithAuthStatus:self.authenticationStatus
                                                                        managedObjectContext:self.syncMOC],
-                                   [[AssetDownloadRequestStrategy alloc] initWithAuthStatus:clientRegistrationStatus
+                                   [[AssetDownloadRequestStrategy alloc] initWithAuthStatus:self.clientRegistrationStatus
                                                                    taskCancellationProvider:taskCancellationProvider
                                                                        managedObjectContext:self.syncMOC],
-                                   [[AssetV3DownloadRequestStrategy alloc] initWithAuthStatus:clientRegistrationStatus
+                                   [[AssetV3DownloadRequestStrategy alloc] initWithAuthStatus:self.clientRegistrationStatus
                                                                      taskCancellationProvider:taskCancellationProvider
                                                                          managedObjectContext:self.syncMOC],
-                                   [[AssetClientMessageRequestStrategy alloc] initWithClientRegistrationStatus:clientRegistrationStatus
+                                   [[AssetClientMessageRequestStrategy alloc] initWithClientRegistrationStatus:self.clientRegistrationStatus
                                                                                           managedObjectContext:self.syncMOC],
-                                   [[AssetV3ImageUploadRequestStrategy alloc] initWithClientRegistrationStatus:clientRegistrationStatus
+                                   [[AssetV3ImageUploadRequestStrategy alloc] initWithClientRegistrationStatus:self.clientRegistrationStatus
                                                                                       taskCancellationProvider:taskCancellationProvider
                                                                                           managedObjectContext:self.syncMOC],
-                                   [[AssetV3PreviewDownloadRequestStrategy alloc] initWithAuthStatus:clientRegistrationStatus
+                                   [[AssetV3PreviewDownloadRequestStrategy alloc] initWithAuthStatus:self.clientRegistrationStatus
                                                                                 managedObjectContext:self.syncMOC],
-                                   [[AssetV3FileUploadRequestStrategy alloc] initWithClientRegistrationStatus:clientRegistrationStatus
+                                   [[AssetV3FileUploadRequestStrategy alloc] initWithClientRegistrationStatus:self.clientRegistrationStatus
                                                                        taskCancellationProvider:taskCancellationProvider
                                                                            managedObjectContext:self.syncMOC],
-                                   [[AddressBookUploadRequestStrategy alloc] initWithAuthenticationStatus:authenticationStatus
-                                                                                 clientRegistrationStatus:clientRegistrationStatus
+                                   [[AddressBookUploadRequestStrategy alloc] initWithAuthenticationStatus:self.authenticationStatus
+                                                                                 clientRegistrationStatus:self.clientRegistrationStatus
                                                                                                       moc:self.syncMOC],
                                    [[UserProfileRequestStrategy alloc] initWithManagedObjectContext:self.syncMOC
-                                                                            userProfileUpdateStatus:userProfileStatus
-                                                                               authenticationStatus:authenticationStatus],
+                                                                            userProfileUpdateStatus:self.userProfileUpdateStatus
+                                                                               authenticationStatus:self.authenticationStatus],
                                    self.fileUploadRequestStrategy,
                                    self.linkPreviewAssetDownloadRequestStrategy,
                                    self.linkPreviewAssetUploadRequestStrategy,
                                    self.imageDownloadRequestStrategy,
                                    self.imageUploadRequestStrategy,
-                                   [[PushTokenStrategy alloc] initWithManagedObjectContext:self.syncMOC clientRegistrationDelegate:clientRegistrationStatus],
-                                   [[TypingStrategy alloc] initWithManagedObjectContext:self.syncMOC clientRegistrationDelegate:clientRegistrationStatus],
-                                   [[SearchUserImageStrategy alloc] initWithManagedObjectContext:self.syncMOC clientRegistrationDelegate:clientRegistrationStatus],
+                                   [[PushTokenStrategy alloc] initWithManagedObjectContext:self.syncMOC clientRegistrationDelegate:self.clientRegistrationStatus],
+                                   [[TypingStrategy alloc] initWithManagedObjectContext:self.syncMOC clientRegistrationDelegate:self.clientRegistrationStatus],
+                                   [[SearchUserImageStrategy alloc] initWithManagedObjectContext:self.syncMOC clientRegistrationDelegate:self.clientRegistrationStatus],
                                    self.connectionTranscoder,
                                    self.conversationTranscoder,
                                    self.userTranscoder,
                                    self.lastUpdateEventIDTranscoder,
                                    self.missingUpdateEventsTranscoder,
-                                   [[UserImageStrategy alloc] initWithManagedObjectContext:self.syncMOC imageProcessingQueue:imageProcessingQueue clientRegistrationDelegate:clientRegistrationStatus],
-                                   [[TopConversationsRequestStrategy alloc] initWithManagedObjectContext:uiMOC authenticationStatus:authenticationStatus conversationDirectory:topConversationsDirectory],
+                                   [[UserImageStrategy alloc] initWithManagedObjectContext:self.syncMOC imageProcessingQueue:imageProcessingQueue clientRegistrationDelegate:self.clientRegistrationStatus],
+                                   [[TopConversationsRequestStrategy alloc] initWithManagedObjectContext:uiMOC authenticationStatus:self.authenticationStatus conversationDirectory:topConversationsDirectory],
                                    self.selfStrategy
                                    ];
 
         self.changeTrackerBootStrap = [[ZMChangeTrackerBootstrap alloc] initWithManagedObjectContext:self.syncMOC changeTrackers:self.allChangeTrackers];
 
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(managedObjectContextDidSave:) name:NSManagedObjectContextDidSaveNotification object:self.syncMOC];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(managedObjectContextDidSave:) name:NSManagedObjectContextDidSaveNotification object:uiMOC];
+        ZM_ALLOW_MISSING_SELECTOR([[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(managedObjectContextDidSave:) name:NSManagedObjectContextDidSaveNotification object:self.syncMOC]);
+        ZM_ALLOW_MISSING_SELECTOR([[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(managedObjectContextDidSave:) name:NSManagedObjectContextDidSaveNotification object:uiMOC]);
 
         [application registerObserverForDidEnterBackground:self selector:@selector(appDidEnterBackground:)];
         [application registerObserverForWillEnterForeground:self selector:@selector(appWillEnterForeground:)];
@@ -247,39 +269,35 @@ ZM_EMPTY_ASSERTING_INIT()
     return self;
 }
 
-- (void)createTranscodersWithClientRegistrationStatus:(ZMClientRegistrationStatus *)clientRegistrationStatus
-                         localNotificationsDispatcher:(ZMLocalNotificationDispatcher *)localNotificationsDispatcher
-                                 authenticationStatus:(ZMAuthenticationStatus *)authenticationStatus
-                         backgroundAPNSPingBackStatus:(BackgroundAPNSPingBackStatus *)backgroundAPNSPingBackStatus
-                                        accountStatus:(ZMAccountStatus *)accountStatus
+- (void)createTranscodersWithLocalNotificationsDispatcher:(ZMLocalNotificationDispatcher *)localNotificationsDispatcher
                                          mediaManager:(id<AVSMediaManager>)mediaManager
                                   onDemandFlowManager:(ZMOnDemandFlowManager *)onDemandFlowManager
                              taskCancellationProvider:(id <ZMRequestCancellation>)taskCancellationProvider
 
 {
     NSManagedObjectContext *uiMOC = self.uiMOC;
-
+    
     self.eventDecoder = [[EventDecoder alloc] initWithEventMOC:self.eventMOC syncMOC:self.syncMOC];
-    self.connectionTranscoder = [[ZMConnectionTranscoder alloc] initWithManagedObjectContext:self.syncMOC syncStatus:self.syncStatus clientRegistrationDelegate:clientRegistrationStatus];
-    self.userTranscoder = [[ZMUserTranscoder alloc] initWithManagedObjectContext:self.syncMOC syncStatus:self.syncStatus clientRegistrationDelegate:clientRegistrationStatus];
-    self.selfStrategy = [[ZMSelfStrategy alloc] initWithClientRegistrationStatus:clientRegistrationStatus managedObjectContext:self.syncMOC];
-    self.conversationTranscoder = [[ZMConversationTranscoder alloc] initWithManagedObjectContext:self.syncMOC authenticationStatus:authenticationStatus accountStatus:accountStatus syncStrategy:self syncStatus:self.syncStatus clientRegistrationDelegate:clientRegistrationStatus];
+    self.connectionTranscoder = [[ZMConnectionTranscoder alloc] initWithManagedObjectContext:self.syncMOC syncStatus:self.syncStatus clientRegistrationDelegate:self.clientRegistrationStatus];
+    self.userTranscoder = [[ZMUserTranscoder alloc] initWithManagedObjectContext:self.syncMOC syncStatus:self.syncStatus clientRegistrationDelegate:self.clientRegistrationStatus];
+    self.selfStrategy = [[ZMSelfStrategy alloc] initWithClientRegistrationStatus:self.clientRegistrationStatus managedObjectContext:self.syncMOC];
+    self.conversationTranscoder = [[ZMConversationTranscoder alloc] initWithManagedObjectContext:self.syncMOC authenticationStatus:self.authenticationStatus accountStatus:self.accountStatus syncStrategy:self syncStatus:self.syncStatus clientRegistrationDelegate:self.clientRegistrationStatus];
     self.systemMessageTranscoder = [ZMMessageTranscoder systemMessageTranscoderWithManagedObjectContext:self.syncMOC localNotificationDispatcher:localNotificationsDispatcher];
-    self.clientMessageTranscoder = [[ZMClientMessageTranscoder alloc ] initWithManagedObjectContext:self.syncMOC localNotificationDispatcher:localNotificationsDispatcher clientRegistrationStatus:clientRegistrationStatus apnsConfirmationStatus: self.apnsConfirmationStatus];
-    self.registrationTranscoder = [[ZMRegistrationTranscoder alloc] initWithManagedObjectContext:self.syncMOC authenticationStatus:authenticationStatus];
-    self.missingUpdateEventsTranscoder = [[ZMMissingUpdateEventsTranscoder alloc] initWithSyncStrategy:self previouslyReceivedEventIDsCollection:self.eventDecoder application:self.application backgroundAPNSPingbackStatus:backgroundAPNSPingBackStatus syncStatus:self.syncStatus clientRegistrationDelegate:clientRegistrationStatus];
-    self.lastUpdateEventIDTranscoder = [[ZMLastUpdateEventIDTranscoder alloc] initWithManagedObjectContext:self.syncMOC objectDirectory:self syncStatus:self.syncStatus clientRegistrationDelegate:clientRegistrationStatus];
+    self.clientMessageTranscoder = [[ZMClientMessageTranscoder alloc ] initWithManagedObjectContext:self.syncMOC localNotificationDispatcher:localNotificationsDispatcher clientRegistrationStatus:self.clientRegistrationStatus apnsConfirmationStatus: self.apnsConfirmationStatus];
+    self.registrationTranscoder = [[ZMRegistrationTranscoder alloc] initWithManagedObjectContext:self.syncMOC authenticationStatus:self.authenticationStatus];
+    self.missingUpdateEventsTranscoder = [[ZMMissingUpdateEventsTranscoder alloc] initWithSyncStrategy:self previouslyReceivedEventIDsCollection:self.eventDecoder application:self.application backgroundAPNSPingbackStatus:self.pingBackStatus syncStatus:self.syncStatus clientRegistrationDelegate:self.clientRegistrationStatus];
+    self.lastUpdateEventIDTranscoder = [[ZMLastUpdateEventIDTranscoder alloc] initWithManagedObjectContext:self.syncMOC objectDirectory:self syncStatus:self.syncStatus clientRegistrationDelegate:self.clientRegistrationStatus];
     self.flowTranscoder = [[ZMFlowSync alloc] initWithMediaManager:mediaManager onDemandFlowManager:onDemandFlowManager syncManagedObjectContext:self.syncMOC uiManagedObjectContext:uiMOC application:self.application];
     self.callStateTranscoder = [[ZMCallStateTranscoder alloc] initWithSyncManagedObjectContext:self.syncMOC uiManagedObjectContext:uiMOC objectStrategyDirectory:self];
-    self.loginTranscoder = [[ZMLoginTranscoder alloc] initWithManagedObjectContext:self.syncMOC authenticationStatus:authenticationStatus clientRegistrationStatus:clientRegistrationStatus];
-    self.loginCodeRequestTranscoder = [[ZMLoginCodeRequestTranscoder alloc] initWithManagedObjectContext:self.syncMOC authenticationStatus:authenticationStatus];
-    self.phoneNumberVerificationTranscoder = [[ZMPhoneNumberVerificationTranscoder alloc] initWithManagedObjectContext:self.syncMOC authenticationStatus:authenticationStatus];
+    self.loginTranscoder = [[ZMLoginTranscoder alloc] initWithManagedObjectContext:self.syncMOC authenticationStatus:self.authenticationStatus clientRegistrationStatus:self.clientRegistrationStatus];
+    self.loginCodeRequestTranscoder = [[ZMLoginCodeRequestTranscoder alloc] initWithManagedObjectContext:self.syncMOC authenticationStatus:self.authenticationStatus];
+    self.phoneNumberVerificationTranscoder = [[ZMPhoneNumberVerificationTranscoder alloc] initWithManagedObjectContext:self.syncMOC authenticationStatus:self.authenticationStatus];
     self.conversationStatusSync = [[ConversationStatusStrategy alloc] initWithManagedObjectContext:self.syncMOC];
-    self.fileUploadRequestStrategy = [[FileUploadRequestStrategy alloc] initWithClientRegistrationStatus:clientRegistrationStatus managedObjectContext:self.syncMOC taskCancellationProvider:taskCancellationProvider];
-    self.linkPreviewAssetDownloadRequestStrategy = [[LinkPreviewAssetDownloadRequestStrategy alloc] initWithAuthStatus:clientRegistrationStatus managedObjectContext:self.syncMOC];
-    self.linkPreviewAssetUploadRequestStrategy = [[LinkPreviewAssetUploadRequestStrategy alloc] initWithClientRegistrationDelegate:clientRegistrationStatus managedObjectContext:self.syncMOC];
-    self.imageDownloadRequestStrategy = [[ImageDownloadRequestStrategy alloc] initWithClientRegistrationStatus:clientRegistrationStatus  managedObjectContext:self.syncMOC];
-    self.imageUploadRequestStrategy = [[ImageUploadRequestStrategy alloc] initWithClientRegistrationStatus:clientRegistrationStatus managedObjectContext:self.syncMOC];
+    self.fileUploadRequestStrategy = [[FileUploadRequestStrategy alloc] initWithClientRegistrationStatus:self.clientRegistrationStatus managedObjectContext:self.syncMOC taskCancellationProvider:taskCancellationProvider];
+    self.linkPreviewAssetDownloadRequestStrategy = [[LinkPreviewAssetDownloadRequestStrategy alloc] initWithAuthStatus:self.clientRegistrationStatus managedObjectContext:self.syncMOC];
+    self.linkPreviewAssetUploadRequestStrategy = [[LinkPreviewAssetUploadRequestStrategy alloc] initWithClientRegistrationDelegate:self.clientRegistrationStatus managedObjectContext:self.syncMOC];
+    self.imageDownloadRequestStrategy = [[ImageDownloadRequestStrategy alloc] initWithClientRegistrationStatus:self.clientRegistrationStatus  managedObjectContext:self.syncMOC];
+    self.imageUploadRequestStrategy = [[ImageUploadRequestStrategy alloc] initWithClientRegistrationStatus:self.clientRegistrationStatus managedObjectContext:self.syncMOC];
 }
 
 - (void)appDidEnterBackground:(NSNotification *)note
@@ -326,19 +344,20 @@ ZM_EMPTY_ASSERTING_INIT()
 
 - (void)didInterruptUpdateEventsStream
 {
-//    if (self.stateMachine.currentState != self.stateMachine.backgroundFetchState
-//        && self.stateMachine.currentState != self.stateMachine.backgroundState
-//        && self.stateMachine.currentState != self.stateMachine.preBackgroundState)
-//    {
-//        // TODO Sabine how should the background states be handled?
-        [self.syncStatus pushChannelDidClose];
-//    }
+    [self.syncStatus pushChannelDidClose];
 }
 
 - (void)tearDown
 {
     self.tornDown = YES;
     [self.apnsConfirmationStatus tearDown];
+    [self.clientUpdateStatus tearDown];
+    self.clientUpdateStatus = nil;
+    [self.clientRegistrationStatus tearDown];
+    self.clientRegistrationStatus = nil;
+    self.authenticationStatus = nil;
+    self.userProfileUpdateStatus = nil;
+    self.proxiedRequestStatus = nil;
     self.eventDecoder = nil;
     [self.eventMOC tearDown];
     self.eventMOC = nil;
@@ -382,100 +401,6 @@ ZM_EMPTY_ASSERTING_INIT()
 }
 
 
-- (void)logDidSaveNotification:(NSNotification *)note;
-{
-    NSManagedObjectContext * ZM_UNUSED moc = note.object;
-    ZMLogWithLevelAndTag(ZMLogLevelDebug, ZMTAG_CORE_DATA, @"<%@: %p> did save. Context type = %@",
-               moc.class, moc,
-               moc.zm_isUserInterfaceContext ? @"UI" : moc.zm_isSyncContext ? @"Sync" : @"");
-    NSSet *inserted = note.userInfo[NSInsertedObjectsKey];
-    if (inserted.count > 0) {
-        NSString * ZM_UNUSED description = [[inserted.allObjects mapWithBlock:^id(NSManagedObject *mo) {
-            return mo.objectID.URIRepresentation;
-        }] componentsJoinedByString:@", "];
-        ZMLogWithLevelAndTag(ZMLogLevelDebug, ZMTAG_CORE_DATA, @"    Inserted: %@", description);
-    }
-    NSSet *updated = note.userInfo[NSUpdatedObjectsKey];
-    if (updated.count > 0) {
-        NSString * ZM_UNUSED description = [[updated.allObjects mapWithBlock:^id(NSManagedObject *mo) {
-            return mo.objectID.URIRepresentation;
-        }] componentsJoinedByString:@", "];
-        ZMLogWithLevelAndTag(ZMLogLevelDebug, ZMTAG_CORE_DATA, @"    Updated: %@", description);
-    }
-    NSSet *deleted = note.userInfo[NSDeletedObjectsKey];
-    if (deleted.count > 0) {
-        NSString * ZM_UNUSED description = [[deleted.allObjects mapWithBlock:^id(NSManagedObject *mo) {
-            return mo.objectID.URIRepresentation;
-        }] componentsJoinedByString:@", "];
-        ZMLogWithLevelAndTag(ZMLogLevelDebug, ZMTAG_CORE_DATA, @"    Deleted: %@", description);
-    }
-}
-
-- (void)managedObjectContextDidSave:(NSNotification *)note;
-{
-    if(self.tornDown || self.contextMergingDisabled) {
-        return;
-    }
-    
-    if([ZMSLog getLevelWithTag:ZMTAG_CORE_DATA] == ZMLogLevelDebug) {
-        [self logDidSaveNotification:note];
-    }
-    
-    NSManagedObjectContext *mocThatSaved = note.object;
-    NSManagedObjectContext *strongUiMoc = self.uiMOC;
-    ZMCallState *callStateChanges = mocThatSaved.zm_callState.createCopyAndResetHasChanges;
-    
-    if (mocThatSaved.zm_isUserInterfaceContext && strongUiMoc != nil) {
-        if(mocThatSaved != strongUiMoc) {
-            RequireString(mocThatSaved == strongUiMoc, "Not the right MOC!");
-        }
-        
-        NSSet *conversationsWithCallChanges = [callStateChanges allContainedConversationsInContext:strongUiMoc];
-        if (conversationsWithCallChanges != nil) {
-            [strongUiMoc.globalManagedObjectContextObserver notifyUpdatedCallState:conversationsWithCallChanges notifyDirectly:YES];
-        }
-        
-        ZM_WEAK(self);
-        [self.syncMOC performGroupedBlock:^{
-            ZM_STRONG(self);
-            if(self == nil || self.tornDown) {
-                return;
-            }
-            NSSet *changedConversations = [self.syncMOC mergeCallStateChanges:callStateChanges];
-            [self.syncMOC mergeChangesFromContextDidSaveNotification:note];
-            
-            [self processSaveWithInsertedObjects:[NSSet set] updateObjects:changedConversations];
-            [self.syncMOC processPendingChanges]; // We need this because merging sometimes leaves the MOC in a 'dirty' state
-        }];
-    } else if (mocThatSaved.zm_isSyncContext) {
-        RequireString(mocThatSaved == self.syncMOC, "Not the right MOC!");
-        
-        ZM_WEAK(self);
-        [strongUiMoc performGroupedBlock:^{
-            ZM_STRONG(self);
-            if(self == nil || self.tornDown) {
-                return;
-            }
-    
-            NSSet *changedConversations = [strongUiMoc mergeCallStateChanges:callStateChanges];
-            [strongUiMoc.globalManagedObjectContextObserver notifyUpdatedCallState:changedConversations notifyDirectly:[self shouldForwardCallStateChangeDirectlyForNote:note]];
-           
-            [strongUiMoc mergeChangesFromContextDidSaveNotification:note];
-            [strongUiMoc processPendingChanges]; // We need this because merging sometimes leaves the MOC in a 'dirty' state
-        }];
-    }
-}
-
-- (BOOL)shouldForwardCallStateChangeDirectlyForNote:(NSNotification *)note
-{
-    if ([(NSSet *)note.userInfo[NSInsertedObjectsKey] count] == 0 &&
-        [(NSSet *)note.userInfo[NSDeletedObjectsKey] count] == 0 &&
-        [(NSSet *)note.userInfo[NSUpdatedObjectsKey] count] == 0 &&
-        [(NSSet *)note.userInfo[NSRefreshedObjectsKey] count] == 0) {
-        return YES;
-    }
-    return NO;
-}
 
 - (NSArray<ZMObjectSyncStrategy *> *)allTranscoders;
 {
@@ -511,18 +436,6 @@ ZM_EMPTY_ASSERTING_INIT()
 }
 
 
-- (BOOL)processSaveWithInsertedObjects:(NSSet *)insertedObjects updateObjects:(NSSet *)updatedObjects
-{
-    NSSet *allObjects = [NSSet zmSetByCompiningSets:insertedObjects, updatedObjects, nil];
-
-    for(id<ZMContextChangeTracker> tracker in self.allChangeTrackers)
-    {
-        [tracker objectsDidChange:allObjects];
-    }
-    
-    return YES;
-}
-
 - (ZMTransportRequest *)nextRequest
 {
     dispatch_once(&_didFetchObjects, ^{
@@ -538,55 +451,6 @@ ZM_EMPTY_ASSERTING_INIT()
         request = [self.requestStrategies firstNonNilReturnedFromSelector:@selector(nextRequest)];
     }
     return request;
-}
-
-- (void)processUpdateEvents:(NSArray *)events ignoreBuffer:(BOOL)ignoreBuffer;
-{
-    if(ignoreBuffer) {
-        [self consumeUpdateEvents:events];
-        return;
-    }
-    
-    NSArray *flowEvents = [events filterWithBlock:^BOOL(ZMUpdateEvent* event) {
-        return event.isFlowEvent;
-    }];
-    if(flowEvents.count > 0) {
-        [self consumeUpdateEvents:flowEvents];
-    }
-    NSArray *callstateEvents = [events filterWithBlock:^BOOL(ZMUpdateEvent* event) {
-        return event.type == ZMUpdateEventCallState;
-    }];
-    NSArray *notFlowEvents = [events filterWithBlock:^BOOL(ZMUpdateEvent* event) {
-        return !event.isFlowEvent;
-    }];
-    
-    if (self.syncStatus.isSyncing) {
-        for(ZMUpdateEvent *event in notFlowEvents) {
-            [self.eventsBuffer addUpdateEvent:event];
-        }
-    }
-    else {
-        switch(self.stateMachine.updateEventsPolicy) {
-            case ZMUpdateEventPolicyIgnore: {
-                if(callstateEvents.count > 0) {
-                    [self consumeUpdateEvents:callstateEvents];
-                }
-                break;
-            }
-            case ZMUpdateEventPolicyBuffer: {
-                for(ZMUpdateEvent *event in notFlowEvents) {
-                    [self.eventsBuffer addUpdateEvent:event];
-                }
-                break;
-            }
-            case ZMUpdateEventPolicyProcess: {
-                if(notFlowEvents.count > 0) {
-                    [self consumeUpdateEvents:notFlowEvents];
-                }
-                break;
-            }
-        }
-    }
 }
 
 - (ZMFetchRequestBatch *)fetchRequestBatchForEvents:(NSArray<ZMUpdateEvent *> *)events
@@ -612,66 +476,6 @@ ZM_EMPTY_ASSERTING_INIT()
     [fetchRequestBatch addConversationRemoteIdentifiersToPrefetchConversations:remoteIdentifiers];
     
     return fetchRequestBatch;
-}
-
-- (void)consumeUpdateEvents:(NSArray<ZMUpdateEvent *>*)events
-{
-    ZM_WEAK(self);
-    [self.eventDecoder processEvents:events block:^(NSArray<ZMUpdateEvent *> * decryptedEvents) {
-        ZM_STRONG(self);
-        if (self == nil){
-            return;
-        }
-        
-        ZMFetchRequestBatch *fetchRequest = [self fetchRequestBatchForEvents:decryptedEvents];
-        ZMFetchRequestBatchResult *prefetchResult = [self.syncMOC executeFetchRequestBatchOrAssert:fetchRequest];
-        NSArray *allObjectStrategies = [self.allTranscoders arrayByAddingObjectsFromArray:self.requestStrategies];
-        
-        for(id obj in allObjectStrategies) {
-            @autoreleasepool {
-                if ([obj conformsToProtocol:@protocol(ZMEventConsumer)]) {
-                    [obj processEvents:decryptedEvents liveEvents:YES prefetchResult:prefetchResult];
-                }
-            }
-        }
-        [self.localNotificationDispatcher processEvents:decryptedEvents liveEvents:YES prefetchResult:nil];
-        [self.syncMOC enqueueDelayedSave];
-    }];
-}
-
-- (void)processDownloadedEvents:(NSArray <ZMUpdateEvent *>*)events;
-{
-    ZM_WEAK(self);
-    [self.eventDecoder processEvents:events block:^(NSArray<ZMUpdateEvent *> * decryptedEvents) {
-        ZM_STRONG(self);
-        if (self  == nil){
-            return;
-        }
-        
-        ZMFetchRequestBatch *fetchRequest = [self fetchRequestBatchForEvents:decryptedEvents];
-        ZMFetchRequestBatchResult *prefetchResult = [self.moc executeFetchRequestBatchOrAssert:fetchRequest];
-        
-        NSArray *allEventConsumers = [self.allTranscoders arrayByAddingObjectsFromArray:self.requestStrategies];
-        for(id<ZMEventConsumer> obj in allEventConsumers) {
-            @autoreleasepool {
-                if ([obj conformsToProtocol:@protocol(ZMEventConsumer)]) {
-                    ZMSTimePoint *tp = [ZMSTimePoint timePointWithInterval:5 label:[NSString stringWithFormat:@"Processing downloaded events in %@", [obj class]]];
-                    [obj processEvents:decryptedEvents liveEvents:NO prefetchResult:prefetchResult];
-                    [tp warnIfLongerThanInterval];
-                }
-            }
-        }
-    }];
-}
-
-- (NSArray *)conversationIdsThatHaveBufferedUpdatesForCallState;
-{
-    return [[self.eventsBuffer updateEvents] mapWithBlock:^id(ZMUpdateEvent *event) {
-        if (event.type == ZMUpdateEventCallState) {
-            return event.conversationUUID;
-        }
-        return nil;
-    }];
 }
 
 - (void)dataDidChange;
@@ -708,4 +512,11 @@ ZM_EMPTY_ASSERTING_INIT()
     [[NSNotificationCenter defaultCenter] postNotificationName:ZMApplicationDidEnterEventProcessingStateNotificationName object:nil];
 }
 
+- (void)didRegisterUserClient:(UserClient *)userClient
+{
+    [self.syncStateDelegate didRegisterUserClient:userClient];
+}
+
 @end
+
+

--- a/Source/UserSession/ZMAccountStatus.swift
+++ b/Source/UserSession/ZMAccountStatus.swift
@@ -29,16 +29,16 @@ import ZMCDataModel
 
 
 @objc public protocol ZMCookieProvider : NSObjectProtocol {
-    var authenticationCookieData : Data! { get }
+    var data : Data! { get }
 }
 
-extension ZMPersistentCookieStorage : ZMCookieProvider {
+extension ZMCookie : ZMCookieProvider {
 }
 
 public final class ZMAccountStatus : NSObject, ZMInitialSyncCompletionObserver, ZMAuthenticationObserver, ZMRegistrationObserver {
 
     let managedObjectContext: NSManagedObjectContext
-    let cookieStorage : ZMCookieProvider
+    let cookieProvider : ZMCookieProvider
     var authenticationToken : ZMAuthenticationObserverToken!
     var registrationToken : ZMRegistrationObserverToken!
     
@@ -53,7 +53,7 @@ public final class ZMAccountStatus : NSObject, ZMInitialSyncCompletionObserver, 
     }()
     
     var hasCookie : Bool {
-        return cookieStorage.authenticationCookieData != nil
+        return cookieProvider.data != nil
     }
     
     @objc public func initialSyncCompleted(_ note: Notification){
@@ -101,7 +101,7 @@ public final class ZMAccountStatus : NSObject, ZMInitialSyncCompletionObserver, 
     
     @objc public init(managedObjectContext: NSManagedObjectContext, cookieStorage: ZMCookieProvider) {
         self.managedObjectContext = managedObjectContext
-        self.cookieStorage = cookieStorage
+        self.cookieProvider = cookieStorage
         
         super.init()
         

--- a/Source/UserSession/ZMClientRegistrationStatus.h
+++ b/Source/UserSession/ZMClientRegistrationStatus.h
@@ -16,6 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
+#import "ZMSyncStateDelegate.h"
 
 @class ZMCredentials;
 @class UserClient;
@@ -24,8 +25,6 @@
 @class ZMCookie;
 
 @protocol ZMCredentialProvider;
-
-
 
 
 typedef NS_ENUM(NSUInteger, ZMClientRegistrationPhase) {
@@ -55,11 +54,7 @@ typedef NS_ENUM(NSUInteger, ZMClientRegistrationPhase) {
 extern NSString *const ZMPersistedClientIdKey;
 
 
-@protocol ZMClientRegistrationStatusDelegate <NSObject>
 
-- (void)didRegisterUserClient:(UserClient *)userClient;
-
-@end
 
 
 @protocol ZMClientClientRegistrationStatusProvider <NSObject>

--- a/Source/UserSession/ZMUserSession+Internal.h
+++ b/Source/UserSession/ZMUserSession+Internal.h
@@ -48,9 +48,6 @@ extern NSString * const ZMAppendAVSLogNotificationName;
 @property (nonatomic, readonly) ZMClientRegistrationStatus *clientRegistrationStatus;
 @property (nonatomic, readonly) ClientUpdateStatus *clientUpdateStatus;
 @property (nonatomic, readonly) ZMAccountStatus *accountStatus;
-@end
-
-@interface ZMUserSession (GiphyRequestStatus)
 @property (nonatomic, readonly) ProxiedRequestsStatus *proxiedRequestStatus;
 @end
 

--- a/Source/UserSession/ZMUserSession+Registration.m
+++ b/Source/UserSession/ZMUserSession+Registration.m
@@ -26,6 +26,8 @@
 #import "ZMUserSession+Internal.h"
 #import "ZMUserSession+Registration.h"
 #import "ZMUserSession+Authentication.h"
+#import "ZMOperationLoop+Private.h"
+#import "ZMSyncStrategy.h"
 #import "NSError+ZMUserSessionInternal.h"
 #import "ZMUserSessionRegistrationNotification.h"
 #import "ZMCredentials.h"

--- a/Tests/Source/MessagingTest.m
+++ b/Tests/Source/MessagingTest.m
@@ -224,7 +224,6 @@
     NSManagedObjectContext *refAlternativeTestMOC = self.alternativeTestMOC;
     NSManagedObjectContext *refSearchMoc = self.searchMOC;
     NSManagedObjectContext *refSyncMoc = self.syncMOC;
-    
     WaitForAllGroupsToBeEmpty(2);
     
     self.uiMOC = nil;

--- a/Tests/Source/Synchronization/Sync States/ZMEventProcessingStateTests.m
+++ b/Tests/Source/Synchronization/Sync States/ZMEventProcessingStateTests.m
@@ -60,16 +60,6 @@
     XCTAssertEqual(self.sut.updateEventsPolicy, ZMUpdateEventPolicyProcess);
 }
 
-- (void)testThatItCallsDoesNotCallDidFinishSyncOnEnter
-{
-    // expect
-    [[(id)self.stateMachine reject] didFinishSync];
-    [[(id)self.objectDirectory stub] processAllEventsInBuffer];
-    
-    // when
-    [self.sut didEnterState];
-}
-
 - (void)testThatItSwitchesToPreBackgroundState
 {
     // expectation

--- a/Tests/Source/Synchronization/Sync States/ZMSyncStateMachineTests.m
+++ b/Tests/Source/Synchronization/Sync States/ZMSyncStateMachineTests.m
@@ -379,30 +379,6 @@
     XCTAssertEqual(request, [self.sut nextRequest]);
 }
 
-- (void)testThatItForwardsDidStartSyncToSyncStateDelegate
-{
-    // expect
-    [[self.syncStateDelegate expect] didStartSync];
-    
-    // when
-    [self.sut didStartSync];
-    
-    // then
-    [self.syncStateDelegate verify];
-}
-
-- (void)testThatItForwardsDidFinishSyncToSyncStateDelegate
-{
-    // expect
-    [[self.syncStateDelegate expect] didFinishSync];
-    
-    // when
-    [self.sut didFinishSync];
-    
-    // then
-    [self.syncStateDelegate verify];
-}
-
 - (void)testThatItForwardsDidEnterBackgroundToTheCurrentState
 {
     // expect

--- a/Tests/Source/Synchronization/SynchronizationMocks.swift
+++ b/Tests/Source/Synchronization/SynchronizationMocks.swift
@@ -160,6 +160,8 @@ public class MockSyncStatus : SyncStatus {
 }
 
 public class MockSyncStateDelegate : NSObject, ZMSyncStateDelegate {
+
+    var registeredUserClient : UserClient?
     var didCallStartSync = false
     var didCallFinishSync = false
 
@@ -169,6 +171,10 @@ public class MockSyncStateDelegate : NSObject, ZMSyncStateDelegate {
     
     public func didFinishSync() {
         didCallFinishSync = true
+    }
+    
+    public func didRegister(_ userClient: UserClient!) {
+        registeredUserClient = userClient
     }
 }
 

--- a/Tests/Source/Synchronization/Transcoders/ObjectTranscoderTests.h
+++ b/Tests/Source/Synchronization/Transcoders/ObjectTranscoderTests.h
@@ -19,6 +19,7 @@
 
 #import "MessagingTest.h"
 #import "ZMSyncStrategy.h"
+#import "ZMSyncStrategy+EventProcessing.h"
 
 
 

--- a/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.m
@@ -26,7 +26,6 @@
 #import "ObjectTranscoderTests.h"
 #import "ZMConversationTranscoder.h"
 #import "ZMConversationTranscoder+Internal.h"
-#import "ZMSyncStrategy.h"
 #import "ZMSimpleListRequestPaginator.h"
 #import "zmessaging_iOS_Tests-Swift.h"
 

--- a/Tests/Source/Synchronization/Transcoders/ZMLastUpdateEventIDTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMLastUpdateEventIDTranscoderTests.m
@@ -20,9 +20,8 @@
 @import ZMTransport;
 @import zmessaging;
 
-#import "MessagingTest.h"
+#import "ObjectTranscoderTests.h"
 #import "ZMLastUpdateEventIDTranscoder+Internal.h"
-#import "ZMSyncStrategy.h"
 #import "ZMObjectStrategyDirectory.h"
 #import "ZMMissingUpdateEventsTranscoder+Internal.h"
 #import "zmessaging_iOS_Tests-Swift.h"

--- a/Tests/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoderTests.m
@@ -23,12 +23,11 @@
 #import <Foundation/Foundation.h>
 
 #import "MessagingTest.h"
-#import "ZMMissingUpdateEventsTranscoder+Internal.h"
-#import "ZMSyncStrategy.h"
-#import "ZMSimpleListRequestPaginator.h"
-#import <zmessaging/zmessaging-Swift.h>
-#import "zmessaging_iOS_Tests-Swift.h"
 #import "ZMSyncStateDelegate.h"
+#import "ZMMissingUpdateEventsTranscoder+Internal.h"
+#import "ZMSyncStrategy+EventProcessing.h"
+#import "ZMSimpleListRequestPaginator.h"
+#import "zmessaging_iOS_Tests-Swift.h"
 
 
 static NSString * const LastUpdateEventIDStoreKey = @"LastUpdateEventID";

--- a/Tests/Source/UserSession/ZMAccountStatusTests.swift
+++ b/Tests/Source/UserSession/ZMAccountStatusTests.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
 // 
@@ -24,7 +24,7 @@ class MockCookieStorage : NSObject, ZMCookieProvider {
     
     var shouldReturnCookie : Bool = false
     
-    var authenticationCookieData : Data! {
+    var data : Data! {
         if shouldReturnCookie {
             return Data()
         }

--- a/Tests/Source/UserSession/ZMUserSessionAuthenticationTests.m
+++ b/Tests/Source/UserSession/ZMUserSessionAuthenticationTests.m
@@ -20,6 +20,7 @@
 #import "ZMUserSessionTestsBase.h"
 #import "ZMUserSession+Authentication.h"
 #import "ZMAuthenticationStatus+Testing.h"
+#import "ZMClientRegistrationStatus.h"
 
 @interface ZMUserSessionAuthenticationTests : ZMUserSessionTestsBase
 

--- a/Tests/Source/UserSession/ZMUserSessionTestsBase.h
+++ b/Tests/Source/UserSession/ZMUserSessionTestsBase.h
@@ -71,4 +71,7 @@
 @property (nonatomic) id<ZMAuthenticationObserver> authenticationObserver;
 @property (nonatomic) id<ZMRegistrationObserver> registrationObserver;
 
+@property (nonatomic) ZMAuthenticationStatus * authenticationStatus;
+@property (nonatomic) ZMClientRegistrationStatus * clientRegistrationStatus;
+@property (nonatomic) ProxiedRequestsStatus *proxiedRequestStatus;
 @end

--- a/zmessaging-cocoa.xcodeproj/project.pbxproj
+++ b/zmessaging-cocoa.xcodeproj/project.pbxproj
@@ -344,6 +344,10 @@
 		F96C8E7A1D7DCCE8004B6D87 /* ZMLocalNotificationDispatcher+Messages.swift in Sources */ = {isa = PBXBuildFile; fileRef = F96C8E791D7DCCE8004B6D87 /* ZMLocalNotificationDispatcher+Messages.swift */; };
 		F96C8E821D7ECECF004B6D87 /* ZMLocalNotificationForMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F96C8E811D7ECECF004B6D87 /* ZMLocalNotificationForMessageTests.swift */; };
 		F96C8E8A1D7F6F8C004B6D87 /* ZMLocalNotificationForSystemMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F96C8E891D7F6F8C004B6D87 /* ZMLocalNotificationForSystemMessageTests.swift */; };
+		F96DBEEA1DF9A570008FE832 /* ZMSyncStrategy+ManagedObjectChanges.h in Headers */ = {isa = PBXBuildFile; fileRef = F96DBEE81DF9A570008FE832 /* ZMSyncStrategy+ManagedObjectChanges.h */; };
+		F96DBEEB1DF9A570008FE832 /* ZMSyncStrategy+ManagedObjectChanges.m in Sources */ = {isa = PBXBuildFile; fileRef = F96DBEE91DF9A570008FE832 /* ZMSyncStrategy+ManagedObjectChanges.m */; };
+		F96DBEEE1DF9A79F008FE832 /* ZMSyncStrategy+EventProcessing.h in Headers */ = {isa = PBXBuildFile; fileRef = F96DBEEC1DF9A79F008FE832 /* ZMSyncStrategy+EventProcessing.h */; };
+		F96DBEEF1DF9A79F008FE832 /* ZMSyncStrategy+EventProcessing.m in Sources */ = {isa = PBXBuildFile; fileRef = F96DBEED1DF9A79F008FE832 /* ZMSyncStrategy+EventProcessing.m */; };
 		F97180531A9E18B5002CEAF8 /* ZMFlowSync.h in Headers */ = {isa = PBXBuildFile; fileRef = 3EAD6A09199BB79200D519DB /* ZMFlowSync.h */; };
 		F97678FA1D76D11400CC075D /* BackgroundAPNSConfirmationStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97678F91D76D11400CC075D /* BackgroundAPNSConfirmationStatus.swift */; };
 		F976790A1D771B3900CC075D /* BackgroundAPNSConfirmationStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97679081D771B2700CC075D /* BackgroundAPNSConfirmationStatusTests.swift */; };
@@ -662,7 +666,7 @@
 		54764B9E1C931E9400BD25E3 /* not_animated.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = not_animated.gif; sourceTree = "<group>"; };
 		5476E3BB19A77C6900E68BAD /* PushChannelTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PushChannelTests.m; sourceTree = "<group>"; };
 		54773ABC1DF093AC00B484AF /* ZMSearchDirectoryAddressBookTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMSearchDirectoryAddressBookTests.swift; sourceTree = "<group>"; };
-		5477CDF01BFE0D2700A36F7A /* Cartfile.resolved */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Cartfile.resolved; sourceTree = "<group>"; };
+		5477CDF01BFE0D2700A36F7A /* º */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "º"; sourceTree = "<group>"; };
 		5478A1401DEC4048006F7268 /* UserProfile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserProfile.swift; sourceTree = "<group>"; };
 		547E5B571DDB4B800038D936 /* UserProfileUpdateStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserProfileUpdateStatus.swift; sourceTree = "<group>"; };
 		547E5B591DDB67390038D936 /* UserProfileUpdateRequestStrategy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserProfileUpdateRequestStrategy.swift; sourceTree = "<group>"; };
@@ -738,7 +742,6 @@
 		54D784FD1A37248000F47798 /* ZMEncodedNSUUIDWithTimestampTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMEncodedNSUUIDWithTimestampTests.m; sourceTree = "<group>"; };
 		54D9331C1AE1643A00C0B91C /* ZMCredentials.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZMCredentials.h; sourceTree = "<group>"; };
 		54D9331F1AE1653000C0B91C /* ZMCredentials.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMCredentials.m; sourceTree = "<group>"; };
-		54D9811519EBBCF400037518 /* ZMSearchTopConversationsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ZMSearchTopConversationsTests.m; path = Search/ZMSearchTopConversationsTests.m; sourceTree = "<group>"; };
 		54DE26B11BC56E62002B5FBC /* ZMHotFixDirectory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZMHotFixDirectory.h; sourceTree = "<group>"; };
 		54DE26B21BC56E62002B5FBC /* ZMHotFixDirectory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMHotFixDirectory.m; sourceTree = "<group>"; };
 		54DE9BEA1DE74FFB00EFFB9C /* RandomHandleGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RandomHandleGenerator.swift; sourceTree = "<group>"; };
@@ -934,6 +937,10 @@
 		F96C8E791D7DCCE8004B6D87 /* ZMLocalNotificationDispatcher+Messages.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMLocalNotificationDispatcher+Messages.swift"; sourceTree = "<group>"; };
 		F96C8E811D7ECECF004B6D87 /* ZMLocalNotificationForMessageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMLocalNotificationForMessageTests.swift; sourceTree = "<group>"; };
 		F96C8E891D7F6F8C004B6D87 /* ZMLocalNotificationForSystemMessageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMLocalNotificationForSystemMessageTests.swift; sourceTree = "<group>"; };
+		F96DBEE81DF9A570008FE832 /* ZMSyncStrategy+ManagedObjectChanges.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ZMSyncStrategy+ManagedObjectChanges.h"; sourceTree = "<group>"; };
+		F96DBEE91DF9A570008FE832 /* ZMSyncStrategy+ManagedObjectChanges.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ZMSyncStrategy+ManagedObjectChanges.m"; sourceTree = "<group>"; };
+		F96DBEEC1DF9A79F008FE832 /* ZMSyncStrategy+EventProcessing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ZMSyncStrategy+EventProcessing.h"; sourceTree = "<group>"; };
+		F96DBEED1DF9A79F008FE832 /* ZMSyncStrategy+EventProcessing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ZMSyncStrategy+EventProcessing.m"; sourceTree = "<group>"; };
 		F97678F91D76D11400CC075D /* BackgroundAPNSConfirmationStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackgroundAPNSConfirmationStatus.swift; sourceTree = "<group>"; };
 		F97679081D771B2700CC075D /* BackgroundAPNSConfirmationStatusTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackgroundAPNSConfirmationStatusTests.swift; sourceTree = "<group>"; };
 		F9771AC71B664D1A00BB04EC /* ZMGSMCallHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZMGSMCallHandler.h; sourceTree = "<group>"; };
@@ -1302,7 +1309,7 @@
 			children = (
 				09284B6A1B8272C300EEE10E /* zmessaging Test Host.entitlements */,
 				09CC4AB71B7CB8B700201C63 /* Cartfile */,
-				5477CDF01BFE0D2700A36F7A /* Cartfile.resolved */,
+				5477CDF01BFE0D2700A36F7A /* º */,
 				09CC4AB81B7CB8BF00201C63 /* Cartfile.private */,
 				3E18605F191A4F6A000FE027 /* README.md */,
 				5423B98C191A49CD0044347D /* Source */,
@@ -1816,6 +1823,10 @@
 				85D853338EC38D9B021D71BF /* ZMSyncStrategy.h */,
 				546BAD5F19F8149B007C4938 /* ZMSyncStrategy+Internal.h */,
 				85D859D47B6EBF09E4137658 /* ZMSyncStrategy.m */,
+				F96DBEE81DF9A570008FE832 /* ZMSyncStrategy+ManagedObjectChanges.h */,
+				F96DBEE91DF9A570008FE832 /* ZMSyncStrategy+ManagedObjectChanges.m */,
+				F96DBEEC1DF9A79F008FE832 /* ZMSyncStrategy+EventProcessing.h */,
+				F96DBEED1DF9A79F008FE832 /* ZMSyncStrategy+EventProcessing.m */,
 				1621D2701D770FB1007108C2 /* ZMSyncStateDelegate.h */,
 				54177D1F19A4CAE70037A220 /* ZMObjectStrategyDirectory.h */,
 				54F7217619A60E88009A8AF5 /* ZMUpdateEventsBuffer.h */,
@@ -2089,6 +2100,7 @@
 				F98EDCDA1D82B913001E65CB /* ZMLocalNotification+Internal.h in Headers */,
 				54D1751A1ADE8AA2001AA338 /* ZMUserSession+Registration.h in Headers */,
 				54D9331E1AE1643A00C0B91C /* ZMCredentials.h in Headers */,
+				F96DBEEE1DF9A79F008FE832 /* ZMSyncStrategy+EventProcessing.h in Headers */,
 				F9410F661DE4A01F007451FF /* ZMPushToken.h in Headers */,
 				54D175241ADE9449001AA338 /* ZMUserSession+Authentication.h in Headers */,
 				F936DB2A1C11DF40005E93AE /* ZMClientUpdateNotification.h in Headers */,
@@ -2132,6 +2144,7 @@
 				54A3F24F1C08523500FE3A6B /* ZMOperationLoop.h in Headers */,
 				544BA12B1A433DE400D3B852 /* ZMSearchDirectory.h in Headers */,
 				54FEAAA91BC7BB9C002DE521 /* ZMBlacklistDownloader+Testing.h in Headers */,
+				F96DBEEA1DF9A570008FE832 /* ZMSyncStrategy+ManagedObjectChanges.h in Headers */,
 				09E393B31BAAABCC00F3EA1B /* ZMAuthenticationStatus_Internal.h in Headers */,
 				F9CA51B71B345F39003AA83A /* ZMStoredLocalNotification.h in Headers */,
 				544BA1311A433DE400D3B852 /* ZMNetworkState.h in Headers */,
@@ -2632,7 +2645,9 @@
 				54B2A08A1DAE71F100BB40B1 /* AnalyticsType.swift in Sources */,
 				54EFF35D1D6D6CE9005DED56 /* ZMSearchResult+AddressBook.swift in Sources */,
 				F98EDCD61D82B913001E65CB /* ZMLocalNotificationForReactions.swift in Sources */,
+				F96DBEEF1DF9A79F008FE832 /* ZMSyncStrategy+EventProcessing.m in Sources */,
 				54991D581DEDCF2B007E282F /* AddressBook.swift in Sources */,
+				F96DBEEB1DF9A570008FE832 /* ZMSyncStrategy+ManagedObjectChanges.m in Sources */,
 				3EDBFD781A65200F0095E2DD /* ZMPushRegistrant.swift in Sources */,
 				F98EDCEF1D82B924001E65CB /* UILocalNotification+UserInfo.m in Sources */,
 				F98EDCF01D82B924001E65CB /* ZMLocalNotificationLocalization+Components.swift in Sources */,


### PR DESCRIPTION
**In this PR**
ZMClientregistrationStatus, ZMAuthenticationStatus et al used to be initialized by ZMUserSession. We are now intializing them in ZMSyncStrategy instead.

Plus some clean-up of remaining previous PRs.

rebased copy of https://github.com/wireapp/wire-ios-sync-engine/pull/179