### PR TITLE
Keep websocket open during a call

### DIFF
--- a/Source/Calling/VoiceChannelV2+CallFlow.m
+++ b/Source/Calling/VoiceChannelV2+CallFlow.m
@@ -218,7 +218,6 @@
     }
     
     [conv.managedObjectContext.zm_userInterfaceContext performGroupedBlock: ^{
-        // FIXME we probably need to do this for V3 calls as well.
         [[NSNotificationCenter defaultCenter] postNotificationName:ZMTransportSessionShouldKeepWebsocketOpenNotificationName object:self userInfo:@{ZMTransportSessionShouldKeepWebsocketOpenKey: @YES}];
     }];
     

--- a/Tests/Source/Calling/CallStateObserverTests.swift
+++ b/Tests/Source/Calling/CallStateObserverTests.swift
@@ -172,4 +172,49 @@ class CallStateObserverTests : MessagingTest {
         XCTAssertEqual(application.scheduledLocalNotifications.count, 1)
     }
     
+    func testThatWeKeepTheWebsocketOpenOnIncomingCalls() {
+        // expect
+        expectation(forNotification: ZMTransportSessionShouldKeepWebsocketOpenNotificationName, object: nil) { (note) -> Bool in
+            if let open = note.userInfo?[ZMTransportSessionShouldKeepWebsocketOpenKey] as? Bool, open == true {
+                return true
+            } else {
+                return false
+            }
+        }
+        
+        // given when
+        sut.callCenterDidChange(callState: .incoming(video: false), conversationId: conversation.remoteIdentifier!, userId: sender.remoteIdentifier!)
+        XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
+    }
+    
+    func testThatWeKeepTheWebsocketOpenOnOutgoingCalls() {
+        // expect
+        expectation(forNotification: ZMTransportSessionShouldKeepWebsocketOpenNotificationName, object: nil) { (note) -> Bool in
+            if let open = note.userInfo?[ZMTransportSessionShouldKeepWebsocketOpenKey] as? Bool, open == true {
+                return true
+            } else {
+                return false
+            }
+        }
+        
+        // given when
+        sut.callCenterDidChange(callState: .outgoing, conversationId: conversation.remoteIdentifier!, userId: sender.remoteIdentifier!)
+        XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
+    }
+    
+    func testThatWeDontKeepTheWebsocketOpenAfterACallIsTerminated() {
+        // expect
+        expectation(forNotification: ZMTransportSessionShouldKeepWebsocketOpenNotificationName, object: nil) { (note) -> Bool in
+            if let open = note.userInfo?[ZMTransportSessionShouldKeepWebsocketOpenKey] as? Bool, open == false {
+                return true
+            } else {
+                return false
+            }
+        }
+        
+        // given when
+        sut.callCenterDidChange(callState: .terminating(reason: .normal), conversationId: conversation.remoteIdentifier!, userId: sender.remoteIdentifier!)
+        XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
+    }
+    
 }


### PR DESCRIPTION
For calling 2 we keep the websocket open during a call. This PR adds the
same logic for calling 3.