### PR TITLE
Profile picture v3: Updating profile

### DIFF
--- a/Source/UserSession/UserProfileImageUpdateStatus.swift
+++ b/Source/UserSession/UserProfileImageUpdateStatus.swift
@@ -141,13 +141,16 @@ public final class UserProfileImageUpdateStatus: NSObject {
 // MARK: Main state transitions
 extension UserProfileImageUpdateStatus {
     internal func setState(state newState: ProfileUpdateState) {
-        let currentState = state
-        guard currentState.canTransition(to: newState) else {
-            // Trying to transition to invalid state - ignore
-            return
+        managedObjectContext.performGroupedBlock {
+
+            let currentState = self.state
+            guard currentState.canTransition(to: newState) else {
+                // Trying to transition to invalid state - ignore
+                return
+            }
+            self.state = newState
+            self.didTransition(from: currentState, to: newState)
         }
-        state = newState
-        didTransition(from: currentState, to: newState)
     }
     
     internal func didTransition(from oldState: ProfileUpdateState, to currentState: ProfileUpdateState) {
@@ -194,14 +197,16 @@ extension UserProfileImageUpdateStatus {
     }
     
     internal func setState(state newState: ImageState, for imageSize: ProfileImageSize) {
-        let currentState = imageState(for: imageSize)
-        guard currentState.canTransition(to: newState) else {
-            // Trying to transition to invalid state - ignore
-            return
+        managedObjectContext.performGroupedBlock {
+            let currentState = self.imageState(for: imageSize)
+            guard currentState.canTransition(to: newState) else {
+                // Trying to transition to invalid state - ignore
+                return
+            }
+            
+            self.imageState[imageSize] = newState
+            self.didTransition(from: currentState, to: newState, for: imageSize)
         }
-        
-        imageState[imageSize] = newState
-        didTransition(from: currentState, to: newState, for: imageSize)
     }
     
     internal func resetImageState() {

--- a/Source/UserSession/UserProfileImageUpdateStatus.swift
+++ b/Source/UserSession/UserProfileImageUpdateStatus.swift
@@ -166,8 +166,7 @@ extension UserProfileImageUpdateStatus {
     
     fileprivate func updateUserProfile(with previewAssetId: String, completeAssetId: String) {
         let selfUser = ZMUser.selfUser(in: managedObjectContext)
-        selfUser.previewProfileAssetIdentifier = previewAssetId
-        selfUser.completeProfileAssetIdentifier = completeAssetId
+        selfUser.updateAndSyncProfileAssetIdentifiers(previewIdentifier: previewAssetId, completeIdentifier: completeAssetId)
         managedObjectContext.saveOrRollback()
         setState(state: .ready)
     }

--- a/Source/UserSession/UserProfileImageUpdateStatus.swift
+++ b/Source/UserSession/UserProfileImageUpdateStatus.swift
@@ -54,6 +54,11 @@ internal protocol UserProfileImageUploadStatusProtocol: class {
     func updateImage(imageData: Data)
 }
 
+internal protocol UserProfileImageUploadStateChangeDelegate: class {
+    func didTransition(from oldState: UserProfileImageUpdateStatus.ProfileUpdateState, to currentState: UserProfileImageUpdateStatus.ProfileUpdateState)
+    func didTransition(from oldState: UserProfileImageUpdateStatus.ImageState, to currentState: UserProfileImageUpdateStatus.ImageState, for size: ProfileImageSize)
+}
+
 public final class UserProfileImageUpdateStatus: NSObject {
     
     internal enum ImageState {
@@ -62,7 +67,6 @@ public final class UserProfileImageUpdateStatus: NSObject {
         case upload(image: Data)
         case uploading
         case uploaded(assetId: String)
-        case completed
         case failed(UserProfileImageUpdateError)
         
         internal func canTransition(to newState: ImageState) -> Bool {
@@ -70,10 +74,9 @@ public final class UserProfileImageUpdateStatus: NSObject {
             case (.ready, .preprocessing),
                  (.preprocessing, .upload),
                  (.upload, .uploading),
-                 (.uploading, .uploaded),
-                 (.uploaded, .completed):
+                 (.uploading, .uploaded):
                 return true
-            case (.completed, .ready),
+            case (.uploaded, .ready),
                  (.failed, .ready):
                 return true
             case (.failed, .failed):
@@ -90,22 +93,17 @@ public final class UserProfileImageUpdateStatus: NSObject {
         case ready
         case preprocess(image: Data)
         case update(previewAssetId: String, completeAssetId: String)
-        case updating
-        case completed
         case failed(UserProfileImageUpdateError)
         
         internal func canTransition(to newState: ProfileUpdateState) -> Bool {
             switch (self, newState) {
             case (.ready, .preprocess),
-                 (.preprocess, .update),
-                 (.update, .updating),
-                 (.updating, .completed):
+                 (.preprocess, .update):
                 return true
-            case (.completed, .ready),
+            case (.update, .ready),
                  (.failed, .ready):
                 return true
-            case (.completed, .failed),
-                 (.failed, .failed):
+            case (.failed, .failed):
                 return false
             case (_, .failed):
                 return true
@@ -117,20 +115,24 @@ public final class UserProfileImageUpdateStatus: NSObject {
     
     internal var preprocessor: ZMAssetsPreprocessorProtocol?
     internal let queue: OperationQueue
-    
+    internal weak var changeDelegate: UserProfileImageUploadStateChangeDelegate?
+
     fileprivate var changeDelegates: [UserProfileImageUpdateStateDelegate] = []
     fileprivate var imageOwner: ImageOwner?
-    
+    fileprivate let managedObjectContext: NSManagedObjectContext
+
     fileprivate var imageState = [ProfileImageSize : ImageState]()
     internal fileprivate(set) var state: ProfileUpdateState = .ready
     
-    public convenience override init() {
-        self.init(preprocessor: ZMAssetsPreprocessor(delegate: nil), queue: ZMImagePreprocessor.createSuitableImagePreprocessingQueue())
+    public convenience init(managedObjectContext: NSManagedObjectContext) {
+        self.init(managedObjectContext: managedObjectContext, preprocessor: ZMAssetsPreprocessor(delegate: nil), queue: ZMImagePreprocessor.createSuitableImagePreprocessingQueue(), delegate: nil)
     }
     
-    internal init(preprocessor: ZMAssetsPreprocessorProtocol, queue: OperationQueue){
+    internal init(managedObjectContext: NSManagedObjectContext, preprocessor: ZMAssetsPreprocessorProtocol, queue: OperationQueue, delegate: UserProfileImageUploadStateChangeDelegate?){
         self.queue = queue
         self.preprocessor = preprocessor
+        self.managedObjectContext = managedObjectContext
+        self.changeDelegate = delegate
         super.init()
         self.preprocessor?.delegate = self
     }
@@ -149,14 +151,25 @@ extension UserProfileImageUpdateStatus {
     }
     
     internal func didTransition(from oldState: ProfileUpdateState, to currentState: ProfileUpdateState) {
+        changeDelegate?.didTransition(from: oldState, to: currentState)
         switch (oldState, currentState) {
         case let (_, .preprocess(image: data)):
             startPreprocessing(imageData: data)
+        case let (_, .update(previewAssetId: previewAssetId, completeAssetId: completeAssetId)):
+            updateUserProfile(with:previewAssetId, completeAssetId: completeAssetId)
         case (_, .failed):
             resetImageState()
         default:
             break
         }
+    }
+    
+    fileprivate func updateUserProfile(with previewAssetId: String, completeAssetId: String) {
+        let selfUser = ZMUser.selfUser(in: managedObjectContext)
+        selfUser.previewProfileAssetIdentifier = previewAssetId
+        selfUser.completeProfileAssetIdentifier = completeAssetId
+        managedObjectContext.saveOrRollback()
+        setState(state: .ready)
     }
     
     fileprivate func startPreprocessing(imageData: Data) {
@@ -189,14 +202,15 @@ extension UserProfileImageUpdateStatus {
         }
         
         imageState[imageSize] = newState
-        didTransition(from: currentState, to: newState)
+        didTransition(from: currentState, to: newState, for: imageSize)
     }
     
     internal func resetImageState() {
         imageState.removeAll()
     }
     
-    internal func didTransition(from oldState: ImageState, to currentState: ImageState) {
+    internal func didTransition(from oldState: ImageState, to currentState: ImageState, for size: ProfileImageSize) {
+        changeDelegate?.didTransition(from: oldState, to: currentState, for: size)
         switch (oldState, currentState) {
         case (_, .uploaded):
             // When one image is uploaded we check state of all other images
@@ -207,6 +221,7 @@ extension UserProfileImageUpdateStatus {
             case let (.uploaded(assetId: previewAssetId), .uploaded(assetId: completeAssetId)):
                 // If both images are uploaded we can update profile
                 setState(state: .update(previewAssetId: previewAssetId, completeAssetId: completeAssetId))
+                resetImageState()
             default:
                 break // Need to wait until both images are uploaded
             }

--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -358,7 +358,7 @@ ZM_EMPTY_ASSERTING_INIT()
             self.onDemandFlowManager = [[ZMOnDemandFlowManager alloc] initWithMediaManager:mediaManager];
             self.proxiedRequestStatus = [[ProxiedRequestsStatus alloc] initWithRequestCancellation:self.transportSession];
             
-            self.profileImageUpdateStatus = [[UserProfileImageUpdateStatus alloc] init];
+            self.profileImageUpdateStatus = [[UserProfileImageUpdateStatus alloc] initWithManagedObjectContext:self.syncManagedObjectContext];
         }];
         
         _application = application;

--- a/Tests/Source/Synchronization/Transcoders/ZMSelfTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMSelfTranscoderTests.m
@@ -295,44 +295,72 @@
 
 @implementation ZMSelfTranscoderTests (UpstreamSync)
 
-- (void)testThatItGeneratesARequestForUpdatingChangedSelfUser
+- (void)testThatItGeneratesARequestForUpdatingAssetsInSelfUser
 {
+    NSString *previewKey = @"new-key-1";
+    NSString *completeKey = @"new-key-2";
     NSDictionary* uploadPayload = @{
-                                    @"name" : @"My new name testThatItGeneratesARequestForUpdatingChangedSelfUser",
-                                    @"accent_id" : @(ZMAccentColorBrightYellow)
+                                    @"assets" : @[
+                                            @{@"size" : @"preview", @"type" : @"image", @"key" : previewKey },
+                                            @{@"size" : @"complete", @"type" : @"image", @"key" : completeKey }
+                                            ],
                                     };
     
-    [self checkThatItGeneratesUpstreamUpdateRequestWithPayload:uploadPayload changedKeys:[NSSet setWithObjects:@"name", @"accentColorValue", nil]];
+    [self checkThatItGeneratesUpstreamUpdateRequestWithPayload:uploadPayload changedKeys:[NSSet setWithObjects:@"previewProfileAssetIdentifier", @"completeProfileAssetIdentifier", nil] userChangeBlock:^(ZMUser *user) {
+        user.previewProfileAssetIdentifier = previewKey;
+        user.completeProfileAssetIdentifier = completeKey;
+    }];
 }
 
 
-- (void)testThatItGeneratesARequestForUpdatingJustTheNameInChangedSelfUser
+- (void)testThatItGeneratesARequestForUpdatingChangedSelfUser
 {
+    NSString *name = @"My new name testThatItGeneratesARequestForUpdatingChangedSelfUser";
+    ZMAccentColor accentColor = ZMAccentColorBrightYellow;
     NSDictionary* uploadPayload = @{
-                                    @"name" : @"My new name testThatItGeneratesARequestForUpdatingJustTheNameInChangedSelfUser",
+                                    @"name" : name,
+                                    @"accent_id" : @(accentColor)
                                     };
     
-    [self checkThatItGeneratesUpstreamUpdateRequestWithPayload:uploadPayload changedKeys:[NSSet setWithObjects:@"name", nil]];
+    [self checkThatItGeneratesUpstreamUpdateRequestWithPayload:uploadPayload changedKeys:[NSSet setWithObjects:@"name", @"accentColorValue", nil] userChangeBlock:^(ZMUser *user) {
+        user.name = name;
+        user.accentColorValue = accentColor;
+    }];
+}
+
+- (void)testThatItGeneratesARequestForUpdatingJustTheNameInChangedSelfUser
+{
+    NSString *name = @"My new name testThatItGeneratesARequestForUpdatingJustTheNameInChangedSelfUser";
+
+    NSDictionary* uploadPayload = @{
+                                    @"name" : name
+                                    };
+    
+    [self checkThatItGeneratesUpstreamUpdateRequestWithPayload:uploadPayload changedKeys:[NSSet setWithObjects:@"name", nil] userChangeBlock:^(ZMUser *user) {
+        user.name = name;
+    }];
 }
 
 
 - (void)testThatItGeneratesARequestForUpdatingJustTheAccentColorInChangedSelfUser
 {
+    ZMAccentColor accentColor = ZMAccentColorBrightYellow;
     NSDictionary* uploadPayload = @{
-                                    @"accent_id" : @(ZMAccentColorBrightYellow)
+                                    @"accent_id" : @(accentColor)
                                     };
     
-    [self checkThatItGeneratesUpstreamUpdateRequestWithPayload:uploadPayload changedKeys:[NSSet setWithObjects:@"accentColorValue", nil]];
+    [self checkThatItGeneratesUpstreamUpdateRequestWithPayload:uploadPayload changedKeys:[NSSet setWithObjects:@"accentColorValue", nil] userChangeBlock:^(ZMUser *user) {
+        user.accentColorValue = accentColor;
+    }];
 }
 
-- (void)checkThatItGeneratesUpstreamUpdateRequestWithPayload:(NSDictionary *)expectedPayload changedKeys:(NSSet *)changedKeys
+- (void)checkThatItGeneratesUpstreamUpdateRequestWithPayload:(NSDictionary *)expectedPayload changedKeys:(NSSet *)changedKeys userChangeBlock:(void (^)(ZMUser *))userChangeBlock
 {
     
     [self.syncMOC performGroupedBlockAndWait:^{
         // given
         ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
-        selfUser.name = expectedPayload[@"name"] ?: @"Random User";
-        selfUser.accentColorValue = (ZMAccentColor) [(expectedPayload[@"accent_id"] ?: @(ZMAccentColorSoftPink)) integerValue];
+        userChangeBlock(selfUser);
         
         // when
         NSSet *updatedKeys = changedKeys;

--- a/Tests/Source/UserSession/UserProfileImageUpdateStatusTests.swift
+++ b/Tests/Source/UserSession/UserProfileImageUpdateStatusTests.swift
@@ -191,7 +191,8 @@ extension UserProfileImageUpdateStatusTests {
     func testThatImageStateCanTransitionToValidState() {
         // WHEN
         sut.setState(state: .preprocessing, for: .complete)
-        
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
         // THEN
         XCTAssertEqual(sut.imageState(for: .complete), .preprocessing)
         XCTAssertEqual(sut.imageState(for: .preview), .ready)
@@ -200,7 +201,8 @@ extension UserProfileImageUpdateStatusTests {
     func testThatImageStateDoesntTransitionToInvalidState() {
         // WHEN
         sut.setState(state: .uploading, for: .preview)
-        
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
         // THEN
         XCTAssertEqual(sut.imageState(for: .preview), .ready)
         XCTAssertEqual(sut.imageState(for: .complete), .ready)
@@ -209,7 +211,8 @@ extension UserProfileImageUpdateStatusTests {
     func testThatImageStateMaintainsSeparateStatesForDifferentSizes() {
         // WHEN
         sut.setState(state: .preprocessing, for: .preview)
-        
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
         // THEN
         XCTAssertEqual(sut.imageState(for: .preview), .preprocessing)
         XCTAssertEqual(sut.imageState(for: .complete), .ready)
@@ -224,6 +227,8 @@ extension UserProfileImageUpdateStatusTests {
         sut.setState(state: sampleUploadState, for: .complete)
         sut.setState(state: .uploading, for: .preview)
         sut.setState(state: .uploading, for: .complete)
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
         XCTAssertEqual(sut.imageState(for: .preview), .uploading)
         XCTAssertEqual(sut.imageState(for: .complete), .uploading)
         let delegate = MockChangeDelegate()
@@ -235,6 +240,7 @@ extension UserProfileImageUpdateStatusTests {
         sut.changeDelegate = delegate
         sut.setState(state: .uploaded(assetId: previewAssetId), for: .preview)
         sut.setState(state: .uploaded(assetId: completeAssetId), for: .complete)
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // THEN
         let states: [ProfileUpdateState] = [.update(previewAssetId: previewAssetId, completeAssetId: completeAssetId), .ready]
@@ -246,6 +252,7 @@ extension UserProfileImageUpdateStatusTests {
         sut.setState(state: .preprocessing, for: .preview)
         sut.setState(state: sampleUploadState, for: .preview)
         sut.setState(state: sampleFailedImageState, for: .preview)
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // THEN
         XCTAssertEqual(sut.state, .failed(.preprocessingFailed))
@@ -269,7 +276,8 @@ extension UserProfileImageUpdateStatusTests {
     func testThatProfileUpdateStateCanTransitionToValidState() {
         // WHEN
         sut.setState(state: samplePreprocessState)
-        
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
         // THEN
         XCTAssertEqual(sut.state, samplePreprocessState)
     }
@@ -277,7 +285,8 @@ extension UserProfileImageUpdateStatusTests {
     func testThatProfileUpdateStateDoesntTransitionToInvalidState() {
         // WHEN
         sut.setState(state: sampleUpdateState)
-        
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
         // THEN
         XCTAssertEqual(sut.state, .ready)
     }
@@ -289,6 +298,7 @@ extension UserProfileImageUpdateStatusTests {
 
         // WHEN
         sut.setState(state: .failed(.preprocessingFailed))
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // THEN
         XCTAssertEqual(sut.state, .failed(.preprocessingFailed))
@@ -302,6 +312,7 @@ extension UserProfileImageUpdateStatusTests {
     func testThatItSetsPreprocessorDelegateWhenProcessing() {
         // WHEN
         sut.updateImage(imageData: tinyImage)
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // THEN
         XCTAssertNotNil(preprocessor.delegate)
@@ -310,6 +321,7 @@ extension UserProfileImageUpdateStatusTests {
     func testThatItAsksPreprocessorForOperationsWithCorrectImageOwner() {
         // WHEN
         sut.updateImage(imageData: tinyImage)
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // THEN
         XCTAssertTrue(preprocessor.operationsCalled)
@@ -324,6 +336,7 @@ extension UserProfileImageUpdateStatusTests {
         
         // WHEN
         sut.updateImage(imageData: tinyImage)
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // THEN
         XCTAssertEqual(sut.state, .failed(.preprocessingFailed))
@@ -354,14 +367,16 @@ extension UserProfileImageUpdateStatusTests {
 
         // WHEN
         sut.completedDownsampleOperation(previewOperation, imageOwner: imageOwner)
-        
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
         // THEN
         XCTAssertEqual(sut.imageState(for: .preview), .upload(image: previewOperation.downsampleImageData))
         XCTAssertEqual(sut.imageState(for: .complete), .preprocessing)
 
         // WHEN
         sut.completedDownsampleOperation(completeOperation, imageOwner: imageOwner)
-        
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
         // THEN
         XCTAssertEqual(sut.imageState(for: .preview), .upload(image: previewOperation.downsampleImageData))
         XCTAssertEqual(sut.imageState(for: .complete), .upload(image: completeOperation.downsampleImageData))
@@ -374,7 +389,8 @@ extension UserProfileImageUpdateStatusTests {
         
         // WHEN
         sut.failedPreprocessingImageOwner(imageOwner)
-        
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
         // THEN
         XCTAssertEqual(sut.state, .failed(.preprocessingFailed))
         XCTAssertEqual(sut.imageState(for: .preview), .ready)
@@ -384,6 +400,7 @@ extension UserProfileImageUpdateStatusTests {
     func testThatItIsNotPossibleToStartPreprocessingAgainIfProfileUpdateFails() {
         // GIVEN
         sut.updateImage(imageData: Data())
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         XCTAssertEqual(sut.state, .preprocess(image: Data()))
         XCTAssertEqual(sut.imageState(for: .preview), .preprocessing)
         XCTAssertEqual(sut.imageState(for: .complete), .preprocessing)
@@ -391,7 +408,8 @@ extension UserProfileImageUpdateStatusTests {
 
         // WHEN
         sut.updateImage(imageData: Data())
-        
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
         // THEN
         XCTAssertEqual(sut.state, .failed(.preprocessingFailed))
         XCTAssertEqual(sut.imageState(for: .preview), .ready)
@@ -412,6 +430,7 @@ extension UserProfileImageUpdateStatusTests {
         XCTAssertFalse(sut.hasImageToUpload(for: .preview))
         sut.setState(state: .preprocessing, for: .preview)
         sut.setState(state: .upload(image: Data()), for: .preview)
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // THEN
         XCTAssertTrue(sut.hasImageToUpload(for: .preview))
@@ -423,11 +442,13 @@ extension UserProfileImageUpdateStatusTests {
         let data = "some".data(using: .utf8)!
         sut.setState(state: .preprocessing, for: .preview)
         sut.setState(state: .upload(image: data), for: .preview)
-        
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
         // WHEN
         let dataToUpload = sut.consumeImage(for: .preview)
         XCTAssertNil(sut.consumeImage(for: .complete))
-        
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
         // THEN
         XCTAssertEqual(data, dataToUpload)
         XCTAssertEqual(sut.imageState(for: .preview), .uploading)
@@ -442,7 +463,8 @@ extension UserProfileImageUpdateStatusTests {
         // WHEN
         let assetId = "1234"
         sut.uploadingDone(imageSize: .preview, assetId: assetId)
-        
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
         // THEN
         XCTAssertEqual(sut.imageState(for: .preview), .uploaded(assetId: assetId))
     }
@@ -455,9 +477,32 @@ extension UserProfileImageUpdateStatusTests {
         
         // WHEN
         sut.uploadingFailed(imageSize: .preview, error: MockUploadError.failed)
-        
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
         // THEN
         XCTAssertEqual(sut.imageState(for: .preview), .ready)
         XCTAssertEqual(sut.state, .failed(.uploadFailed(MockUploadError.failed)))
+    }
+}
+
+// MARK: - User profile update
+extension UserProfileImageUpdateStatusTests {
+    func testThatItUpdatesUserProfileAndMarksPropertiesToBeUploaded() {
+        // GIVEN
+        preprocessor.operations = [Operation()]
+        let previewId = "foo"
+        let completeId = "bar"
+        sut.setState(state: .preprocess(image: Data()))
+        
+        // WHEN
+        sut.setState(state: .update(previewAssetId: previewId, completeAssetId: completeId))
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // THEN
+        let selfUser = ZMUser.selfUser(in: syncMOC)
+        XCTAssertEqual(selfUser.previewProfileAssetIdentifier, previewId)
+        XCTAssertEqual(selfUser.completeProfileAssetIdentifier, completeId)
+        XCTAssert(selfUser.hasLocalModifications(forKey: #keyPath(ZMUser.previewProfileAssetIdentifier)))
+        XCTAssert(selfUser.hasLocalModifications(forKey: #keyPath(ZMUser.completeProfileAssetIdentifier)))
     }
 }


### PR DESCRIPTION
* Updated SelfTranscoder to pick up changes for profile picture assets
* Removed some states from the `UserProfileImageUpdateStatus` that are not relevant anymore because it is handled by SelfTranscoder
* Made sure we run on sync thread and sprinkled tests with `waitForAllGroupsToBeEmpty`