### PR TITLE
Fix multithreading violation in ZMSyncStateMachine

### DIFF
--- a/Source/Synchronization/Sync States/ZMSyncStateMachine.m
+++ b/Source/Synchronization/Sync States/ZMSyncStateMachine.m
@@ -119,7 +119,9 @@ static NSString *ZMLogTag ZM_UNUSED = @"State machine";
         self.authNotificationToken = [ZMUserSessionAuthenticationNotification addObserverWithBlock:^(ZMUserSessionAuthenticationNotification *note) {
             ZM_STRONG(self);
             if (note.type == ZMAuthenticationNotificationAuthenticationDidFail) {
-                [self didFailAuthentication];
+                [self.directory.moc performGroupedBlock:^{
+                    [self didFailAuthentication];
+                }];
             }
         }];
 


### PR DESCRIPTION
# What's in this PR?

* The authentication notification is fired on the main queue and we did not dispatch to the sync queue.