### PR TITLE
Fix missed call notifications appearing after answering a call

### DIFF
--- a/Source/Notifications/Push notifications/Notification Types/ZMLocalNotificationForCallState.swift
+++ b/Source/Notifications/Push notifications/Notification Types/ZMLocalNotificationForCallState.swift
@@ -95,7 +95,7 @@ final public class ZMLocalNotificationForCallState : ZMLocalNotification {
     
     func shouldCreateNotificationFor(callState: CallState) -> Bool {
         switch callState {
-        case .terminating(reason: .anweredElsewhere):
+        case .terminating(reason: .anweredElsewhere), .terminating(reason: .normal):
             return false
         case .incoming,
              .terminating,

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationForCallEventTests.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationForCallEventTests.swift
@@ -88,15 +88,20 @@ class ZMLocalNotificationForCallStateTests : MessagingTest {
         XCTAssertEqual(uiNote.soundName, ZMCustomSound.notificationNewMessageSoundName())
     }
     
-    func testAnsweredElsewhereCall() {
+    func testCallClosedReasonsWhichShouldBeIgnored() {
         // given
         let note = ZMLocalNotificationForCallState(conversation: conversation, sender: sender)
-        note.update(forCallState: .terminating(reason: .anweredElsewhere))
+        let ignoredCallClosedReasons : [CallClosedReason] = [.anweredElsewhere, .normal]
+        
+        // when
+        for reason in ignoredCallClosedReasons {
+            note.update(forCallState: .terminating(reason: reason))
+        }
         
         // then
         XCTAssertEqual(note.notifications.count, 0)
     }
-
+    
     
     func testMissedCall() {
         // given


### PR DESCRIPTION
### background
When a call is over it transitions to the `.terminating(reason: CallClosedReason)` state. We only want to show a notification about missed calls if the user didn't answer the call. An answered call closes with the `.normal` reason which we should ignore.


https://wearezeta.atlassian.net/browse/ZIOS-7999
