### PR TITLE
Add possibility to change email

### DIFF
--- a/Source/Synchronization/Strategies/UserProfileUpdateRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/UserProfileUpdateRequestStrategy.swift
@@ -77,7 +77,8 @@ extension UserProfileRequestStrategy : RequestStrategy {
             return self.phoneUpdateSync.nextRequest()
         }
         
-        if self.userProfileUpdateStatus.currentlySettingEmail {
+        if self.userProfileUpdateStatus.currentlySettingEmail ||
+            self.userProfileUpdateStatus.currentlyChangingEmail {
             self.emailUpdateSync.readyForNextRequestIfNotBusy()
             return self.emailUpdateSync.nextRequest()
         }

--- a/Source/UserSession/UserProfile.swift
+++ b/Source/UserSession/UserProfile.swift
@@ -26,8 +26,13 @@ import Foundation
     /// and call `requestPhoneNumberChange` with that PIN
     func requestPhoneVerificationCode(phoneNumber: String)
     
-    /// Requests phone number changed, with a PIN received earlier
+    /// Requests phone number change, with a PIN received earlier
     func requestPhoneNumberChange(credentials: ZMPhoneCredentials)
+
+    /// Requests email change
+    /// The email will need to be verified externally
+    /// - throws: if the email is not already set, or if empty email is passed
+    func requestEmailChange(email: String) throws
     
     /// Requests to set an email and password, for a user that does not have either.
     /// Once this is called, we expect the user to eventually verify the email externally.

--- a/Source/UserSession/UserProfileUpdateStatus.swift
+++ b/Source/UserSession/UserProfileUpdateStatus.swift
@@ -103,17 +103,13 @@ extension UserProfileUpdateStatus : UserProfile {
             throw UserProfileUpdateError.missingArgument
         }
         
-        
-        let selfUser = ZMUser.selfUser(in: self.managedObjectContext)
-        guard selfUser.emailAddress == nil else {
-            self.managedObjectContext.performGroupedBlock {
-                self.emailToSet = nil
-                self.passwordToSet = nil
-            }
-            throw UserProfileUpdateError.emailAlreadySet
-        }
-
         self.managedObjectContext.performGroupedBlock {
+            let selfUser = ZMUser.selfUser(in: self.managedObjectContext)
+            guard selfUser.emailAddress == nil else {
+                self.didFailEmailUpdate(error: UserProfileUpdateError.emailAlreadySet)
+                return
+            }
+            
             self.lastEmailAndPassword = credentials
             
             self.emailToSet = email

--- a/Source/UserSession/UserProfileUpdateStatus.swift
+++ b/Source/UserSession/UserProfileUpdateStatus.swift
@@ -98,6 +98,23 @@ extension UserProfileUpdateStatus : UserProfile {
 
     }
     
+    public func requestEmailChange(email: String) throws {
+        guard !email.isEmpty else {
+            throw UserProfileUpdateError.missingArgument
+        }
+        
+        self.managedObjectContext.performGroupedBlock {
+            let selfUser = ZMUser.selfUser(in: self.managedObjectContext)
+            guard selfUser.emailAddress != nil else {
+                self.didFailEmailUpdate(error: UserProfileUpdateError.emailNotSet)
+                return
+            }
+            
+            self.emailToSet = email
+            self.newRequestCallback()
+        }
+    }
+    
     public func requestSettingEmailAndPassword(credentials: ZMEmailCredentials) throws {
         guard let email = credentials.email, let password = credentials.password else {
             throw UserProfileUpdateError.missingArgument
@@ -333,8 +350,15 @@ extension UserProfileUpdateStatus {
         return selfUser.phoneNumber != nil && selfUser.phoneNumber != ""
     }
     
+    /// Whether we are currently changing email
+    public var currentlyChangingEmail : Bool {
+        guard self.selfUserHasEmail else {
+            return false
+        }
+        return self.emailToSet != nil
+    }
+    
     /// Whether we are currently setting the email.
-    /// If the app starts and this is set, the app is waiting for the user to confirm her email
     public var currentlySettingEmail : Bool {
         
         guard !self.selfUserHasEmail else {
@@ -389,5 +413,6 @@ extension UserProfileUpdateStatus {
 @objc public enum UserProfileUpdateError: Int, Error {
     case missingArgument
     case emailAlreadySet
+    case emailNotSet
 }
 

--- a/Tests/Source/Synchronization/Transcoders/UserProfileUpdateRequestStrategyTests.swift
+++ b/Tests/Source/Synchronization/Transcoders/UserProfileUpdateRequestStrategyTests.swift
@@ -121,6 +121,26 @@ extension UserProfileUpdateRequestStrategyTests {
         XCTAssertEqual(request, expected)
     }
     
+    func testThatItCreatesARequestToChangeEmail() {
+        
+        // GIVEN
+        let selfUser = ZMUser.selfUser(in: self.uiMOC)
+        selfUser.emailAddress = "foo@email.com"
+
+        let newEmail = "mario@example.com"
+        try! self.userProfileUpdateStatus.requestEmailChange(email: newEmail)
+        XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.2))
+        
+        // WHEN
+        let request = self.sut.nextRequest()
+        
+        // THEN
+        XCTAssertEqual(request?.path, "/self/email")
+        XCTAssertEqual(request?.method, .methodPUT)
+        let emailInPayload = request?.payload?.asDictionary()?["email"] as? String
+        XCTAssertEqual(emailInPayload, newEmail)
+    }
+    
     func testThatItCreatesARequestToUpdateEmailAfterUpdatingPassword() {
         
         // GIVEN

--- a/Tests/Source/Synchronization/Transcoders/UserProfileUpdateRequestStrategyTests.swift
+++ b/Tests/Source/Synchronization/Transcoders/UserProfileUpdateRequestStrategyTests.swift
@@ -358,7 +358,24 @@ extension UserProfileUpdateRequestStrategyTests {
         XCTAssertEqual(self.userProfileUpdateStatus.recordedDidFailPasswordUpdate , 1)
     }
     
-    func testThatItCallsDidUpdateEmailSuccessfully() {
+    func testThatItCallsDidUpdateEmailSuccessfullyWhenChangingEmail() {
+        
+        // GIVEN
+        let selfUser = ZMUser.selfUser(in: self.uiMOC)
+        selfUser.emailAddress = "foo@email.com"
+        try! self.userProfileUpdateStatus.requestEmailChange(email: "mario@example.com")
+        XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.2))
+        
+        // WHEN
+        let request = self.sut.nextRequest()
+        request?.complete(with: self.successResponse())
+        
+        // THEN
+        XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        XCTAssertEqual(self.userProfileUpdateStatus.recordedDidUpdateEmailSuccessfully , 1)
+    }
+    
+    func testThatItCallsDidUpdateEmailSuccessfullyWhenSettingEmailAndPassword() {
         
         // GIVEN
         let credentials = ZMEmailCredentials(email: "mario@example.com", password: "princess")

--- a/Tests/Source/Synchronization/Transcoders/UserProfileUpdateRequestStrategyTests.swift
+++ b/Tests/Source/Synchronization/Transcoders/UserProfileUpdateRequestStrategyTests.swift
@@ -121,7 +121,7 @@ extension UserProfileUpdateRequestStrategyTests {
         XCTAssertEqual(request, expected)
     }
     
-    func tetThatItCreatesARequestToUpdateEmailAfterUpdatingPassword() {
+    func testThatItCreatesARequestToUpdateEmailAfterUpdatingPassword() {
         
         // GIVEN
         let credentials = ZMEmailCredentials(email: "mario@example.com", password: "princess")

--- a/Tests/Source/UserSession/UserProfileUpdateStatusTests.swift
+++ b/Tests/Source/UserSession/UserProfileUpdateStatusTests.swift
@@ -99,13 +99,21 @@ extension UserProfileUpdateStatusTests {
         // WHEN
         do {
             try self.sut.requestSettingEmailAndPassword(credentials: credentials)
-            XCTFail("Should have thrown")
         } catch {
+            XCTFail("Should not throw")
             return
         }
-        
-        // THEN
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.2))
+
+        // THEN
+        XCTAssertEqual(self.observer.invokedCallbacks.count, 1)
+        guard let first = self.observer.invokedCallbacks.first else { return }
+        switch first {
+        case .emailUpdateDidFail(error: UserProfileUpdateError.emailAlreadySet):
+            break
+        default:
+            XCTFail()
+        }
     }
     
     func testThatItCanCancelSettingEmailAndPassword() {

--- a/Tests/Source/UserSession/UserProfileUpdateStatusTests.swift
+++ b/Tests/Source/UserSession/UserProfileUpdateStatusTests.swift
@@ -57,6 +57,58 @@ class UserProfileUpdateStatusTests : MessagingTest {
     }
 }
 
+// MARK: - Changing email
+extension UserProfileUpdateStatusTests {
+    func testThatItReturnsErrorWhenPreparingForEmailChangeAndUserUserHasNoEmail() {
+        
+        // GIVEN
+        let selfUser = ZMUser.selfUser(in: self.uiMOC)
+        selfUser.emailAddress = nil
+        
+        // WHEN
+        do {
+            try self.sut.requestEmailChange(email: "foo@example.com")
+        } catch {
+            XCTFail("Should not throw")
+            return
+        }
+        XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.2))
+        
+        // THEN
+        XCTAssertEqual(self.observer.invokedCallbacks.count, 1)
+        guard let first = self.observer.invokedCallbacks.first else { return }
+        switch first {
+        case .emailUpdateDidFail(error: UserProfileUpdateError.emailNotSet):
+            break
+        default:
+            XCTFail()
+        }
+    }
+    
+    func testThatItPreparesForEmailChangeIfSelfUserHasEmail() {
+        
+        // GIVEN
+        let selfUser = ZMUser.selfUser(in: self.uiMOC)
+        selfUser.emailAddress = "my@fo.example.com"
+        
+        // WHEN
+        do {
+            try self.sut.requestEmailChange(email: "foo@example.com")
+        } catch {
+            XCTFail("Should not throw")
+            return
+        }
+        XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.2))
+        
+        // THEN
+        XCTAssertTrue(self.sut.currentlyChangingEmail)
+        XCTAssertFalse(self.sut.currentlySettingEmail)
+        XCTAssertFalse(self.sut.currentlySettingPassword)
+        XCTAssertEqual(self.newRequestCallbackCount, 1)
+    }
+
+}
+
 // MARK: - Set email and password
 extension UserProfileUpdateStatusTests {
     


### PR DESCRIPTION
## What's in this PR

We had possibility to set the email, but not to change it afterwards, so added a new method for this. 

Also fixed a threading issue which means `requestSettingEmailAndPassword` method returns an `emailAlreadySet` error in the delegate instead of throwing. 