### PR TITLE
Update state handling due to API change

### DIFF
--- a/Source/Calling/WireCallCenter.swift
+++ b/Source/Calling/WireCallCenter.swift
@@ -60,8 +60,6 @@ extension CallClosedReason {
         switch self {
         case .lostMedia:
             return VoiceChannelV2CallEndReason.disconnected
-        case .normalSelf:
-            return VoiceChannelV2CallEndReason.requestedSelf
         case .normal, .anweredElsewhere, .canceled:
             return VoiceChannelV2CallEndReason.requested
         case .timeout:

--- a/Source/Calling/ZMCallKitDelegate+WireCallCenter.swift
+++ b/Source/Calling/ZMCallKitDelegate+WireCallCenter.swift
@@ -52,7 +52,7 @@ extension ZMCallKitDelegate : WireCallCenterCallStateObserver, WireCallCenterMis
             }
             
             indicateIncomingCall(from: user, in: conversation, video: video)
-        case let .terminating(reason: reason) where reason != .normalSelf:
+        case let .terminating(reason: reason) where !(reason == .normal && userId == ZMUser.selfUser(inUserSession: userSession).remoteIdentifier):
             if #available(iOS 10.0, *) {
                 provider.reportCall(with: conversationId, endedAt: nil, reason: UInt(reason.CXCallEndedReason.rawValue))
             }

--- a/Tests/Source/Calling/CallStateObserverTests.swift
+++ b/Tests/Source/Calling/CallStateObserverTests.swift
@@ -119,7 +119,6 @@ class CallStateObserverTests : MessagingTest {
         // given
         let ignoredCallStates : [CallState] = [.terminating(reason: .anweredElsewhere),
                                                .terminating(reason: .normal),
-                                               .terminating(reason: .normalSelf),
                                                .terminating(reason: .lostMedia),
                                                .terminating(reason: .internalError),
                                                .terminating(reason: .unknown),

--- a/Tests/Source/Calling/ZMCallKitDelegateTests.swift
+++ b/Tests/Source/Calling/ZMCallKitDelegateTests.swift
@@ -662,10 +662,10 @@ class ZMCallKitDelegateTest: MessagingTest {
     func testThatItDoesntReportCallEndedAt_v3_Terminating_normalSelf() {
         // given
         let conversation = self.conversation()
-        let otherUser = self.otherUser(moc: self.uiMOC)
+        let selfUser = ZMUser.selfUser(in: self.uiMOC)
         
         // when
-        sut.callCenterDidChange(callState: .terminating(reason: .normalSelf), conversationId: conversation.remoteIdentifier!, userId: otherUser.remoteIdentifier!)
+        sut.callCenterDidChange(callState: .terminating(reason: .normal), conversationId: conversation.remoteIdentifier!, userId: selfUser.remoteIdentifier!)
         
         // then
         XCTAssertEqual(self.callKitProvider.timesReportCallEndedAtCalled, 0)


### PR DESCRIPTION
Previously AVS was only reporting state changes for actions you
didn't initiate, that's no longer the case so we need to remove
our own state change reporting to avoid duplicate state changes.

- [x] depends on a bug fix from AVS which reports the wrong user when a call is hangup