### PR TITLE
Add mapping for IO error from AVS

### DIFF
--- a/Source/Calling/VoiceChannelV2.h
+++ b/Source/Calling/VoiceChannelV2.h
@@ -58,7 +58,8 @@ typedef NS_ENUM(uint8_t, VoiceChannelV2CallEndReason) {
     VoiceChannelV2CallEndReasonRequestedAVS, ///< AVS requested to end call. (media wasn't flowing etc.)
     VoiceChannelV2CallEndReasonOtherLostMedia, ///< Other participant lost media flow
     VoiceChannelV2CallEndReasonInterrupted, ///< When GSM call interrupts call
-    VoiceChannelV2CallEndReasonDisconnected ///< When the client disconnects from the service due to other technical reasons
+    VoiceChannelV2CallEndReasonDisconnected, ///< When the client disconnects from the service due to other technical reasons
+    VoiceChannelV2CallEndReasonInputOutputError ///< When the client disconnects from the service due to input output error (microphone not working)
 };
 
 // The voice channel of a conversation.

--- a/Source/Calling/WireCallCenter.swift
+++ b/Source/Calling/WireCallCenter.swift
@@ -64,6 +64,8 @@ extension CallClosedReason {
             return VoiceChannelV2CallEndReason.requested
         case .timeout:
             return VoiceChannelV2CallEndReason.requestedAVS
+        case .inputOutputError:
+            return VoiceChannelV2CallEndReason.inputOutputError
         case .internalError, .unknown:
             return VoiceChannelV2CallEndReason.interrupted
         }

--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -55,6 +55,8 @@ public enum CallClosedReason : Int32 {
     case normal
     /// Call was closed because of internal error in AVS
     case internalError
+    /// Call was closed due to a input/output error (couldn't access microphone)
+    case inputOutputError
     /// Outgoing call timed out
     case timeout
     /// Ongoing call lost media and was closed
@@ -80,6 +82,8 @@ public enum CallClosedReason : Int32 {
             self = .lostMedia
         case WCALL_REASON_ERROR:
             self = .internalError
+        case WCALL_REASON_IO_ERROR:
+            self = .inputOutputError
         default:
             self = .unknown
         }


### PR DESCRIPTION
We want to track how often user run into the io errors during
call setup so AVS added an additional close reason for this.