### PR TITLE
Add notification category for images

### DIFF
--- a/Source/Notifications/Push notifications/Notification Types/MessageNotifications/ZMLocalNotificationForMessage.swift
+++ b/Source/Notifications/Push notifications/Notification Types/MessageNotifications/ZMLocalNotificationForMessage.swift
@@ -68,6 +68,7 @@ extension NotificationForMessage {
     func conversationCategory(ephemeral: Bool) -> String {
         guard !ephemeral else { return ZMConversationCategory }
         switch contentType {
+        case .image: return ZMConversationCategoryImage
         case .knock, .system(_), .undefined : return ZMConversationCategory
         default: return ZMConversationCategoryIncludingLike
         }

--- a/Source/UserSession/ZMUserSession+Background.m
+++ b/Source/UserSession/ZMUserSession+Background.m
@@ -142,6 +142,7 @@ static NSString *ZMLogTag = @"Push";
     [application registerForRemoteNotifications];
     NSSet *categories = [NSSet setWithArray:@[
                                               self.replyCategory,
+                                              self.replyCategoryImage,
                                               self.replyCategoryIncludingLike,
                                               self.missedCallCategory,
                                               self.incomingCallCategory,

--- a/Source/UserSession/ZMUserSession+UserNotificationCategories.h
+++ b/Source/UserSession/ZMUserSession+UserNotificationCategories.h
@@ -21,8 +21,10 @@
 
 #import "ZMUserSession.h"
 
-extern NSString *const ZMConversationCategory;
-extern NSString *const ZMConversationCategoryIncludingLike;
+extern NSString *const ZMConversationCategory; // Non ephemeral messages (excluding images).
+extern NSString *const ZMConversationCategoryImage; // Non ephemeral image messages.
+extern NSString *const ZMConversationCategoryIncludingLike; // Ehemeral messages.
+
 extern NSString *const ZMConversationOpenAction;
 extern NSString *const ZMConversationDirectReplyAction;
 extern NSString *const ZMConversationMuteAction;
@@ -43,7 +45,9 @@ extern NSString *const ZMConnectAcceptAction;
 @interface ZMUserSession (UserNotificationCategories)
 
 - (UIUserNotificationCategory *)replyCategory;
+- (UIUserNotificationCategory *)replyCategoryImage;
 - (UIUserNotificationCategory *)replyCategoryIncludingLike;
+
 - (UIUserNotificationCategory *)incomingCallCategory;
 - (UIUserNotificationCategory *)missedCallCategory;
 

--- a/Source/UserSession/ZMUserSession+UserNotificationCategories.m
+++ b/Source/UserSession/ZMUserSession+UserNotificationCategories.m
@@ -22,6 +22,7 @@
 
 NSString *const ZMConversationCategory = @"conversationCategory";
 NSString *const ZMConversationCategoryIncludingLike = @"conversationCategoryWithLike";
+NSString *const ZMConversationCategoryImage = @"conversationCategoryImage";
 NSString *const ZMConversationOpenAction = @"conversationOpenAction";
 NSString *const ZMConversationDirectReplyAction = @"conversationDirectReplyAction";
 NSString *const ZMConversationMuteAction = @"conversationMuteAction";
@@ -73,18 +74,31 @@ static NSString * ZMPushActionLocalizedString(NSString *key)
 
 - (UIUserNotificationCategory *)replyCategory
 {
-    return [self replyCategoryInlcudingLike:NO];
+    return [self replyCategoryInlcudingLike:NO image:NO];
+}
+
+- (UIUserNotificationCategory *)replyCategoryImage
+{
+    return [self replyCategoryInlcudingLike:YES image:YES];
 }
 
 - (UIUserNotificationCategory *)replyCategoryIncludingLike
 {
-    return [self replyCategoryInlcudingLike:YES];
+    return [self replyCategoryInlcudingLike:YES image:NO];
 }
 
-- (UIUserNotificationCategory *)replyCategoryInlcudingLike:(BOOL)includingLike
+- (UIUserNotificationCategory *)replyCategoryInlcudingLike:(BOOL)includingLike image:(BOOL)isImage
 {
     UIMutableUserNotificationCategory *category = [[UIMutableUserNotificationCategory alloc] init];
-    category.identifier = includingLike ? ZMConversationCategoryIncludingLike : ZMConversationCategory;
+    NSString *identifier = ZMConversationCategory;
+    if (includingLike) {
+        identifier = ZMConversationCategoryIncludingLike;
+    }
+    if (isImage) {
+        identifier = ZMConversationCategoryImage;
+    }
+
+    category.identifier = identifier;
     NSMutableArray *actions = @[[self replyActionDirectMessage: NO], [self muteConversationBackgroundAction]].mutableCopy;
 
     if (includingLike) {


### PR DESCRIPTION
# What's in this PR?

* Add a new notification category with the identifier `conversationCategoryImage` for use in a notification content extension to identify image notifications. This category will only be set for non-ephemeral images.