### PR TITLE
Show push notification when receiving an unknown message

### DIFF
--- a/Resources/Base.lproj/Push.strings
+++ b/Resources/Base.lproj/Push.strings
@@ -28,6 +28,14 @@
 "push.notification.add.message.oneonone" = "%1$@: %2$@";
 "push.notification.add.message.oneonone.nousername" = "New message: %1$@";
 
+"push.notification.add.unknown.group" = "%1$@ sent a message in %2$@";
+"push.notification.add.unknown.group.nousername" = "New message in %1$@";
+"push.notification.add.unknown.group.nousername.noconversationname" = "New message";
+"push.notification.add.unknown.group.noconversationname" = "%1$@ sent a message";
+
+"push.notification.add.unknown.oneonone" = "%1$@ sent a message";
+"push.notification.add.unknown.oneonone.nousername" = "New message";
+
 "push.notification.add.image.group" = "%1$@ shared a picture in %2$@";
 "push.notification.add.image.group.nousername" = "New picture in %1$@";
 "push.notification.add.image.group.nousername.noconversationname" = "New picture in a conversation";

--- a/Source/Notifications/Push notifications/Notification Types/MessageNotifications/ZMLocalNotificationContentType.swift
+++ b/Source/Notifications/Push notifications/Notification Types/MessageNotifications/ZMLocalNotificationContentType.swift
@@ -81,7 +81,7 @@ public func ==(rhs: ZMLocalNotificationContentType, lhs: ZMLocalNotificationCont
         return left == right
     case (.system(let lType), .system(let rType)):
         return lType == rType
-    case (.image, .image), (.video, .video), (.audio, .audio), (.location, .location), (.fileUpload, .fileUpload), (.knock, .knock):
+    case (.image, .image), (.video, .video), (.audio, .audio), (.location, .location), (.fileUpload, .fileUpload), (.knock, .knock), (.undefined, .undefined):
         return true
     default:
         return false

--- a/Source/Notifications/Push notifications/Notification Types/MessageNotifications/ZMLocalNotificationForMessage.swift
+++ b/Source/Notifications/Push notifications/Notification Types/MessageNotifications/ZMLocalNotificationForMessage.swift
@@ -134,14 +134,16 @@ final public class ZMLocalNotificationForMessage : ZMLocalNotification, Notifica
         case .knock:
             let knockCount = NSNumber(value: eventCount)
             return ZMPushStringKnock.localizedString(with: sender, conversation:conversation, count:knockCount)
-        default:
+        case .undefined:
+            return ZMPushStringUnknownAdd.localizedString(with: sender, conversation: conversation)
+        case .system(_):
             return ""
         }
     }
     
     class func canCreateNotification(_ message : ZMOTRMessage, contentType: ZMLocalNotificationContentType) -> Bool {
         switch contentType {
-        case .undefined, .system:
+        case .system:
             return false
         default:
            return shouldCreateNotification(message)

--- a/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification.h
+++ b/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification.h
@@ -39,6 +39,7 @@ extern NSString * _Null_unspecified const ZMPushStringVideoAdd;
 extern NSString * _Null_unspecified const ZMPushStringAudioAdd;
 extern NSString * _Null_unspecified const ZMPushStringFileAdd;
 extern NSString * _Null_unspecified const ZMPushStringLocationAdd;
+extern NSString * _Null_unspecified const ZMPushStringUnknownAdd;
 extern NSString * _Null_unspecified const ZMPushStringMessageAddMany;
 
 extern NSString * _Null_unspecified const ZMPushStringMemberJoin;

--- a/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification.m
+++ b/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification.m
@@ -54,6 +54,7 @@ NSString *const ZMPushStringVideoAdd = @"add.video"; // "[senderName] shared a v
 NSString *const ZMPushStringAudioAdd = @"add.audio"; // "[senderName] shared an audio message in [conversationName]"
 NSString *const ZMPushStringFileAdd = @"add.file"; // "[senderName] shared a file in [conversationName]"
 NSString *const ZMPushStringLocationAdd = @"add.location"; // "[senderName] shared a location in [conversationName]"
+NSString *const ZMPushStringUnknownAdd = @"add.unknown"; // "[senderName] sent a message in [conversationName]"
 NSString *const ZMPushStringMessageAddMany = @"add.message.many"; // "x new messages in [conversationName] / from [senderName]"
 
 /// 2 users, 1 conversation


### PR DESCRIPTION
If in the future we add new message types we want users with old clients to be informed that they are receiving message that they can't read. This PR will notify the user of such messages with a local notification.