### PR TITLE
Mark connected users to be re-downloaded in HotFix

### DIFF
--- a/Source/Synchronization/ZMHotFixDirectory+Swift.swift
+++ b/Source/Synchronization/ZMHotFixDirectory+Swift.swift
@@ -91,9 +91,7 @@ extension ZMHotFixDirectory {
         }
     }
 
-    /// We need to refetch all connected users as they might alreday have updated their username (62.3.1) or uploaded profile
-    /// pictures using the /assets/v3 endpoint which we do not yet have locally and couldn't download before we updated to
-    /// a version supporting them. 
+    /// Marks all connected users (including self) to be refetched.
     /// Unconnected users are refreshed with a call to `refreshData` when information is displayed.
     /// See also the related `ZMUserSession.isPendingHotFixChanges` in `ZMHotFix+PendingChanges.swift`.
     public static func refetchConnectedUsers(_ context: NSManagedObjectContext) {

--- a/Source/Synchronization/ZMHotFixDirectory+Swift.swift
+++ b/Source/Synchronization/ZMHotFixDirectory+Swift.swift
@@ -91,8 +91,11 @@ extension ZMHotFixDirectory {
         }
     }
 
-    /// We need to refetch all connected users as they might alreday have updated their username before we updated to
-    /// a version supporting them. Unconnected users are refreshed with a call to `refreshData` when information is displayed.
+    /// We need to refetch all connected users as they might alreday have updated their username (62.3.1) or uploaded profile
+    /// pictures using the /assets/v3 endpoint which we do not yet have locally and couldn't download before we updated to
+    /// a version supporting them. 
+    /// Unconnected users are refreshed with a call to `refreshData` when information is displayed.
+    /// See also the related `ZMUserSession.isPendingHotFixChanges` in `ZMHotFix+PendingChanges.swift`.
     public static func refetchConnectedUsers(_ context: NSManagedObjectContext) {
         let predicate = NSPredicate(format: "connection != nil")
         let request = ZMUser.sortedFetchRequest(with: predicate)

--- a/Source/Synchronization/ZMHotFixDirectory.m
+++ b/Source/Synchronization/ZMHotFixDirectory.m
@@ -90,18 +90,24 @@ static NSString* ZMLogTag ZM_UNUSED = @"HotFix";
                      patchCode:^(__unused NSManagedObjectContext *context) {
                         [ZMHotFixDirectory purgePINCachesInHostBundle];
                     }],
+
+                    /// Introduction of usernames: We need to refetch all connected users as they might already
+                    /// have updated their username before we updated to a version supporting them.
                     [ZMHotFixPatch
-                     patchWithVersion:@"62.3.1" // Username added
+                     patchWithVersion:@"62.3.1"
                      patchCode:^(NSManagedObjectContext *context) {
                          [ZMHotFixDirectory refetchConnectedUsers:context];
                      }],
+
+                    /// Introcution of Asset V3 Profile Pictures: We need to refetch all connected users as they might
+                    /// already have uploaded profile pictures using the /assets/v3 endpoint which we do not yet have
+                    /// locally and couldn't download before we updated to a version supporting them.
                     [ZMHotFixPatch
-                     patchWithVersion:@"76.0.0" // Asset v3 profile pictures
+                     patchWithVersion:@"76.0.0"
                      patchCode:^(NSManagedObjectContext *context) {
                          [ZMHotFixDirectory refetchConnectedUsers:context];
                      }],
-                    ]
-                    ;
+                    ];
     });
     return patches;
 }

--- a/Source/Synchronization/ZMHotFixDirectory.m
+++ b/Source/Synchronization/ZMHotFixDirectory.m
@@ -91,10 +91,15 @@ static NSString* ZMLogTag ZM_UNUSED = @"HotFix";
                         [ZMHotFixDirectory purgePINCachesInHostBundle];
                     }],
                     [ZMHotFixPatch
-                     patchWithVersion:@"62.3.1"
+                     patchWithVersion:@"62.3.1" // Username added
                      patchCode:^(NSManagedObjectContext *context) {
                          [ZMHotFixDirectory refetchConnectedUsers:context];
-                     }]
+                     }],
+                    [ZMHotFixPatch
+                     patchWithVersion:@"76.0.0" // Asset v3 profile pictures
+                     patchCode:^(NSManagedObjectContext *context) {
+                         [ZMHotFixDirectory refetchConnectedUsers:context];
+                     }],
                     ]
                     ;
     });


### PR DESCRIPTION
# What's in this PR?

* We need to refetch all connected users as they might alreday have uploaded profile pictures using the `/assets/v3` endpoint which we do not yet have locally and couldn't download before we updated to the latest version (The update event has already been processed so the client won't know about the new picture). The `selfUser` might have uploaded a picture using the new endpoint form a different client as well in the meantime and we need to re-download it. This might lead to a race condition, e.g. we want to migrate the profile picture from the old endpoint to the new one if the user does not yet have a v3 asset, but we need to ensure that we re-download the `selfUser` first, otherwise we might redundantly re-upload a picture that was already uploaded from a different client, or, worse upload an old profile picture that is not up-to-date anymore using the new endpoint.
* The same `HotFix` was used with the introduction of usernames, where the client needed to re-download all users to update their usernames which might have been updated in the meantime but could not be processed.