### PR TITLE
Don't ignore calls in newly created groups

### DIFF
--- a/Source/Synchronization/ZMCallStateTranscoder.m
+++ b/Source/Synchronization/ZMCallStateTranscoder.m
@@ -275,7 +275,6 @@ _Pragma("clang diagnostic pop")
         }
         else if (event.type == ZMUpdateEventConversationCreate) {
             conversation.callStateNeedsToBeUpdatedFromBackend = YES;
-            conversation.isIgnoringCall = YES;
         }
     }
 }


### PR DESCRIPTION
We were previously ignoring calls in newly created groups because they would
show up during sync. But now the CallState transcoder is only listening to live
events so this should not be necessary anymore.

see line: https://github.com/wireapp/wire-ios-sync-engine/blob/226997e1f3db0d2d04f0d01e2946d2bb1d9dc357/Source/Synchronization/ZMCallStateTranscoder.m#L247

https://wearezeta.atlassian.net/browse/ZIOS-5969