### PR TITLE
Fix group calls not hanging up properly

### DIFF
--- a/Source/Calling/ZMCallKitDelegate.m
+++ b/Source/Calling/ZMCallKitDelegate.m
@@ -377,8 +377,6 @@ NS_ASSUME_NONNULL_END
         if (nil != error) {
             [self logErrorForConversation:conversation.remoteIdentifier.transportString line:__LINE__ format:@"Cannot end call: %@", error];
         }
-
-        [conversation.voiceChannelRouter.currentVoiceChannel leave];
     }];
 }
 


### PR DESCRIPTION
We should not leave the voice channel immediately when we request to leave