### PR TITLE
Unify V2 & V3 receiving video observering

### DIFF
--- a/Source/Calling/VoiceChanneRouter+CallFlow.swift
+++ b/Source/Calling/VoiceChanneRouter+CallFlow.swift
@@ -62,6 +62,10 @@ public extension VoiceChannelRouter {
         return WireCallCenter.addVoiceGainObserver(observer: observer, forConversation: conversation!, context: conversation!.managedObjectContext!)
     }
     
+    func addReceivedVideoObserver(_ observer: ReceivedVideoObserver) -> WireCallCenterObserverToken {
+        return WireCallCenter.addReceivedVideoObserver(observer: observer, forConversation: conversation!, context: conversation!.managedObjectContext!)
+    }
+    
     class func addStateObserver(_ observer: VoiceChannelStateObserver, userSession: ZMUserSession) -> WireCallCenterObserverToken {
         return WireCallCenter.addVoiceChannelStateObserver(observer: observer, context: userSession.managedObjectContext!)
     }

--- a/Source/Calling/VoiceChanneRouter+CallFlow.swift
+++ b/Source/Calling/VoiceChanneRouter+CallFlow.swift
@@ -50,22 +50,27 @@ public protocol CallFlow {
 
 public extension VoiceChannelRouter {
     
+    /// Add observer of voice channel state. Returns a token which needs to be retained as long as the observer should be active.
     func addStateObserver(_ observer: VoiceChannelStateObserver) -> WireCallCenterObserverToken {
         return WireCallCenter.addVoiceChannelStateObserver(conversation: conversation!, observer: observer, context: conversation!.managedObjectContext!)
     }
     
+    /// Add observer of voice channel participants. Returns a token which needs to be retained as long as the observer should be active.
     func addParticipantObserver(_ observer: VoiceChannelParticipantObserver) -> WireCallCenterObserverToken {
         return WireCallCenter.addVoiceChannelParticipantObserver(observer: observer, forConversation: conversation!, context: conversation!.managedObjectContext!)
     }
     
+    /// Add observer of voice gain. Returns a token which needs to be retained as long as the observer should be active.
     func addVoiceGainObserver(_ observer: VoiceGainObserver) -> WireCallCenterObserverToken {
         return WireCallCenter.addVoiceGainObserver(observer: observer, forConversation: conversation!, context: conversation!.managedObjectContext!)
     }
     
+    /// Add observer of received video. Returns a token which needs to be retained as long as the observer should be active.
     func addReceivedVideoObserver(_ observer: ReceivedVideoObserver) -> WireCallCenterObserverToken {
         return WireCallCenter.addReceivedVideoObserver(observer: observer, forConversation: conversation!, context: conversation!.managedObjectContext!)
     }
     
+    /// Add observer of the state of all voice channels. Returns a token which needs to be retained as long as the observer should be active.
     class func addStateObserver(_ observer: VoiceChannelStateObserver, userSession: ZMUserSession) -> WireCallCenterObserverToken {
         return WireCallCenter.addVoiceChannelStateObserver(observer: observer, context: userSession.managedObjectContext!)
     }

--- a/Source/Calling/WireCallCenter.swift
+++ b/Source/Calling/WireCallCenter.swift
@@ -197,22 +197,27 @@ class ReceivedVideoObserverToken : NSObject {
 @objc
 public class WireCallCenter : NSObject {
     
+    /// Add observer of the state of a converations's voice channel. Returns a token which needs to be retained as long as the observer should be active.
     public class func addVoiceChannelStateObserver(conversation: ZMConversation, observer: VoiceChannelStateObserver, context: NSManagedObjectContext) -> WireCallCenterObserverToken {
         return VoiceChannelStateObserverFilter(context: context, observer: observer, conversation: conversation)
     }
     
+    /// Add observer of the state of all voice channels. Returns a token which needs to be retained as long as the observer should be active.
     public class func addVoiceChannelStateObserver(observer: VoiceChannelStateObserver, context: NSManagedObjectContext) -> WireCallCenterObserverToken {
         return VoiceChannelStateObserverToken(context: context, observer: observer)
     }
     
+    /// Add observer of particpants in a voice channel. Returns a token which needs to be retained as long as the observer should be active.
     public class func addVoiceChannelParticipantObserver(observer: VoiceChannelParticipantObserver, forConversation conversation: ZMConversation, context: NSManagedObjectContext) -> WireCallCenterObserverToken {
         return WireCallCenterV2.addVoiceChannelParticipantObserver(observer: observer, forConversation: conversation, context: context)
     }
     
+    /// Add observer of voice gain. Returns a token which needs to be retained as long as the observer should be active.
     public class func addVoiceGainObserver(observer: VoiceGainObserver, forConversation conversation: ZMConversation, context: NSManagedObjectContext) -> WireCallCenterObserverToken {
         return WireCallCenterV2.addVoiceGainObserver(observer: observer, forConversation: conversation, context: context)
     }
     
+    /// Add observer of received video. Returns a token which needs to be retained as long as the observer should be active.
     public class func addReceivedVideoObserver(observer: ReceivedVideoObserver, forConversation conversation: ZMConversation, context: NSManagedObjectContext) -> WireCallCenterObserverToken {
         return ReceivedVideoObserverToken(context: context, observer: observer, conversation: conversation)
     }

--- a/Source/Calling/WireCallCenterV2.swift
+++ b/Source/Calling/WireCallCenterV2.swift
@@ -311,6 +311,7 @@ public class WireCallCenterV2 : NSObject {
                                                object: nil)
     }
     
+    /// Add observer of the state of all voice channels. Returns a token which needs to unregistered with `removeObserver(token:)` to stop observing.
     public class func addVoiceChannelStateObserver(observer: WireCallCenterV2CallStateObserver, context: NSManagedObjectContext) -> WireCallCenterObserverToken {
         return NotificationCenter.default.addObserver(forName: VoiceChannelStateNotification.notificationName, object: nil, queue: nil) { [weak observer] (note) in
             if let note = note.userInfo?[VoiceChannelStateNotification.userInfoKey] as? VoiceChannelStateNotification {
@@ -323,14 +324,17 @@ public class WireCallCenterV2 : NSObject {
         }
     }
     
+    /// Add observer of particpants in a voice channel. Returns a token which needs to be retained as long as the observer should be active.
     public class func addVoiceChannelParticipantObserver(observer: VoiceChannelParticipantObserver, forConversation conversation: ZMConversation, context: NSManagedObjectContext) -> WireCallCenterObserverToken {
         return VoiceChannelParticipantsObserverToken(context: context, conversation: conversation, observer: observer)
     }
     
+    /// Add observer of voice gain. Returns a token which needs to be retained as long as the observer should be active.
     public class func addVoiceGainObserver(observer: VoiceGainObserver, forConversation conversation: ZMConversation, context: NSManagedObjectContext) -> WireCallCenterObserverToken {
         return VoiceGainObserverToken(context: context, conversationId: conversation.remoteIdentifier!, observer: observer)
     }
     
+    /// Add observer of received video. Returns a token which needs to be retained as long as the observer should be active.
     public class func addReceivedVideoObserver(observer: ReceivedVideoObserver, forConversation conversation: ZMConversation, context: NSManagedObjectContext) -> WireCallCenterObserverToken {
         return WireCallCenterV2ReceivedVideoObserverToken(context: context, conversation: conversation, observer: observer)
     }

--- a/Source/Calling/WireCallCenterV2.swift
+++ b/Source/Calling/WireCallCenterV2.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import ZMUtilities
+import avs
 
 @objc
 public class VoiceGainNotification : NSObject  {
@@ -148,6 +149,10 @@ class VoiceChannelParticipantsObserverToken : NSObject {
     fileprivate let conversation : ZMConversation
     fileprivate weak var observer : VoiceChannelParticipantObserver?
     
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
     init(context: NSManagedObjectContext, conversation: ZMConversation, observer : VoiceChannelParticipantObserver) {
         self.context = context
         self.conversation = conversation
@@ -204,6 +209,74 @@ class VoiceChannelParticipantsObserverToken : NSObject {
     
 }
 
+class WireCallCenterV2ReceivedVideoObserverToken : NSObject {
+    
+    fileprivate let conversation : ZMConversation
+    fileprivate let context: NSManagedObjectContext
+    fileprivate weak var observer : ReceivedVideoObserver?
+    
+    /// remote side has the intent to send video
+    fileprivate var isVideoEnabled = false
+    // remote side does send video
+    fileprivate var isVideoStarted = true
+    // remote side has a bad connection
+    fileprivate var isBadConnection = false
+    
+    fileprivate var previousState : ReceivedVideoState = .stopped
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
+    init(context: NSManagedObjectContext, conversation: ZMConversation, observer: ReceivedVideoObserver) {
+        self.context = context
+        self.conversation = conversation
+        self.observer = observer
+        
+        super.init()
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(callStateDidChange(note:)), name: WireCallCenterV2.CallStateDidChangeNotification, object: nil)
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(flowManagerDidChangeReceivedVideoState(note:)), name: NSNotification.Name(rawValue: FlowManagerVideoReceiveStateNotification), object: nil)
+    }
+    
+    func flowManagerDidChangeReceivedVideoState(note: Notification) {
+        if let changeInfo = note.object as? AVSVideoStateChangeInfo {
+            isVideoStarted = changeInfo.state == .FLOWMANAGER_VIDEO_RECEIVE_STARTED
+            isBadConnection = changeInfo.reason == .FLOWMANAGER_VIDEO_BAD_CONNECTION
+            notifyObserverIfStateChanged()
+        }
+    }
+    
+    func callStateDidChange(note: Notification) {
+        if let conversations = note.userInfo?["updated"] as? Set<ZMConversation>, conversations.contains(conversation) {
+            isVideoEnabled = !conversation.otherActiveVideoCallParticipants.isEmpty
+            notifyObserverIfStateChanged()
+        }
+    }
+    
+    var state : ReceivedVideoState {
+        
+        if !isVideoEnabled {
+            return .stopped
+        }
+        
+        if isBadConnection {
+            return .badConnection
+        }
+        
+        return isVideoStarted ? .started : .stopped
+    }
+    
+    func notifyObserverIfStateChanged() {
+        if state != previousState {
+            previousState = state
+            observer?.callCenterDidChange(receivedVideoState: state)
+        }
+    }
+    
+}
+
 
 @objc
 public class WireCallCenterV2 : NSObject {
@@ -214,6 +287,9 @@ public class WireCallCenterV2 : NSObject {
     let context : NSManagedObjectContext
     var voiceChannelStates : [ZMConversation : VoiceChannelV2State] = [:]
 
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
     
     public init(context: NSManagedObjectContext) {
         self.context = context
@@ -253,6 +329,10 @@ public class WireCallCenterV2 : NSObject {
     
     public class func addVoiceGainObserver(observer: VoiceGainObserver, forConversation conversation: ZMConversation, context: NSManagedObjectContext) -> WireCallCenterObserverToken {
         return VoiceGainObserverToken(context: context, conversationId: conversation.remoteIdentifier!, observer: observer)
+    }
+    
+    public class func addReceivedVideoObserver(observer: ReceivedVideoObserver, forConversation conversation: ZMConversation, context: NSManagedObjectContext) -> WireCallCenterObserverToken {
+        return WireCallCenterV2ReceivedVideoObserverToken(context: context, conversation: conversation, observer: observer)
     }
     
     public class func removeObserver(token: WireCallCenterObserverToken) {

--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -327,6 +327,7 @@ private typealias WireCallMessageToken = UnsafeMutableRawPointer
     // MARK - Observer
     
     /// Register observer of the call center call state. This will inform you when there's an incoming call etc.
+    /// Returns a token which needs to unregistered with `removeObserver(token:)` to stop observing.
     public class func addCallStateObserver(observer: WireCallCenterCallStateObserver) -> WireCallCenterObserverToken  {
         return NotificationCenter.default.addObserver(forName: WireCallCenterCallStateNotification.notificationName, object: nil, queue: .main) { [weak observer] (note) in
             if let note = note.userInfo?[WireCallCenterCallStateNotification.userInfoKey] as? WireCallCenterCallStateNotification {
@@ -336,6 +337,7 @@ private typealias WireCallMessageToken = UnsafeMutableRawPointer
     }
     
     /// Register observer of missed calls.
+    /// Returns a token which needs to unregistered with `removeObserver(token:)` to stop observing.
     public class func addMissedCallObserver(observer: WireCallCenterMissedCallObserver) -> WireCallCenterObserverToken  {
         return NotificationCenter.default.addObserver(forName: WireCallCenterMissedCallNotification.notificationName, object: nil, queue: .main) { [weak observer] (note) in
             if let note = note.userInfo?[WireCallCenterMissedCallNotification.userInfoKey] as? WireCallCenterMissedCallNotification {
@@ -345,6 +347,7 @@ private typealias WireCallMessageToken = UnsafeMutableRawPointer
     }
     
     /// Register observer of the video state. This will inform you when the remote caller starts, stops sending video.
+    /// Returns a token which needs to unregistered with `removeObserver(token:)` to stop observing.
     public class func addReceivedVideoObserver(observer: ReceivedVideoObserver) -> WireCallCenterObserverToken {
         return NotificationCenter.default.addObserver(forName: WireCallCenterV3VideoNotification.notificationName, object: nil, queue: .main) { [weak observer] (note) in
             if let note = note.userInfo?[WireCallCenterV3VideoNotification.userInfoKey] as? WireCallCenterV3VideoNotification {

--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -62,42 +62,23 @@ public enum CallState : Equatable {
     }
 }
 
-@objc(AVSVideoReceiveState)
-public enum VideoReceiveState : Int32 {
-    /// Sender is not sending video
-    case stopped
-    /// Sender is sending video
-    case started
-    /// Sender is sending video but currently has a bad connection
-    case badConnection
-}
-
 public typealias WireCallCenterObserverToken = NSObjectProtocol
 
-/// MARK - Video State Observer
-
-@objc
-public protocol WireCallCenterVideoObserver : class {
-    
-    func receivingVideoDidChange(state: VideoReceiveState)
-    
-}
-
-struct WireCallCenterVideoNotification {
+struct WireCallCenterV3VideoNotification {
     
     static let notificationName = Notification.Name("WireCallCenterVideoNotification")
     static let userInfoKey = notificationName.rawValue
     
-    let videoReceiveState : VideoReceiveState
+    let receivedVideoState : ReceivedVideoState
     
-    init(videoReceiveState: VideoReceiveState) {
-        self.videoReceiveState = videoReceiveState
+    init(receivedVideoState: ReceivedVideoState) {
+        self.receivedVideoState = receivedVideoState
     }
     
     func post() {
-        NotificationCenter.default.post(name: WireCallCenterVideoNotification.notificationName,
+        NotificationCenter.default.post(name: WireCallCenterV3VideoNotification.notificationName,
                                         object: nil,
-                                        userInfo: [WireCallCenterVideoNotification.userInfoKey : self])
+                                        userInfo: [WireCallCenterV3VideoNotification.userInfoKey : self])
     }
 }
 
@@ -272,10 +253,10 @@ private typealias WireCallMessageToken = UnsafeMutableRawPointer
             }
             
             wcall_set_video_state_handler({ (state, _) in
-                guard let state = VideoReceiveState(rawValue: state) else { return }
+                guard let state = ReceivedVideoState(rawValue: UInt(state)) else { return }
                 
                 DispatchQueue.main.async {
-                    WireCallCenterVideoNotification(videoReceiveState: state).post()
+                    WireCallCenterV3VideoNotification(receivedVideoState: state).post()
                 }
             })
         }
@@ -364,10 +345,10 @@ private typealias WireCallMessageToken = UnsafeMutableRawPointer
     }
     
     /// Register observer of the video state. This will inform you when the remote caller starts, stops sending video.
-    public class func addVideoObserver(observer: WireCallCenterVideoObserver) -> WireCallCenterObserverToken {
-        return NotificationCenter.default.addObserver(forName: WireCallCenterVideoNotification.notificationName, object: nil, queue: .main) { [weak observer] (note) in
-            if let note = note.userInfo?[WireCallCenterVideoNotification.userInfoKey] as? WireCallCenterVideoNotification {
-                observer?.receivingVideoDidChange(state: note.videoReceiveState)
+    public class func addReceivedVideoObserver(observer: ReceivedVideoObserver) -> WireCallCenterObserverToken {
+        return NotificationCenter.default.addObserver(forName: WireCallCenterV3VideoNotification.notificationName, object: nil, queue: .main) { [weak observer] (note) in
+            if let note = note.userInfo?[WireCallCenterV3VideoNotification.userInfoKey] as? WireCallCenterV3VideoNotification {
+                observer?.callCenterDidChange(receivedVideoState: note.receivedVideoState)
             }
         }
     }


### PR DESCRIPTION
Both V2 & V3 call centers now implement the `ReceivedVideoObserver` protocol. This simplifies the UI code since will now only need to hook up one observer.