### PR TITLE
Remove "ghost clients" when fetching the clients list

### DIFF
--- a/Tests/Source/E2EE/UserClientRequestStrategyTests.swift
+++ b/Tests/Source/E2EE/UserClientRequestStrategyTests.swift
@@ -436,6 +436,28 @@ extension UserClientRequestStrategyTests {
             }
         }
     }
+    
+    func testThatDeletesClientsThatWereNotInTheFetchResponse() {
+        
+        // given
+        let selfClient = self.createSelfClient()
+        let selfUser = ZMUser.selfUser(in: self.syncMOC)
+        let nextResponse = ZMTransportResponse(payload: payloadForClients() as ZMTransportData?, httpStatus: 200, transportSessionError: nil)
+        let newClient = UserClient.insertNewObject(in: self.syncMOC)
+        newClient.user = selfUser
+        newClient.remoteIdentifier = "deleteme"
+        self.syncMOC.saveOrRollback()
+        
+        // when
+        _ = sut.nextRequest()
+        sut.didReceive(nextResponse, forSingleRequest: nil)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.2))
+        
+        // then
+        XCTAssertTrue(selfUser.clients.contains(selfClient))
+        XCTAssertFalse(selfUser.clients.contains(newClient))
+        
+    }
 }
 
 


### PR DESCRIPTION
# Reason for this pull request
On some devices we observed a list of "ghost users" that were previously deleted, but that are still in the list of clients for the self user.

# Changes
We now make sure to remove any client (other than self) that we don't see in the list of clients received from the BE