### PR TITLE
Always initialize the flow manager for now

### DIFF
--- a/Source/Calling/ZMFlowSync.m
+++ b/Source/Calling/ZMFlowSync.m
@@ -78,9 +78,8 @@ static NSString *ZMLogTag ZM_UNUSED = @"Calling";
         self.voiceGainNotificationQueue = [[NSNotificationQueue alloc] initWithNotificationCenter:[NSNotificationCenter defaultCenter]];
 
         self.onDemandFlowManager = onDemandFlowManager;
-        if (self.application.applicationState != UIApplicationStateBackground || [ZMUserSession useCallKit]) {
-            [self setUpFlowManagerIfNeeded];
-        }
+        
+        [self setUpFlowManagerIfNeeded];
         
         [application registerObserverForDidBecomeActive:self selector:@selector(appDidBecomeActive:)];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(pushChannelDidChange:) name:ZMPushChannelStateChangeNotificationName object:nil];

--- a/Tests/Source/Calling/ZMFlowSyncTests.m
+++ b/Tests/Source/Calling/ZMFlowSyncTests.m
@@ -1033,6 +1033,9 @@ static NSString * const FlowEventName2 = @"conversation.member-join";
 @end
 
 
+/* NOTE
+ * FlowManager is not initialized on demand anymore since WireCallCenterV3
+ * is not initialized on demand.
 @implementation ZMFlowSyncTests (FlowManagerSetup)
 
 - (void)testThatItSetsUpTheFlowManagerOnApplicationDidBecomeActive
@@ -1087,3 +1090,4 @@ static NSString * const FlowEventName2 = @"conversation.member-join";
 }
 
 @end
+ */


### PR DESCRIPTION
Calling 3 which is initialized with `wcall_init` requires the flow manager to already be started. Since `wcall_init` is currently not called on demand it also makes no sense to have the flow manager started to on demand.