### PR TITLE
Re-upload existing image when user does not have v3 image yet

### DIFF
--- a/Source/Synchronization/ZMSyncStrategy.m
+++ b/Source/Synchronization/ZMSyncStrategy.m
@@ -103,6 +103,7 @@
 
 @property (nonatomic, weak) ZMAuthenticationStatus *authenticationStatus;
 @property (nonatomic, weak) ZMClientRegistrationStatus *clientRegistrationStatus;
+@property (nonatomic, weak) UserProfileImageUpdateStatus *profileImageStatus;
 @property (nonatomic) NotificationDispatcher *notificationDispatcher;
 
 @end
@@ -146,6 +147,7 @@ ZM_EMPTY_ASSERTING_INIT()
         self.localNotificationDispatcher = localNotificationsDispatcher;
         self.authenticationStatus = authenticationStatus;
         self.clientRegistrationStatus = clientRegistrationStatus;
+        self.profileImageStatus = profileImageStatus;
         self.syncMOC = syncMOC;
         self.uiMOC = uiMOC;
         self.eventMOC = [NSManagedObjectContext createEventContextWithAppGroupIdentifier:appGroupIdentifier];
@@ -521,7 +523,7 @@ ZM_EMPTY_ASSERTING_INIT()
             }
             return nil;
         }]];
-        _allChangeTrackers = [_allChangeTrackers arrayByAddingObject:self.conversationStatusSync];
+        _allChangeTrackers = [_allChangeTrackers arrayByAddingObjectsFromArray:@[self.conversationStatusSync, self.profileImageStatus]];
     }
     
     return _allChangeTrackers;

--- a/Source/UserSession/UserProfileImageUpdateStatus.swift
+++ b/Source/UserSession/UserProfileImageUpdateStatus.swift
@@ -249,7 +249,7 @@ extension UserProfileImageUpdateStatus: UserProfileImageUpdateProtocol {
     }
 }
 
-// Called internally with existing image data to reupload to v3 (no proprocessing needed)
+// Called internally with existing image data to reupload to v3 (no preprocessing needed)
 extension UserProfileImageUpdateStatus: ZMContextChangeTracker {
 
     public func objectsDidChange(_ object: Set<NSManagedObject>) {


### PR DESCRIPTION
# What's in this PR?

* Add function to re-upload existing user images without preprocessing them again.
* `UserProfileImageUpdateStatus` is a `ZMContextChangeTracker` now and will check if it needs to re-upload the image to v3 if the self user changes, does not need to be updated from the backend and if there are  no medium and small image data as well as no asset v3 identifiers in the database yet.
* This functionality is still missing integration tests (which in turn require `wire-ios-mocktransport` to handle the v3 upload).