### PR TITLE
Fix incorrect SetChangeInfo for voice participants

### DIFF
--- a/Source/Calling/WireCallCenterV2.swift
+++ b/Source/Calling/WireCallCenterV2.swift
@@ -321,9 +321,7 @@ extension WireCallCenterV2 {
                 let strongObserver = observer
                 else { return }
             
-            context.performGroupedBlock {
                 strongObserver.voiceChannelParticipantsDidChange(note.setChangeInfo)
-            }
         }
     }
     


### PR DESCRIPTION
If we receive two set change updates at the same time enqueing
them on the context will defer them and make them out of date.