### PR TITLE
Need manually notify about answered calls again

### DIFF
--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -472,7 +472,13 @@ private typealias WireCallMessageToken = UnsafeMutableRawPointer
     
     @objc(answerCallForConversationID:)
     public func answerCall(conversationId: UUID) -> Bool {
-        return wcall_answer(conversationId.transportString()) == 0
+        let answered = wcall_answer(conversationId.transportString()) == 0
+        
+        if answered {
+            WireCallCenterCallStateNotification(callState: .answered, conversationId: conversationId, userId: self.userId).post()
+        }
+        
+        return answered
     }
     
     @objc(startCallForConversationID:video:)


### PR DESCRIPTION
AVS updated their API in 3.2.X with a new `answerh`callback which only fires when the remote participant answers the call. So when we accept an incoming call we must notify manually.