### PR TITLE
Fix double save on requesting profile image

### DIFF
--- a/Source/Data Model/ZMUser+UserSession.m
+++ b/Source/Data Model/ZMUser+UserSession.m
@@ -32,11 +32,17 @@
     
     if (self.localMediumRemoteIdentifier != nil) {
         self.localMediumRemoteIdentifier = nil;
-        [self.managedObjectContext saveOrRollback];
+        ZMSDispatchGroup *group = [ZMSDispatchGroup groupWithLabel:@"ZMUser"];
+        [self.managedObjectContext enqueueDelayedSaveWithGroup:group];
+        
+        [group notifyOnQueue:dispatch_get_main_queue() block:^{
+            [UserImageStrategy requestAssetForUserWith:self.objectID];
+            [ZMRequestAvailableNotification notifyNewRequestsAvailable:self];
+        }];
+    } else {
+        [UserImageStrategy requestAssetForUserWith:self.objectID];
+        [ZMRequestAvailableNotification notifyNewRequestsAvailable:self];
     }
-    
-    [UserImageStrategy requestAssetForUserWith:self.objectID];
-    [ZMRequestAvailableNotification notifyNewRequestsAvailable:self];
 }
 
 - (void)requestSmallProfileImageInUserSession:(ZMUserSession *)userSession;
@@ -49,11 +55,17 @@
     
     if (self.localSmallProfileRemoteIdentifier != nil) {
         self.localSmallProfileRemoteIdentifier = nil;
-        [self.managedObjectContext saveOrRollback];
+        ZMSDispatchGroup *group = [ZMSDispatchGroup groupWithLabel:@"ZMUser"];
+        [self.managedObjectContext enqueueDelayedSaveWithGroup:group];
+        
+        [group notifyOnQueue:dispatch_get_main_queue() block:^{
+            [UserImageStrategy requestSmallAssetForUserWith:self.objectID];
+            [ZMRequestAvailableNotification notifyNewRequestsAvailable:self];
+        }];
+    } else {
+        [UserImageStrategy requestSmallAssetForUserWith:self.objectID];
+        [ZMRequestAvailableNotification notifyNewRequestsAvailable:self];
     }
-    
-    [UserImageStrategy requestSmallAssetForUserWith:self.objectID];
-    [ZMRequestAvailableNotification notifyNewRequestsAvailable:self];
 }
 
 - (id<ZMCommonContactsSearchToken>)searchCommonContactsInUserSession:(ZMUserSession *)session withDelegate:(id<ZMCommonContactsSearchDelegate>)delegate


### PR DESCRIPTION
Replace immediate save with a delayed save when requesting a
profile image, because it can result in a nested save if the
requesting is done as a result of a save.

https://wearezeta.atlassian.net/browse/ZIOS-7846