### PR TITLE
Fix threading violation

### DIFF
--- a/Source/UserSession/ZMUserSession+Background.m
+++ b/Source/UserSession/ZMUserSession+Background.m
@@ -230,7 +230,7 @@ static NSString *ZMLogTag = @"Push";
     // Wrap the handler:
     ZMBackgroundFetchHandler handler = ^(ZMBackgroundFetchResult const result){
         ZM_STRONG(self);
-        [self.managedObjectContext.zm_userInterfaceContext performGroupedBlock:^{
+        [self.managedObjectContext performGroupedBlock:^{
             switch (result) {
                 case ZMBackgroundFetchResultNewData:
                     completionHandler(UIBackgroundFetchResultNewData);


### PR DESCRIPTION
### Scenario
While executing on the SE context, `managedObjectContext.zm_userInterfaceContext` is called.
This is threading violation since we are accessing the `userInfo` property of the UI context
from the SE context.

<img width="406" alt="screen shot 2017-01-16 at 14 57 03" src="https://cloud.githubusercontent.com/assets/7156/21990535/783befb0-dc0f-11e6-975d-2c2442f9d474.png">

### Solution
If we want run on UI context we can just do a `performGroupedBlock` directly on `mangedObjectContext`