### PR TITLE
Update for API changes in AVS 3.2

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 github "wireapp/wire-ios-message-strategy" ~> 21.0.0
-github "wireapp/avs-ios-binaries" == 3.1.79
+github "wireapp/avs-ios-binaries" == 3.2.85
 

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "wireapp/PINCache" "2.3.3"
-github "wireapp/avs-ios-binaries" "3.1.79"
+github "wireapp/avs-ios-binaries" "3.2.85"
 github "wireapp/libPhoneNumber-iOS" "0.9.2"
 github "wireapp/ocmock" "v3.3.2"
 github "wireapp/ono" "1.3.1"

--- a/Source/Calling/VoiceChannelV3.swift
+++ b/Source/Calling/VoiceChannelV3.swift
@@ -101,7 +101,7 @@ extension VoiceChannelV3 : CallActionsInternal {
     public func ignore() {
         guard let remoteIdentifier = conversation?.remoteIdentifier else { return }
         
-        WireCallCenterV3.activeInstance?.closeCall(conversationId: remoteIdentifier)
+        WireCallCenterV3.activeInstance?.rejectCall(conversationId: remoteIdentifier)
     }
     
 }


### PR DESCRIPTION
AVS 3.2 has some minor API changes:

- `answeredh` handler has been added. (no need to register for separate state handler) 
- `wcall_reject` has been added which should called when you ignore calls
- `WCALL_STATE_TERMINATING ` has been split into `WCALL_STATE_TERM_LOCAL` and `WCALL_STATE_TERM_REMOTE ` but we don't care atm since we check the `userId`