### PR TITLE
Fix thread violation

### DIFF
--- a/Source/UserSession/ZMUserSession+Background.m
+++ b/Source/UserSession/ZMUserSession+Background.m
@@ -309,7 +309,7 @@ static NSString *ZMLogTag = @"Push";
         return;
     }
     
-    [self.managedObjectContext.zm_userInterfaceContext performGroupedBlock: ^{
+    [self.managedObjectContext performGroupedBlock: ^{
         ZMStoredLocalNotification *note = self.pendingLocalNotification;
         
         if ([note.category isEqualToString:ZMConnectCategory]) {
@@ -421,7 +421,7 @@ static NSString *ZMLogTag = @"Push";
         ZM_WEAK(self);
         [self.operationLoop startBackgroundTaskWithCompletionHandler:^(ZMBackgroundTaskResult result) {
             ZM_STRONG(self);
-            [self.managedObjectContext.zm_userInterfaceContext performGroupedBlock: ^{
+            [self.managedObjectContext performGroupedBlock: ^{
                 if (result == ZMBackgroundTaskResultFailed) {
                     [self.localNotificationDispatcher didFailToSendMessageInConversation:conversation];
                 }


### PR DESCRIPTION
There were some more cases similar to https://github.com/wireapp/wire-ios-sync-engine/pull/210

In the user session it can never be correct to call `self.managedObjectContext.zm_userInterfaceContext`

<b>When running on SE context:</b>
threading violation

<b>When running UI context:</b>
 doesn't fail but is also equivalent to `self.managedObjectContext`