### PR TITLE
Check if conversation has remoteIdentifier before calling

### DIFF
--- a/Source/Calling/VoiceChannelV2+CallFlow.m
+++ b/Source/Calling/VoiceChannelV2+CallFlow.m
@@ -212,6 +212,10 @@
 {
     ZMConversation *conv = self.conversation;
     
+    if (conv.remoteIdentifier.transportString.length == 0) {
+        return NO;
+    }
+    
     if ([self hasOngoingGSMCall] && ![ZMUserSession useCallKit]) {
         [conv.managedObjectContext.zm_userInterfaceContext performGroupedBlock: ^{
             [CallingInitialisationNotification notifyCallingFailedWithErrorCode:VoiceChannelV2ErrorCodeOngoingGSMCall];
@@ -235,15 +239,19 @@
 
 - (BOOL)joinVideoCall
 {
-    ZMConversation *strongConversation = self.conversation;
+    ZMConversation *conversation = self.conversation;
+    
+    if (conversation.remoteIdentifier.transportString.length == 0) {
+        return NO;
+    }
     
     // if there is already an ongoing audioCall we can not switch to videoCall
-    if (strongConversation.callDeviceIsActive && !strongConversation.isVideoCall) {
+    if (conversation.callDeviceIsActive && !conversation.isVideoCall) {
         ZMLogError(@"Can't start video call because there's already an ongoing audio call");
         return NO;
     }
     
-    strongConversation.isVideoCall = YES;
+    conversation.isVideoCall = YES;
     
     [self join];
     


### PR DESCRIPTION
- Calling does not make sense if there is no remote identifier.
- Issue can happen for just created locally conversations.
- This case is already handled in calling V3 (YAY)