### PR TITLE
Fix interrupting audio session when receiving a 2nd call

### DIFF
--- a/Source/Calling/ZMCallKitDelegate.m
+++ b/Source/Calling/ZMCallKitDelegate.m
@@ -499,6 +499,7 @@ NS_ASSUME_NONNULL_END
 
 - (void)provider:(CXProvider * __unused)provider performAnswerCallAction:(CXAnswerCallAction *)action
 {
+    [self logInfoForConversation:nil line:__LINE__ format:@"CXProvider %@ performAnswerCallAction", provider];
     [self.userSession performChanges:^{
         ZMConversation *callConversation = [action conversationInContext:self.userSession.managedObjectContext];
         [callConversation.voiceChannelRouter.currentVoiceChannel joinWithVideo:NO];
@@ -508,8 +509,6 @@ NS_ASSUME_NONNULL_END
 
 - (void)provider:(CXProvider *)provider performEndCallAction:(nonnull CXEndCallAction *)action
 {
-    [self.mediaManager resetAudioDevice];
-    
     ZMUserSession *userSession = self.userSession;
 
     ZMConversation *callConversation = [action conversationInContext:userSession.managedObjectContext];
@@ -565,6 +564,8 @@ NS_ASSUME_NONNULL_END
 - (void)provider:(CXProvider *)provider didDeactivateAudioSession:(AVAudioSession __unused *)audioSession
 {
     [self logInfoForConversation:nil line:__LINE__ format:@"CXProvider %@ didDeactivateAudioSession", provider];
+    
+    [self.mediaManager resetAudioDevice];
 }
 
 @end


### PR DESCRIPTION
We were reset:ing the audio session on performing the end call action. This is
a problem when you are already in a call and receives a 2nd call. Declining that
second call would interrupt audio session and leave you muted for the rest of call.

A better for for reset:ing the audio session is in the `didDeactivateAudioSession`
which is called after a call is over