### PR TITLE
Expose calling protocol in observers for tracking purposes

### DIFF
--- a/Source/Calling/VoiceChannelRouter.swift
+++ b/Source/Calling/VoiceChannelRouter.swift
@@ -44,14 +44,14 @@ public class VoiceChannelRouter : NSObject, VoiceChannel {
             return v3
         }
         
-        switch ZMUserSession.callingProtocol {
+        switch ZMUserSession.callingProtocolStrategy {
         case .negotiate:
-            guard let protocolVersion = WireCallCenterV3.activeInstance?.protocolVersion else {
+            guard let callingProtocol = WireCallCenterV3.activeInstance?.callingProtocol else {
                 zmLog.warn("Attempt to use voice channel without an active call center")
                 return v2
             }
             
-            switch protocolVersion {
+            switch callingProtocol {
             case .version2: return v2
             case .version3: return v3
             }

--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -50,11 +50,6 @@ private class Box<T : Any> {
     }
 }
 
-public enum CallingProtocolVersion : Int {
-    case version2 = 2
-    case version3 = 3
-}
-
 public enum CallClosedReason : Int32 {
     /// Ongoing call was closed by remote
     case normal
@@ -248,7 +243,7 @@ private typealias WireCallMessageToken = UnsafeMutableRawPointer
     
     public weak var transport : WireCallCenterTransport? = nil
     
-    public private(set) var protocolVersion : CallingProtocolVersion = .version2
+    public private(set) var callingProtocol : CallingProtocol = .version2
     
     deinit {
         wcall_close()
@@ -274,8 +269,8 @@ private typealias WireCallMessageToken = UnsafeMutableRawPointer
                     if let context = context {
                         let selfReference = Unmanaged<WireCallCenterV3>.fromOpaque(context).takeUnretainedValue()
                         
-                        if let protocolVersion = CallingProtocolVersion(rawValue: Int(version)) {
-                            selfReference.protocolVersion = protocolVersion
+                        if let callingProtocol = CallingProtocol(rawValue: Int(version)) {
+                            selfReference.callingProtocol = callingProtocol
                         } else {
                             selfReference.zmLog.error("wcall initialized with unknown protocol version: \(version)")
                         }

--- a/Source/Public/CallingProtocolStrategy.h
+++ b/Source/Public/CallingProtocolStrategy.h
@@ -16,8 +16,8 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-typedef NS_ENUM(NSUInteger, CallingProtocol) {
-    CallingProtocolNegotiate = 0,
-    CallingProtocolVersion2,
-    CallingProtocolVersion3
+typedef NS_ENUM(NSUInteger, CallingProtocolStrategy) {
+    CallingProtocolStrategyNegotiate = 0,
+    CallingProtocolStrategyVersion2,
+    CallingProtocolStrategyVersion3
 };

--- a/Source/Public/ZMUserSession.h
+++ b/Source/Public/ZMUserSession.h
@@ -24,7 +24,7 @@
 
 #import <zmessaging/ZMNetworkState.h>
 #import <ZMTransport/ZMTransportRequest.h>
-#import <zmessaging/CallingProtocol.h>
+#import <zmessaging/CallingProtocolStrategy.h>
 
 @class ZMTransportSession;
 @class ZMSearchDirectory;
@@ -172,7 +172,7 @@ extern NSString * const ZMTransportRequestLoopNotificationName;
 @interface ZMUserSession (Calling)
 
 @property (class) BOOL useCallKit;
-@property (class) CallingProtocol callingProtocol;
+@property (class) CallingProtocolStrategy callingProtocolStrategy;
 
 @end
 

--- a/Source/Public/zmessaging.h
+++ b/Source/Public/zmessaging.h
@@ -34,7 +34,7 @@
 #import <zmessaging/ZMTypingUsers.h>
 #import <zmessaging/ZMOnDemandFlowManager.h>
 #import <zmessaging/VoiceChannelV2.h>
-#import <zmessaging/CallingProtocol.h>
+#import <zmessaging/CallingProtocolStrategy.h>
 
 
 // PRIVATE

--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -28,7 +28,6 @@
 
 #import "ZMUserSession+Internal.h"
 #import "ZMSyncStrategy.h"
-//#import "ZMOperationLoop.h"
 #import "NSError+ZMUserSessionInternal.h"
 #import "ZMCredentials.h"
 #import "ZMSearchDirectory+Internal.h"
@@ -53,7 +52,7 @@
 #import "ZMClientRegistrationStatus.h"
 #import "ZMLocalNotificationDispatcher.h"
 #import "ZMCallKitDelegate+TypeConformance.h"
-#import "CallingProtocol.h"
+#import "CallingProtocolStrategy.h"
 
 NSString * const ZMPhoneVerificationCodeKey = @"code";
 NSString * const ZMLaunchedWithPhoneVerificationCodeNotificationName = @"ZMLaunchedWithPhoneVerificationCode";
@@ -1033,16 +1032,16 @@ static BOOL ZMUserSessionUseCallKit = NO;
     ZMUserSessionUseCallKit = useCallKit;
 }
 
-static CallingProtocol ZMUserSessionCallingProtocol = CallingProtocolNegotiate;
+static CallingProtocolStrategy ZMUserSessionCallingProtocolStrategy = CallingProtocolStrategyNegotiate;
 
-+ (CallingProtocol)callingProtocol
++ (CallingProtocolStrategy)callingProtocolStrategy
 {
-    return ZMUserSessionCallingProtocol;
+    return ZMUserSessionCallingProtocolStrategy;
 }
 
-+ (void)setCallingProtocol:(CallingProtocol)callingProtocol
++ (void)setCallingProtocolStrategy:(CallingProtocolStrategy)callingProtocolStrategy
 {
-    ZMUserSessionCallingProtocol = callingProtocol;
+    ZMUserSessionCallingProtocolStrategy = callingProtocolStrategy;
 }
 
 @end

--- a/Tests/Source/Calling/VoiceChannelRouterTests.swift
+++ b/Tests/Source/Calling/VoiceChannelRouterTests.swift
@@ -44,7 +44,7 @@ class VoiceChannelRouterTests : MessagingTest {
     override func tearDown() {
         super.tearDown()
         
-        ZMUserSession.callingProtocol = .negotiate
+        ZMUserSession.callingProtocolStrategy = .negotiate
         wireCallCenterMock = nil
     }
     
@@ -54,7 +54,7 @@ class VoiceChannelRouterTests : MessagingTest {
         conversation?.conversationType = .oneOnOne
         
         // when
-        ZMUserSession.callingProtocol = .version2
+        ZMUserSession.callingProtocolStrategy = .version2
         
         // then
         XCTAssertTrue(sut.currentVoiceChannel === sut.v2)
@@ -66,7 +66,7 @@ class VoiceChannelRouterTests : MessagingTest {
         conversation?.conversationType = .oneOnOne
         
         // when
-        ZMUserSession.callingProtocol = .version3
+        ZMUserSession.callingProtocolStrategy = .version3
         
         // then
         XCTAssertTrue(sut.currentVoiceChannel === sut.v3)
@@ -78,7 +78,7 @@ class VoiceChannelRouterTests : MessagingTest {
         conversation?.conversationType = .group
         
         // when
-        ZMUserSession.callingProtocol = .version3
+        ZMUserSession.callingProtocolStrategy = .version3
         
         // then
         XCTAssertTrue(sut.currentVoiceChannel === sut.v2)
@@ -91,7 +91,7 @@ class VoiceChannelRouterTests : MessagingTest {
         
         // when
         conversation?.callDeviceIsActive = true
-        ZMUserSession.callingProtocol = .version3
+        ZMUserSession.callingProtocolStrategy = .version3
         
         // then
         XCTAssertTrue(sut.currentVoiceChannel === sut.v2)
@@ -104,7 +104,7 @@ class VoiceChannelRouterTests : MessagingTest {
         
         // when
         wireCallCenterMock?.callState = .incoming(video: false)
-        ZMUserSession.callingProtocol = .version2
+        ZMUserSession.callingProtocolStrategy = .version2
         
         // then
         XCTAssertTrue(sut.currentVoiceChannel === sut.v3)
@@ -116,8 +116,8 @@ class VoiceChannelRouterTests : MessagingTest {
         conversation?.conversationType = .oneOnOne
         
         // when
-        ZMUserSession.callingProtocol = .negotiate
-        wireCallCenterMock?.overridenProtocolVersion = .version2
+        ZMUserSession.callingProtocolStrategy = .negotiate
+        wireCallCenterMock?.overridenCallingProtocol = .version2
         
         // then
         XCTAssertTrue(sut.currentVoiceChannel === sut.v2)
@@ -129,8 +129,8 @@ class VoiceChannelRouterTests : MessagingTest {
         conversation?.conversationType = .oneOnOne
         
         // when
-        ZMUserSession.callingProtocol = .negotiate
-        wireCallCenterMock?.overridenProtocolVersion = .version3
+        ZMUserSession.callingProtocolStrategy = .negotiate
+        wireCallCenterMock?.overridenCallingProtocol = .version3
         
         // then
         XCTAssertTrue(sut.currentVoiceChannel === sut.v3)

--- a/Tests/Source/Calling/WireCallCenterV3Mock.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Mock.swift
@@ -23,10 +23,10 @@ import Foundation
 public class WireCallCenterV3Mock : WireCallCenterV3 {
     
     public var callState : CallState = .none
-    public var overridenProtocolVersion : CallingProtocolVersion = .version2
+    public var overridenCallingProtocol : CallingProtocol = .version2
     
-    public override var protocolVersion: CallingProtocolVersion {
-        return overridenProtocolVersion
+    public override var callingProtocol: CallingProtocol {
+        return overridenCallingProtocol
     }
     
     public required init(userId: UUID, clientId: String, registerObservers: Bool) {

--- a/zmessaging-cocoa.xcodeproj/project.pbxproj
+++ b/zmessaging-cocoa.xcodeproj/project.pbxproj
@@ -78,7 +78,7 @@
 		16C22BA41BF4D5D7007099D9 /* NSError+ZMUserSessionInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 3E05F254192A50CC00F22D80 /* NSError+ZMUserSessionInternal.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		16D3FCDD1E323D180052A535 /* WireCallCenterV2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D3FCDC1E323D180052A535 /* WireCallCenterV2Tests.swift */; };
 		16D3FCDF1E365ABC0052A535 /* CallStateObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D3FCDE1E365ABC0052A535 /* CallStateObserverTests.swift */; };
-		16D3FCE31E37582E0052A535 /* CallingProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 16D3FCE21E3757CA0052A535 /* CallingProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		16D3FCE31E37582E0052A535 /* CallingProtocolStrategy.h in Headers */ = {isa = PBXBuildFile; fileRef = 16D3FCE21E3757CA0052A535 /* CallingProtocolStrategy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		16D3FCE51E37A8050052A535 /* NSManagedObjectContext+ServerTimeDelta.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D3FCE41E37A8050052A535 /* NSManagedObjectContext+ServerTimeDelta.swift */; };
 		16DABFAE1DCF98D3001973E3 /* CallingRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16DABFAD1DCF98D3001973E3 /* CallingRequestStrategy.swift */; };
 		16DCAD671B0F9447008C1DD9 /* NSURL+LaunchOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 16DCAD641B0F9447008C1DD9 /* NSURL+LaunchOptions.h */; };
@@ -593,7 +593,7 @@
 		1671F9FE1E2FAF50009F3150 /* ZMLocalNotificationForCallEventTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMLocalNotificationForCallEventTests.swift; sourceTree = "<group>"; };
 		16D3FCDC1E323D180052A535 /* WireCallCenterV2Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WireCallCenterV2Tests.swift; sourceTree = "<group>"; };
 		16D3FCDE1E365ABC0052A535 /* CallStateObserverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CallStateObserverTests.swift; sourceTree = "<group>"; };
-		16D3FCE21E3757CA0052A535 /* CallingProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CallingProtocol.h; sourceTree = "<group>"; };
+		16D3FCE21E3757CA0052A535 /* CallingProtocolStrategy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CallingProtocolStrategy.h; sourceTree = "<group>"; };
 		16D3FCE41E37A8050052A535 /* NSManagedObjectContext+ServerTimeDelta.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+ServerTimeDelta.swift"; sourceTree = "<group>"; };
 		16DABFAD1DCF98D3001973E3 /* CallingRequestStrategy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CallingRequestStrategy.swift; sourceTree = "<group>"; };
 		16DCAD641B0F9447008C1DD9 /* NSURL+LaunchOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURL+LaunchOptions.h"; sourceTree = "<group>"; };
@@ -1213,7 +1213,7 @@
 			isa = PBXGroup;
 			children = (
 				165D3A3A1E1D55F20052E654 /* VoiceChannelV2.h */,
-				16D3FCE21E3757CA0052A535 /* CallingProtocol.h */,
+				16D3FCE21E3757CA0052A535 /* CallingProtocolStrategy.h */,
 				879861C91DA7E12E00152584 /* VoiceChannelV2+CallFlow.h */,
 				8785CA5E1C568D1F00FD671C /* VoiceChannelV2+VideoCalling.h */,
 				F9B71F461CB29600001DB03F /* ZMBareUser+UserSession.h */,
@@ -2192,7 +2192,7 @@
 				F9B71F471CB29600001DB03F /* ZMBareUser+UserSession.h in Headers */,
 				3E17FA671A6690AA00DFA12F /* ZMPushRegistrant.h in Headers */,
 				54DE26B31BC56E62002B5FBC /* ZMHotFixDirectory.h in Headers */,
-				16D3FCE31E37582E0052A535 /* CallingProtocol.h in Headers */,
+				16D3FCE31E37582E0052A535 /* CallingProtocolStrategy.h in Headers */,
 				0932EA4D1AE6952A00D1BFD1 /* ZMAuthenticationStatus.h in Headers */,
 				09CC4ADE1B7D076700201C63 /* ZMEnvironmentsSetup.h in Headers */,
 				5430E9251BAA0D9F00395E05 /* ZMessagingLogs.h in Headers */,


### PR DESCRIPTION
## Why this PR
We need distinguish between calling version 2/3 in our tracking.

## What changed 
this PR adds a `callingProtocol` to some of the call observers methods. The name of calling protocol enums where not good so I've renamed them.

`CallingProtocol` > `CallingProtocolStrategy`
`CallingProtocolVersion` >  `CallingProtocol`
