### PR TITLE
Add support for BE calling protocol flag

### DIFF
--- a/Source/Calling/WireCallCenter.swift
+++ b/Source/Calling/WireCallCenter.swift
@@ -36,8 +36,6 @@ public protocol ReceivedVideoObserver : class {
     
 }
 
-
-
 @objc
 public protocol VoiceChannelStateObserver : class {
     

--- a/Source/Notifications/Push notifications/Notification Types/EventNotifications/ZMLocalNotificationForEvent.swift
+++ b/Source/Notifications/Push notifications/Notification Types/EventNotifications/ZMLocalNotificationForEvent.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
 // 
@@ -57,7 +57,7 @@ public extension ZMLocalNotificationForEvent {
         case .userContactJoin:
             return ZMLocalNotificationForNewUserEvent(events: [event], conversation: conversation,  managedObjectContext: managedObjectContext, application: application)
         case .callState:
-            if !ZMUserSession.useCallKit() {
+            if !ZMUserSession.useCallKit {
                 return ZMLocalNotificationForCallEvent(events: [event], conversation: conversation, managedObjectContext: managedObjectContext, application: application, sessionTracker: sessionTracker)
             }
             else {

--- a/Source/Public/CallingProtocol.h
+++ b/Source/Public/CallingProtocol.h
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+typedef NS_ENUM(NSUInteger, CallingProtocol) {
+    CallingProtocolNegotiate = 0,
+    CallingProtocolVersion2,
+    CallingProtocolVersion3
+};

--- a/Source/Public/ZMUserSession.h
+++ b/Source/Public/ZMUserSession.h
@@ -24,6 +24,7 @@
 
 #import <zmessaging/ZMNetworkState.h>
 #import <ZMTransport/ZMTransportRequest.h>
+#import <zmessaging/CallingProtocol.h>
 
 @class ZMTransportSession;
 @class ZMSearchDirectory;
@@ -169,9 +170,10 @@ extern NSString * const ZMTransportRequestLoopNotificationName;
 
 
 @interface ZMUserSession (Calling)
-+ (BOOL)useCallKit;
-+ (void)setUseCallKit:(BOOL)useCallKit;
-+ (void)setEnableCallingV3:(BOOL)enableCallingV3;
+
+@property (class) BOOL useCallKit;
+@property (class) CallingProtocol callingProtocol;
+
 @end
 
 

--- a/Source/Public/zmessaging.h
+++ b/Source/Public/zmessaging.h
@@ -34,6 +34,7 @@
 #import <zmessaging/ZMTypingUsers.h>
 #import <zmessaging/ZMOnDemandFlowManager.h>
 #import <zmessaging/VoiceChannelV2.h>
+#import <zmessaging/CallingProtocol.h>
 
 
 // PRIVATE

--- a/Source/UserSession/CallStateObserver.swift
+++ b/Source/UserSession/CallStateObserver.swift
@@ -52,7 +52,7 @@ public final class CallStateObserver : NSObject {
 extension CallStateObserver : WireCallCenterCallStateObserver, WireCallCenterMissedCallObserver  {
     
     public func callCenterDidChange(callState: CallState, conversationId: UUID, userId: UUID?) {
-        guard !ZMUserSession.useCallKit() else { return }
+        guard !ZMUserSession.useCallKit else { return }
         
         managedObjectContext.performGroupedBlock {
             guard
@@ -72,7 +72,7 @@ extension CallStateObserver : WireCallCenterCallStateObserver, WireCallCenterMis
     }
     
     public func callCenterMissedCall(conversationId: UUID, userId: UUID, timestamp: Date, video: Bool) {
-        guard !ZMUserSession.useCallKit() else { return }
+        guard !ZMUserSession.useCallKit else { return }
         
         managedObjectContext.performGroupedBlock {
             guard

--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -53,6 +53,7 @@
 #import "ZMClientRegistrationStatus.h"
 #import "ZMLocalNotificationDispatcher.h"
 #import "ZMCallKitDelegate+TypeConformance.h"
+#import "CallingProtocol.h"
 
 NSString * const ZMPhoneVerificationCodeKey = @"code";
 NSString * const ZMLaunchedWithPhoneVerificationCodeNotificationName = @"ZMLaunchedWithPhoneVerificationCode";
@@ -1032,9 +1033,16 @@ static BOOL ZMUserSessionUseCallKit = NO;
     ZMUserSessionUseCallKit = useCallKit;
 }
 
-+ (void)setEnableCallingV3:(BOOL)enableCallingV3
+static CallingProtocol ZMUserSessionCallingProtocol = CallingProtocolNegotiate;
+
++ (CallingProtocol)callingProtocol
 {
-    [VoiceChannelRouter setIsCallingV3Enabled:enableCallingV3];
+    return ZMUserSessionCallingProtocol;
+}
+
++ (void)setCallingProtocol:(CallingProtocol)callingProtocol
+{
+    ZMUserSessionCallingProtocol = callingProtocol;
 }
 
 @end

--- a/Tests/Source/Calling/VoiceChannelRouterTests.swift
+++ b/Tests/Source/Calling/VoiceChannelRouterTests.swift
@@ -44,55 +44,93 @@ class VoiceChannelRouterTests : MessagingTest {
     override func tearDown() {
         super.tearDown()
         
-        VoiceChannelRouter.isCallingV3Enabled = false
+        ZMUserSession.callingProtocol = .negotiate
         wireCallCenterMock = nil
     }
     
-    func testCurrenVoiceChannel_oneToOne_idle_callingV3Disabled() {
+    func testCurrenVoiceChannel_oneToOne_idle_version2Selected() {
         // given
         let sut = VoiceChannelRouter(conversation: conversation!)
         conversation?.conversationType = .oneOnOne
+        
+        // when
+        ZMUserSession.callingProtocol = .version2
         
         // then
         XCTAssertTrue(sut.currentVoiceChannel === sut.v2)
     }
     
-    func testCurrenVoiceChannel_oneToOne_idle_callingV3Enabled() {
+    func testCurrenVoiceChannel_oneToOne_idle_version3Selected() {
         // given
         let sut = VoiceChannelRouter(conversation: conversation!)
         conversation?.conversationType = .oneOnOne
-        VoiceChannelRouter.isCallingV3Enabled = true
+        
+        // when
+        ZMUserSession.callingProtocol = .version3
         
         // then
         XCTAssertTrue(sut.currentVoiceChannel === sut.v3)
     }
     
-    func testCurrenVoiceChannel_group_idle_callingV3Enabled() {
+    func testCurrenVoiceChannel_group_idle_version3Selected() {
         // given
         let sut = VoiceChannelRouter(conversation: conversation!)
         conversation?.conversationType = .group
-        VoiceChannelRouter.isCallingV3Enabled = true
+        
+        // when
+        ZMUserSession.callingProtocol = .version3
         
         // then
         XCTAssertTrue(sut.currentVoiceChannel === sut.v2)
     }
     
-    func testCurrenVoiceChannel_oneToOne_incomingV2Call_callingV3Enabled() {
+    func testCurrenVoiceChannel_oneToOne_incomingV2Call_version3Selected() {
         // given
         let sut = VoiceChannelRouter(conversation: conversation!)
         conversation?.conversationType = .oneOnOne
+        
+        // when
         conversation?.callDeviceIsActive = true
-        VoiceChannelRouter.isCallingV3Enabled = true
+        ZMUserSession.callingProtocol = .version3
         
         // then
         XCTAssertTrue(sut.currentVoiceChannel === sut.v2)
     }
     
-    func testCurrenVoiceChannel_oneToOne_incomingV3Call_callingV3Disabled() {
+    func testCurrenVoiceChannel_oneToOne_incomingV3Call_callingV2Selected() {
         // given
         let sut = VoiceChannelRouter(conversation: conversation!)
         conversation?.conversationType = .oneOnOne
+        
+        // when
         wireCallCenterMock?.callState = .incoming(video: false)
+        ZMUserSession.callingProtocol = .version2
+        
+        // then
+        XCTAssertTrue(sut.currentVoiceChannel === sut.v3)
+    }
+    
+    func testCurrenVoiceChannel_oneToOne_idle_version2Negotiated() {
+        // given
+        let sut = VoiceChannelRouter(conversation: conversation!)
+        conversation?.conversationType = .oneOnOne
+        
+        // when
+        ZMUserSession.callingProtocol = .negotiate
+        wireCallCenterMock?.overridenProtocolVersion = .version2
+        
+        // then
+        XCTAssertTrue(sut.currentVoiceChannel === sut.v2)
+    }
+    
+    func testCurrenVoiceChannel_oneToOne_idle_version3Negotiated() {
+        // given
+        let sut = VoiceChannelRouter(conversation: conversation!)
+        conversation?.conversationType = .oneOnOne
+        
+        // when
+        ZMUserSession.callingProtocol = .negotiate
+        wireCallCenterMock?.overridenProtocolVersion = .version3
         
         // then
         XCTAssertTrue(sut.currentVoiceChannel === sut.v3)

--- a/Tests/Source/Calling/WireCallCenterV3Mock.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Mock.swift
@@ -23,6 +23,11 @@ import Foundation
 public class WireCallCenterV3Mock : WireCallCenterV3 {
     
     public var callState : CallState = .none
+    public var overridenProtocolVersion : CallingProtocolVersion = .version2
+    
+    public override var protocolVersion: CallingProtocolVersion {
+        return overridenProtocolVersion
+    }
     
     public required init(userId: UUID, clientId: String, registerObservers: Bool) {
         super.init(userId: userId, clientId: clientId, registerObservers: false)

--- a/Tests/Source/Calling/ZMCallKitDelegateTests.swift
+++ b/Tests/Source/Calling/ZMCallKitDelegateTests.swift
@@ -113,7 +113,7 @@ class ZMCallKitDelegateTest: MessagingTest { // FIXME update these test for v2 a
     
     override func setUp() {
         super.setUp()
-        ZMUserSession.setUseCallKit(true)
+        ZMUserSession.useCallKit = true
         
         let selfUser = ZMUser.selfUser(in: self.uiMOC)
         selfUser.emailAddress = "self@user.mail"
@@ -133,7 +133,7 @@ class ZMCallKitDelegateTest: MessagingTest { // FIXME update these test for v2 a
     
     override func tearDown() {
         super.tearDown()
-        ZMUserSession.setUseCallKit(false)
+        ZMUserSession.useCallKit = false
         self.sut = nil
     }
     

--- a/zmessaging-cocoa.xcodeproj/project.pbxproj
+++ b/zmessaging-cocoa.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		16C22BA41BF4D5D7007099D9 /* NSError+ZMUserSessionInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 3E05F254192A50CC00F22D80 /* NSError+ZMUserSessionInternal.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		16D3FCDD1E323D180052A535 /* WireCallCenterV2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D3FCDC1E323D180052A535 /* WireCallCenterV2Tests.swift */; };
 		16D3FCDF1E365ABC0052A535 /* CallStateObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D3FCDE1E365ABC0052A535 /* CallStateObserverTests.swift */; };
+		16D3FCE31E37582E0052A535 /* CallingProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 16D3FCE21E3757CA0052A535 /* CallingProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		16DABFAE1DCF98D3001973E3 /* CallingRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16DABFAD1DCF98D3001973E3 /* CallingRequestStrategy.swift */; };
 		16DCAD671B0F9447008C1DD9 /* NSURL+LaunchOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 16DCAD641B0F9447008C1DD9 /* NSURL+LaunchOptions.h */; };
 		16DCAD691B0F9447008C1DD9 /* NSURL+LaunchOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 16DCAD651B0F9447008C1DD9 /* NSURL+LaunchOptions.m */; };
@@ -591,6 +592,7 @@
 		1671F9FE1E2FAF50009F3150 /* ZMLocalNotificationForCallEventTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMLocalNotificationForCallEventTests.swift; sourceTree = "<group>"; };
 		16D3FCDC1E323D180052A535 /* WireCallCenterV2Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WireCallCenterV2Tests.swift; sourceTree = "<group>"; };
 		16D3FCDE1E365ABC0052A535 /* CallStateObserverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CallStateObserverTests.swift; sourceTree = "<group>"; };
+		16D3FCE21E3757CA0052A535 /* CallingProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CallingProtocol.h; sourceTree = "<group>"; };
 		16DABFAD1DCF98D3001973E3 /* CallingRequestStrategy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CallingRequestStrategy.swift; sourceTree = "<group>"; };
 		16DCAD641B0F9447008C1DD9 /* NSURL+LaunchOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURL+LaunchOptions.h"; sourceTree = "<group>"; };
 		16DCAD651B0F9447008C1DD9 /* NSURL+LaunchOptions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURL+LaunchOptions.m"; sourceTree = "<group>"; };
@@ -1209,6 +1211,7 @@
 			isa = PBXGroup;
 			children = (
 				165D3A3A1E1D55F20052E654 /* VoiceChannelV2.h */,
+				16D3FCE21E3757CA0052A535 /* CallingProtocol.h */,
 				879861C91DA7E12E00152584 /* VoiceChannelV2+CallFlow.h */,
 				8785CA5E1C568D1F00FD671C /* VoiceChannelV2+VideoCalling.h */,
 				F9B71F461CB29600001DB03F /* ZMBareUser+UserSession.h */,
@@ -2186,6 +2189,7 @@
 				F9B71F471CB29600001DB03F /* ZMBareUser+UserSession.h in Headers */,
 				3E17FA671A6690AA00DFA12F /* ZMPushRegistrant.h in Headers */,
 				54DE26B31BC56E62002B5FBC /* ZMHotFixDirectory.h in Headers */,
+				16D3FCE31E37582E0052A535 /* CallingProtocol.h in Headers */,
 				0932EA4D1AE6952A00D1BFD1 /* ZMAuthenticationStatus.h in Headers */,
 				09CC4ADE1B7D076700201C63 /* ZMEnvironmentsSetup.h in Headers */,
 				5430E9251BAA0D9F00395E05 /* ZMessagingLogs.h in Headers */,


### PR DESCRIPTION
The `callingV3Enabled` flag on user session has been replaced with `callingProtocol`
which can be set to `negotiate`, `version2` and `version3`. If it's set to `negotiate`,
which is the default, the calling protocol to use is decided by checking a flag
on the BE.