### PR TITLE
CallKit crash fixed when there is no handle

### DIFF
--- a/Source/Calling/ZMCallKitDelegate.m
+++ b/Source/Calling/ZMCallKitDelegate.m
@@ -359,8 +359,15 @@ NS_ASSUME_NONNULL_END
     else {
         [self endAllOngoingCallKitCallsExcept:conversation];
         
+        CXHandle *handle = conversation.callKitHandle;
+        
+        if (handle == nil) {
+            [self logErrorForConversation:conversation.remoteIdentifier.transportString line:__LINE__ format:@"Cannot get call kit handle for conversation"];
+            return;
+        }
+        
         CXStartCallAction *startCallAction = [[CXStartCallAction alloc] initWithCallUUID:conversation.remoteIdentifier
-                                                                                  handle:conversation.callKitHandle];
+                                                                                  handle:handle];
         startCallAction.video = video;
         startCallAction.contactIdentifier = [conversation localizedCallerNameWithCallFromUser:[ZMUser selfUserInUserSession:self.userSession]];
         


### PR DESCRIPTION
- Crash happens when we are trying to initialize `CXStartCallAction` with nil handle.
- Handle is nil when conversation is nil, or conversation is of an unknown type, or it does not have a remote identifier yet. In all those cases there seems to be no reason to start the call.