### PR TITLE
Manually fire a notification for the list indicator when the call state changes

### DIFF
--- a/Source/Calling/WireCallCenterV2.swift
+++ b/Source/Calling/WireCallCenterV2.swift
@@ -240,7 +240,15 @@ public class WireCallCenterV2 : NSObject {
     
     @objc
     public func callStateDidChange(conversations: Set<ZMConversation>) {
-        conversations.forEach{ updateVoiceChannelState(forConversation: $0) }
+        conversations.forEach{
+            if updateVoiceChannelState(forConversation: $0), let context = $0.managedObjectContext {
+                NotificationDispatcher.notifyNonCoreDataChanges(
+                    objectID: $0.objectID,
+                    changedKeys: [ZMConversationListIndicatorKey],
+                    uiContext: context
+                )
+            }
+        }
         videoSnapshot?.callStateDidChange(for: conversations)
         participantSnapshot?.callStateDidChange(for: conversations)
     }


### PR DESCRIPTION
# What's in this PR?

* This is needed in order to properly update the conversation list indicator on the UI.
