### PR TITLE
Add degraded variant for connecting state

### DIFF
--- a/Source/Calling/VoiceChannelV2+CallFlow.m
+++ b/Source/Calling/VoiceChannelV2+CallFlow.m
@@ -61,6 +61,7 @@
         case VoiceChannelV2StateIncomingCallInactive:
         case VoiceChannelV2StateOutgoingCallDegraded:
         case VoiceChannelV2StateOutgoingCallInactive:
+        case VoiceChannelV2StateSelfIsJoiningActiveChannelDegraded:
             break;
     }
 }

--- a/Source/Calling/VoiceChannelV2.h
+++ b/Source/Calling/VoiceChannelV2.h
@@ -35,33 +35,34 @@ NS_ASSUME_NONNULL_BEGIN
 typedef NS_ENUM(uint8_t, VoiceChannelV2ConnectionState) {
     VoiceChannelV2ConnectionStateInvalid,
     VoiceChannelV2ConnectionStateNotConnected,
-    VoiceChannelV2ConnectionStateConnecting,    ///<  The user is in the process of joining the media flow channel
-    VoiceChannelV2ConnectionStateConnected      ///<  The media flow channel is established.  The user is fully connected and can participate in the voice channel
+    VoiceChannelV2ConnectionStateConnecting,    ///  The user is in the process of joining the media flow channel
+    VoiceChannelV2ConnectionStateConnected      ///  The media flow channel is established.  The user is fully connected and can participate in the voice channel
 };
 
 typedef NS_ENUM(uint8_t, VoiceChannelV2State) {
     VoiceChannelV2StateInvalid = 0,
-    VoiceChannelV2StateNoActiveUsers, ///< Nobody is active on the voice channel
-    VoiceChannelV2StateOutgoingCall, ///< We are connecting and nobody is in a connected state on the voice channel yet (ie: we are calling)
-    VoiceChannelV2StateOutgoingCallDegraded, ///< We are doing an outgoing call but we can't proceed since the conversation security is degraded
-    VoiceChannelV2StateOutgoingCallInactive, ///< We are connecting and nobody is in a connected state on the voice channel yet (ie: we are calling) but not ringing anymore.
-    VoiceChannelV2StateIncomingCall, ///< Someone else is calling (ringing) you on the voice channel.
-    VoiceChannelV2StateIncomingCallDegraded, ///< Someone else is calling but we can't proceed since the conversation security is degraded
-    VoiceChannelV2StateIncomingCallInactive, ///< Group call is in progress but it's not ringing for us.
-    VoiceChannelV2StateSelfIsJoiningActiveChannel, ///< Somebody else is in a connected state on the voice channel and we are connecting (ie: we are joining)
-    VoiceChannelV2StateSelfConnectedToActiveChannel, ///< Self connects to voice channel AND there is someone already connected on the channel
-    VoiceChannelV2StateDeviceTransferReady, ///< This device is ready to have the call transfered to it
+    VoiceChannelV2StateNoActiveUsers, /// Nobody is active on the voice channel
+    VoiceChannelV2StateOutgoingCall, /// We are connecting and nobody is in a connected state on the voice channel yet (ie: we are calling)
+    VoiceChannelV2StateOutgoingCallDegraded, /// We are doing an outgoing call but can't proceed since the conversation security is degraded
+    VoiceChannelV2StateOutgoingCallInactive, /// We are connecting and nobody is in a connected state on the voice channel yet (ie: we are calling) but not ringing anymore.
+    VoiceChannelV2StateIncomingCall, /// Someone else is calling (ringing) you on the voice channel.
+    VoiceChannelV2StateIncomingCallDegraded, /// Someone else is calling, but can't proceed since the conversation security is degraded
+    VoiceChannelV2StateIncomingCallInactive, /// Group call is in progress but it's not ringing for us.
+    VoiceChannelV2StateSelfIsJoiningActiveChannel, /// We are connecting to the voice channel
+    VoiceChannelV2StateSelfIsJoiningActiveChannelDegraded, /// We are connecting to the voice channel, but can't proceed since the conversation security is degraded
+    VoiceChannelV2StateSelfConnectedToActiveChannel, /// Self connects to voice channel AND there is someone already connected on the channel
+    VoiceChannelV2StateDeviceTransferReady, /// This device is ready to have the call transfered to it
 };
 
 
 typedef NS_ENUM(uint8_t, VoiceChannelV2CallEndReason) {
-    VoiceChannelV2CallEndReasonRequested, ///< Default when other user ends the call
-    VoiceChannelV2CallEndReasonRequestedSelf, ///< when self user ends the call
-    VoiceChannelV2CallEndReasonRequestedAVS, ///< AVS requested to end call. (media wasn't flowing etc.)
-    VoiceChannelV2CallEndReasonOtherLostMedia, ///< Other participant lost media flow
-    VoiceChannelV2CallEndReasonInterrupted, ///< When GSM call interrupts call
-    VoiceChannelV2CallEndReasonDisconnected, ///< When the client disconnects from the service due to other technical reasons
-    VoiceChannelV2CallEndReasonInputOutputError ///< When the client disconnects from the service due to input output error (microphone not working)
+    VoiceChannelV2CallEndReasonRequested, /// Default when other user ends the call
+    VoiceChannelV2CallEndReasonRequestedSelf, /// when self user ends the call
+    VoiceChannelV2CallEndReasonRequestedAVS, /// AVS requested to end call. (media wasn't flowing etc.)
+    VoiceChannelV2CallEndReasonOtherLostMedia, /// Other participant lost media flow
+    VoiceChannelV2CallEndReasonInterrupted, /// When GSM call interrupts call
+    VoiceChannelV2CallEndReasonDisconnected, /// When the client disconnects from the service due to other technical reasons
+    VoiceChannelV2CallEndReasonInputOutputError /// When the client disconnects from the service due to input output error (microphone not working)
 };
 
 // The voice channel of a conversation.

--- a/Source/Calling/VoiceChannelV3.swift
+++ b/Source/Calling/VoiceChannelV3.swift
@@ -131,6 +131,8 @@ public extension CallState {
             return .incomingCallDegraded
         case .incoming:
             return .incomingCall
+        case .answered where securityLevel == .secureWithIgnored:
+            return .selfIsJoiningActiveChannelDegraded
         case .answered:
             return .selfIsJoiningActiveChannel
         case .established:

--- a/Source/Synchronization/Transcoders/ZMCallStateLogger.m
+++ b/Source/Synchronization/Transcoders/ZMCallStateLogger.m
@@ -89,6 +89,8 @@
             return @"OutgoingCallInactive";
         case VoiceChannelV2StateSelfIsJoiningActiveChannel:
             return @"SelfIsJoiningActiveChannel";
+        case VoiceChannelV2StateSelfIsJoiningActiveChannelDegraded:
+            return @"SelfIsJoiningActiveChannelDegraded";
     }
 }
 

--- a/Tests/Source/Calling/VoiceChannelV2Tests.m
+++ b/Tests/Source/Calling/VoiceChannelV2Tests.m
@@ -162,9 +162,11 @@
     
     self.otherConversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
     self.otherConversation.conversationType = ZMConversationTypeOneOnOne;
+    self.otherConversation.remoteIdentifier = [NSUUID new];
     
     self.groupConversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
     self.groupConversation.conversationType = ZMConversationTypeGroup;
+    self.groupConversation.remoteIdentifier = [NSUUID new];
     
     self.selfUser = [ZMUser selfUserInContext:self.uiMOC];
     self.selfUser.name = @"Me Myself";
@@ -188,6 +190,7 @@
         self.syncGroupConversation = (id)[self.syncMOC objectWithID:self.groupConversation.objectID];
         self.syncOneOnOneConversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
         self.syncOneOnOneConversation.conversationType = ZMConversationTypeOneOnOne;
+        self.syncOneOnOneConversation.remoteIdentifier = NSUUID.createUUID;
         [self.syncMOC saveOrRollback];
     }];
 }

--- a/Tests/Source/Calling/VoiceChannelV3Tests.swift
+++ b/Tests/Source/Calling/VoiceChannelV3Tests.swift
@@ -88,7 +88,7 @@ class VoiceChannelV3Tests : MessagingTest {
         // given
         let callStates : [CallState] =  [.none, .incoming(video: false), .answered, .established, .outgoing, .terminating(reason: CallClosedReason.normal), .unknown]
         let notSecureMapping : [VoiceChannelV2State] = [.noActiveUsers, .incomingCall, .selfIsJoiningActiveChannel, .selfConnectedToActiveChannel, .outgoingCall, .noActiveUsers, .invalid]
-        let secureWithIgnoredMapping : [VoiceChannelV2State] = [.noActiveUsers, .incomingCallDegraded, .selfIsJoiningActiveChannel, .selfConnectedToActiveChannel, .outgoingCallDegraded, .noActiveUsers, .invalid]
+        let secureWithIgnoredMapping : [VoiceChannelV2State] = [.noActiveUsers, .incomingCallDegraded, .selfIsJoiningActiveChannelDegraded, .selfConnectedToActiveChannel, .outgoingCallDegraded, .noActiveUsers, .invalid]
         
         // then
         XCTAssertEqual(callStates.map({ $0.voiceChannelState(securityLevel: .notSecure)}), notSecureMapping)

--- a/Tests/Source/Calling/ZMCallStateTests+VideoCalling.swift
+++ b/Tests/Source/Calling/ZMCallStateTests+VideoCalling.swift
@@ -28,6 +28,7 @@ class ZMCallStateTests : MessagingTest {
         // given
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
         conversation.conversationType = .oneOnOne
+        conversation.remoteIdentifier = UUID.create()
         self.uiMOC.saveOrRollback()
         
         // when

--- a/Tests/Source/Calling/ZMGSMCallHandlerTest.m
+++ b/Tests/Source/Calling/ZMGSMCallHandlerTest.m
@@ -48,6 +48,7 @@
     
     [self.syncMOC performGroupedBlockAndWait:^{
         self.activeSyncCallConversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
+        self.activeSyncCallConversation.remoteIdentifier = [NSUUID createUUID];
         self.activeSyncCallConversation.conversationType = ZMConversationTypeGroup;
         self.activeSyncCallConversation.callDeviceIsActive = YES;
         [self.activeSyncCallConversation resetHasLocalModificationsForCallDeviceIsActive];
@@ -57,6 +58,7 @@
     
     [self.syncMOC performGroupedBlockAndWait:^{
         self.inactiveSyncCallConversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
+        self.inactiveSyncCallConversation.remoteIdentifier = [NSUUID createUUID];
         self.inactiveSyncCallConversation.conversationType = ZMConversationTypeGroup;
         [self.syncMOC saveOrRollback];
     }];

--- a/Tests/Source/Synchronization/Transcoders/ZMCallStateTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMCallStateTranscoderTests.m
@@ -3733,10 +3733,13 @@
 
 - (void)testThatOnStartUpItSetsCallStateNeedsToBeUpdatedFromBackend_NotInterruptedbyGSMCall
 {
-    // given
     ZMConversation *conversation = self.syncSelfToUser1Conversation;
-    [[conversation mutableOrderedSetValueForKey:@"callParticipants"] addObject:self.syncOtherUser1];
-    [self.syncMOC saveOrRollback];
+    
+    // given
+    [self.syncMOC performGroupedBlockAndWait:^{
+        [[conversation mutableOrderedSetValueForKey:@"callParticipants"] addObject:self.syncOtherUser1];
+        [self.syncMOC saveOrRollback];
+    }];
     
     XCTAssertTrue(conversation.callParticipants.count > 0);
     XCTAssertFalse(conversation.callStateNeedsToBeUpdatedFromBackend);


### PR DESCRIPTION
We need degraded variant for the connecting state. This is handles the case when you find out the call is degraded after you've accepted the call.