### PR TITLE
Only consider client and asset messages in top people calculation

### DIFF
--- a/Source/UserSession/Search/TopConversationsDirectory.swift
+++ b/Source/UserSession/Search/TopConversationsDirectory.swift
@@ -142,8 +142,8 @@ fileprivate extension ZMConversation {
 
     func lastMonthMessageCount() -> Int {
         guard let identifier = remoteIdentifier, let moc = managedObjectContext else { return 0 }
-        let assetCount = ZMAssetClientMessage.countOfMessageInTheLastMonth(in: identifier, context: moc)
-        let messageCount = ZMClientMessage.countOfMessageInTheLastMonth(in: identifier, context: moc)
+        let assetCount = ZMAssetClientMessage.countOfMessagesInTheLastMonth(in: identifier, context: moc)
+        let messageCount = ZMClientMessage.countOfMessagesInTheLastMonth(in: identifier, context: moc)
         return assetCount + messageCount
     }
 
@@ -165,7 +165,7 @@ fileprivate extension ZMMessage {
         return NSCompoundPredicate(andPredicateWithSubpredicates: [lastMonthPredicate, conversationPredicate])
     }
 
-    static func countOfMessageInTheLastMonth(in identifier: UUID, context: NSManagedObjectContext) -> Int {
+    static func countOfMessagesInTheLastMonth(in identifier: UUID, context: NSManagedObjectContext) -> Int {
         guard let predicate = predicateForMessagesInTheLastMonth(in: identifier) else { return 0 }
         guard let request = sortedFetchRequest(with: predicate) else { return 0 }
         return (try? context.count(for: request)) ?? 0

--- a/Source/UserSession/Search/TopConversationsDirectory.swift
+++ b/Source/UserSession/Search/TopConversationsDirectory.swift
@@ -142,9 +142,9 @@ fileprivate extension ZMConversation {
 
     func lastMonthMessageCount() -> Int {
         guard let identifier = remoteIdentifier, let moc = managedObjectContext else { return 0 }
-        guard let predicate = ZMMessage.predicateForNonSystemMessagesInTheLastMonth(in: identifier) else { return 0 }
-        guard let request = ZMMessage.sortedFetchRequest(with: predicate) else { return 0 }
-        return (try? moc.count(for: request)) ?? 0
+        let assetCount = ZMAssetClientMessage.countOfMessageInTheLastMonth(in: identifier, context: moc)
+        let messageCount = ZMClientMessage.countOfMessageInTheLastMonth(in: identifier, context: moc)
+        return assetCount + messageCount
     }
 
 }
@@ -152,7 +152,7 @@ fileprivate extension ZMConversation {
 
 fileprivate extension ZMMessage {
 
-    static func predicateForNonSystemMessagesInTheLastMonth(in identifier: UUID) -> NSPredicate? {
+    static func predicateForMessagesInTheLastMonth(in identifier: UUID) -> NSPredicate? {
         guard let oneMonthAgo = Calendar.current.date(byAdding: .month, value: -1, to: Date()) else { return nil }
         let lastMonthPredicate = NSPredicate(format: "%K >= %@", #keyPath(ZMMessage.serverTimestamp), oneMonthAgo as NSDate)
         let conversationPredicate = NSPredicate(
@@ -165,5 +165,11 @@ fileprivate extension ZMMessage {
         return NSCompoundPredicate(andPredicateWithSubpredicates: [lastMonthPredicate, conversationPredicate])
     }
 
+    static func countOfMessageInTheLastMonth(in identifier: UUID, context: NSManagedObjectContext) -> Int {
+        guard let predicate = predicateForMessagesInTheLastMonth(in: identifier) else { return 0 }
+        guard let request = sortedFetchRequest(with: predicate) else { return 0 }
+        return (try? context.count(for: request)) ?? 0
+    }
+    
 }
 

--- a/Tests/Source/UserSession/TopConversationsDirectoryTests.swift
+++ b/Tests/Source/UserSession/TopConversationsDirectoryTests.swift
@@ -105,6 +105,22 @@ class TopConversationsDirectoryTests : MessagingTest {
         XCTAssertEqual(sut.topConversations, [conv2])
     }
 
+    func testThatItDoesNotReturnConversationsWithSystemMessages() {
+        // GIVEN
+        let conv1 = createConversation(in: uiMOC, fillWithNew: 0)
+        conv1.appendStartedUsingThisDeviceMessage()
+
+        let conv2 = createConversation(in: uiMOC, fillWithNew: 1)
+        conv2.appendKnock()
+
+        // WHEN
+        sut.refreshTopConversations()
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.2))
+
+        // THEN
+        XCTAssertEqual(sut.topConversations, [conv2])
+    }
+
     func testThatItDoesNotReturnConversationsWithoutMessagesInTheLastMonth() {
         // GIVEN
         createConversation(in: uiMOC, fillWithNew: 0, old: 2)
@@ -138,6 +154,7 @@ class TopConversationsDirectoryTests : MessagingTest {
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.2))
 
         // THEN
+        XCTAssertEqual(sut.topConversations, [conv3, conv2, conv1])
     }
     
     func testThatItSetsTopConversationFromTheRightContext() {
@@ -156,7 +173,7 @@ class TopConversationsDirectoryTests : MessagingTest {
         
         // THEN
         XCTAssertEqual(self.sut.topConversations.map { $0.objectID }, expectedConversationsIds)
-        XCTAssertEqual(self.sut.topConversations.map { $0.managedObjectContext! }, [self.uiMOC, self.uiMOC])
+        XCTAssertEqual(self.sut.topConversations.flatMap { $0.managedObjectContext }, [self.uiMOC, self.uiMOC])
     }
     
     func testThatItDoesNotReturnConversationsIfTheyAreDeleted() {


### PR DESCRIPTION
# What's in this PR?

* System messages were taking into account in the top people calculation.
* Fetch `ZMAssetClientMessage` and `ZMClientMessage` count instead of `ZMMessage`.
* This will add an extra request per conversation, we will have to see if this performs well and otherwise might want to reverse iterate over the messages in a conversation until the `serverTimestamp` is older than a month.
* Add missing test assertion.