### PR TITLE
Read server time delta from notification stream response

### DIFF
--- a/Source/Data Model/NSManagedObjectContext+ServerTimeDelta.swift
+++ b/Source/Data Model/NSManagedObjectContext+ServerTimeDelta.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
+// Copyright (C) 2017 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/Source/Data Model/NSManagedObjectContext+ServerTimeDelta.swift
+++ b/Source/Data Model/NSManagedObjectContext+ServerTimeDelta.swift
@@ -27,10 +27,12 @@ public extension NSManagedObjectContext {
     var serverTimeDelta : TimeInterval {
         
         get {
+            precondition(zm_isSyncContext, "serverTimeDelta can only be accessed on the sync context")
             return userInfo[NSManagedObjectContext.ServerTimeDeltaKey] as? TimeInterval ?? 0
         }
         
         set {
+            precondition(zm_isSyncContext, "serverTimeDelta can only be accessed on the sync context")
             userInfo[NSManagedObjectContext.ServerTimeDeltaKey] = newValue
         }
         

--- a/Source/Data Model/NSManagedObjectContext+ServerTimeDelta.swift
+++ b/Source/Data Model/NSManagedObjectContext+ServerTimeDelta.swift
@@ -1,0 +1,39 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+
+public extension NSManagedObjectContext {
+    
+    private static let ServerTimeDeltaKey = "ServerTimeDeltaKey"
+    
+    @objc
+    var serverTimeDelta : TimeInterval {
+        
+        get {
+            return userInfo[NSManagedObjectContext.ServerTimeDeltaKey] as? TimeInterval ?? 0
+        }
+        
+        set {
+            userInfo[NSManagedObjectContext.ServerTimeDeltaKey] = newValue
+        }
+        
+    }
+        
+}

--- a/Source/Synchronization/Strategies/CallingRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/CallingRequestStrategy.swift
@@ -88,6 +88,9 @@ extension CallingRequestStrategy : ZMContextChangeTracker, ZMContextChangeTracke
 extension CallingRequestStrategy : ZMEventConsumer {
     
     public func processEvents(_ events: [ZMUpdateEvent], liveEvents: Bool, prefetchResult: ZMFetchRequestBatchResult?) {
+        
+        let serverTimeDelta = managedObjectContext.serverTimeDelta
+        
         for event in events {
             guard event.type == .conversationOtrMessageAdd else { continue }
             
@@ -104,7 +107,12 @@ extension CallingRequestStrategy : ZMEventConsumer {
                     continue
                 }
                 
-                callCenter?.received(data: payload, currentTimestamp: Date(), serverTimestamp: eventTimestamp, conversationId: conversationUUID, userId: senderUUID, clientId: clientId)
+                callCenter?.received(data: payload,
+                                     currentTimestamp: Date().addingTimeInterval(serverTimeDelta),
+                                     serverTimestamp: eventTimestamp,
+                                     conversationId: conversationUUID,
+                                     userId: senderUUID,
+                                     clientId: clientId)
             }
         }
     }

--- a/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
@@ -126,6 +126,12 @@ previouslyReceivedEventIDsCollection:(id<PreviouslyReceivedEventIDsCollection>)e
     }
 }
 
+- (void)updateServerTimeDeltaWithTimestamp:(NSString *)timestamp {
+    NSDate *serverTime = [NSDate dateWithTransportString:timestamp];
+    NSTimeInterval serverTimeDelta = [serverTime timeIntervalSinceNow];
+    self.managedObjectContext.serverTimeDelta = serverTimeDelta;
+}
+
 + (NSArray<NSDictionary *> *)eventDictionariesFromPayload:(id<ZMTransportData>)payload
 {
     return [payload.asDictionary optionalArrayForKey:@"notifications"].asDictionaries;
@@ -270,6 +276,11 @@ previouslyReceivedEventIDsCollection:(id<PreviouslyReceivedEventIDsCollection>)e
 - (NSUUID *)nextUUIDFromResponse:(ZMTransportResponse *)response forListPaginator:(ZMSimpleListRequestPaginator *)paginator
 {
     NOT_USED(paginator);
+    
+    NSString *timestamp = ((NSString *) response.payload.asDictionary[@"time"]);
+    if (timestamp) {
+        [self updateServerTimeDeltaWithTimestamp:timestamp];
+    }
     
     NSUUID *latestEventId = [self processUpdateEventsAndReturnLastNotificationIDFromPayload:response.payload syncStrategy:self.syncStrategy];
     if (latestEventId != nil) {

--- a/Tests/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoderTests.m
@@ -1060,3 +1060,26 @@ static NSString * const LastUpdateEventIDStoreKey = @"LastUpdateEventID";
 }
 
 @end
+
+
+@implementation ZMMissingUpdateEventsTranscoderTests (ServerTimeDelta)
+
+- (void)testThatServerTimeDeltaIsUpdatedWhenTimeFieldIsPresent
+{
+    // given
+    NSTimeInterval delta = 500;
+    NSDate *localTime = [NSDate date];
+    NSDate *serverTime = [localTime dateByAddingTimeInterval:delta];
+    
+    NSDictionary *payload = @{@"time": [serverTime transportString],
+                              @"notifications" : @[]};
+    
+    // when
+    [(id)self.sut.listPaginator didReceiveResponse:[ZMTransportResponse responseWithPayload:payload HTTPStatus:200 transportSessionError:nil] forSingleRequest:nil];
+    
+    
+    // then
+    XCTAssertEqualWithAccuracy(self.sut.managedObjectContext.serverTimeDelta, delta, 1);
+}
+
+@end

--- a/Tests/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoderTests.m
@@ -1075,11 +1075,14 @@ static NSString * const LastUpdateEventIDStoreKey = @"LastUpdateEventID";
                               @"notifications" : @[]};
     
     // when
-    [(id)self.sut.listPaginator didReceiveResponse:[ZMTransportResponse responseWithPayload:payload HTTPStatus:200 transportSessionError:nil] forSingleRequest:nil];
-    
+    [self performPretendingUiMocIsSyncMoc:^{
+        [(id)self.sut.listPaginator didReceiveResponse:[ZMTransportResponse responseWithPayload:payload HTTPStatus:200 transportSessionError:nil] forSingleRequest:nil];
+    }];
     
     // then
-    XCTAssertEqualWithAccuracy(self.sut.managedObjectContext.serverTimeDelta, delta, 1);
+    [self performPretendingUiMocIsSyncMoc:^{
+        XCTAssertEqualWithAccuracy(self.sut.managedObjectContext.serverTimeDelta, delta, 1);
+    }];
 }
 
 @end

--- a/zmessaging-cocoa.xcodeproj/project.pbxproj
+++ b/zmessaging-cocoa.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		16D3FCDD1E323D180052A535 /* WireCallCenterV2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D3FCDC1E323D180052A535 /* WireCallCenterV2Tests.swift */; };
 		16D3FCDF1E365ABC0052A535 /* CallStateObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D3FCDE1E365ABC0052A535 /* CallStateObserverTests.swift */; };
 		16D3FCE31E37582E0052A535 /* CallingProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 16D3FCE21E3757CA0052A535 /* CallingProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		16D3FCE51E37A8050052A535 /* NSManagedObjectContext+ServerTimeDelta.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D3FCE41E37A8050052A535 /* NSManagedObjectContext+ServerTimeDelta.swift */; };
 		16DABFAE1DCF98D3001973E3 /* CallingRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16DABFAD1DCF98D3001973E3 /* CallingRequestStrategy.swift */; };
 		16DCAD671B0F9447008C1DD9 /* NSURL+LaunchOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 16DCAD641B0F9447008C1DD9 /* NSURL+LaunchOptions.h */; };
 		16DCAD691B0F9447008C1DD9 /* NSURL+LaunchOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 16DCAD651B0F9447008C1DD9 /* NSURL+LaunchOptions.m */; };
@@ -593,6 +594,7 @@
 		16D3FCDC1E323D180052A535 /* WireCallCenterV2Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WireCallCenterV2Tests.swift; sourceTree = "<group>"; };
 		16D3FCDE1E365ABC0052A535 /* CallStateObserverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CallStateObserverTests.swift; sourceTree = "<group>"; };
 		16D3FCE21E3757CA0052A535 /* CallingProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CallingProtocol.h; sourceTree = "<group>"; };
+		16D3FCE41E37A8050052A535 /* NSManagedObjectContext+ServerTimeDelta.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+ServerTimeDelta.swift"; sourceTree = "<group>"; };
 		16DABFAD1DCF98D3001973E3 /* CallingRequestStrategy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CallingRequestStrategy.swift; sourceTree = "<group>"; };
 		16DCAD641B0F9447008C1DD9 /* NSURL+LaunchOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURL+LaunchOptions.h"; sourceTree = "<group>"; };
 		16DCAD651B0F9447008C1DD9 /* NSURL+LaunchOptions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURL+LaunchOptions.m"; sourceTree = "<group>"; };
@@ -1285,6 +1287,7 @@
 				3E26BEE01A408DBE0071B4C9 /* ZMTypingUsers.h */,
 				3E26BEE11A408DBE0071B4C9 /* ZMTypingUsers.m */,
 				5435C5541E13D9A0002D9766 /* NSManagedObjectContext+KeyValueStore.swift */,
+				16D3FCE41E37A8050052A535 /* NSManagedObjectContext+ServerTimeDelta.swift */,
 				3EFFDE481A13B01B00E80E22 /* Push Token */,
 			);
 			path = "Data Model";
@@ -2662,6 +2665,7 @@
 				16DCAD691B0F9447008C1DD9 /* NSURL+LaunchOptions.m in Sources */,
 				F9F631421DE3524100416938 /* TypingStrategy.swift in Sources */,
 				F98EDCEB1D82B924001E65CB /* NotificationSounds.swift in Sources */,
+				16D3FCE51E37A8050052A535 /* NSManagedObjectContext+ServerTimeDelta.swift in Sources */,
 				54D175211ADE8B18001AA338 /* ZMUserSession+Registration.m in Sources */,
 				549816291A432BC800A7CE2E /* ZMConnectionTranscoder.m in Sources */,
 				165911531DEF38EC007FA847 /* CallStateObserver.swift in Sources */,


### PR DESCRIPTION
### Why this change
To handle the case when client's clock has the wrong time a `time` field has been added to the notifications stream response. This time is used to calculate a delta between the client and server time, which is used to correct the current time when passing calling messages to AVS.