### PR TITLE
Remove upload method from AnalyticsType protocol

### DIFF
--- a/Source/Analytics/AnalyticsType.swift
+++ b/Source/Analytics/AnalyticsType.swift
@@ -23,7 +23,6 @@ import Foundation
     
     func tagEvent(_ event: String)
     func tagEvent(_ event: String, attributes: [String: NSObject])
-    func upload()
     
 }
 
@@ -37,8 +36,5 @@ import Foundation
     public func tagEvent(_ event: String, attributes: [String : NSObject]) {
         print(Date(), "[ANALYTICS]", #function, event, attributes)
     }
-    
-    public func upload() {
-        print(Date(), "[ANALYTICS]", #function)
-    }
+
 }


### PR DESCRIPTION
# What's in this PR?

* Remove `upload` method requirement from the `AnalyticsType` protocol (see https://github.com/wireapp/wire-ios/pull/614).