### PR TITLE
Revert to use direct core data observing for call center

### DIFF
--- a/Source/Synchronization/ZMSyncStrategy.m
+++ b/Source/Synchronization/ZMSyncStrategy.m
@@ -146,7 +146,6 @@ ZM_EMPTY_ASSERTING_INIT()
     self = [super init];
     if (self) {
         self.notificationDispatcher = [[NotificationDispatcher alloc] initWithManagedObjectContext: uiMOC];
-        [self.notificationDispatcher addChangeInfoConsumer:uiMOC.wireCallCenterV2];
         self.application = application;
         self.localNotificationDispatcher = localNotificationsDispatcher;
         self.authenticationStatus = authenticationStatus;

--- a/Tests/Source/Calling/WireCallCenterV2Tests.swift
+++ b/Tests/Source/Calling/WireCallCenterV2Tests.swift
@@ -81,7 +81,6 @@ class WireCallCenterV2Tests : MessagingTest {
     private var user1 : ZMUser!
     private var user2 : ZMUser!
     private var token : WireCallCenterObserverToken?
-    private var notificationDispatcher : NotificationDispatcher!
     private var sut : WireCallCenterV2 {
         return uiMOC.wireCallCenterV2
     }
@@ -104,15 +103,14 @@ class WireCallCenterV2Tests : MessagingTest {
         
         ZMUserSession.callingProtocolStrategy = .version2
         self.uiMOC.saveOrRollback()
+        
+        // make sure sut is initialized
+        _ = sut
 
-        // In order for all changes to be forwarded, we need to initialize the notificationDispatcher and add the callCenter as a consumer
-        notificationDispatcher = NotificationDispatcher(managedObjectContext: uiMOC)
-        notificationDispatcher.addChangeInfoConsumer(sut)
     }
 
     override func tearDown() {
         uiMOC.userInfo[NSManagedObjectContext.WireCallCenterV2Key] = nil
-        notificationDispatcher.tearDown()
         ZMUserSession.callingProtocolStrategy = .negotiate
         if let token = token {
             WireCallCenterV2.removeObserver(token: token)


### PR DESCRIPTION
We need to do observing when in the background for calls which the new observer system doesn't support. Since v2 calling will be removed eventually it's easier to revert to direct observing of core data than to add support for background observing.