### PR TITLE
Fix/migration on startup

### DIFF
--- a/Source/Public/ZMVoiceChannel+VideoCalling.h
+++ b/Source/Public/ZMVoiceChannel+VideoCalling.h
@@ -19,7 +19,6 @@
 
 @import Foundation;
 @import ZMCDataModel;
-#import <ZMCDataModel/ZMVoiceChannel.h>
 
 @class ZMUser;
 @class UIView;

--- a/Source/Synchronization/Sync States/ZMEventProcessingState.m
+++ b/Source/Synchronization/Sync States/ZMEventProcessingState.m
@@ -94,7 +94,7 @@
 {
     id<ZMObjectStrategyDirectory> directory = self.objectStrategyDirectory;
     [directory processAllEventsInBuffer];
-    [self.hotFix applyPatches];
+    [self.hotFix applyPatchesAfterSyncCompleted];
 
     [[NSNotificationCenter defaultCenter] postNotificationName:ZMApplicationDidEnterEventProcessingStateNotificationName object:nil];
     [self.stateMachineDelegate didFinishSync];

--- a/Source/Synchronization/ZMHotFix.h
+++ b/Source/Synchronization/ZMHotFix.h
@@ -40,9 +40,13 @@ extern NSString * const ZMSkipHotfix;
 
 - (instancetype)initWithSyncMOC:(NSManagedObjectContext *)syncMOC;
 
-/// This method is supposed to be called once on startup
+/// It checks if there is a last version stored in the persistentStore and then applies patches (once) for older versions and saves the current version in the persistentStore.
+/// This executes only the patches that are supposed to be executed at startup (as soon as the database is loaded)
+- (void)applyPatchesAtStartup;
+
 /// It checks if there is a last version stored in the persistentStore and then applies patches (once) for older versions and saves the current version in the persistentStore
-- (void)applyPatches;
+/// This executes only the patches that are supposed to be executed after processing the notification stream
+- (void)applyPatchesAfterSyncCompleted;
 
 
 @end
@@ -51,7 +55,7 @@ extern NSString * const ZMSkipHotfix;
 @interface ZMHotFix (Testing)
 
 - (instancetype)initWithHotFixDirectory:(ZMHotFixDirectory *)hotFixDirectory syncMOC:(NSManagedObjectContext *)syncMOC;
-- (void)applyPatchesForCurrentVersion:(NSString *)currentVersion;
+- (void)applyPatchesForCurrentVersion:(NSString *)currentVersion afterSync:(BOOL)afterSync;
 
 @end
 

--- a/Source/Synchronization/ZMHotFixDirectory.h
+++ b/Source/Synchronization/ZMHotFixDirectory.h
@@ -38,7 +38,10 @@ typedef void(^ZMHotFixPatchCode)(NSManagedObjectContext *moc);
 /// List of hot fixes to run on the data organized by version
 @interface ZMHotFixDirectory : NSObject
 
-/// List of ZMHotFixPatch that can be applied, ordered by version
-@property (nonatomic, readonly) NSArray *patches;
+/// List of ZMHotFixPatch that can be applied after sync, ordered by version
+@property (nonatomic, readonly) NSArray *patchesAfterSync;
+
+/// List of ZMHotFixPatch that can be applied at startup, ordered by version
+@property (nonatomic, readonly) NSArray *patchesAtStartup;
 
 @end

--- a/Source/Synchronization/ZMHotFixDirectory.m
+++ b/Source/Synchronization/ZMHotFixDirectory.m
@@ -44,7 +44,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"HotFix";
 
 @implementation ZMHotFixDirectory
 
-- (NSArray *)patches
+- (NSArray *)patchesAfterSync
 {
     static dispatch_once_t onceToken;
     static NSArray *patches;
@@ -95,12 +95,26 @@ static NSString* ZMLogTag ZM_UNUSED = @"HotFix";
                      patchCode:^(NSManagedObjectContext *context) {
                          [ZMHotFixDirectory refetchConnectedUsers:context];
                      }]
-                    ]
-                    ;
+                    ];
     });
     return patches;
 }
 
+- (NSArray *)patchesAtStartup
+{
+    static dispatch_once_t onceToken;
+    static NSArray *patches;
+    dispatch_once(&onceToken, ^{
+        patches = @[
+                    [ZMHotFixPatch
+                     patchWithVersion:@"67.0.0"
+                     patchCode:^(NSManagedObjectContext *context) {
+                         [ZMHotFixDirectory migrateClientSessionIdentfiersInMOC:context];
+                     }]
+                    ];
+    });
+    return patches;
+}
 
 + (void)resetPushTokens
 {

--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -28,7 +28,7 @@
 
 #import "ZMUserSession+Internal.h"
 #import "ZMSyncStrategy.h"
-//#import "ZMOperationLoop.h"
+#import "ZMHotFix.h"
 #import "NSError+ZMUserSessionInternal.h"
 #import "ZMCredentials.h"
 #import "ZMSearchDirectory+Internal.h"
@@ -356,6 +356,9 @@ ZM_EMPTY_ASSERTING_INIT()
         
         [self.syncManagedObjectContext performBlockAndWait:^{
     
+            // patch to be executed at start
+            [[[ZMHotFix alloc] initWithSyncMOC:self.syncManagedObjectContext] applyPatchesAtStartup];
+            
             self.operationLoop = operationLoop ?: [[ZMOperationLoop alloc] initWithTransportSession:session
                                                                                authenticationStatus:self.authenticationStatus
                                                                             userProfileUpdateStatus:self.userProfileUpdateStatus

--- a/Tests/Source/Synchronization/ZMHotFixTests.m
+++ b/Tests/Source/Synchronization/ZMHotFixTests.m
@@ -190,7 +190,7 @@
     [self saveNewVersion];
 
     // when
-    [self.sut applyPatchesForCurrentVersion:@"1.0"];
+    [self.sut applyPatchesForCurrentVersion:@"1.0" afterSync:YES];
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
@@ -202,7 +202,7 @@
 - (void)testThatItCallsAllMethodsIfThereIsNoLastSavedVersion
 {
     // when
-    [self.sut applyPatchesForCurrentVersion:@"1.0"];
+    [self.sut applyPatchesForCurrentVersion:@"1.0" afterSync:YES];
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
@@ -217,14 +217,14 @@
     [self saveNewVersion];
     
     // when
-    [self.sut applyPatchesForCurrentVersion:@"1.0"];
+    [self.sut applyPatchesForCurrentVersion:@"1.0" afterSync:YES];
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
     XCTAssertEqual(self.fakeHotFixDirectory.method1CallCount, 1u);
     
     // and when
-    [self.sut applyPatchesForCurrentVersion:@"1.0"];
+    [self.sut applyPatchesForCurrentVersion:@"1.0" afterSync:YES];
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
@@ -237,7 +237,7 @@
     [self saveNewVersion];
     
     // when
-    [self.sut applyPatchesForCurrentVersion:@"1.2"];
+    [self.sut applyPatchesForCurrentVersion:@"1.2" afterSync:YES];
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
@@ -260,20 +260,20 @@
     
     // when
     self.sut = [[ZMHotFix alloc] initWithSyncMOC:self.syncMOC];
-    [self.sut applyPatchesForCurrentVersion:@"40.4"];
+    [self.sut applyPatchesForCurrentVersion:@"40.4" afterSync:YES];
     WaitForAllGroupsToBeEmpty(0.5);
 
     NSString *newVersion = [self.syncMOC persistentStoreMetadataForKey:@"lastSavedVersion"];
     XCTAssertEqualObjects(newVersion, @"40.4");
     
-    [self.sut applyPatchesForCurrentVersion:@"40.4"];
+    [self.sut applyPatchesForCurrentVersion:@"40.4" afterSync:YES];
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
     XCTAssertEqual(observer.notificationCount, 1lu);
     
     // when
-    [self.sut applyPatchesForCurrentVersion:@"40.5"];
+    [self.sut applyPatchesForCurrentVersion:@"40.5" afterSync:YES];
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
@@ -295,7 +295,7 @@
     
     // when
     self.sut = [[ZMHotFix alloc] initWithSyncMOC:self.syncMOC];
-    [self.sut applyPatchesForCurrentVersion:@"40.23"];
+    [self.sut applyPatchesForCurrentVersion:@"40.23" afterSync:YES];
     WaitForAllGroupsToBeEmpty(0.5);
 
     // then
@@ -315,7 +315,7 @@
 
     // when
     self.sut = [[ZMHotFix alloc] initWithSyncMOC:self.syncMOC];
-    [self.sut applyPatchesForCurrentVersion:@"41.42"];
+    [self.sut applyPatchesForCurrentVersion:@"41.42" afterSync:YES];
     WaitForAllGroupsToBeEmpty(0.5);
     
     NSString *newVersion = [self.syncMOC persistentStoreMetadataForKey:@"lastSavedVersion"];
@@ -332,7 +332,7 @@
     userClient.apsDecryptionKey = [NSData randomEncryptionKey];
     userClient.apsVerificationKey = [NSData randomEncryptionKey];
     
-    [self.sut applyPatchesForCurrentVersion:@"41.43"];
+    [self.sut applyPatchesForCurrentVersion:@"41.43" afterSync:YES];
     WaitForAllGroupsToBeEmpty(0.5);
     
     NSString *newVersion2 = [self.syncMOC persistentStoreMetadataForKey:@"lastSavedVersion"];
@@ -356,7 +356,7 @@
     
     // when
     self.sut = [[ZMHotFix alloc] initWithSyncMOC:self.syncMOC];
-    [self.sut applyPatchesForCurrentVersion:@"41.42"];
+    [self.sut applyPatchesForCurrentVersion:@"41.42" afterSync:YES];
     WaitForAllGroupsToBeEmpty(0.5);
     
     NSString *newVersion = [self.syncMOC persistentStoreMetadataForKey:@"lastSavedVersion"];
@@ -372,7 +372,7 @@
     userClient.needsToUploadSignalingKeys = NO;
     [userClient resetLocallyModifiedKeys:[NSSet setWithObject:@"needsToUploadSignalingKeys"]];
     
-    [self.sut applyPatchesForCurrentVersion:@"41.43"];
+    [self.sut applyPatchesForCurrentVersion:@"41.43" afterSync:YES];
     WaitForAllGroupsToBeEmpty(0.5);
     
     NSString *newVersion2 = [self.syncMOC persistentStoreMetadataForKey:@"lastSavedVersion"];
@@ -424,7 +424,7 @@
     
     // when
     self.sut = [[ZMHotFix alloc] initWithSyncMOC:self.syncMOC];
-    [self.sut applyPatchesForCurrentVersion:@"42.11"];
+    [self.sut applyPatchesForCurrentVersion:@"42.11" afterSync:YES];
     WaitForAllGroupsToBeEmpty(0.5);
     
     NSString *newVersion = [self.syncMOC persistentStoreMetadataForKey:@"lastSavedVersion"];
@@ -474,7 +474,7 @@
     
     // when
     self.sut = [[ZMHotFix alloc] initWithSyncMOC:self.syncMOC];
-    [self.sut applyPatchesForCurrentVersion:@"44.4"];
+    [self.sut applyPatchesForCurrentVersion:@"44.4" afterSync:YES];
     WaitForAllGroupsToBeEmpty(0.5);
     
     NSString *newVersion = [self.syncMOC persistentStoreMetadataForKey:@"lastSavedVersion"];
@@ -517,7 +517,7 @@
     
     // when
     self.sut = [[ZMHotFix alloc] initWithSyncMOC:self.syncMOC];
-    [self.sut applyPatchesForCurrentVersion:@"54.0.1"];
+    [self.sut applyPatchesForCurrentVersion:@"54.0.1" afterSync:YES];
     WaitForAllGroupsToBeEmpty(0.5);
     
     [self.syncMOC saveOrRollback];
@@ -546,7 +546,7 @@
     
     // when
     self.sut = [[ZMHotFix alloc] initWithSyncMOC:self.syncMOC];
-    [self.sut applyPatchesForCurrentVersion:@"61.0.0"];
+    [self.sut applyPatchesForCurrentVersion:@"61.0.0" afterSync:YES];
     WaitForAllGroupsToBeEmpty(0.5);
     
     [self.syncMOC saveOrRollback];
@@ -596,7 +596,7 @@
 
     // when
     self.sut = [[ZMHotFix alloc] initWithSyncMOC:self.syncMOC];
-    [self.sut applyPatchesForCurrentVersion:@"62.3.1"];
+    [self.sut applyPatchesForCurrentVersion:@"62.3.1" afterSync:YES];
     WaitForAllGroupsToBeEmpty(0.5);
 
     [self.syncMOC saveOrRollback];
@@ -607,5 +607,44 @@
     XCTAssertTrue(selfUser.needsToBeUpdatedFromBackend);
 }
 
+- (void)testThatItMigrateClientSessionsIdentifier_67_0_0
+{
+    // GIVEN
+    UserClient *client = [self createSelfClient];
+    
+    ZMUser *newUser = [ZMUser insertNewObjectInManagedObjectContext:self.syncMOC];
+    newUser.remoteIdentifier = [NSUUID createUUID];
+    UserClient *newClient = [UserClient insertNewObjectInManagedObjectContext:self.syncMOC];
+    newClient.user = newUser;
+    newClient.remoteIdentifier = @"aabbccdd";
+    NSURL *otrURL = client.keysStore.encryptionContext.path;
+    
+    [client establishSessionWithClient:newClient usingPreKey:@"pQABAQUCoQBYIEIir0myj5MJTvs19t585RfVi1dtmL2nJsImTaNXszRwA6EAoQBYIGpa1sQFpCugwFJRfD18d9+TNJN2ZL3H0Mfj/0qZw0ruBPY="];
+    [self.syncMOC saveOrRollback];
+    
+    NSURL *sessionsURL = [otrURL URLByAppendingPathComponent:@"sessions"];
+    NSURL *oldSession = [sessionsURL URLByAppendingPathComponent:newClient.remoteIdentifier];
+    NSURL *newSession = [sessionsURL URLByAppendingPathComponent:
+                         [NSString stringWithFormat:@"%@_%@", newUser.remoteIdentifier, newClient.remoteIdentifier]
+                         ];
+    XCTAssertTrue([NSFileManager.defaultManager fileExistsAtPath:newSession.path]);
+    NSData *previousData = [NSData dataWithContentsOfFile:newSession.path];
+    
+    // move to fake old session
+    XCTAssertTrue([NSFileManager.defaultManager moveItemAtURL:newSession toURL:oldSession error:nil]);
+    XCTAssertFalse([NSFileManager.defaultManager fileExistsAtPath:newSession.path]);
+    XCTAssertTrue([NSFileManager.defaultManager fileExistsAtPath:oldSession.path]);
+    
+    // WHEN
+    self.sut = [[ZMHotFix alloc] initWithSyncMOC:self.syncMOC];
+    [self.sut applyPatchesForCurrentVersion:@"67.0.0" afterSync:NO];
+    WaitForAllGroupsToBeEmpty(0.5);
+    
+    // THEN
+    
+    NSData *readData = [NSData dataWithContentsOfFile:newSession.path];
+    XCTAssertEqualObjects(readData, previousData);
+    XCTAssertFalse([NSFileManager.defaultManager fileExistsAtPath:oldSession.path]);
+}
 @end
 

--- a/zmessaging-cocoa.xcodeproj/project.pbxproj
+++ b/zmessaging-cocoa.xcodeproj/project.pbxproj
@@ -226,6 +226,7 @@
 		54A3F24F1C08523500FE3A6B /* ZMOperationLoop.h in Headers */ = {isa = PBXBuildFile; fileRef = 85D85F3EC8565FD102AC0E5B /* ZMOperationLoop.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		54AB428E1DF5C5B400381F2C /* TopConversationsDirectoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54AB428D1DF5C5B400381F2C /* TopConversationsDirectoryTests.swift */; };
 		54ADA7631E3B3D8E00B90C7D /* IntegrationTestBase+Encryption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54ADA7611E3B3CBE00B90C7D /* IntegrationTestBase+Encryption.swift */; };
+		54B05F411E40E742000DD9BA /* ZMCDataModel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 54B05F401E40E742000DD9BA /* ZMCDataModel.framework */; };
 		54B2A0891DAE71F100BB40B1 /* AddressBookTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54B2A0831DAE71F100BB40B1 /* AddressBookTracker.swift */; };
 		54B2A08A1DAE71F100BB40B1 /* AnalyticsType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54B2A0841DAE71F100BB40B1 /* AnalyticsType.swift */; };
 		54B2A08B1DAE71F100BB40B1 /* APNSPerformanceTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54B2A0851DAE71F100BB40B1 /* APNSPerformanceTracker.swift */; };
@@ -709,6 +710,7 @@
 		54A3ACC21A261603008AF8DF /* BackgroundTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BackgroundTests.m; sourceTree = "<group>"; };
 		54AB428D1DF5C5B400381F2C /* TopConversationsDirectoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopConversationsDirectoryTests.swift; sourceTree = "<group>"; };
 		54ADA7611E3B3CBE00B90C7D /* IntegrationTestBase+Encryption.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "IntegrationTestBase+Encryption.swift"; sourceTree = "<group>"; };
+		54B05F401E40E742000DD9BA /* ZMCDataModel.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ZMCDataModel.framework; path = Carthage/Build/iOS/ZMCDataModel.framework; sourceTree = "<group>"; };
 		54B2A0831DAE71F100BB40B1 /* AddressBookTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddressBookTracker.swift; sourceTree = "<group>"; };
 		54B2A0841DAE71F100BB40B1 /* AnalyticsType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsType.swift; sourceTree = "<group>"; };
 		54B2A0851DAE71F100BB40B1 /* APNSPerformanceTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APNSPerformanceTracker.swift; sourceTree = "<group>"; };
@@ -914,13 +916,11 @@
 		BF8367301C52651900364B37 /* store125.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = store125.wiredatabase; sourceTree = "<group>"; };
 		BF838F031C6A4885001C5BF7 /* ZMCookie.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZMCookie.h; sourceTree = "<group>"; };
 		BF838F041C6A4885001C5BF7 /* ZMCookie.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMCookie.m; sourceTree = "<group>"; };
-		BF8899911DC7882F00187CBD /* ZMTransport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ZMTransport.framework; path = "../wire-ios-transport/build/Debug-iphoneos/ZMTransport.framework"; sourceTree = "<group>"; };
 		BFB524CD1C7722EC006BCE23 /* BackgroundAPNSPingBackStatusTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackgroundAPNSPingBackStatusTests.swift; sourceTree = "<group>"; };
 		BFC747B91CE0975D00F74333 /* zimages.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = zimages.framework; path = "../zmc-images/build/Debug-iphoneos/zimages.framework"; sourceTree = "<group>"; };
 		BFCE9A581C4E4C4D00951B3D /* store124.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = store124.wiredatabase; sourceTree = "<group>"; };
 		BFE53F541D5A2F7000398378 /* DeleteMessagesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeleteMessagesTests.swift; sourceTree = "<group>"; };
 		CE35B7F61D353CC4007CF3F8 /* LinkPreviewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LinkPreviewTests.m; sourceTree = "<group>"; };
-		CE59DD7B1CFC7D6C0009F8FD /* ZMCDataModel.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ZMCDataModel.framework; path = "../../../../Library/Developer/Xcode/DerivedData/ZClient-iOS-dkzruzvfpikqstehiyrcjhyckwcj/Build/Products/Debug-iphonesimulator/ZMCDataModel.framework"; sourceTree = "<group>"; };
 		CE99C49E1D378C5D0001D297 /* MockLinkPreviewDetector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MockLinkPreviewDetector.h; sourceTree = "<group>"; };
 		CE99C49F1D378C5D0001D297 /* MockLinkPreviewDetector.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MockLinkPreviewDetector.m; sourceTree = "<group>"; };
 		CE99C4A11D37ACC60001D297 /* Ono.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Ono.framework; path = Carthage/Build/iOS/Ono.framework; sourceTree = "<group>"; };
@@ -1086,6 +1086,7 @@
 				F9A754121DA3D44900094937 /* ZMProtos.framework in Frameworks */,
 				097E36AA1B7A58570039CC4C /* ZMCSystem.framework in Frameworks */,
 				BF0D67A41C901DEC007CE00F /* libPhoneNumber.framework in Frameworks */,
+				54B05F411E40E742000DD9BA /* ZMCDataModel.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1349,10 +1350,9 @@
 		540029B61918CA8500578793 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				BF8899911DC7882F00187CBD /* ZMTransport.framework */,
+				54B05F401E40E742000DD9BA /* ZMCDataModel.framework */,
 				1621D26E1D77098B007108C2 /* WireRequestStrategy.framework */,
 				CE99C4A11D37ACC60001D297 /* Ono.framework */,
-				CE59DD7B1CFC7D6C0009F8FD /* ZMCDataModel.framework */,
 				F9B71F361CB26FB2001DB03F /* ZMUtilities.framework */,
 				169AED691C8F09A700E5F17E /* AVS */,
 				BF0D67A31C901DEC007CE00F /* libPhoneNumber.framework */,


### PR DESCRIPTION
# Reason for this pull request
Perform migration of session identifiers

# Changes
We need to apply the patch that performs the migration BEFORE the notification stream or any APNS is processed. So I distinguished between patches applied after the initial sync, and patches applied at startup.

# Known issues
The same hotfix should be applied when running share extension. So we should later move this code to data model, otherwise `wire-ios-share-engine` won't be able to access it. In fact, we should move the entire hotfix structure to data model.