### PR TITLE
Don't include conversations without messages in the last month in the top people directory

### DIFF
--- a/Source/UserSession/Search/TopConversationsDirectory.swift
+++ b/Source/UserSession/Search/TopConversationsDirectory.swift
@@ -49,7 +49,7 @@ extension TopConversationsDirectory {
             let conversations = self.fetchOneOnOneConversations()
             // Mapping from conversation to message count in the last month
             let countByConversation = conversations.mapToDictionary { $0.lastMonthMessageCount() }
-            let sorted = countByConversation.sorted {  $0.1 > $1.1 }.prefix(TopConversationsDirectory.topConversationSize)
+            let sorted = countByConversation.filter { $0.1 > 0 }.sorted {  $0.1 > $1.1 }.prefix(TopConversationsDirectory.topConversationSize)
             let identifiers = sorted.flatMap { $0.0.objectID }
             self.updateUIList(with: identifiers)
         }

--- a/Tests/Source/UserSession/TopConversationsDirectoryTests.swift
+++ b/Tests/Source/UserSession/TopConversationsDirectoryTests.swift
@@ -91,6 +91,34 @@ class TopConversationsDirectoryTests : MessagingTest {
         XCTAssertEqual(sut.topConversations, [conv2, conv1, conv3])
     }
 
+    func testThatItDoesNotReturnConversationsWithoutMessages() {
+        // GIVEN
+        createConversation(in: uiMOC, fillWithNew: 0)
+        let conv2 = createConversation(in: uiMOC, fillWithNew: 1)
+        createConversation(in: uiMOC, fillWithNew: 0)
+
+        // WHEN
+        sut.refreshTopConversations()
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.2))
+
+        // THEN
+        XCTAssertEqual(sut.topConversations, [conv2])
+    }
+
+    func testThatItDoesNotReturnConversationsWithoutMessagesInTheLastMonth() {
+        // GIVEN
+        createConversation(in: uiMOC, fillWithNew: 0, old: 2)
+        let conv2 = createConversation(in: uiMOC, fillWithNew: 1)
+        createConversation(in: uiMOC, fillWithNew: 0)
+
+        // WHEN
+        sut.refreshTopConversations()
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.2))
+
+        // THEN
+        XCTAssertEqual(sut.topConversations, [conv2])
+    }
+
     func testThatItUpdatesTheConversationsWhenRefreshIsCalledSubsequently() {
         // GIVEN
         let conv1 = createConversation(in: uiMOC, fillWithNew: 5, old: 15)
@@ -119,7 +147,7 @@ class TopConversationsDirectoryTests : MessagingTest {
         // WHEN
         let conv1 = self.createConversation(in: self.uiMOC, fillWithNew: 2)
         expectedConversationsIds.append(conv1.objectID)
-        let conv2 = self.createConversation(in: self.uiMOC)
+        let conv2 = self.createConversation(in: self.uiMOC, fillWithNew: 1)
         expectedConversationsIds.append(conv2.objectID)
 
         sut.refreshTopConversations()
@@ -134,8 +162,8 @@ class TopConversationsDirectoryTests : MessagingTest {
     func testThatItDoesNotReturnConversationsIfTheyAreDeleted() {
         
         // GIVEN
-        let conv1 = self.createConversation(in: self.uiMOC)
-        let conv2 = self.createConversation(in: self.uiMOC)
+        let conv1 = self.createConversation(in: self.uiMOC, fillWithNew: 1)
+        let conv2 = self.createConversation(in: self.uiMOC, fillWithNew: 1)
 
         // WHEN
         self.sut.refreshTopConversations()
@@ -151,8 +179,8 @@ class TopConversationsDirectoryTests : MessagingTest {
     func testThatItDoesNotReturnConversationsIfTheyAreBlocked() {
         
         // GIVEN
-        let conv1 = self.createConversation(in: self.uiMOC)
-        let conv2 = self.createConversation(in: self.uiMOC)
+        let conv1 = self.createConversation(in: self.uiMOC, fillWithNew: 1)
+        let conv2 = self.createConversation(in: self.uiMOC, fillWithNew: 1)
         
         // WHEN
         conv1.connection?.status = .blocked
@@ -183,7 +211,7 @@ class TopConversationsDirectoryTests : MessagingTest {
     func testThatItLimitsTheNumberOfResults() {
         // GIVEN
         for _ in 0...30 {
-            createConversation(in: uiMOC)
+            createConversation(in: uiMOC, fillWithNew: 1)
         }
 
         // WHEN


### PR DESCRIPTION
 What's in this PR?

* We do not want to show conversations without any messages in the top conversations directory.
