### PR TITLE
Enable changing phone number after it was added to the profile

### DIFF
--- a/Source/Synchronization/Strategies/UserProfileUpdateRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/UserProfileUpdateRequestStrategy.swift
@@ -178,7 +178,8 @@ extension UserProfileRequestStrategy : ZMSingleRequestTranscoder {
             if response.result == .success {
                 self.userProfileUpdateStatus.didChangePhoneSuccesfully()
             } else {
-                let error : Error = NSError.userSessionErrorWith(ZMUserSessionErrorCode.unkownError, userInfo: nil)
+                let error : Error = NSError.invalidPhoneVerificationCodeError(with: response) ??
+                    NSError.userSessionErrorWith(ZMUserSessionErrorCode.unkownError, userInfo: nil)
                 self.userProfileUpdateStatus.didFailChangingPhone(error: error)
             }
             

--- a/Source/UserSession/UserProfileUpdateStatus.swift
+++ b/Source/UserSession/UserProfileUpdateStatus.swift
@@ -384,10 +384,6 @@ extension UserProfileUpdateStatus {
     
     /// Whether we are currently requesting a change of phone number
     public var currentlySettingPhone : Bool {
-        guard !self.selfUserHasPhoneNumber else {
-            return false
-        }
-        
         return self.phoneNumberToSet != nil
     }
     

--- a/Tests/Source/Synchronization/Transcoders/UserProfileUpdateRequestStrategyTests.swift
+++ b/Tests/Source/Synchronization/Transcoders/UserProfileUpdateRequestStrategyTests.swift
@@ -88,6 +88,27 @@ extension UserProfileUpdateRequestStrategyTests {
     func testThatItCreatesARequestToChangePhone() {
         
         // GIVEN
+        ZMUser.selfUser(in: self.uiMOC).phoneNumber = "+1234567890"
+        let credentials = ZMPhoneCredentials(phoneNumber: "+155523123123", verificationCode: "12345")
+        self.userProfileUpdateStatus.requestPhoneNumberChange(credentials: credentials)
+        XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.2))
+        
+        // WHEN
+        let request = self.sut.nextRequest()
+        
+        // THEN
+        let expected = ZMTransportRequest(path: "/activate", method: .methodPOST, payload: [
+            "phone":credentials.phoneNumber!,
+            "code":credentials.phoneNumberVerificationCode!,
+            "dryrun":false
+            ] as NSDictionary)
+        XCTAssertEqual(request, expected)
+    }
+    
+    func testThatItCreatesARequestToAddPhone() {
+        
+        // GIVEN
+        ZMUser.selfUser(in: self.uiMOC).phoneNumber = nil
         let credentials = ZMPhoneCredentials(phoneNumber: "+155523123123", verificationCode: "12345")
         self.userProfileUpdateStatus.requestPhoneNumberChange(credentials: credentials)
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.2))


### PR DESCRIPTION
Initially it was used only for adding phone initially, not for changing it afterwards