### PR TITLE
Fix multithreading violation in ZMCallTimer

### DIFF
--- a/Source/Calling/ZMCallTimer.swift
+++ b/Source/Calling/ZMCallTimer.swift
@@ -127,9 +127,12 @@ public final class ZMCallTimer : NSObject, ZMTimerClient {
             if let testDelegate = self.testDelegate {
                 testDelegate.callTimerDidFire(self)
             }
-            guard let conversation = self.managedObjectContext?.object(with: conversationID) as? ZMConversation , !conversation.isZombieObject
-            else { return }
-            conversation.voiceChannel?.callTimerDidFire(self)
+
+            managedObjectContext?.performGroupedBlock {
+                let object = try? self.managedObjectContext?.existingObject(with: conversationID)
+                guard let conversation =  object as? ZMConversation, !conversation.isZombieObject else { return }
+                conversation.voiceChannel?.callTimerDidFire(self)
+            }
             
             break;
         }

--- a/Source/Calling/ZMVoiceChannel+CallTimer.swift
+++ b/Source/Calling/ZMVoiceChannel+CallTimer.swift
@@ -42,11 +42,12 @@ extension ZMVoiceChannel {
               let context = conversation.managedObjectContext , context.zm_isSyncContext
         else { return }
         let uiContext = context.zm_userInterface
-        
-        guard let uiConv = (try? uiContext?.existingObject(with: conversation.objectID)) as? ZMConversation , !uiConv.isZombieObject
-        else { return }
+
         
         uiContext?.performGroupedBlock { () -> Void in
+            guard let uiConv = (try? uiContext?.existingObject(with: conversation.objectID)) as? ZMConversation, !uiConv.isZombieObject
+                else { return }
+
             if  uiConv.conversationType == .group ||
                 (uiConv.conversationType == .oneOnOne && !uiConv.isOutgoingCall)
             {


### PR DESCRIPTION
# What's in this PR?

* Add missing `performGroupedBlock` in `ZMCallTimer`.
* We were checking `isZombieObject` in `ZMVoiceChannel+CallTimer` before dispatching to the correct queue.