### PR TITLE
Revert answer call handling

### DIFF
--- a/Source/Calling/ZMCallKitDelegate.m
+++ b/Source/Calling/ZMCallKitDelegate.m
@@ -548,11 +548,11 @@ NS_ASSUME_NONNULL_END
     [self.calls setObject:call forKey:callConversation.remoteIdentifier];
     
     call.onEstablished = ^{
-        [action fulfillWithDateConnected:[NSDate date]];
+//        [action fulfillWithDateConnected:[NSDate date]]; Disabled for now, pending further investigation
     };
     
     call.onFailedToJoin = ^{
-        [action fail];
+//        [action fail]; Disabled for now, pending further investigation
     };
     
     [userSession performChanges:^{
@@ -560,6 +560,8 @@ NS_ASSUME_NONNULL_END
             [action fail];
         }
     }];
+    
+    [action fulfill];
 }
 
 - (void)provider:(CXProvider *)provider performEndCallAction:(nonnull CXEndCallAction *)action

--- a/Tests/Source/Calling/ZMCallKitDelegateTests.swift
+++ b/Tests/Source/Calling/ZMCallKitDelegateTests.swift
@@ -306,6 +306,7 @@ class ZMCallKitDelegateTest: MessagingTest {
     
     // Actions - answer / start call
     
+    /* Disabled for now, pending furter investigation
     func testThatCallAnswerActionIsFulfilledWhenCallIsEstablished() {
         // given
         let provider = MockProvider(foo: true)
@@ -333,6 +334,7 @@ class ZMCallKitDelegateTest: MessagingTest {
         // then
         XCTAssertTrue(action.hasFailed)
     }
+     */
     
     func testThatStartCallActionIsFulfilledWhenCallIsJoined() {
         // given


### PR DESCRIPTION
We need to revert the answer call handling until we have more time investigate why the "correct" api usage breaks incoming calls.