### PR TITLE
Do not notify pingback status if notificationEventsToCancel is nil

### DIFF
--- a/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
@@ -160,7 +160,7 @@ previouslyReceivedEventIDsCollection:(id<PreviouslyReceivedEventIDsCollection>)e
         }
     }
 
-    if (self.isFetchingStreamForAPNS) {
+    if (self.isFetchingStreamForAPNS && self.notificationEventsToCancel != nil) {
         // In case we are fetching the stream because we have received a push notification we need to forward them to the pingback status
         // The status will forward them to the operationloop and check if the received notification was contained in this batch.
         NSArray <ZMUpdateEvent *> *events = [parsedEvents arrayByAddingObjectsFromArray:lastCallStateEvents.allValues];


### PR DESCRIPTION
# Issue

We detected the crash issue happening in `pingbackStatus`'es `didReceiveEncryptedEvents:originalEvents:...` when referencing `originalEvents`. Current hypothesis is that for the parameter `originalEvents` the nil value is passed from Obj-C caller in `ZMMissingUpdateEventsTranscoder`. This situation is theoretically possible (there is no concrete steps to reproduce).

# Solution

There is no reason to call `didReceiveEncryptedEvents:originalEvents:...` if `originalEvents` is nil, therefore the call is guarded by if on the caller side.
