### PR TITLE
Turn ZMFlowSync into a request strategy

### DIFF
--- a/Source/Calling/ZMCallFlowRequestStrategy.h
+++ b/Source/Calling/ZMCallFlowRequestStrategy.h
@@ -32,10 +32,10 @@ typedef NS_ENUM(int16_t, ZMFlowManagerCategory) {
     ZMFlowManagerCategoryCallInProgress,
 };
 
-extern id ZMFlowSyncInternalFlowManagerOverride;
-extern id ZMFlowSyncInternalDeploymentEnvironmentOverride;
+extern id ZMCallFlowRequestStrategyInternalFlowManagerOverride;
+extern id ZMCallFlowRequestStrategyInternalDeploymentEnvironmentOverride;
 
-@interface ZMFlowSync : ZMAbstractRequestStrategy <ZMEventConsumer>
+@interface ZMCallFlowRequestStrategy : ZMAbstractRequestStrategy <ZMEventConsumer>
 
 - (instancetype)initWithMediaManager:(id)mediaManager
                  onDemandFlowManager:(ZMOnDemandFlowManager *)onDemandFlowManager

--- a/Source/Calling/ZMCallFlowRequestStrategy.m
+++ b/Source/Calling/ZMCallFlowRequestStrategy.m
@@ -98,6 +98,11 @@ static NSString *ZMLogTag ZM_UNUSED = @"Calling";
     return self;
 }
 
+- (ZMStrategyConfigurationOption)configuration
+{
+    return ZMStrategyConfigurationOptionAllowsRequestsDuringEventProcessing | ZMStrategyConfigurationOptionAllowsRequestsDuringSync;
+}
+
 - (void)setUpFlowManagerIfNeeded
 {
     [self.onDemandFlowManager initializeFlowManagerWithDelegate:self];
@@ -140,7 +145,7 @@ static NSString *ZMLogTag ZM_UNUSED = @"Calling";
     self.eventTypesToForward = [types copy];
 }
 
-- (ZMTransportRequest *)nextRequest
+- (ZMTransportRequest *)nextRequestIfAllowed
 {
     if (!self.pushChannelIsOpen && ![ZMUserSession useCallKit]) {
         return nil;

--- a/Source/Calling/ZMCallFlowRequestStrategy.m
+++ b/Source/Calling/ZMCallFlowRequestStrategy.m
@@ -21,7 +21,7 @@
 @import ZMUtilities;
 @import ZMCDataModel;
 
-#import "ZMFlowSync.h"
+#import "ZMCallFlowRequestStrategy.h"
 #import "ZMAVSBridge.h"
 #import <zmessaging/zmessaging-Swift.h>
 #import "ZMUserSessionAuthenticationNotification.h"
@@ -29,11 +29,11 @@
 #import "VoiceChannelV2+VideoCalling.h"
 
 static NSString * const DefaultMediaType = @"application/json";
-id ZMFlowSyncInternalDeploymentEnvironmentOverride;
+id ZMCallFlowRequestStrategyInternalDeploymentEnvironmentOverride;
 
 static NSString *ZMLogTag ZM_UNUSED = @"Calling";
 
-@interface ZMFlowSync ()
+@interface ZMCallFlowRequestStrategy ()
 
 @property (nonatomic, readonly) NSMutableArray *requestStack; ///< inverted FIFO
 @property (nonatomic) ZMOnDemandFlowManager *onDemandFlowManager;
@@ -53,12 +53,12 @@ static NSString *ZMLogTag ZM_UNUSED = @"Calling";
 
 
 
-@interface ZMFlowSync (FlowManagerDelegate) <AVSFlowManagerDelegate>
+@interface ZMCallFlowRequestStrategy (FlowManagerDelegate) <AVSFlowManagerDelegate>
 @end
 
 
 
-@implementation ZMFlowSync
+@implementation ZMCallFlowRequestStrategy
 
 - (instancetype)initWithMediaManager:(id)mediaManager
                  onDemandFlowManager:(ZMOnDemandFlowManager *)onDemandFlowManager
@@ -392,7 +392,7 @@ static NSString *ZMLogTag ZM_UNUSED = @"Calling";
 
 
 
-@implementation ZMFlowSync (FlowManagerDelegate)
+@implementation ZMCallFlowRequestStrategy (FlowManagerDelegate)
 
 
 - (BOOL)requestWithPath:(NSString *)path

--- a/Source/Calling/ZMCallKitDelegate.h
+++ b/Source/Calling/ZMCallKitDelegate.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class INPerson;
 @class ZMUserSession;
 @class ZMConversation;
-@class ZMFlowSync;
+@class ZMCallFlowRequestStrategy;
 @class ZMOnDemandFlowManager;
 @class AVSMediaManager;
 @class CXProviderConfiguration;

--- a/Source/Calling/ZMFlowSync.h
+++ b/Source/Calling/ZMFlowSync.h
@@ -19,6 +19,7 @@
 
 #import <Foundation/Foundation.h>
 @import WireRequestStrategy;
+@import WireMessageStrategy;
 @import avs;
 
 @class ZMConversation;
@@ -34,12 +35,12 @@ typedef NS_ENUM(int16_t, ZMFlowManagerCategory) {
 extern id ZMFlowSyncInternalFlowManagerOverride;
 extern id ZMFlowSyncInternalDeploymentEnvironmentOverride;
 
-@interface ZMFlowSync : ZMObjectSyncStrategy <ZMObjectStrategy>
+@interface ZMFlowSync : ZMAbstractRequestStrategy <ZMEventConsumer>
 
 - (instancetype)initWithMediaManager:(id)mediaManager
                  onDemandFlowManager:(ZMOnDemandFlowManager *)onDemandFlowManager
-            syncManagedObjectContext:(NSManagedObjectContext *)syncManagedObjectContext
-              uiManagedObjectContext:(NSManagedObjectContext *)uiManagedObjectContext
+                managedObjectContext:(NSManagedObjectContext *)managedObjectContext
+                    appStateDelegate:(id<ZMAppStateDelegate>)appStateDelegate
                          application:(id<ZMApplication>)application;
 
 

--- a/Source/Calling/ZMFlowSync.m
+++ b/Source/Calling/ZMFlowSync.m
@@ -62,13 +62,13 @@ static NSString *ZMLogTag ZM_UNUSED = @"Calling";
 
 - (instancetype)initWithMediaManager:(id)mediaManager
                  onDemandFlowManager:(ZMOnDemandFlowManager *)onDemandFlowManager
-            syncManagedObjectContext:(NSManagedObjectContext *)syncManagedObjectContext
-              uiManagedObjectContext:(NSManagedObjectContext *)uiManagedObjectContext
+                managedObjectContext:(NSManagedObjectContext *)managedObjectContext
+                    appStateDelegate:(id<ZMAppStateDelegate>)appStateDelegate
                          application:(id<ZMApplication>)application
 {
-    self = [super initWithManagedObjectContext:syncManagedObjectContext];
+    self = [super initWithManagedObjectContext:managedObjectContext appStateDelegate:appStateDelegate];
     if(self != nil) {
-        _uiManagedObjectContext = uiManagedObjectContext;
+        _uiManagedObjectContext = managedObjectContext.zm_userInterfaceContext;
         _mediaManager = mediaManager;
         _requestStack = [NSMutableArray array];
         _application = application;
@@ -138,17 +138,6 @@ static NSString *ZMLogTag ZM_UNUSED = @"Calling";
         }
     }
     self.eventTypesToForward = [types copy];
-}
-
-- (NSArray *)contextChangeTrackers
-{
-    return @[];
-}
-
-
-- (NSArray *)requestGenerators;
-{
-    return @[self];
 }
 
 - (ZMTransportRequest *)nextRequest

--- a/Source/Synchronization/Sync States/ZMBackgroundState.m
+++ b/Source/Synchronization/Sync States/ZMBackgroundState.m
@@ -102,7 +102,7 @@
 {
     id<ZMObjectStrategyDirectory> directory = self.objectStrategyDirectory;
     NSMutableArray *transcoders = @[
-                            directory.flowTranscoder,
+                            directory.callFlowRequestStrategy,
                             ].mutableCopy;
 
     if ([ZMUserSession useCallKit]) {

--- a/Source/Synchronization/Sync States/ZMBackgroundState.m
+++ b/Source/Synchronization/Sync States/ZMBackgroundState.m
@@ -100,14 +100,7 @@
 
 - (ZMTransportRequest *)nextRequest
 {
-    id<ZMObjectStrategyDirectory> directory = self.objectStrategyDirectory;
-    NSMutableArray *transcoders = @[
-                            directory.callFlowRequestStrategy,
-                            ].mutableCopy;
-
-    if ([ZMUserSession useCallKit]) {
-        [transcoders addObject:directory.callStateRequestStrategy];
-    }
+    NSMutableArray *transcoders = @[].mutableCopy;
     
     ZMTransportRequest *nextRequest = [self nextRequestFromTranscoders:transcoders];
     

--- a/Source/Synchronization/Sync States/ZMEventProcessingState.m
+++ b/Source/Synchronization/Sync States/ZMEventProcessingState.m
@@ -30,7 +30,6 @@
 
 @interface ZMEventProcessingState ()
 
-@property (nonatomic) NSArray *syncObjects;
 @property (nonatomic) BOOL isSyncing; // Only used to send a notification to UI that syncing finished
 @property (nonatomic) SyncStatus *synStatus;
 
@@ -58,32 +57,13 @@
                           stateMachineDelegate:stateMachineDelegate];
     if (self) {
         self.synStatus = synStatus;
-        self.syncObjects = @[
-                             objectStrategyDirectory.callFlowRequestStrategy
-                             ];
-        
-        for (id<ZMObjectStrategy> syncObject in self.syncObjects) {
-            Require([syncObject conformsToProtocol:@protocol(ZMObjectStrategy)]);
-        }
     }
     return self;
 }
 
 - (ZMTransportRequest *)nextRequest
 {
-    if (self.synStatus.currentSyncPhase != SyncPhaseDone) {
-        // TODO Sabine: Message related transcoders should probably not send messages at this point in order to not get the enryption keys out of order
-        return nil;
-    }
-    
-    ZMTransportRequest *request = [self nextRequestFromTranscoders:self.syncObjects];
-    if (self.isSyncing && request == nil) {
-        self.isSyncing = NO;
-    }
-    
-    self.isSyncing = (request != nil);
-    
-    return request;
+    return nil;
 }
 
 - (void)didEnterState
@@ -93,7 +73,6 @@
 
 - (void)tearDown
 {
-    self.syncObjects = nil;
     [super tearDown];
 }
 

--- a/Source/Synchronization/Sync States/ZMEventProcessingState.m
+++ b/Source/Synchronization/Sync States/ZMEventProcessingState.m
@@ -59,7 +59,7 @@
     if (self) {
         self.synStatus = synStatus;
         self.syncObjects = @[
-                             objectStrategyDirectory.flowTranscoder
+                             objectStrategyDirectory.callFlowRequestStrategy
                              ];
         
         for (id<ZMObjectStrategy> syncObject in self.syncObjects) {

--- a/Source/Synchronization/Sync States/ZMPreBackgroundState.m
+++ b/Source/Synchronization/Sync States/ZMPreBackgroundState.m
@@ -22,7 +22,7 @@
 @import WireMessageStrategy;
 
 #import "ZMPreBackgroundState.h"
-#import "ZMFlowSync.h"
+#import "ZMCallFlowRequestStrategy.h"
 #import "ZMObjectStrategyDirectory.h"
 #import "ZMStateMachineDelegate.h"
 
@@ -83,7 +83,7 @@
 {
     id<ZMObjectStrategyDirectory> directory = self.objectStrategyDirectory;
     NSArray *transcoders = @[
-                             directory.flowTranscoder,
+                             directory.callFlowRequestStrategy,
                              ];
     
     ZMTransportRequest *nextRequest = [self nextRequestFromTranscoders:transcoders];

--- a/Source/Synchronization/Sync States/ZMPreBackgroundState.m
+++ b/Source/Synchronization/Sync States/ZMPreBackgroundState.m
@@ -81,10 +81,7 @@
 
 - (ZMTransportRequest *)nextRequest
 {
-    id<ZMObjectStrategyDirectory> directory = self.objectStrategyDirectory;
-    NSArray *transcoders = @[
-                             directory.callFlowRequestStrategy,
-                             ];
+    NSArray *transcoders = @[];
     
     ZMTransportRequest *nextRequest = [self nextRequestFromTranscoders:transcoders];
     return nextRequest;

--- a/Source/Synchronization/Transcoders/ZMCallStateLogger.h
+++ b/Source/Synchronization/Transcoders/ZMCallStateLogger.h
@@ -28,7 +28,7 @@
 @property (nonatomic) BOOL pushChannelIsOpen;
 
 
-- (instancetype)initWithFlowSync:(ZMFlowSync *)flowSync;
+- (instancetype)initWithFlowSync:(ZMCallFlowRequestStrategy *)callFlowRequestStrategy;
 
 - (void)logCurrentStateForConversation:(ZMConversation *)conversation
                            withMessage:(NSString *)message;

--- a/Source/Synchronization/Transcoders/ZMCallStateLogger.m
+++ b/Source/Synchronization/Transcoders/ZMCallStateLogger.m
@@ -21,7 +21,7 @@
 @import ZMCDataModel;
 
 #import "ZMCallStateLogger.h"
-#import "ZMFlowSync.h"
+#import "ZMCallFlowRequestStrategy.h"
 #import "ZMOperationLoop.h"
 #import "ZMUserSession+Internal.h"
 
@@ -29,18 +29,18 @@
 
 @interface ZMCallStateLogger ()
 
-@property (nonatomic) ZMFlowSync *flowSync;
+@property (nonatomic) ZMCallFlowRequestStrategy *callFlowRequestStrategy;
 
 @end
 
 @implementation ZMCallStateLogger
 
 
-- (instancetype)initWithFlowSync:(ZMFlowSync *)flowSync
+- (instancetype)initWithFlowSync:(ZMCallFlowRequestStrategy *)callFlowRequestStrategy
 {
     self = [super init];
     if (self) {
-        self.flowSync= flowSync;
+        self.callFlowRequestStrategy= callFlowRequestStrategy;
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appendLogMessageWithNotification:) name:ZMAppendAVSLogNotificationName object:nil];
     }
     return self;
@@ -117,7 +117,7 @@
 {
     NSString *finalMessage = [self messageForConversation:conversation withMessage:message];
     if (finalMessage != nil) {
-        [self.flowSync appendLogForConversationID:conversation.remoteIdentifier message:finalMessage];
+        [self.callFlowRequestStrategy appendLogForConversationID:conversation.remoteIdentifier message:finalMessage];
     }
 }
 
@@ -176,7 +176,7 @@
     [VoiceChannelV2 setLastSessionIdentifier:sessionID];
     [VoiceChannelV2 setLastSessionStartDate:[NSDate date]];
     if (sessionID != nil) {
-        [self.flowSync setSessionIdentifier:sessionID forConversationIdentifier:conversation.remoteIdentifier];
+        [self.callFlowRequestStrategy setSessionIdentifier:sessionID forConversationIdentifier:conversation.remoteIdentifier];
     }
 }
 
@@ -193,13 +193,13 @@
                          conversation.remoteIdentifier.transportString,
                          @(oldCallDeviceIsActive)];
     
-    [self.flowSync appendLogForConversationID:conversation.remoteIdentifier message:message];
+    [self.callFlowRequestStrategy appendLogForConversationID:conversation.remoteIdentifier message:message];
     
     if (conversation.hasLocalModificationsForCallDeviceIsActive) {
-        [self.flowSync appendLogForConversationID:conversation.remoteIdentifier message:[NSString stringWithFormat:@"Rejecting state change - conversation has local modifications for call device is active (local: %@)",@(conversation.callDeviceIsActive)]];
+        [self.callFlowRequestStrategy appendLogForConversationID:conversation.remoteIdentifier message:[NSString stringWithFormat:@"Rejecting state change - conversation has local modifications for call device is active (local: %@)",@(conversation.callDeviceIsActive)]];
     }
     if (!conversation.callDeviceIsActive && oldCallDeviceIsActive) {
-        [self.flowSync appendLogForConversationID:conversation.remoteIdentifier message:@"Setting callDeviceIsActive to NO"];
+        [self.callFlowRequestStrategy appendLogForConversationID:conversation.remoteIdentifier message:@"Setting callDeviceIsActive to NO"];
     }
 }
 
@@ -232,7 +232,7 @@
                          @(oldIsJoined),
                          participant.remoteIdentifier.transportString, change];
     
-    [self.flowSync appendLogForConversationID:conversation.remoteIdentifier message:message];
+    [self.callFlowRequestStrategy appendLogForConversationID:conversation.remoteIdentifier message:message];
 }
 
 

--- a/Source/Synchronization/ZMCallStateRequestStrategy.h
+++ b/Source/Synchronization/ZMCallStateRequestStrategy.h
@@ -41,7 +41,7 @@ typedef NS_ENUM(uint8_t, ZMCallEventSource) {
 
 - (instancetype)initWithManagedObjectContext:(NSManagedObjectContext *)managedObjectContext
                             appStateDelegate:(id<ZMAppStateDelegate>)appStateDelegate
-                     objectStrategyDirectory:(id<ZMObjectStrategyDirectory>)directory;
+                     callFlowRequestStrategy:(ZMCallFlowRequestStrategy *)callFlowRequestStrategy;
 
 - (NSNumber *)lastSequenceForConversation:(ZMConversation *)conversation;
 
@@ -54,7 +54,7 @@ typedef NS_ENUM(uint8_t, ZMCallEventSource) {
 
 - (instancetype)initWithManagedObjectContext:(NSManagedObjectContext *)managedObjectContext
                             appStateDelegate:(id<ZMAppStateDelegate>)appStateDelegate
-                     objectStrategyDirectory:(id<ZMObjectStrategyDirectory>)directory
+                     callFlowRequestStrategy:(ZMCallFlowRequestStrategy *)callFlowRequestStrategy
                               gsmCallHandler:(ZMGSMCallHandler *)gsmCallHandler;
 
 @property (nonatomic, readonly) ZMGSMCallHandler *gsmCallHandler;

--- a/Source/Synchronization/ZMCallStateRequestStrategy.m
+++ b/Source/Synchronization/ZMCallStateRequestStrategy.m
@@ -28,7 +28,7 @@
 #import "ZMCallStateLogger.h"
 #import "ZMGSMCallHandler.h"
 #import "ZMLocalNotificationDispatcher.h"
-#import "ZMFlowSync.h"
+#import "ZMCallFlowRequestStrategy.h"
 #import <zmessaging/zmessaging-Swift.h>
 
 static NSString * const StateKey = @"state";
@@ -61,7 +61,7 @@ static NSTimeInterval const UpstreamRequestTimeout = 30;
 @property (nonatomic) ZMDownstreamObjectSync *downstreamSync;
 @property (nonatomic) ZMUpstreamModifiedObjectSync *upstreamSync;
 @property (nonatomic, weak) id<ZMObjectStrategyDirectory> objectStrategyDirectory;
-@property (nonatomic, weak, readonly) ZMFlowSync *flowSync;
+@property (nonatomic, weak, readonly) ZMCallFlowRequestStrategy *callFlowRequestStrategy;
 @property (nonatomic) NSMutableDictionary *convToSequenceMap;
 @property (nonatomic) ZMConversation *lastConversation;
 @property (nonatomic) BOOL pushChannelIsOpen;
@@ -108,7 +108,7 @@ static NSTimeInterval const UpstreamRequestTimeout = 30;
     if (self) {
         self.uiManagedObjectContext = managedObjectContext.zm_userInterfaceContext;
         self.objectStrategyDirectory = directory;
-        self.callStateLogger = [[ZMCallStateLogger alloc] initWithFlowSync:directory.flowTranscoder];
+        self.callStateLogger = [[ZMCallStateLogger alloc] initWithFlowSync:directory.callFlowRequestStrategy];
         self.convToSequenceMap = [NSMutableDictionary dictionary];
         self.pushChannelIsOpen = NO;
         
@@ -172,7 +172,7 @@ static NSTimeInterval const UpstreamRequestTimeout = 30;
 - (void)objectsDidChange:(NSSet *)objects
 {
     for (ZMConversation *conv in objects) {
-        ZMFlowSync *strongSync = self.flowSync;
+        ZMCallFlowRequestStrategy *strongSync = self.callFlowRequestStrategy;
         if ([conv isKindOfClass:[ZMConversation class]]){
             if ([self.upstreamFetchPredicate evaluateWithObject:conv] && !conv.callDeviceIsActive && conv.hasLocalModificationsForCallDeviceIsActive) {
                 // we need to release the flows as soon as the user wants to leave the call
@@ -310,7 +310,7 @@ static NSTimeInterval const UpstreamRequestTimeout = 30;
                 // when the selfuser was removed from a conversation while in a call (which should not happen), we should reset the call state locally
                 // we are not able to set the call state on the be because the be would refuse requests
                 conversation.callDeviceIsActive = NO;
-                [self.flowSync updateFlowsForConversation:conversation];
+                [self.callFlowRequestStrategy updateFlowsForConversation:conversation];
                 [conversation.voiceChannelRouter.v2 resetCallState];
                 [conversation.voiceChannelRouter.v2 resetTimer];
             }
@@ -319,9 +319,9 @@ static NSTimeInterval const UpstreamRequestTimeout = 30;
     }
 }
 
-- (ZMFlowSync *)flowSync;
+- (ZMCallFlowRequestStrategy *)callFlowRequestStrategy;
 {
-    return self.objectStrategyDirectory.flowTranscoder;
+    return self.objectStrategyDirectory.callFlowRequestStrategy;
 }
 
 - (void)pushChannelDidChange:(NSNotification *)note
@@ -551,7 +551,7 @@ static NSTimeInterval const UpstreamRequestTimeout = 30;
     }
     
     if(!conversation.callDeviceIsActive) { // do not "force join"
-        [self.flowSync updateFlowsForConversation:conversation];
+        [self.callFlowRequestStrategy updateFlowsForConversation:conversation];
         [self.gsmCallHandler setActiveCallSyncConversation:nil];
     }
     
@@ -628,7 +628,7 @@ static NSTimeInterval const UpstreamRequestTimeout = 30;
     if(changeToActive && !participantWasJoined) {
         [conversation.voiceChannelRouter.v2 addCallParticipant:participant];
         if (eventSource == ZMCallEventSourceUpstream && conversation.callDeviceIsActive && !participant.isSelfUser) {
-            [self.flowSync addJoinedCallParticipant:participant inConversation:conversation];
+            [self.callFlowRequestStrategy addJoinedCallParticipant:participant inConversation:conversation];
         }
     }
     else if(changeToIdle && participantWasJoined) {
@@ -679,7 +679,7 @@ static NSTimeInterval const UpstreamRequestTimeout = 30;
     // If the user left the voice channel, we are supposed to release the flow immediately, before getting a
     // reply from the backend.
     if (!conversation.callDeviceIsActive) {
-        [self.flowSync updateFlowsForConversation:conversation];
+        [self.callFlowRequestStrategy updateFlowsForConversation:conversation];
     }
     
     NSString *path = [self callStatePathForConversation:conversation];
@@ -746,7 +746,7 @@ static NSTimeInterval const UpstreamRequestTimeout = 30;
                 [conversation.voiceChannelRouter.v2 resetTimer];
             }
         }
-        [self.flowSync updateFlowsForConversation:conversation];
+        [self.callFlowRequestStrategy updateFlowsForConversation:conversation];
     }
 }
 
@@ -795,7 +795,7 @@ static NSTimeInterval const UpstreamRequestTimeout = 30;
             [self.upstreamSync objectsDidChange:[NSSet setWithObject:conversation]];
         }
         // we dont need to set hasLocalModifications since it was never reset, the upstreamsync will pick this object up again
-        [self.flowSync updateFlowsForConversation:conversation];
+        [self.callFlowRequestStrategy updateFlowsForConversation:conversation];
     }
 }
 
@@ -825,7 +825,7 @@ static NSTimeInterval const UpstreamRequestTimeout = 30;
     
     [self updateObject:conversation withPayload:response.payload eventSource:ZMCallEventSourceUpstream];
     if (![self.gsmCallHandler isInterruptedCallConversation:conversation]) {
-        [self.flowSync updateFlowsForConversation:conversation];
+        [self.callFlowRequestStrategy updateFlowsForConversation:conversation];
     }
     [self.gsmCallHandler setActiveCallSyncConversation:(conversation.callDeviceIsActive) ? conversation : nil];
     

--- a/Source/Synchronization/ZMCallStateRequestStrategy.m
+++ b/Source/Synchronization/ZMCallStateRequestStrategy.m
@@ -60,8 +60,7 @@ static NSTimeInterval const UpstreamRequestTimeout = 30;
 
 @property (nonatomic) ZMDownstreamObjectSync *downstreamSync;
 @property (nonatomic) ZMUpstreamModifiedObjectSync *upstreamSync;
-@property (nonatomic, weak) id<ZMObjectStrategyDirectory> objectStrategyDirectory;
-@property (nonatomic, weak, readonly) ZMCallFlowRequestStrategy *callFlowRequestStrategy;
+@property (nonatomic, weak) ZMCallFlowRequestStrategy *callFlowRequestStrategy;
 @property (nonatomic) NSMutableDictionary *convToSequenceMap;
 @property (nonatomic) ZMConversation *lastConversation;
 @property (nonatomic) BOOL pushChannelIsOpen;
@@ -93,22 +92,22 @@ static NSTimeInterval const UpstreamRequestTimeout = 30;
 
 - (instancetype)initWithManagedObjectContext:(NSManagedObjectContext *)managedObjectContext
                             appStateDelegate:(id<ZMAppStateDelegate>)appStateDelegate
-                     objectStrategyDirectory:(id<ZMObjectStrategyDirectory>)directory
+                     callFlowRequestStrategy:(ZMCallFlowRequestStrategy *)callFlowRequestStrategy
 {
-    return [self initWithManagedObjectContext:managedObjectContext appStateDelegate:appStateDelegate objectStrategyDirectory:directory gsmCallHandler:nil];
+    return [self initWithManagedObjectContext:managedObjectContext appStateDelegate:appStateDelegate callFlowRequestStrategy:callFlowRequestStrategy gsmCallHandler:nil];
 }
 
 
 - (instancetype)initWithManagedObjectContext:(NSManagedObjectContext *)managedObjectContext
                             appStateDelegate:(id<ZMAppStateDelegate>)appStateDelegate
-                     objectStrategyDirectory:(id<ZMObjectStrategyDirectory>)directory
+                     callFlowRequestStrategy:(ZMCallFlowRequestStrategy *)callFlowRequestStrategy
                               gsmCallHandler:(ZMGSMCallHandler *)gsmCallHandler
 {
     self = [super initWithManagedObjectContext:managedObjectContext appStateDelegate:appStateDelegate];
     if (self) {
         self.uiManagedObjectContext = managedObjectContext.zm_userInterfaceContext;
-        self.objectStrategyDirectory = directory;
-        self.callStateLogger = [[ZMCallStateLogger alloc] initWithFlowSync:directory.callFlowRequestStrategy];
+        self.callFlowRequestStrategy = callFlowRequestStrategy;
+        self.callStateLogger = [[ZMCallStateLogger alloc] initWithFlowSync:callFlowRequestStrategy];
         self.convToSequenceMap = [NSMutableDictionary dictionary];
         self.pushChannelIsOpen = NO;
         
@@ -135,7 +134,7 @@ static NSTimeInterval const UpstreamRequestTimeout = 30;
 
 - (ZMStrategyConfigurationOption)configuration
 {
-    return ZMStrategyConfigurationOptionAllowsRequestsDuringEventProcessing | ZMStrategyConfigurationOptionAllowsRequestsDuringSync;
+    return ZMStrategyConfigurationOptionAllowsRequestsDuringEventProcessing;
 }
 
 - (NSNumber *)lastSequenceForConversation:(ZMConversation *)conversation;
@@ -317,11 +316,6 @@ static NSTimeInterval const UpstreamRequestTimeout = 30;
             break;
         }
     }
-}
-
-- (ZMCallFlowRequestStrategy *)callFlowRequestStrategy;
-{
-    return self.objectStrategyDirectory.callFlowRequestStrategy;
 }
 
 - (void)pushChannelDidChange:(NSNotification *)note

--- a/Source/Synchronization/ZMObjectStrategyDirectory.h
+++ b/Source/Synchronization/ZMObjectStrategyDirectory.h
@@ -52,10 +52,6 @@
 @property (nonatomic, readonly) ZMPhoneNumberVerificationTranscoder *phoneNumberVerificationTranscoder;
 @property (nonatomic, readonly) ZMLoginTranscoder *loginTranscoder;
 @property (nonatomic, readonly) ZMLoginCodeRequestTranscoder *loginCodeRequestTranscoder;
-//@property (nonatomic, readonly) ZMCallFlowRequestStrategy *callFlowRequestStrategy;
-//@property (nonatomic, readonly) ZMCallStateRequestStrategy *callStateRequestStrategy;
-
-
 @property (nonatomic, readonly) NSManagedObjectContext *moc;
 
 - (NSArray *)allTranscoders;

--- a/Source/Synchronization/ZMObjectStrategyDirectory.h
+++ b/Source/Synchronization/ZMObjectStrategyDirectory.h
@@ -52,8 +52,8 @@
 @property (nonatomic, readonly) ZMPhoneNumberVerificationTranscoder *phoneNumberVerificationTranscoder;
 @property (nonatomic, readonly) ZMLoginTranscoder *loginTranscoder;
 @property (nonatomic, readonly) ZMLoginCodeRequestTranscoder *loginCodeRequestTranscoder;
-@property (nonatomic, readonly) ZMCallFlowRequestStrategy *callFlowRequestStrategy;
-@property (nonatomic, readonly) ZMCallStateRequestStrategy *callStateRequestStrategy;
+//@property (nonatomic, readonly) ZMCallFlowRequestStrategy *callFlowRequestStrategy;
+//@property (nonatomic, readonly) ZMCallStateRequestStrategy *callStateRequestStrategy;
 
 
 @property (nonatomic, readonly) NSManagedObjectContext *moc;

--- a/Source/Synchronization/ZMObjectStrategyDirectory.h
+++ b/Source/Synchronization/ZMObjectStrategyDirectory.h
@@ -27,7 +27,7 @@
 @class ZMConversationTranscoder;
 @class ZMMissingUpdateEventsTranscoder;
 @class ZMRegistrationTranscoder;
-@class ZMFlowSync;
+@class ZMCallFlowRequestStrategy;
 @class ZMCallStateRequestStrategy;
 @class ZMLastUpdateEventIDTranscoder;
 @class ZMLoginTranscoder;
@@ -52,7 +52,7 @@
 @property (nonatomic, readonly) ZMPhoneNumberVerificationTranscoder *phoneNumberVerificationTranscoder;
 @property (nonatomic, readonly) ZMLoginTranscoder *loginTranscoder;
 @property (nonatomic, readonly) ZMLoginCodeRequestTranscoder *loginCodeRequestTranscoder;
-@property (nonatomic, readonly) ZMFlowSync *flowTranscoder;
+@property (nonatomic, readonly) ZMCallFlowRequestStrategy *callFlowRequestStrategy;
 @property (nonatomic, readonly) ZMCallStateRequestStrategy *callStateRequestStrategy;
 
 

--- a/Source/Synchronization/ZMSyncStrategy+Internal.h
+++ b/Source/Synchronization/ZMSyncStrategy+Internal.h
@@ -19,6 +19,7 @@
 
 #import "ZMSyncStrategy.h"
 @class ZMSyncStateMachine;
+@class ZMGSMCallHandler;
 
 @interface ZMSyncStrategy (Internal)
 
@@ -53,6 +54,7 @@
 @interface ZMSyncStrategy (Testing)
 
 @property (nonatomic) BOOL contextMergingDisabled;
+@property (nonatomic, readonly) ZMGSMCallHandler *gsmCallHandler;
 
 - (ZMFetchRequestBatch *)fetchRequestBatchForEvents:(NSArray<ZMUpdateEvent *> *)events;
 

--- a/Source/Synchronization/ZMSyncStrategy.m
+++ b/Source/Synchronization/ZMSyncStrategy.m
@@ -255,7 +255,7 @@ ZM_EMPTY_ASSERTING_INIT()
     self.lastUpdateEventIDTranscoder = [[ZMLastUpdateEventIDTranscoder alloc] initWithManagedObjectContext:self.syncMOC appStateDelegate:self.syncStateManager syncStatus:self.syncStateManager.syncStatus objectDirectory:self];
     self.callFlowRequestStrategy = [[ZMCallFlowRequestStrategy alloc] initWithMediaManager:mediaManager onDemandFlowManager:onDemandFlowManager managedObjectContext:self.syncMOC appStateDelegate:self.syncStateManager application:self.application];
     self.callingRequestStrategy = [[CallingRequestStrategy alloc] initWithManagedObjectContext:self.syncMOC clientRegistrationDelegate:self.syncStateManager.clientRegistrationStatus];
-    self.callStateRequestStrategy = [[ZMCallStateRequestStrategy alloc] initWithManagedObjectContext:self.syncMOC appStateDelegate:self.syncStateManager objectStrategyDirectory:self];
+    self.callStateRequestStrategy = [[ZMCallStateRequestStrategy alloc] initWithManagedObjectContext:self.syncMOC appStateDelegate:self.syncStateManager callFlowRequestStrategy:self.callFlowRequestStrategy];
     self.loginTranscoder = [[ZMLoginTranscoder alloc] initWithManagedObjectContext:self.syncMOC authenticationStatus:self.syncStateManager.authenticationStatus clientRegistrationStatus:self.syncStateManager.clientRegistrationStatus];
     self.loginCodeRequestTranscoder = [[ZMLoginCodeRequestTranscoder alloc] initWithManagedObjectContext:self.syncMOC authenticationStatus:self.syncStateManager.authenticationStatus];
     self.phoneNumberVerificationTranscoder = [[ZMPhoneNumberVerificationTranscoder alloc] initWithManagedObjectContext:self.syncMOC authenticationStatus:self.syncStateManager.authenticationStatus];
@@ -446,6 +446,11 @@ ZM_EMPTY_ASSERTING_INIT()
 - (void)updateBadgeCount;
 {
     self.application.applicationIconBadgeNumber = (NSInteger)[ZMConversation unreadConversationCountInContext:self.syncMOC];
+}
+
+- (ZMGSMCallHandler *)gsmCallHandler
+{
+    return self.callStateRequestStrategy.gsmCallHandler;
 }
 
 

--- a/Source/Synchronization/ZMSyncStrategy.m
+++ b/Source/Synchronization/ZMSyncStrategy.m
@@ -224,6 +224,7 @@ ZM_EMPTY_ASSERTING_INIT()
                                    self.clientMessageTranscoder,
                                    self.callingRequestStrategy,
                                    self.callStateRequestStrategy,
+                                   self.flowTranscoder,
                                    ];
 
         self.changeTrackerBootStrap = [[ZMChangeTrackerBootstrap alloc] initWithManagedObjectContext:self.syncMOC changeTrackers:self.allChangeTrackers];
@@ -242,8 +243,6 @@ ZM_EMPTY_ASSERTING_INIT()
                                          mediaManager:(id<AVSMediaManager>)mediaManager
                                   onDemandFlowManager:(ZMOnDemandFlowManager *)onDemandFlowManager
 {
-    NSManagedObjectContext *uiMOC = self.uiMOC;
-    
     self.eventDecoder = [[EventDecoder alloc] initWithEventMOC:self.eventMOC syncMOC:self.syncMOC];
     self.connectionTranscoder = [[ZMConnectionTranscoder alloc] initWithManagedObjectContext:self.syncMOC appStateDelegate:self.syncStateManager syncStatus:self.syncStateManager.syncStatus];
     self.userTranscoder = [[ZMUserTranscoder alloc] initWithManagedObjectContext:self.syncMOC appStateDelegate:self.syncStateManager syncStatus:self.syncStateManager.syncStatus];
@@ -254,7 +253,7 @@ ZM_EMPTY_ASSERTING_INIT()
     self.registrationTranscoder = [[ZMRegistrationTranscoder alloc] initWithManagedObjectContext:self.syncMOC authenticationStatus:self.syncStateManager.authenticationStatus];
     self.missingUpdateEventsTranscoder = [[ZMMissingUpdateEventsTranscoder alloc] initWithSyncStrategy:self previouslyReceivedEventIDsCollection:self.eventDecoder application:self.application backgroundAPNSPingbackStatus:self.syncStateManager.pingBackStatus syncStatus:self.syncStateManager.syncStatus];
     self.lastUpdateEventIDTranscoder = [[ZMLastUpdateEventIDTranscoder alloc] initWithManagedObjectContext:self.syncMOC appStateDelegate:self.syncStateManager syncStatus:self.syncStateManager.syncStatus objectDirectory:self];
-    self.flowTranscoder = [[ZMFlowSync alloc] initWithMediaManager:mediaManager onDemandFlowManager:onDemandFlowManager syncManagedObjectContext:self.syncMOC uiManagedObjectContext:uiMOC application:self.application];
+    self.flowTranscoder = [[ZMFlowSync alloc] initWithMediaManager:mediaManager onDemandFlowManager:onDemandFlowManager managedObjectContext:self.syncMOC appStateDelegate:self.syncStateManager application:self.application];
     self.callingRequestStrategy = [[CallingRequestStrategy alloc] initWithManagedObjectContext:self.syncMOC clientRegistrationDelegate:self.syncStateManager.clientRegistrationStatus];
     self.callStateRequestStrategy = [[ZMCallStateRequestStrategy alloc] initWithManagedObjectContext:self.syncMOC appStateDelegate:self.syncStateManager objectStrategyDirectory:self];
     self.loginTranscoder = [[ZMLoginTranscoder alloc] initWithManagedObjectContext:self.syncMOC authenticationStatus:self.syncStateManager.authenticationStatus clientRegistrationStatus:self.syncStateManager.clientRegistrationStatus];
@@ -367,7 +366,6 @@ ZM_EMPTY_ASSERTING_INIT()
 {
     return @[
              self.registrationTranscoder,
-             self.flowTranscoder,
              self.phoneNumberVerificationTranscoder,
              self.loginCodeRequestTranscoder,
              self.loginTranscoder,

--- a/Source/Synchronization/ZMSyncStrategy.m
+++ b/Source/Synchronization/ZMSyncStrategy.m
@@ -42,7 +42,7 @@
 #import "ZMMissingUpdateEventsTranscoder.h"
 #import "ZMLastUpdateEventIDTranscoder.h"
 #import "ZMRegistrationTranscoder.h"
-#import "ZMFlowSync.h"
+#import "ZMCallFlowRequestStrategy.h"
 #import "ZMLoginTranscoder.h"
 #import "ZMCallStateRequestStrategy.h"
 #import "ZMPhoneNumberVerificationTranscoder.h"
@@ -76,7 +76,7 @@
 @property (nonatomic) ZMPhoneNumberVerificationTranscoder *phoneNumberVerificationTranscoder;
 @property (nonatomic) ZMLoginTranscoder *loginTranscoder;
 @property (nonatomic) ZMLoginCodeRequestTranscoder *loginCodeRequestTranscoder;
-@property (nonatomic) ZMFlowSync *flowTranscoder;
+@property (nonatomic) ZMCallFlowRequestStrategy *callFlowRequestStrategy;
 @property (nonatomic) ZMCallStateRequestStrategy *callStateRequestStrategy;
 @property (nonatomic) LinkPreviewAssetUploadRequestStrategy *linkPreviewAssetUploadRequestStrategy;
 @property (nonatomic) ImageUploadRequestStrategy *imageUploadRequestStrategy;
@@ -224,7 +224,7 @@ ZM_EMPTY_ASSERTING_INIT()
                                    self.clientMessageTranscoder,
                                    self.callingRequestStrategy,
                                    self.callStateRequestStrategy,
-                                   self.flowTranscoder,
+                                   self.callFlowRequestStrategy,
                                    ];
 
         self.changeTrackerBootStrap = [[ZMChangeTrackerBootstrap alloc] initWithManagedObjectContext:self.syncMOC changeTrackers:self.allChangeTrackers];
@@ -253,7 +253,7 @@ ZM_EMPTY_ASSERTING_INIT()
     self.registrationTranscoder = [[ZMRegistrationTranscoder alloc] initWithManagedObjectContext:self.syncMOC authenticationStatus:self.syncStateManager.authenticationStatus];
     self.missingUpdateEventsTranscoder = [[ZMMissingUpdateEventsTranscoder alloc] initWithSyncStrategy:self previouslyReceivedEventIDsCollection:self.eventDecoder application:self.application backgroundAPNSPingbackStatus:self.syncStateManager.pingBackStatus syncStatus:self.syncStateManager.syncStatus];
     self.lastUpdateEventIDTranscoder = [[ZMLastUpdateEventIDTranscoder alloc] initWithManagedObjectContext:self.syncMOC appStateDelegate:self.syncStateManager syncStatus:self.syncStateManager.syncStatus objectDirectory:self];
-    self.flowTranscoder = [[ZMFlowSync alloc] initWithMediaManager:mediaManager onDemandFlowManager:onDemandFlowManager managedObjectContext:self.syncMOC appStateDelegate:self.syncStateManager application:self.application];
+    self.callFlowRequestStrategy = [[ZMCallFlowRequestStrategy alloc] initWithMediaManager:mediaManager onDemandFlowManager:onDemandFlowManager managedObjectContext:self.syncMOC appStateDelegate:self.syncStateManager application:self.application];
     self.callingRequestStrategy = [[CallingRequestStrategy alloc] initWithManagedObjectContext:self.syncMOC clientRegistrationDelegate:self.syncStateManager.clientRegistrationStatus];
     self.callStateRequestStrategy = [[ZMCallStateRequestStrategy alloc] initWithManagedObjectContext:self.syncMOC appStateDelegate:self.syncStateManager objectStrategyDirectory:self];
     self.loginTranscoder = [[ZMLoginTranscoder alloc] initWithManagedObjectContext:self.syncMOC authenticationStatus:self.syncStateManager.authenticationStatus clientRegistrationStatus:self.syncStateManager.clientRegistrationStatus];
@@ -440,7 +440,7 @@ ZM_EMPTY_ASSERTING_INIT()
 
 - (void)transportSessionAccessTokenDidSucceedWithToken:(NSString *)token ofType:(NSString *)type;
 {
-    [self.flowTranscoder accessTokenDidChangeWithToken:token ofType:type];
+    [self.callFlowRequestStrategy accessTokenDidChangeWithToken:token ofType:type];
 }
 
 - (void)updateBadgeCount;

--- a/Source/UserSession/ZMAVSBridge.m
+++ b/Source/UserSession/ZMAVSBridge.m
@@ -22,7 +22,7 @@
 
 #import "ZMAVSBridge.h"
 
-id ZMFlowSyncInternalFlowManagerOverride;
+id ZMCallFlowRequestStrategyInternalFlowManagerOverride;
 
 @implementation ZMAVSBridge
 
@@ -31,8 +31,8 @@ id ZMFlowSyncInternalFlowManagerOverride;
     Class flowManagerClass = NSClassFromString(@"AVSFlowManager");
     RequireString(flowManagerClass != nil, "No AVS library linked? Missing FlowManager class");
     
-    if (ZMFlowSyncInternalFlowManagerOverride != nil) {
-        flowManagerClass = [ZMFlowSyncInternalFlowManagerOverride class];
+    if (ZMCallFlowRequestStrategyInternalFlowManagerOverride != nil) {
+        flowManagerClass = [ZMCallFlowRequestStrategyInternalFlowManagerOverride class];
     } 
     
     if ([[NSUserDefaults standardUserDefaults] boolForKey:@"ZMDisableAVS"]) {
@@ -44,7 +44,7 @@ id ZMFlowSyncInternalFlowManagerOverride;
 
 + (id)overrideFlowManager 
 {
-    return ZMFlowSyncInternalFlowManagerOverride;
+    return ZMCallFlowRequestStrategyInternalFlowManagerOverride;
 }
 
 + (AVSFlowManager *)flowManagerInstance

--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -45,7 +45,7 @@
 #import "ZMAVSBridge.h"
 #import "ZMOnDemandFlowManager.h"
 #import "ZMCookie.h"
-#import "ZMFlowSync.h"
+#import "ZMCallFlowRequestStrategy.h"
 #import "ZMCallKitDelegate.h"
 #import "ZMOperationLoop+Private.h"
 #import <zmessaging/zmessaging-Swift.h>

--- a/Tests/Source/Calling/VoiceChannelV2Tests+VideoCalling.m
+++ b/Tests/Source/Calling/VoiceChannelV2Tests+VideoCalling.m
@@ -26,7 +26,7 @@
 
 @import ZMCMockTransport;
 
-extern id ZMFlowSyncInternalFlowManagerOverride;
+extern id ZMCallFlowRequestStrategyInternalFlowManagerOverride;
 
 @implementation VoiceChannelV2Tests (VideoCalling)
 
@@ -49,7 +49,7 @@ extern id ZMFlowSyncInternalFlowManagerOverride;
         return YES;
     }]];
 
-    ZMFlowSyncInternalFlowManagerOverride = flowManagerMock;
+    ZMCallFlowRequestStrategyInternalFlowManagerOverride = flowManagerMock;
     
     // when
     NSError *error = nil;
@@ -60,13 +60,13 @@ extern id ZMFlowSyncInternalFlowManagerOverride;
     XCTAssertNil(error);
     XCTAssertTrue([self waitForCustomExpectationsWithTimeout:0.5f]);
     
-    ZMFlowSyncInternalFlowManagerOverride = nil;
+    ZMCallFlowRequestStrategyInternalFlowManagerOverride = nil;
 }
 
 - (void)testThatItCallsIsSendingVideoForParticipantAndReturnValue_noFlowManager
 {
     // given
-    ZMFlowSyncInternalFlowManagerOverride = nil;
+    ZMCallFlowRequestStrategyInternalFlowManagerOverride = nil;
     // when
     NSError *error = nil;
     BOOL result = [self.conversation.voiceChannelRouter.v2 isSendingVideoForParticipant:self.conversation.connection.to error:&error];
@@ -75,7 +75,7 @@ extern id ZMFlowSyncInternalFlowManagerOverride;
     XCTAssertFalse(result);
     XCTAssertNotNil(error);
     
-    ZMFlowSyncInternalFlowManagerOverride = nil;
+    ZMCallFlowRequestStrategyInternalFlowManagerOverride = nil;
 }
 
 - (void)testThatItCallsIsSendingVideoForParticipantAndReturnValue_FlowManagerNotReady
@@ -83,7 +83,7 @@ extern id ZMFlowSyncInternalFlowManagerOverride;
     // given
     id flowManagerMock = [OCMockObject mockForClass:[MockFlowManager class]];
     [[[flowManagerMock stub] andReturnValue:@(NO)] isReady];
-    ZMFlowSyncInternalFlowManagerOverride = flowManagerMock;
+    ZMCallFlowRequestStrategyInternalFlowManagerOverride = flowManagerMock;
 
     // when
     NSError *error = nil;
@@ -93,7 +93,7 @@ extern id ZMFlowSyncInternalFlowManagerOverride;
     XCTAssertFalse(result);
     XCTAssertNotNil(error);
     
-    ZMFlowSyncInternalFlowManagerOverride = nil;
+    ZMCallFlowRequestStrategyInternalFlowManagerOverride = nil;
 }
 
 - (void)testThatItCallsSetVideoSendActiveAndReturnValue_hasFlowManager
@@ -115,7 +115,7 @@ extern id ZMFlowSyncInternalFlowManagerOverride;
     [[[flowManagerMock stub] andReturnValue:@(YES)] isMediaEstablishedInConversation:OCMOCK_ANY];
     [[[flowManagerMock stub] andReturnValue:@(YES)] canSendVideoForConversation:OCMOCK_ANY];
     
-    ZMFlowSyncInternalFlowManagerOverride = flowManagerMock;
+    ZMCallFlowRequestStrategyInternalFlowManagerOverride = flowManagerMock;
     
     // when
     NSError *error = nil;
@@ -125,14 +125,14 @@ extern id ZMFlowSyncInternalFlowManagerOverride;
     XCTAssertTrue(result);
     XCTAssertNil(error);
     XCTAssertTrue([self waitForCustomExpectationsWithTimeout:0.5f]);
-    ZMFlowSyncInternalFlowManagerOverride = nil;
+    ZMCallFlowRequestStrategyInternalFlowManagerOverride = nil;
 }
 
 - (void)testThatItCallsSetVideoSendActiveAndReturnValue_noFlowManager
 {
     // given
     
-    ZMFlowSyncInternalFlowManagerOverride = nil;
+    ZMCallFlowRequestStrategyInternalFlowManagerOverride = nil;
     
     // when
     NSError *error = nil;
@@ -141,7 +141,7 @@ extern id ZMFlowSyncInternalFlowManagerOverride;
     // then
     XCTAssertFalse(result);
     XCTAssertNotNil(error);
-    ZMFlowSyncInternalFlowManagerOverride = nil;
+    ZMCallFlowRequestStrategyInternalFlowManagerOverride = nil;
 }
 
 - (void)testThatItCallsSetVideoSendActiveAndReturnValue_noMedia
@@ -153,7 +153,7 @@ extern id ZMFlowSyncInternalFlowManagerOverride;
     [[[flowManagerMock stub] andReturnValue:@(NO)] isMediaEstablishedInConversation:OCMOCK_ANY];
     [[[flowManagerMock stub] andReturnValue:@(YES)] canSendVideoForConversation:OCMOCK_ANY];
     
-    ZMFlowSyncInternalFlowManagerOverride = flowManagerMock;
+    ZMCallFlowRequestStrategyInternalFlowManagerOverride = flowManagerMock;
     
     // when
     NSError *error = nil;
@@ -163,7 +163,7 @@ extern id ZMFlowSyncInternalFlowManagerOverride;
     XCTAssertFalse(result);
     XCTAssertNotNil(error);
     XCTAssertTrue([self waitForCustomExpectationsWithTimeout:0.5f]);
-    ZMFlowSyncInternalFlowManagerOverride = nil;
+    ZMCallFlowRequestStrategyInternalFlowManagerOverride = nil;
 }
 
 - (void)testThatItCallsSetVideoSendActiveAndReturnValue_cannotSend
@@ -175,7 +175,7 @@ extern id ZMFlowSyncInternalFlowManagerOverride;
     [[[flowManagerMock stub] andReturnValue:@(YES)] isMediaEstablishedInConversation:OCMOCK_ANY];
     [[[flowManagerMock stub] andReturnValue:@(NO)] canSendVideoForConversation:OCMOCK_ANY];
     
-    ZMFlowSyncInternalFlowManagerOverride = flowManagerMock;
+    ZMCallFlowRequestStrategyInternalFlowManagerOverride = flowManagerMock;
     
     // when
     NSError *error = nil;
@@ -185,7 +185,7 @@ extern id ZMFlowSyncInternalFlowManagerOverride;
     XCTAssertFalse(result);
     XCTAssertNotNil(error);
     XCTAssertTrue([self waitForCustomExpectationsWithTimeout:0.5f]);
-    ZMFlowSyncInternalFlowManagerOverride = nil;
+    ZMCallFlowRequestStrategyInternalFlowManagerOverride = nil;
 }
 
 // FIXME move to VoiceChannelRouterTests
@@ -209,7 +209,7 @@ extern id ZMFlowSyncInternalFlowManagerOverride;
         return YES;
     }]];
     
-    ZMFlowSyncInternalFlowManagerOverride = flowManagerMock;
+    ZMCallFlowRequestStrategyInternalFlowManagerOverride = flowManagerMock;
     
     // when
     NSError *error = nil;
@@ -219,7 +219,7 @@ extern id ZMFlowSyncInternalFlowManagerOverride;
     XCTAssertTrue(result);
     XCTAssertNil(error);
     XCTAssertTrue([self waitForCustomExpectationsWithTimeout:0.5f]);
-    ZMFlowSyncInternalFlowManagerOverride = nil;
+    ZMCallFlowRequestStrategyInternalFlowManagerOverride = nil;
 
 }
 
@@ -227,7 +227,7 @@ extern id ZMFlowSyncInternalFlowManagerOverride;
 - (void)testThatItCallsSetVideoCaptureDeviceAndReturnValue_noFlowManager
 {
     // given
-    ZMFlowSyncInternalFlowManagerOverride = nil;
+    ZMCallFlowRequestStrategyInternalFlowManagerOverride = nil;
     
     // when
     NSError *error = nil;
@@ -236,7 +236,7 @@ extern id ZMFlowSyncInternalFlowManagerOverride;
     // then
     XCTAssertFalse(result);
     XCTAssertNotNil(error);
-    ZMFlowSyncInternalFlowManagerOverride = nil;
+    ZMCallFlowRequestStrategyInternalFlowManagerOverride = nil;
 
 }
 

--- a/Tests/Source/Calling/VoiceChannelV2Tests+VideoCalling.m
+++ b/Tests/Source/Calling/VoiceChannelV2Tests+VideoCalling.m
@@ -59,14 +59,10 @@ extern id ZMCallFlowRequestStrategyInternalFlowManagerOverride;
     XCTAssertTrue(result);
     XCTAssertNil(error);
     XCTAssertTrue([self waitForCustomExpectationsWithTimeout:0.5f]);
-    
-    ZMCallFlowRequestStrategyInternalFlowManagerOverride = nil;
 }
 
 - (void)testThatItCallsIsSendingVideoForParticipantAndReturnValue_noFlowManager
 {
-    // given
-    ZMCallFlowRequestStrategyInternalFlowManagerOverride = nil;
     // when
     NSError *error = nil;
     BOOL result = [self.conversation.voiceChannelRouter.v2 isSendingVideoForParticipant:self.conversation.connection.to error:&error];
@@ -74,8 +70,6 @@ extern id ZMCallFlowRequestStrategyInternalFlowManagerOverride;
     // then
     XCTAssertFalse(result);
     XCTAssertNotNil(error);
-    
-    ZMCallFlowRequestStrategyInternalFlowManagerOverride = nil;
 }
 
 - (void)testThatItCallsIsSendingVideoForParticipantAndReturnValue_FlowManagerNotReady
@@ -92,8 +86,6 @@ extern id ZMCallFlowRequestStrategyInternalFlowManagerOverride;
     // then
     XCTAssertFalse(result);
     XCTAssertNotNil(error);
-    
-    ZMCallFlowRequestStrategyInternalFlowManagerOverride = nil;
 }
 
 - (void)testThatItCallsSetVideoSendActiveAndReturnValue_hasFlowManager
@@ -125,15 +117,10 @@ extern id ZMCallFlowRequestStrategyInternalFlowManagerOverride;
     XCTAssertTrue(result);
     XCTAssertNil(error);
     XCTAssertTrue([self waitForCustomExpectationsWithTimeout:0.5f]);
-    ZMCallFlowRequestStrategyInternalFlowManagerOverride = nil;
 }
 
 - (void)testThatItCallsSetVideoSendActiveAndReturnValue_noFlowManager
 {
-    // given
-    
-    ZMCallFlowRequestStrategyInternalFlowManagerOverride = nil;
-    
     // when
     NSError *error = nil;
     BOOL result = [self.conversation.voiceChannelRouter.v2 setVideoSendState:FLOWMANAGER_VIDEO_SEND error:&error];
@@ -141,7 +128,6 @@ extern id ZMCallFlowRequestStrategyInternalFlowManagerOverride;
     // then
     XCTAssertFalse(result);
     XCTAssertNotNil(error);
-    ZMCallFlowRequestStrategyInternalFlowManagerOverride = nil;
 }
 
 - (void)testThatItCallsSetVideoSendActiveAndReturnValue_noMedia
@@ -163,7 +149,6 @@ extern id ZMCallFlowRequestStrategyInternalFlowManagerOverride;
     XCTAssertFalse(result);
     XCTAssertNotNil(error);
     XCTAssertTrue([self waitForCustomExpectationsWithTimeout:0.5f]);
-    ZMCallFlowRequestStrategyInternalFlowManagerOverride = nil;
 }
 
 - (void)testThatItCallsSetVideoSendActiveAndReturnValue_cannotSend
@@ -185,7 +170,6 @@ extern id ZMCallFlowRequestStrategyInternalFlowManagerOverride;
     XCTAssertFalse(result);
     XCTAssertNotNil(error);
     XCTAssertTrue([self waitForCustomExpectationsWithTimeout:0.5f]);
-    ZMCallFlowRequestStrategyInternalFlowManagerOverride = nil;
 }
 
 // FIXME move to VoiceChannelRouterTests
@@ -219,25 +203,18 @@ extern id ZMCallFlowRequestStrategyInternalFlowManagerOverride;
     XCTAssertTrue(result);
     XCTAssertNil(error);
     XCTAssertTrue([self waitForCustomExpectationsWithTimeout:0.5f]);
-    ZMCallFlowRequestStrategyInternalFlowManagerOverride = nil;
-
 }
 
 // FIXME move to VoiceChannelRouterTests
 - (void)testThatItCallsSetVideoCaptureDeviceAndReturnValue_noFlowManager
 {
     // given
-    ZMCallFlowRequestStrategyInternalFlowManagerOverride = nil;
-    
-    // when
     NSError *error = nil;
     BOOL result = [self.conversation.voiceChannel setVideoCaptureDeviceWithDevice:ZMCaptureDeviceFront error:&error];
     
     // then
     XCTAssertFalse(result);
     XCTAssertNotNil(error);
-    ZMCallFlowRequestStrategyInternalFlowManagerOverride = nil;
-
 }
 
 - (void)testThatItSetsIsVideoCallWhenJoiningVideoCall

--- a/Tests/Source/Calling/VoiceChannelV2Tests.m
+++ b/Tests/Source/Calling/VoiceChannelV2Tests.m
@@ -22,7 +22,7 @@
 @import ZMCDataModel;
 
 #import "VoiceChannelV2Tests.h"
-#import "ZMFlowSync.h"
+#import "ZMCallFlowRequestStrategy.h"
 #import "ZMUserSession.h"
 #import "ZMAVSBridge.h"
 

--- a/Tests/Source/Calling/VoiceChannelV2Tests.m
+++ b/Tests/Source/Calling/VoiceChannelV2Tests.m
@@ -199,6 +199,8 @@
     
     [ZMUserSession setCallingProtocolStrategy:CallingProtocolStrategyNegotiate];
     
+    ZMCallFlowRequestStrategyInternalFlowManagerOverride = nil;
+    
     self.conversation = nil;
     self.otherConversation = nil;
     self.groupConversation = nil;

--- a/Tests/Source/Calling/ZMCallFlowRequestStrategyTests.m
+++ b/Tests/Source/Calling/ZMCallFlowRequestStrategyTests.m
@@ -62,6 +62,8 @@ static NSString * const FlowEventName2 = @"conversation.member-join";
     self.deploymentEnvironment = [OCMockObject niceMockForClass:ZMDeploymentEnvironment.class];
     ZMCallFlowRequestStrategyInternalDeploymentEnvironmentOverride = self.deploymentEnvironment;
     [[[self.deploymentEnvironment stub] andReturnValue:OCMOCK_VALUE(ZMDeploymentEnvironmentTypeInternal)] environmentType];
+    
+    [[[self.mockAppStateDelegate stub] andReturnValue:@(ZMAppStateEventProcessing)] appState];
 
     [self recreateSUT];
     
@@ -100,6 +102,11 @@ static NSString * const FlowEventName2 = @"conversation.member-join";
 {
     [[NSNotificationCenter defaultCenter] postNotificationName:ZMPushChannelStateChangeNotificationName object:nil
                                                       userInfo:@{ZMPushChannelIsOpenKey: @(YES)}];
+}
+
+- (void)testThatUsesCorrectRequestStrategyConfiguration
+{
+    XCTAssertEqual(self.sut.configuration, ZMStrategyConfigurationOptionAllowsRequestsDuringEventProcessing | ZMStrategyConfigurationOptionAllowsRequestsDuringSync);
 }
 
 - (void)testThatItReleasesTheFlowForCallDeviceIsActive_No

--- a/Tests/Source/Calling/ZMCallFlowRequestStrategyTests.m
+++ b/Tests/Source/Calling/ZMCallFlowRequestStrategyTests.m
@@ -35,9 +35,9 @@ static NSString * const FlowEventName2 = @"conversation.member-join";
 
 
 
-@interface ZMFlowSyncTests : ObjectTranscoderTests
+@interface ZMCallFlowRequestStrategyTests : ObjectTranscoderTests
 
-@property (nonatomic) ZMFlowSync<AVSFlowManagerDelegate, ZMRequestGenerator> *sut;
+@property (nonatomic) ZMCallFlowRequestStrategy<AVSFlowManagerDelegate, ZMRequestGenerator> *sut;
 @property (nonatomic) id internalFlowManager;
 @property (nonatomic) ZMOnDemandFlowManager *onDemandFlowManager;
 @property (nonatomic) id deploymentEnvironment;
@@ -46,21 +46,21 @@ static NSString * const FlowEventName2 = @"conversation.member-join";
 
 
 
-@implementation ZMFlowSyncTests
+@implementation ZMCallFlowRequestStrategyTests
 
 - (void)setUp
 {
     [super setUp];
         
     self.internalFlowManager = [OCMockObject mockForClass:AVSFlowManager.class];
-    ZMFlowSyncInternalFlowManagerOverride = self.internalFlowManager;
+    ZMCallFlowRequestStrategyInternalFlowManagerOverride = self.internalFlowManager;
     self.onDemandFlowManager = [[ZMOnDemandFlowManager alloc] initWithMediaManager:nil];
     NSArray *events = @[FlowEventName1, FlowEventName2];
     [(AVSFlowManager *)[[self.internalFlowManager stub] andReturn:events] events];
     [[self.internalFlowManager stub] setValue:OCMOCK_ANY forKey:@"delegate"];
     
     self.deploymentEnvironment = [OCMockObject niceMockForClass:ZMDeploymentEnvironment.class];
-    ZMFlowSyncInternalDeploymentEnvironmentOverride = self.deploymentEnvironment;
+    ZMCallFlowRequestStrategyInternalDeploymentEnvironmentOverride = self.deploymentEnvironment;
     [[[self.deploymentEnvironment stub] andReturnValue:OCMOCK_VALUE(ZMDeploymentEnvironmentTypeInternal)] environmentType];
 
     [self recreateSUT];
@@ -77,8 +77,8 @@ static NSString * const FlowEventName2 = @"conversation.member-join";
     [self.internalFlowManager stopMocking];
 
     self.deploymentEnvironment = nil;
-    ZMFlowSyncInternalDeploymentEnvironmentOverride = nil;
-    ZMFlowSyncInternalFlowManagerOverride = nil;
+    ZMCallFlowRequestStrategyInternalDeploymentEnvironmentOverride = nil;
+    ZMCallFlowRequestStrategyInternalFlowManagerOverride = nil;
     
     [super tearDown];
 }
@@ -86,7 +86,7 @@ static NSString * const FlowEventName2 = @"conversation.member-join";
 - (void)recreateSUT;
 {
     [self.sut tearDown];
-    self.sut = (id) [[ZMFlowSync alloc] initWithMediaManager:nil onDemandFlowManager:self.onDemandFlowManager managedObjectContext:self.syncMOC appStateDelegate:self.mockAppStateDelegate application:self.application];
+    self.sut = (id) [[ZMCallFlowRequestStrategy alloc] initWithMediaManager:nil onDemandFlowManager:self.onDemandFlowManager managedObjectContext:self.syncMOC appStateDelegate:self.mockAppStateDelegate application:self.application];
     WaitForAllGroupsToBeEmpty(0.5);
 }
 
@@ -569,7 +569,7 @@ static NSString * const FlowEventName2 = @"conversation.member-join";
 
 
 
-@implementation ZMFlowSyncTests (VoiceGain)
+@implementation ZMCallFlowRequestStrategyTests (VoiceGain)
 
 - (void)testThatItSendsAVoiceGainNotification;
 {
@@ -807,7 +807,7 @@ static NSString * const FlowEventName2 = @"conversation.member-join";
 
 @end
 
-@implementation ZMFlowSyncTests (VideoCall)
+@implementation ZMCallFlowRequestStrategyTests (VideoCall)
 
 - (void)testThatItTellsAVSToEstablishVideoCall;
 {
@@ -1036,7 +1036,7 @@ static NSString * const FlowEventName2 = @"conversation.member-join";
 /* NOTE
  * FlowManager is not initialized on demand anymore since WireCallCenterV3
  * is not initialized on demand.
-@implementation ZMFlowSyncTests (FlowManagerSetup)
+@implementation ZMCallFlowRequestStrategyTests (FlowManagerSetup)
 
 - (void)testThatItSetsUpTheFlowManagerOnApplicationDidBecomeActive
 {

--- a/Tests/Source/Calling/ZMFlowSyncTests.m
+++ b/Tests/Source/Calling/ZMFlowSyncTests.m
@@ -23,7 +23,7 @@
 @import zmessaging;
 @import avs;
 
-#import "MessagingTest.h"
+#import "ObjectTranscoderTests.h"
 #import "ZMOperationLoop.h"
 #import "ZMUserSessionAuthenticationNotification.h"
 #import "ZMOnDemandFlowManager.h"
@@ -35,7 +35,7 @@ static NSString * const FlowEventName2 = @"conversation.member-join";
 
 
 
-@interface ZMFlowSyncTests : MessagingTest
+@interface ZMFlowSyncTests : ObjectTranscoderTests
 
 @property (nonatomic) ZMFlowSync<AVSFlowManagerDelegate, ZMRequestGenerator> *sut;
 @property (nonatomic) id internalFlowManager;
@@ -86,7 +86,7 @@ static NSString * const FlowEventName2 = @"conversation.member-join";
 - (void)recreateSUT;
 {
     [self.sut tearDown];
-    self.sut = (id) [[ZMFlowSync alloc] initWithMediaManager:nil onDemandFlowManager:self.onDemandFlowManager syncManagedObjectContext:self.syncMOC uiManagedObjectContext:self.uiMOC application:self.application];
+    self.sut = (id) [[ZMFlowSync alloc] initWithMediaManager:nil onDemandFlowManager:self.onDemandFlowManager managedObjectContext:self.syncMOC appStateDelegate:self.mockAppStateDelegate application:self.application];
     WaitForAllGroupsToBeEmpty(0.5);
 }
 
@@ -161,7 +161,7 @@ static NSString * const FlowEventName2 = @"conversation.member-join";
     
     // when
     [self.syncMOC performBlockAndWait:^{
-        ZMTransportRequest *request = [self.sut.requestGenerators nextRequest];
+        ZMTransportRequest *request = [self.sut nextRequest];
         
         // then
         XCTAssertNotNil(request);
@@ -190,7 +190,7 @@ static NSString * const FlowEventName2 = @"conversation.member-join";
         
         // when
         [self.syncMOC performBlockAndWait:^{
-            ZMTransportRequest *request = [self.sut.requestGenerators nextRequest];
+            ZMTransportRequest *request = [self.sut nextRequest];
             
             // then
             XCTAssertNotNil(request);
@@ -213,8 +213,8 @@ static NSString * const FlowEventName2 = @"conversation.member-join";
     
     // when
     [self.syncMOC performBlockAndWait:^{
-        ZMTransportRequest *request1 = [self.sut.requestGenerators nextRequest];
-        ZMTransportRequest *request2 = [self.sut.requestGenerators nextRequest];
+        ZMTransportRequest *request1 = [self.sut nextRequest];
+        ZMTransportRequest *request2 = [self.sut nextRequest];
         
         // then
         XCTAssertNotNil(request1);
@@ -248,7 +248,7 @@ static NSString * const FlowEventName2 = @"conversation.member-join";
     // when
     __block ZMTransportRequest *request;
     [self.syncMOC performBlockAndWait:^{
-        request = [self.sut.requestGenerators nextRequest];
+        request = [self.sut nextRequest];
     }];
     
 
@@ -277,7 +277,7 @@ static NSString * const FlowEventName2 = @"conversation.member-join";
     // when
     __block ZMTransportRequest *request;
     [self.syncMOC performBlockAndWait:^{
-        request = [self.sut.requestGenerators nextRequest];
+        request = [self.sut nextRequest];
     }];
     
     [request completeWithResponse:response];

--- a/Tests/Source/Integration/IntegrationTestBase.m
+++ b/Tests/Source/Integration/IntegrationTestBase.m
@@ -30,7 +30,7 @@
 #import "ZMCredentials.h"
 #import <zmessaging/ZMAuthenticationStatus+Testing.h>
 #import <zmessaging/zmessaging-Swift.h>
-#import "ZMFlowSync.h"
+#import "ZMCallFlowRequestStrategy.h"
 #import "ZMGSMCallHandler.h"
 #import "ZMOperationLoop+Private.h"
 #import "ZMSyncStrategy.h"
@@ -76,7 +76,7 @@ NSString * const SelfUserPassword = @"fgf0934';$@#%";
 
 + (instancetype)getInstance
 {
-    return ZMFlowSyncInternalFlowManagerOverride;
+    return ZMCallFlowRequestStrategyInternalFlowManagerOverride;
 }
 
 @end
@@ -94,7 +94,7 @@ NSString * const SelfUserPassword = @"fgf0934';$@#%";
     self.mockObjectIDToRemoteID = [NSMutableDictionary dictionary];
     self.mockFlowManager = self.mockTransportSession.mockFlowManager;
 
-    ZMFlowSyncInternalFlowManagerOverride = self.mockFlowManager;
+    ZMCallFlowRequestStrategyInternalFlowManagerOverride = self.mockFlowManager;
     WireCallCenterV3Factory.wireCallCenterClass = WireCallCenterV3Mock.self;
     
     [self createObjects];
@@ -127,7 +127,7 @@ NSString * const SelfUserPassword = @"fgf0934';$@#%";
 
     WaitForAllGroupsToBeEmpty(0.5);
     
-    ZMFlowSyncInternalFlowManagerOverride = nil;
+    ZMCallFlowRequestStrategyInternalFlowManagerOverride = nil;
     
     [self.userSession tearDown];
     WaitForAllGroupsToBeEmpty(0.5);

--- a/Tests/Source/Integration/IntegrationTestBase.m
+++ b/Tests/Source/Integration/IntegrationTestBase.m
@@ -34,6 +34,7 @@
 #import "ZMGSMCallHandler.h"
 #import "ZMOperationLoop+Private.h"
 #import "ZMSyncStrategy.h"
+#import "ZMSyncStrategy+Internal.h"
 #import "ZMCallStateRequestStrategy.h"
 #import "MockLinkPreviewDetector.h"
 #import "zmessaging_iOS_Tests-Swift.h"
@@ -110,7 +111,7 @@ NSString * const SelfUserPassword = @"fgf0934';$@#%";
 
 - (ZMGSMCallHandler *)gsmCallHandler
 {
-    return self.userSession.operationLoop.syncStrategy.callStateRequestStrategy.gsmCallHandler;
+    return self.userSession.operationLoop.syncStrategy.gsmCallHandler;
 }
 
 - (void)tearDown

--- a/Tests/Source/MessagingTest.m
+++ b/Tests/Source/MessagingTest.m
@@ -353,8 +353,6 @@
     [[[objectDirectory stub] andReturn:registrationTranscoder] registrationTranscoder];
     [[[objectDirectory stub] andReturn:phoneNumberVerificationTranscoder] phoneNumberVerificationTranscoder];
     [[[objectDirectory stub] andReturn:missingUpdateEventsTranscoder] missingUpdateEventsTranscoder];
-    [[[objectDirectory stub] andReturn:callFlowRequestStrategy] callFlowRequestStrategy];
-    [[[objectDirectory stub] andReturn:callStateRequestStrategy] callStateRequestStrategy];
     [[[objectDirectory stub] andReturn:loginTranscoder] loginTranscoder];
     [[[objectDirectory stub] andReturn:loginCodeRequestTranscoder] loginCodeRequestTranscoder];
     
@@ -365,8 +363,6 @@
                                         registrationTranscoder,
                                         phoneNumberVerificationTranscoder,
                                         missingUpdateEventsTranscoder,
-                                        callFlowRequestStrategy,
-                                        callStateRequestStrategy,
                                         loginTranscoder,
                                         loginCodeRequestTranscoder,
                                         ]] allTranscoders];

--- a/Tests/Source/MessagingTest.m
+++ b/Tests/Source/MessagingTest.m
@@ -43,7 +43,7 @@
 #import "ZMPhoneNumberVerificationTranscoder.h"
 #import "ZMMissingUpdateEventsTranscoder.h"
 #import "ZMLastUpdateEventIDTranscoder.h"
-#import "ZMFlowSync.h"
+#import "ZMCallFlowRequestStrategy.h"
 #import "ZMCallStateRequestStrategy.h"
 #import "ZMLoginTranscoder.h"
 #import "ZMLoginCodeRequestTranscoder.h"
@@ -337,8 +337,8 @@
     [self verifyMockLater:phoneNumberVerificationTranscoder];
     id missingUpdateEventsTranscoder = [OCMockObject mockForClass:ZMMissingUpdateEventsTranscoder.class];
     [self verifyMockLater:missingUpdateEventsTranscoder];
-    id flowTranscoder = [OCMockObject mockForClass:ZMFlowSync.class];
-    [self verifyMockLater:flowTranscoder];
+    id callFlowRequestStrategy = [OCMockObject mockForClass:ZMCallFlowRequestStrategy.class];
+    [self verifyMockLater:callFlowRequestStrategy];
     id callStateRequestStrategy = [OCMockObject mockForClass:ZMCallStateRequestStrategy.class];
     [self verifyMockLater:callStateRequestStrategy];
     id loginTranscoder = [OCMockObject mockForClass:ZMLoginTranscoder.class];
@@ -353,7 +353,7 @@
     [[[objectDirectory stub] andReturn:registrationTranscoder] registrationTranscoder];
     [[[objectDirectory stub] andReturn:phoneNumberVerificationTranscoder] phoneNumberVerificationTranscoder];
     [[[objectDirectory stub] andReturn:missingUpdateEventsTranscoder] missingUpdateEventsTranscoder];
-    [[[objectDirectory stub] andReturn:flowTranscoder] flowTranscoder];
+    [[[objectDirectory stub] andReturn:callFlowRequestStrategy] callFlowRequestStrategy];
     [[[objectDirectory stub] andReturn:callStateRequestStrategy] callStateRequestStrategy];
     [[[objectDirectory stub] andReturn:loginTranscoder] loginTranscoder];
     [[[objectDirectory stub] andReturn:loginCodeRequestTranscoder] loginCodeRequestTranscoder];
@@ -365,7 +365,7 @@
                                         registrationTranscoder,
                                         phoneNumberVerificationTranscoder,
                                         missingUpdateEventsTranscoder,
-                                        flowTranscoder,
+                                        callFlowRequestStrategy,
                                         callStateRequestStrategy,
                                         loginTranscoder,
                                         loginCodeRequestTranscoder,

--- a/Tests/Source/Synchronization/Sync States/StateBaseTest.h
+++ b/Tests/Source/Synchronization/Sync States/StateBaseTest.h
@@ -40,8 +40,6 @@
 
 - (void)checkThatItCallsRequestGeneratorsOnObjectsOfClass:(NSArray *)objectsToTest creationOfStateBlock:(ZMSyncState *(^)(id<ZMObjectStrategyDirectory> directory))creationBlock;
 
-- (void)stubRequestsOnHighPriorityObjectSync;
-
 - (id<ZMRequestGenerator>)generatorReturningNiceMockRequest;
 - (id<ZMRequestGenerator>)generatorReturningRequest:(ZMTransportRequest *)request;
 

--- a/Tests/Source/Synchronization/Sync States/StateBaseTest.m
+++ b/Tests/Source/Synchronization/Sync States/StateBaseTest.m
@@ -88,12 +88,6 @@
     _clientUpdateStatus = nil;
 }
 
-- (void)stubRequestsOnHighPriorityObjectSync
-{
-    [[[(id)[self.objectDirectory callFlowRequestStrategy] stub] andReturn:@[]] requestGenerators];
-    [[[(id)[self.objectDirectory callStateRequestStrategy] stub] andReturn:@[]] requestGenerators];
-}
-
 - (void)checkThatItCallsRequestGeneratorsOnObjectsOfClass:(NSArray *)objectsToTest creationOfStateBlock:(ZMSyncState *(^)(id<ZMObjectStrategyDirectory> directory))creationBlock;
 {
     /*

--- a/Tests/Source/Synchronization/Sync States/StateBaseTest.m
+++ b/Tests/Source/Synchronization/Sync States/StateBaseTest.m
@@ -90,7 +90,7 @@
 
 - (void)stubRequestsOnHighPriorityObjectSync
 {
-    [[[(id)[self.objectDirectory flowTranscoder] stub] andReturn:@[]] requestGenerators];
+    [[[(id)[self.objectDirectory callFlowRequestStrategy] stub] andReturn:@[]] requestGenerators];
     [[[(id)[self.objectDirectory callStateRequestStrategy] stub] andReturn:@[]] requestGenerators];
 }
 

--- a/Tests/Source/Synchronization/Sync States/ZMBackgroundStateTests.m
+++ b/Tests/Source/Synchronization/Sync States/ZMBackgroundStateTests.m
@@ -89,7 +89,7 @@
 - (NSArray *)syncObjectsUsedByState
 {
     return  @[ /* Note: these must be in the same order as in the class */
-              self.objectDirectory.flowTranscoder,
+              self.objectDirectory.callFlowRequestStrategy,
               ];
 }
 

--- a/Tests/Source/Synchronization/Sync States/ZMBackgroundStateTests.m
+++ b/Tests/Source/Synchronization/Sync States/ZMBackgroundStateTests.m
@@ -88,9 +88,7 @@
 
 - (NSArray *)syncObjectsUsedByState
 {
-    return  @[ /* Note: these must be in the same order as in the class */
-              self.objectDirectory.callFlowRequestStrategy,
-              ];
+    return  @[ /* Note: these must be in the same order as in the class */ ];
 }
 
 - (void)testThatItReturnsTheFirstRequestReturnedByASync

--- a/Tests/Source/Synchronization/Sync States/ZMEventProcessingStateTests.m
+++ b/Tests/Source/Synchronization/Sync States/ZMEventProcessingStateTests.m
@@ -47,10 +47,7 @@
 
 - (NSArray *)syncObjectsUsedByState
 {
-    return  @[ /* Note: these must be in the same order as in the class */
-        self.objectDirectory.callFlowRequestStrategy,
-        self.objectDirectory.callStateRequestStrategy,
-        ];
+    return  @[ /* Note: these must be in the same order as in the class */ ];
 }
 
 - (void)testThatThePolicyIsToProcessEvents

--- a/Tests/Source/Synchronization/Sync States/ZMEventProcessingStateTests.m
+++ b/Tests/Source/Synchronization/Sync States/ZMEventProcessingStateTests.m
@@ -48,7 +48,7 @@
 - (NSArray *)syncObjectsUsedByState
 {
     return  @[ /* Note: these must be in the same order as in the class */
-        self.objectDirectory.flowTranscoder,
+        self.objectDirectory.callFlowRequestStrategy,
         self.objectDirectory.callStateRequestStrategy,
         ];
 }

--- a/Tests/Source/Synchronization/Sync States/ZMPreBackgroundStateTest.m
+++ b/Tests/Source/Synchronization/Sync States/ZMPreBackgroundStateTest.m
@@ -74,7 +74,7 @@
 - (NSArray *)syncObjectsUsedByState
 {
     return  @[ /* Note: these must be in the same order as in the class */
-              self.objectDirectory.flowTranscoder,
+              self.objectDirectory.callFlowRequestStrategy,
               ];
 }
 

--- a/Tests/Source/Synchronization/Sync States/ZMPreBackgroundStateTest.m
+++ b/Tests/Source/Synchronization/Sync States/ZMPreBackgroundStateTest.m
@@ -73,9 +73,7 @@
 
 - (NSArray *)syncObjectsUsedByState
 {
-    return  @[ /* Note: these must be in the same order as in the class */
-              self.objectDirectory.callFlowRequestStrategy,
-              ];
+    return  @[ /* Note: these must be in the same order as in the class */ ];
 }
 
 - (void)testThatItReturnsTheFirstRequestReturnedByASync

--- a/Tests/Source/Synchronization/Transcoders/ZMCallStateLoggerTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMCallStateLoggerTests.m
@@ -19,7 +19,7 @@
 
 #import "MessagingTest.h"
 #import "ZMCallStateLogger.h"
-#import "ZMFlowSync.h"
+#import "ZMCallFlowRequestStrategy.h"
 #import "ZMUserSession+Internal.h"
 
 @interface ZMCallStateLoggerTests : MessagingTest
@@ -33,7 +33,7 @@
 
 - (void)setUp {
     [super setUp];
-    self.mockFlowSync = [OCMockObject niceMockForClass:[ZMFlowSync class]];
+    self.mockFlowSync = [OCMockObject niceMockForClass:[ZMCallFlowRequestStrategy class]];
     [self verifyMockLater:self.mockFlowSync];
     
     self.sut = [[ZMCallStateLogger alloc] initWithFlowSync:self.mockFlowSync];

--- a/Tests/Source/Synchronization/Transcoders/ZMCallStateRequestStrategyTests+VideoCalling.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMCallStateRequestStrategyTests+VideoCalling.m
@@ -216,7 +216,7 @@
     XCTAssertTrue(conversation.hasLocalModificationsForIsSendingVideo);
     
     // expect
-    [self.flowTranscoder releaseFlowsForConversation:conversation];
+    [self.callFlowRequestStrategy releaseFlowsForConversation:conversation];
     
     // when
     [self.sut requestExpiredForObject:conversation forKeys:self.keys];
@@ -236,7 +236,7 @@
     XCTAssertTrue(conversation.hasLocalModificationsForIsSendingVideo);
     
     // expect
-    [self.flowTranscoder releaseFlowsForConversation:conversation];
+    [self.callFlowRequestStrategy releaseFlowsForConversation:conversation];
     
     // when
     [self.sut requestExpiredForObject:conversation forKeys:[NSSet setWithObject:ZMConversationIsSendingVideoKey]];
@@ -259,7 +259,7 @@
     XCTAssertNotNil(request);
     
     // expect
-    [self.flowTranscoder releaseFlowsForConversation:conversation];
+    [self.callFlowRequestStrategy releaseFlowsForConversation:conversation];
     
     // when
     [request.transportRequest completeWithResponse:response];

--- a/Tests/Source/Synchronization/Transcoders/ZMCallStateRequestStrategyTests.h
+++ b/Tests/Source/Synchronization/Transcoders/ZMCallStateRequestStrategyTests.h
@@ -32,7 +32,6 @@
 @interface ZMCallStateRequestStrategyTests : ObjectTranscoderTests
 
 @property (nonatomic) ZMCallStateRequestStrategy<ZMDownstreamTranscoder, ZMUpstreamTranscoder> *sut;
-@property (nonatomic) id objectStrategyDirectory;
 @property (nonatomic) id callFlowRequestStrategy;
 @property (nonatomic) ZMConversation *syncSelfToUser1Conversation;
 @property (nonatomic) ZMConversation *syncSelfToUser2Conversation;

--- a/Tests/Source/Synchronization/Transcoders/ZMCallStateRequestStrategyTests.h
+++ b/Tests/Source/Synchronization/Transcoders/ZMCallStateRequestStrategyTests.h
@@ -23,7 +23,7 @@
 #import "MessagingTest.h"
 #import "ObjectTranscoderTests.h"
 #import "ZMCallStateRequestStrategy.h"
-#import "ZMFlowSync.h"
+#import "ZMCallFlowRequestStrategy.h"
 #import "ZMObjectStrategyDirectory.h"
 #import "ZMUserSession+Internal.h"
 #import "ZMOperationLoop.h"
@@ -33,7 +33,7 @@
 
 @property (nonatomic) ZMCallStateRequestStrategy<ZMDownstreamTranscoder, ZMUpstreamTranscoder> *sut;
 @property (nonatomic) id objectStrategyDirectory;
-@property (nonatomic) id flowTranscoder;
+@property (nonatomic) id callFlowRequestStrategy;
 @property (nonatomic) ZMConversation *syncSelfToUser1Conversation;
 @property (nonatomic) ZMConversation *syncSelfToUser2Conversation;
 @property (nonatomic) ZMConversation *syncGroupConversation;

--- a/Tests/Source/Synchronization/Transcoders/ZMCallStateRequestStrategyTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMCallStateRequestStrategyTests.m
@@ -66,15 +66,13 @@
     
     self.callFlowRequestStrategy = [OCMockObject niceMockForClass:[ZMCallFlowRequestStrategy class]];
     [self verifyMockLater:self.callFlowRequestStrategy];
-    self.objectStrategyDirectory = [OCMockObject mockForProtocol:@protocol(ZMObjectStrategyDirectory)];
-    (void)[((id<ZMObjectStrategyDirectory>) [[self.objectStrategyDirectory stub] andReturn:self.callFlowRequestStrategy]) callFlowRequestStrategy];
     
     self.gsmCallHandler = [OCMockObject niceMockForClass:[ZMGSMCallHandler class]];
     [self verifyMockLater:self.gsmCallHandler];
     
     [[[self.mockAppStateDelegate stub] andReturnValue:@(ZMAppStateEventProcessing)] appState];
 
-    self.sut = (id) [[ZMCallStateRequestStrategy alloc] initWithManagedObjectContext:self.syncMOC appStateDelegate:self.mockAppStateDelegate objectStrategyDirectory:self.objectStrategyDirectory gsmCallHandler:self.gsmCallHandler];
+    self.sut = (id) [[ZMCallStateRequestStrategy alloc] initWithManagedObjectContext:self.syncMOC appStateDelegate:self.mockAppStateDelegate callFlowRequestStrategy:self.callFlowRequestStrategy gsmCallHandler:self.gsmCallHandler];
 
     [self simulateOpeningPushChannel];
 }
@@ -145,7 +143,7 @@
 
 - (void)testThatUsesCorrectRequestStrategyConfiguration
 {
-    XCTAssertEqual(self.sut.configuration, ZMStrategyConfigurationOptionAllowsRequestsDuringEventProcessing | ZMStrategyConfigurationOptionAllowsRequestsDuringSync);
+    XCTAssertEqual(self.sut.configuration, ZMStrategyConfigurationOptionAllowsRequestsDuringEventProcessing);
 }
 
 - (void)testThatItReturnsTheContextChangeTrackers;
@@ -3601,7 +3599,7 @@
     
     // when
     [self.sut tearDown];
-    self.sut = (id) [[ZMCallStateRequestStrategy alloc] initWithManagedObjectContext:self.syncMOC appStateDelegate:self.mockAppStateDelegate objectStrategyDirectory:self.objectStrategyDirectory gsmCallHandler:self.gsmCallHandler];
+    self.sut = (id) [[ZMCallStateRequestStrategy alloc] initWithManagedObjectContext:self.syncMOC appStateDelegate:self.mockAppStateDelegate callFlowRequestStrategy:self.callFlowRequestStrategy gsmCallHandler:self.gsmCallHandler];
     WaitForAllGroupsToBeEmpty(0.5);
 
     // then
@@ -3622,7 +3620,7 @@
     
     // when
     [self.sut tearDown];
-    self.sut = (id) [[ZMCallStateRequestStrategy alloc] initWithManagedObjectContext:self.syncMOC appStateDelegate:self.mockAppStateDelegate objectStrategyDirectory:self.objectStrategyDirectory gsmCallHandler:self.gsmCallHandler];
+    self.sut = (id) [[ZMCallStateRequestStrategy alloc] initWithManagedObjectContext:self.syncMOC appStateDelegate:self.mockAppStateDelegate callFlowRequestStrategy:self.callFlowRequestStrategy gsmCallHandler:self.gsmCallHandler];
     WaitForAllGroupsToBeEmpty(0.5);
 
     // then
@@ -3647,7 +3645,7 @@
     
     // when
     [self.sut tearDown];
-    self.sut = (id) [[ZMCallStateRequestStrategy alloc] initWithManagedObjectContext:self.syncMOC appStateDelegate:self.mockAppStateDelegate objectStrategyDirectory:self.objectStrategyDirectory gsmCallHandler:self.gsmCallHandler];
+    self.sut = (id) [[ZMCallStateRequestStrategy alloc] initWithManagedObjectContext:self.syncMOC appStateDelegate:self.mockAppStateDelegate callFlowRequestStrategy:self.callFlowRequestStrategy gsmCallHandler:self.gsmCallHandler];
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then

--- a/Tests/Source/Synchronization/Transcoders/ZMCallStateRequestStrategyTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMCallStateRequestStrategyTests.m
@@ -64,10 +64,10 @@
         [self.syncMOC saveOrRollback];
     }];
     
-    self.flowTranscoder = [OCMockObject niceMockForClass:[ZMFlowSync class]];
-    [self verifyMockLater:self.flowTranscoder];
+    self.callFlowRequestStrategy = [OCMockObject niceMockForClass:[ZMCallFlowRequestStrategy class]];
+    [self verifyMockLater:self.callFlowRequestStrategy];
     self.objectStrategyDirectory = [OCMockObject mockForProtocol:@protocol(ZMObjectStrategyDirectory)];
-    (void)[((id<ZMObjectStrategyDirectory>) [[self.objectStrategyDirectory stub] andReturn:self.flowTranscoder]) flowTranscoder];
+    (void)[((id<ZMObjectStrategyDirectory>) [[self.objectStrategyDirectory stub] andReturn:self.callFlowRequestStrategy]) callFlowRequestStrategy];
     
     self.gsmCallHandler = [OCMockObject niceMockForClass:[ZMGSMCallHandler class]];
     [self verifyMockLater:self.gsmCallHandler];
@@ -651,13 +651,13 @@
         ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:payload HTTPStatus:200 transportSessionError:nil];
         
         // expect
-        [[self.flowTranscoder expect] setSessionIdentifier:sessionID forConversationIdentifier:conversationID];
+        [[self.callFlowRequestStrategy expect] setSessionIdentifier:sessionID forConversationIdentifier:conversationID];
         
         // when
         [self.sut updateObject:conversation withResponse:response downstreamSync:nil];
         
         // then
-        [self.flowTranscoder verify];
+        [self.callFlowRequestStrategy verify];
     }];
     
     WaitForAllGroupsToBeEmpty(0.5);
@@ -688,7 +688,7 @@
         ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:payload HTTPStatus:200 transportSessionError:nil];
         
         // expect
-        [[self.flowTranscoder stub] setSessionIdentifier:OCMOCK_ANY forConversationIdentifier:OCMOCK_ANY];
+        [[self.callFlowRequestStrategy stub] setSessionIdentifier:OCMOCK_ANY forConversationIdentifier:OCMOCK_ANY];
         
         // when
         [self.sut updateObject:conversation withResponse:response downstreamSync:nil];
@@ -1691,7 +1691,7 @@
                                   @"participants":@{}
                                   };
         // expect
-        [[self.flowTranscoder expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
+        [[self.callFlowRequestStrategy expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
             XCTAssertEqualObjects(conversation, conv);
             XCTAssertTrue(!conv.callDeviceIsActive);
             return true;
@@ -1701,7 +1701,7 @@
         
         // when
         [self.sut updateObject:conversation withResponse:response downstreamSync:nil];
-        [self.flowTranscoder verify];
+        [self.callFlowRequestStrategy verify];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
 }
@@ -1721,7 +1721,7 @@
         ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:payload HTTPStatus:200 transportSessionError:nil];
         
         // expect
-        [[self.flowTranscoder expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
+        [[self.callFlowRequestStrategy expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
             XCTAssertEqualObjects(conversation, conv);
             XCTAssertTrue(!conv.callDeviceIsActive);
             return true;
@@ -1729,7 +1729,7 @@
         
         // when
         [self.sut updateObject:conversation withResponse:response downstreamSync:nil];
-        [self.flowTranscoder verify];
+        [self.callFlowRequestStrategy verify];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
 }
@@ -1757,7 +1757,7 @@
         ZMUpdateEvent *event = [ZMUpdateEvent eventsArrayFromPushChannelData:payload][0];
         
         // expect
-        [[self.flowTranscoder expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
+        [[self.callFlowRequestStrategy expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
             XCTAssertEqualObjects(conversation, conv);
             XCTAssertTrue(!conv.callDeviceIsActive);
             return true;
@@ -1765,7 +1765,7 @@
         
         // when
         [self.sut processEvents:@[event] liveEvents:YES prefetchResult:nil];
-        [self.flowTranscoder verify];
+        [self.callFlowRequestStrategy verify];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
 }
@@ -1793,7 +1793,7 @@
         ZMUpdateEvent *event = [ZMUpdateEvent eventsArrayFromPushChannelData:payload][0];
         
         // expect
-        [[self.flowTranscoder expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
+        [[self.callFlowRequestStrategy expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
             XCTAssertEqualObjects(conversation, conv);
             XCTAssertTrue(!conv.callDeviceIsActive);
             return true;
@@ -1801,7 +1801,7 @@
         
         // when
         [self.sut processEvents:@[event] liveEvents:YES prefetchResult:nil];
-        [self.flowTranscoder verify];
+        [self.callFlowRequestStrategy verify];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
 }
@@ -1838,7 +1838,7 @@
         ZMUpdateEvent *event = [ZMUpdateEvent eventsArrayFromPushChannelData:payload][0];
         
         // expect
-        [[self.flowTranscoder expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
+        [[self.callFlowRequestStrategy expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
             XCTAssertEqualObjects(conversation, conv);
             XCTAssertTrue(!conv.callDeviceIsActive);
             return true;
@@ -1846,7 +1846,7 @@
         
         // when
         [self.sut processEvents:@[event] liveEvents:YES prefetchResult:nil];
-        [self.flowTranscoder verify];
+        [self.callFlowRequestStrategy verify];
         
         // then
         XCTAssertFalse(conversation.callDeviceIsActive);
@@ -1886,11 +1886,11 @@
         ZMUpdateEvent *event = [ZMUpdateEvent eventsArrayFromPushChannelData:payload][0];
         
         // expect
-        [[self.flowTranscoder reject] updateFlowsForConversation:conversation];
+        [[self.callFlowRequestStrategy reject] updateFlowsForConversation:conversation];
         
         // when
         [self.sut processEvents:@[event] liveEvents:YES prefetchResult:nil];
-        [self.flowTranscoder verify];
+        [self.callFlowRequestStrategy verify];
         
         // then
         XCTAssertTrue(conversation.callDeviceIsActive);
@@ -1929,7 +1929,7 @@
         ZMConversation *syncConversation = (id)[self.syncMOC objectWithID:uiConversation.objectID];
         
         // expect
-        [[self.flowTranscoder reject] updateFlowsForConversation:syncConversation];
+        [[self.callFlowRequestStrategy reject] updateFlowsForConversation:syncConversation];
         
         // when
         for (id<ZMContextChangeTracker> t in self.sut.contextChangeTrackers) {
@@ -1938,7 +1938,7 @@
         XCTAssertNotNil([self.sut nextRequest]);
         
         // finally
-        XCTAssertNoThrow([self.flowTranscoder verify]);
+        XCTAssertNoThrow([self.callFlowRequestStrategy verify]);
         
         [syncConversation.voiceChannelRouter.v2 tearDown];
     }];
@@ -1959,7 +1959,7 @@
         // expect
         XCTAssertFalse(syncConversation.callDeviceIsActive);
         XCTAssertTrue(syncConversation.hasLocalModificationsForCallDeviceIsActive);
-        [[self.flowTranscoder expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
+        [[self.callFlowRequestStrategy expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
             XCTAssertEqualObjects(syncConversation, conv);
             XCTAssertTrue(!conv.callDeviceIsActive);
             return true;
@@ -1970,7 +1970,7 @@
             [t objectsDidChange:[NSSet setWithObject:syncConversation]];
         }
         // finally
-        XCTAssertNoThrow([self.flowTranscoder verify]);
+        XCTAssertNoThrow([self.callFlowRequestStrategy verify]);
         
         [syncConversation.voiceChannelRouter.v2 tearDown];
     }];
@@ -1991,7 +1991,7 @@
                                                                                            @"quality": @1}} HTTPStatus:200 transportSessionError:nil];
         
         // expect
-        [[self.flowTranscoder expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
+        [[self.callFlowRequestStrategy expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
             XCTAssertEqualObjects(syncConversation, conv);
             XCTAssertTrue(conv.callDeviceIsActive);
             return true;
@@ -2001,7 +2001,7 @@
         [self.sut updateUpdatedObject:syncConversation requestUserInfo:nil response:response keysToParse:self.keys];
         
         // finally
-        XCTAssertNoThrow([self.flowTranscoder verify]);
+        XCTAssertNoThrow([self.callFlowRequestStrategy verify]);
         
         [syncConversation.voiceChannelRouter.v2 tearDown];
     }];
@@ -2024,7 +2024,7 @@
         XCTAssertFalse(syncConversation.callDeviceIsActive);
         XCTAssertTrue(syncConversation.hasLocalModificationsForCallDeviceIsActive);
         
-        [[self.flowTranscoder expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
+        [[self.callFlowRequestStrategy expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
             XCTAssertEqualObjects(syncConversation, conv);
             XCTAssertTrue(!conv.callDeviceIsActive);
             return true;
@@ -2037,7 +2037,7 @@
         XCTAssertNotNil([self.sut nextRequest]);
         
         // finally
-        XCTAssertNoThrow([self.flowTranscoder verify]);
+        XCTAssertNoThrow([self.callFlowRequestStrategy verify]);
         [syncConversation.voiceChannelRouter.v2 tearDown];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
@@ -2060,7 +2060,7 @@
 
     [self.syncMOC performGroupedBlockAndWait:^{
         // expect
-        [[self.flowTranscoder expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
+        [[self.callFlowRequestStrategy expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
             XCTAssertEqualObjects(syncConversation, conv);
             XCTAssertTrue(!conv.callDeviceIsActive);
             return true;
@@ -2078,7 +2078,7 @@
         
     // finally
     [self.syncMOC performGroupedBlockAndWait:^{
-        XCTAssertNoThrow([self.flowTranscoder verify]);
+        XCTAssertNoThrow([self.callFlowRequestStrategy verify]);
         
         [syncConversation.voiceChannelRouter.v2 tearDown];
     }];
@@ -2103,7 +2103,7 @@
                                                        transportSessionError:nil];
     [self.syncMOC performGroupedBlockAndWait:^{
         // expect
-        [[self.flowTranscoder expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
+        [[self.callFlowRequestStrategy expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
             XCTAssertEqualObjects(syncConversation, conv);
             XCTAssertTrue(conv.callDeviceIsActive);
             return true;
@@ -2123,7 +2123,7 @@
     
     // finally
     [self.syncMOC performGroupedBlockAndWait:^{
-        XCTAssertNoThrow([self.flowTranscoder verify]);
+        XCTAssertNoThrow([self.callFlowRequestStrategy verify]);
         
         [syncConversation.voiceChannelRouter.v2 tearDown];
     }];
@@ -2394,7 +2394,7 @@
                                                                           userIDs:@[self.syncSelfUser.remoteIdentifier]
                                                                         eventType:@"conversation.member-leave"];
         // expect
-        [[self.flowTranscoder expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
+        [[self.callFlowRequestStrategy expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
             XCTAssertEqualObjects(conversation, conv);
             XCTAssertTrue(!conv.callDeviceIsActive);
             return true;
@@ -2405,7 +2405,7 @@
         
         // then
         XCTAssertFalse(conversation.callDeviceIsActive);
-        [self.flowTranscoder verify];
+        [self.callFlowRequestStrategy verify];
     }];
 }
 
@@ -2532,7 +2532,7 @@
         XCTAssertTrue(conversation.callDeviceIsActive);
 
         // expect
-        [[self.flowTranscoder expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
+        [[self.callFlowRequestStrategy expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
             XCTAssertEqualObjects(conversation, conv);
             XCTAssertTrue(!conv.callDeviceIsActive);
             return true;
@@ -2543,7 +2543,7 @@
         
         // then
         XCTAssertFalse(conversation.callDeviceIsActive);
-        [self.flowTranscoder verify];
+        [self.callFlowRequestStrategy verify];
     }];
 }
 
@@ -2881,7 +2881,7 @@
         XCTAssertNotNil(request);
         
         // expect
-        [[self.flowTranscoder expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
+        [[self.callFlowRequestStrategy expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
             XCTAssertEqualObjects(conversation, conv);
             XCTAssertTrue(!conv.callDeviceIsActive);
             return true;
@@ -2926,7 +2926,7 @@
         XCTAssertNotNil(request);
         
         // expect
-        [[self.flowTranscoder expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
+        [[self.callFlowRequestStrategy expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
             XCTAssertEqualObjects(conversation, conv);
             XCTAssertTrue(!conv.callDeviceIsActive);
             return true;
@@ -3014,7 +3014,7 @@
         ZMUpstreamRequest *request = [self.sut requestForUpdatingObject:conversation forKeys:self.keys];
         
         //expect
-        [[self.flowTranscoder expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
+        [[self.callFlowRequestStrategy expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
             XCTAssertEqualObjects(conversation, conv);
             XCTAssertTrue(!conv.callDeviceIsActive);
             return true;
@@ -3033,7 +3033,7 @@
         XCTAssertTrue(conversation.hasLocalModificationsForCallDeviceIsActive);
         XCTAssertFalse(conversation.callStateNeedsToBeUpdatedFromBackend);
         
-        [self.flowTranscoder verify];
+        [self.callFlowRequestStrategy verify];
         [conversation.voiceChannelRouter.v2 tearDown];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
@@ -3053,13 +3053,13 @@
         ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@{} HTTPStatus:400 transportSessionError:nil];
         
         // expect
-        [[self.flowTranscoder expect] updateFlowsForConversation:conversation];
+        [[self.callFlowRequestStrategy expect] updateFlowsForConversation:conversation];
         
         // when
         ZMUpstreamRequest *request = [self.sut requestForUpdatingObject:conversation forKeys:self.keys];
 
         // expect
-        [[self.flowTranscoder expect] updateFlowsForConversation:conversation];
+        [[self.callFlowRequestStrategy expect] updateFlowsForConversation:conversation];
         
         // when
         [request.transportRequest completeWithResponse:response];
@@ -3194,12 +3194,12 @@
         XCTAssertFalse([syncConversation.callParticipants containsObject:self.syncSelfUser]);
         
         // expect
-        [[self.flowTranscoder reject] addJoinedCallParticipant:self.syncSelfUser inConversation:syncConversation];
+        [[self.callFlowRequestStrategy reject] addJoinedCallParticipant:self.syncSelfUser inConversation:syncConversation];
 
         if (shouldCallAddUsers) {
-            [[self.flowTranscoder expect] addJoinedCallParticipant:self.syncOtherUser1 inConversation:syncConversation];
+            [[self.callFlowRequestStrategy expect] addJoinedCallParticipant:self.syncOtherUser1 inConversation:syncConversation];
         } else {
-            [[self.flowTranscoder reject] addJoinedCallParticipant:self.syncOtherUser1 inConversation:syncConversation];
+            [[self.callFlowRequestStrategy reject] addJoinedCallParticipant:self.syncOtherUser1 inConversation:syncConversation];
         }
         
         // when
@@ -3223,7 +3223,7 @@
         [syncConversation.voiceChannelRouter.v2 tearDown];
     }];
     
-    [self.flowTranscoder verify];
+    [self.callFlowRequestStrategy verify];
 }
 
 - (void)testThatItCallsAddUsersOnFLowSyncOnlyOnOtherUsers
@@ -3365,10 +3365,10 @@
     ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:payload1 HTTPStatus:200 transportSessionError:nil];
 
     // then
-    [[self.flowTranscoder expect] appendLogForConversationID:conversation1.remoteIdentifier message:[OCMArg checkWithBlock:^BOOL(NSString *message) {
+    [[self.callFlowRequestStrategy expect] appendLogForConversationID:conversation1.remoteIdentifier message:[OCMArg checkWithBlock:^BOOL(NSString *message) {
         return [message hasPrefix:@"PushChannel did close"];
     }]];
-    [[self.flowTranscoder expect] appendLogForConversationID:conversation1.remoteIdentifier message:[OCMArg checkWithBlock:^BOOL(NSString *message) {
+    [[self.callFlowRequestStrategy expect] appendLogForConversationID:conversation1.remoteIdentifier message:[OCMArg checkWithBlock:^BOOL(NSString *message) {
         return [message hasPrefix:@"PushChannel did open"];
     }]];
 
@@ -3382,7 +3382,7 @@
     [self simulateOpeningPushChannel];
     
     // then
-    [self.flowTranscoder verify];
+    [self.callFlowRequestStrategy verify];
 }
 
 - (void)testThatItAppendsTheLogForAllConversations_Push
@@ -3549,13 +3549,13 @@
     
     // expect
     [[[self.gsmCallHandler expect] andReturnValue:OCMOCK_VALUE(YES)] isInterruptedCallConversation:conversation];
-    [[self.flowTranscoder reject] updateFlowsForConversation:OCMOCK_ANY];
+    [[self.callFlowRequestStrategy reject] updateFlowsForConversation:OCMOCK_ANY];
 
     // when
     ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@{} HTTPStatus:200 transportSessionError:nil];
     [self.sut updateUpdatedObject:conversation requestUserInfo:nil response:response keysToParse:self.keys];
     
-    [self.flowTranscoder verify];
+    [self.callFlowRequestStrategy verify];
 }
 
 
@@ -3567,7 +3567,7 @@
     
     // expect
     [[[self.gsmCallHandler expect] andReturnValue:OCMOCK_VALUE(NO)] isInterruptedCallConversation:conversation];
-    [[self.flowTranscoder expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
+    [[self.callFlowRequestStrategy expect] updateFlowsForConversation:[OCMArg checkWithBlock:^BOOL(ZMConversation *conv) {
         XCTAssertEqualObjects(conversation, conv);
         XCTAssertTrue(!conv.callDeviceIsActive);
         return true;
@@ -3577,7 +3577,7 @@
     ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@{} HTTPStatus:200 transportSessionError:nil];
     [self.sut updateUpdatedObject:conversation requestUserInfo:nil response:response keysToParse:self.keys];
     
-    [self.flowTranscoder verify];
+    [self.callFlowRequestStrategy verify];
 }
 
 @end

--- a/Tests/Source/Synchronization/ZMSyncStrategyTests.m
+++ b/Tests/Source/Synchronization/ZMSyncStrategyTests.m
@@ -159,13 +159,13 @@
     [[[[missingUpdateEventsTranscoder expect] andReturn:missingUpdateEventsTranscoder] classMethod] alloc];
     (void) [[[missingUpdateEventsTranscoder expect] andReturn:missingUpdateEventsTranscoder] initWithSyncStrategy:OCMOCK_ANY previouslyReceivedEventIDsCollection:OCMOCK_ANY application:OCMOCK_ANY backgroundAPNSPingbackStatus:OCMOCK_ANY syncStatus:OCMOCK_ANY];
     
-    id callFlowRequestStrategy = [OCMockObject mockForClass:ZMCallFlowRequestStrategy.class];
+    id callFlowRequestStrategy = [OCMockObject niceMockForClass:ZMCallFlowRequestStrategy.class];
     [[[[callFlowRequestStrategy expect] andReturn:callFlowRequestStrategy] classMethod] alloc];
     (void)[[[callFlowRequestStrategy expect] andReturn:callFlowRequestStrategy] initWithMediaManager:nil onDemandFlowManager:nil managedObjectContext:self.syncMOC appStateDelegate:OCMOCK_ANY application:self.application];
 
-    id callStateRequestStrategy = [OCMockObject mockForClass:ZMCallStateRequestStrategy.class];
+    id callStateRequestStrategy = [OCMockObject niceMockForClass:ZMCallStateRequestStrategy.class];
     [[[[callStateRequestStrategy expect] andReturn:callStateRequestStrategy] classMethod] alloc];
-    (void) [[[callStateRequestStrategy expect] andReturn:callStateRequestStrategy] initWithManagedObjectContext:self.syncMOC appStateDelegate:OCMOCK_ANY objectStrategyDirectory:OCMOCK_ANY];
+    (void) [[[callStateRequestStrategy expect] andReturn:callStateRequestStrategy] initWithManagedObjectContext:self.syncMOC appStateDelegate:OCMOCK_ANY callFlowRequestStrategy:OCMOCK_ANY];
         
     id loginCodeRequestTranscoder = [OCMockObject mockForClass:ZMLoginCodeRequestTranscoder.class];
     [[[[loginCodeRequestTranscoder expect] andReturn:loginCodeRequestTranscoder] classMethod] alloc];
@@ -203,8 +203,6 @@
                          clientMessageTranscoder,
                          missingUpdateEventsTranscoder,
                          registrationTranscoder,
-                         callFlowRequestStrategy,
-                         callStateRequestStrategy,
                          loginCodeRequestTranscoder,
                          phoneNumberVerificationTranscoder
     ];
@@ -240,8 +238,6 @@
     XCTAssertEqual(self.sut.selfStrategy, selfStrategy);
     XCTAssertEqual(self.sut.connectionTranscoder, connectionTranscoder);
     XCTAssertEqual(self.sut.registrationTranscoder, registrationTranscoder);
-    XCTAssertEqual(self.sut.callFlowRequestStrategy, callFlowRequestStrategy);
-    XCTAssertEqual(self.sut.callStateRequestStrategy, callStateRequestStrategy);
     XCTAssertEqual(self.sut.loginCodeRequestTranscoder, loginCodeRequestTranscoder);
     XCTAssertEqual(self.sut.phoneNumberVerificationTranscoder, phoneNumberVerificationTranscoder);
     

--- a/Tests/Source/Synchronization/ZMSyncStrategyTests.m
+++ b/Tests/Source/Synchronization/ZMSyncStrategyTests.m
@@ -52,7 +52,7 @@
 #import "ZMSelfStrategy.h"
 #import "ZMMissingUpdateEventsTranscoder.h"
 #import "ZMRegistrationTranscoder.h"
-#import "ZMFlowSync.h"
+#import "ZMCallFlowRequestStrategy.h"
 #import "ZMCallStateRequestStrategy.h"
 #import "ZMConnectionTranscoder.h"
 #import "ZMLoginCodeRequestTranscoder.h"
@@ -159,9 +159,9 @@
     [[[[missingUpdateEventsTranscoder expect] andReturn:missingUpdateEventsTranscoder] classMethod] alloc];
     (void) [[[missingUpdateEventsTranscoder expect] andReturn:missingUpdateEventsTranscoder] initWithSyncStrategy:OCMOCK_ANY previouslyReceivedEventIDsCollection:OCMOCK_ANY application:OCMOCK_ANY backgroundAPNSPingbackStatus:OCMOCK_ANY syncStatus:OCMOCK_ANY];
     
-    id flowTranscoder = [OCMockObject mockForClass:ZMFlowSync.class];
-    [[[[flowTranscoder expect] andReturn:flowTranscoder] classMethod] alloc];
-    (void)[[[flowTranscoder expect] andReturn:flowTranscoder] initWithMediaManager:nil onDemandFlowManager:nil managedObjectContext:self.syncMOC appStateDelegate:OCMOCK_ANY application:self.application];
+    id callFlowRequestStrategy = [OCMockObject mockForClass:ZMCallFlowRequestStrategy.class];
+    [[[[callFlowRequestStrategy expect] andReturn:callFlowRequestStrategy] classMethod] alloc];
+    (void)[[[callFlowRequestStrategy expect] andReturn:callFlowRequestStrategy] initWithMediaManager:nil onDemandFlowManager:nil managedObjectContext:self.syncMOC appStateDelegate:OCMOCK_ANY application:self.application];
 
     id callStateRequestStrategy = [OCMockObject mockForClass:ZMCallStateRequestStrategy.class];
     [[[[callStateRequestStrategy expect] andReturn:callStateRequestStrategy] classMethod] alloc];
@@ -203,7 +203,7 @@
                          clientMessageTranscoder,
                          missingUpdateEventsTranscoder,
                          registrationTranscoder,
-                         flowTranscoder,
+                         callFlowRequestStrategy,
                          callStateRequestStrategy,
                          loginCodeRequestTranscoder,
                          phoneNumberVerificationTranscoder
@@ -240,7 +240,7 @@
     XCTAssertEqual(self.sut.selfStrategy, selfStrategy);
     XCTAssertEqual(self.sut.connectionTranscoder, connectionTranscoder);
     XCTAssertEqual(self.sut.registrationTranscoder, registrationTranscoder);
-    XCTAssertEqual(self.sut.flowTranscoder, flowTranscoder);
+    XCTAssertEqual(self.sut.callFlowRequestStrategy, callFlowRequestStrategy);
     XCTAssertEqual(self.sut.callStateRequestStrategy, callStateRequestStrategy);
     XCTAssertEqual(self.sut.loginCodeRequestTranscoder, loginCodeRequestTranscoder);
     XCTAssertEqual(self.sut.phoneNumberVerificationTranscoder, phoneNumberVerificationTranscoder);

--- a/Tests/Source/Synchronization/ZMSyncStrategyTests.m
+++ b/Tests/Source/Synchronization/ZMSyncStrategyTests.m
@@ -161,7 +161,7 @@
     
     id flowTranscoder = [OCMockObject mockForClass:ZMFlowSync.class];
     [[[[flowTranscoder expect] andReturn:flowTranscoder] classMethod] alloc];
-    (void)[[[flowTranscoder expect] andReturn:flowTranscoder] initWithMediaManager:nil onDemandFlowManager:nil syncManagedObjectContext:self.syncMOC uiManagedObjectContext:self.uiMOC application:self.application];
+    (void)[[[flowTranscoder expect] andReturn:flowTranscoder] initWithMediaManager:nil onDemandFlowManager:nil managedObjectContext:self.syncMOC appStateDelegate:OCMOCK_ANY application:self.application];
 
     id callStateRequestStrategy = [OCMockObject mockForClass:ZMCallStateRequestStrategy.class];
     [[[[callStateRequestStrategy expect] andReturn:callStateRequestStrategy] classMethod] alloc];

--- a/Tests/Source/UserSession/ZMUserSessionTests.m
+++ b/Tests/Source/UserSession/ZMUserSessionTests.m
@@ -1558,7 +1558,7 @@
 
 @end
 
-@interface ZMFlowSync (FlowManagerDelegate) <AVSFlowManagerDelegate>
+@interface ZMCallFlowRequestStrategy (FlowManagerDelegate) <AVSFlowManagerDelegate>
 @end
 
 @implementation ZMUserSessionTests (AVSLogObserver)
@@ -1594,7 +1594,7 @@
     [ZMUserSession removeAVSLogObserver:token];
     
     // when
-    [ZMFlowSync logMessage:testMessage];
+    [ZMCallFlowRequestStrategy logMessage:testMessage];
     
     // then
     [logObserver verify];

--- a/Tests/Source/UserSession/ZMUserSessionTestsBase.h
+++ b/Tests/Source/UserSession/ZMUserSessionTestsBase.h
@@ -36,7 +36,7 @@
 #import "ZMCredentials.h"
 #import "ZMSyncStrategy.h"
 #import "ZMOperationLoop.h"
-#import "ZMFlowSync.h"
+#import "ZMCallFlowRequestStrategy.h"
 #import "ZMPushToken.h"
 #import "ZMCommonContactsSearch.h"
 

--- a/zmessaging-cocoa.xcodeproj/project.pbxproj
+++ b/zmessaging-cocoa.xcodeproj/project.pbxproj
@@ -146,7 +146,7 @@
 		544BA1271A433DE400D3B852 /* NSError+ZMUserSession.h in Headers */ = {isa = PBXBuildFile; fileRef = 3E05F247192A4F8900F22D80 /* NSError+ZMUserSession.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		544BA12B1A433DE400D3B852 /* ZMSearchDirectory.h in Headers */ = {isa = PBXBuildFile; fileRef = 54BE367A196C10CB00D15ECF /* ZMSearchDirectory.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		544BA1311A433DE400D3B852 /* ZMNetworkState.h in Headers */ = {isa = PBXBuildFile; fileRef = 546D45FD19E29D92004C478D /* ZMNetworkState.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		544BA1361A43401400D3B852 /* ZMFlowSyncTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EAD6A10199BBEE200D519DB /* ZMFlowSyncTests.m */; };
+		544BA1361A43401400D3B852 /* ZMCallFlowRequestStrategyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EAD6A10199BBEE200D519DB /* ZMCallFlowRequestStrategyTests.m */; };
 		544BA1571A43424F00D3B852 /* zmessaging.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 549815931A43232400A7CE2E /* zmessaging.framework */; };
 		544D1C281DF95224003B2FC8 /* AddressBookIOS8.swift in Sources */ = {isa = PBXBuildFile; fileRef = 544D1C271DF95224003B2FC8 /* AddressBookIOS8.swift */; };
 		544F8FF31DDCD34600D1AB04 /* UserProfileUpdateNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 544F8FF21DDCD34600D1AB04 /* UserProfileUpdateNotifications.swift */; };
@@ -232,7 +232,7 @@
 		549816461A432BC800A7CE2E /* ZMOperationLoop+Background.m in Sources */ = {isa = PBXBuildFile; fileRef = F962A8E919FFC06E00FD0F80 /* ZMOperationLoop+Background.m */; };
 		549816471A432BC800A7CE2E /* ZMSyncStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = 85D859D47B6EBF09E4137658 /* ZMSyncStrategy.m */; };
 		5498165A1A432BC800A7CE2E /* ZMUpdateEventsBuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = 54F7217919A611DE009A8AF5 /* ZMUpdateEventsBuffer.m */; };
-		549816601A432BC800A7CE2E /* ZMFlowSync.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EAD6A0A199BB79200D519DB /* ZMFlowSync.m */; };
+		549816601A432BC800A7CE2E /* ZMCallFlowRequestStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EAD6A0A199BB79200D519DB /* ZMCallFlowRequestStrategy.m */; };
 		549816611A432BC800A7CE2E /* VoiceChannelV2+CallFlow.m in Sources */ = {isa = PBXBuildFile; fileRef = 3ED03B75196C212D00B40DB0 /* VoiceChannelV2+CallFlow.m */; };
 		54991D581DEDCF2B007E282F /* AddressBook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54991D571DEDCF2B007E282F /* AddressBook.swift */; };
 		54991D5A1DEDD07E007E282F /* AddressBookIOS9.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54991D591DEDD07E007E282F /* AddressBookIOS9.swift */; };
@@ -388,7 +388,7 @@
 		F96DBEEB1DF9A570008FE832 /* ZMSyncStrategy+ManagedObjectChanges.m in Sources */ = {isa = PBXBuildFile; fileRef = F96DBEE91DF9A570008FE832 /* ZMSyncStrategy+ManagedObjectChanges.m */; };
 		F96DBEEE1DF9A79F008FE832 /* ZMSyncStrategy+EventProcessing.h in Headers */ = {isa = PBXBuildFile; fileRef = F96DBEEC1DF9A79F008FE832 /* ZMSyncStrategy+EventProcessing.h */; };
 		F96DBEEF1DF9A79F008FE832 /* ZMSyncStrategy+EventProcessing.m in Sources */ = {isa = PBXBuildFile; fileRef = F96DBEED1DF9A79F008FE832 /* ZMSyncStrategy+EventProcessing.m */; };
-		F97180531A9E18B5002CEAF8 /* ZMFlowSync.h in Headers */ = {isa = PBXBuildFile; fileRef = 3EAD6A09199BB79200D519DB /* ZMFlowSync.h */; };
+		F97180531A9E18B5002CEAF8 /* ZMCallFlowRequestStrategy.h in Headers */ = {isa = PBXBuildFile; fileRef = 3EAD6A09199BB79200D519DB /* ZMCallFlowRequestStrategy.h */; };
 		F97678FA1D76D11400CC075D /* BackgroundAPNSConfirmationStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97678F91D76D11400CC075D /* BackgroundAPNSConfirmationStatus.swift */; };
 		F976790A1D771B3900CC075D /* BackgroundAPNSConfirmationStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97679081D771B2700CC075D /* BackgroundAPNSConfirmationStatusTests.swift */; };
 		F9771ACA1B664D1A00BB04EC /* ZMGSMCallHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = F9771AC71B664D1A00BB04EC /* ZMGSMCallHandler.h */; };
@@ -648,9 +648,9 @@
 		3EA1EC6519BDE3F400AA1384 /* ZMPushToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZMPushToken.h; sourceTree = "<group>"; };
 		3EA1EC6619BDE3F400AA1384 /* ZMPushToken.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMPushToken.m; sourceTree = "<group>"; };
 		3EA1EC6B19BDE4C800AA1384 /* ZMPushTokenTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMPushTokenTests.m; sourceTree = "<group>"; };
-		3EAD6A09199BB79200D519DB /* ZMFlowSync.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZMFlowSync.h; sourceTree = "<group>"; };
-		3EAD6A0A199BB79200D519DB /* ZMFlowSync.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMFlowSync.m; sourceTree = "<group>"; };
-		3EAD6A10199BBEE200D519DB /* ZMFlowSyncTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMFlowSyncTests.m; sourceTree = "<group>"; };
+		3EAD6A09199BB79200D519DB /* ZMCallFlowRequestStrategy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZMCallFlowRequestStrategy.h; sourceTree = "<group>"; };
+		3EAD6A0A199BB79200D519DB /* ZMCallFlowRequestStrategy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMCallFlowRequestStrategy.m; sourceTree = "<group>"; };
+		3EAD6A10199BBEE200D519DB /* ZMCallFlowRequestStrategyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMCallFlowRequestStrategyTests.m; sourceTree = "<group>"; };
 		3EC2357F192B617700B72C21 /* ZMUserSession+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ZMUserSession+Internal.h"; sourceTree = "<group>"; };
 		3EC4998F1A92463D003F9E32 /* ZMBackgroundFetchState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZMBackgroundFetchState.h; sourceTree = "<group>"; };
 		3EC499901A92463D003F9E32 /* ZMBackgroundFetchState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMBackgroundFetchState.m; sourceTree = "<group>"; };
@@ -1313,8 +1313,8 @@
 				165D3A191E1D43870052E654 /* VoiceChannelRouter.swift */,
 				165D3A1E1E1D43870052E654 /* CallingInitialisationNotification.swift */,
 				F991C0A81CB5391C004D8465 /* ZMCallTimer.swift */,
-				3EAD6A09199BB79200D519DB /* ZMFlowSync.h */,
-				3EAD6A0A199BB79200D519DB /* ZMFlowSync.m */,
+				3EAD6A09199BB79200D519DB /* ZMCallFlowRequestStrategy.h */,
+				3EAD6A0A199BB79200D519DB /* ZMCallFlowRequestStrategy.m */,
 				F9771AC71B664D1A00BB04EC /* ZMGSMCallHandler.h */,
 				F9771AC81B664D1A00BB04EC /* ZMGSMCallHandler.m */,
 				87DC8A0D1C57979B00B7B4F2 /* ZMOnDemandFlowManager.h */,
@@ -1343,7 +1343,7 @@
 				F9B71FAC1CB2C20D001DB03F /* VoiceChannelV2Tests.h */,
 				F9B71FAD1CB2C20D001DB03F /* VoiceChannelV2Tests.m */,
 				87DC8A121C57A8B300B7B4F2 /* VoiceChannelV2Tests+VideoCalling.m */,
-				3EAD6A10199BBEE200D519DB /* ZMFlowSyncTests.m */,
+				3EAD6A10199BBEE200D519DB /* ZMCallFlowRequestStrategyTests.m */,
 				F9771AD01B664D3D00BB04EC /* ZMGSMCallHandlerTest.m */,
 				F9B71FAA1CB2C0FA001DB03F /* ZMCallStateTests+VideoCalling.swift */,
 				872C99511DB5256E006A3BDE /* ZMCallKitDelegateTests.swift */,
@@ -2226,7 +2226,7 @@
 				16DCAD671B0F9447008C1DD9 /* NSURL+LaunchOptions.h in Headers */,
 				544BA1241A433DE400D3B852 /* ZMUserSession+Background.h in Headers */,
 				09531F161AE960E300B8556A /* ZMLoginCodeRequestTranscoder.h in Headers */,
-				F97180531A9E18B5002CEAF8 /* ZMFlowSync.h in Headers */,
+				F97180531A9E18B5002CEAF8 /* ZMCallFlowRequestStrategy.h in Headers */,
 				F992985B1BE143570058D42F /* ZMClientRegistrationStatus+Internal.h in Headers */,
 				F98EDCDB1D82B913001E65CB /* ZMLocalNotification.h in Headers */,
 				87DC8A0F1C57979B00B7B4F2 /* ZMOnDemandFlowManager.h in Headers */,
@@ -2476,7 +2476,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				544BA1361A43401400D3B852 /* ZMFlowSyncTests.m in Sources */,
+				544BA1361A43401400D3B852 /* ZMCallFlowRequestStrategyTests.m in Sources */,
 				54ADA7631E3B3D8E00B90C7D /* IntegrationTestBase+Encryption.swift in Sources */,
 				F991CE161CB55512004D8465 /* ZMUser+Testing.m in Sources */,
 				F9D1CD141DF6C131002F6E80 /* SyncStatusTests.swift in Sources */,
@@ -2708,7 +2708,7 @@
 				F98DD6D51ABB2F7C001D58CF /* ZMUserSession+UserNotificationCategories.m in Sources */,
 				09BCDB8F1BCE7F000020DCC7 /* ZMAPSMessageDecoder.m in Sources */,
 				5498163B1A432BC800A7CE2E /* ZMEventProcessingState.m in Sources */,
-				549816601A432BC800A7CE2E /* ZMFlowSync.m in Sources */,
+				549816601A432BC800A7CE2E /* ZMCallFlowRequestStrategy.m in Sources */,
 				546392721D79D5210094EC66 /* Application.swift in Sources */,
 				546E73EE1ADFD9F200AFF9BE /* ZMUserSessionAuthenticationNotification.m in Sources */,
 				09CC4ADF1B7D076700201C63 /* ZMEnvironmentsSetup.m in Sources */,


### PR DESCRIPTION
For the ongoing project of removing the old state machine we need to convert all transcoder into request strategies.