### PR TITLE
Fix missing video when answering a call from the lock screen

### DIFF
--- a/Source/Calling/WireCallCenterV2.swift
+++ b/Source/Calling/WireCallCenterV2.swift
@@ -436,9 +436,13 @@ extension WireCallCenterV2 {
     
     @objc
     func applicationDidBecomeActive(note: Notification) {
-        if let connectedCallConversation =  conversations(withVoiceChannelStates: [.selfConnectedToActiveChannel]).first, connectedCallConversation.isVideoCall {
-            // We need to start video in conversation that accepted video call in background but did not start the recording yet
-            try? connectedCallConversation.voiceChannelRouter?.v2.setVideoSendActive(true)
+        context.performGroupedBlock {
+            if let connectedCallConversation =  self.conversations(withVoiceChannelStates: [.selfConnectedToActiveChannel]).first, connectedCallConversation.isVideoCall {
+                
+                // We need to start video in conversation that accepted video call in background but did not start the recording yet
+                try? connectedCallConversation.voiceChannelRouter?.v2.setVideoSendActive(true)
+                self.context.enqueueDelayedSave()
+            }
         }
     }
     


### PR DESCRIPTION
We didn't start the video due to a missing save call.