### PR TITLE
Unify API to set a profile picture

### DIFF
--- a/Source/UserSession/UserProfileImageUpdateStatus.swift
+++ b/Source/UserSession/UserProfileImageUpdateStatus.swift
@@ -239,11 +239,14 @@ extension UserProfileImageUpdateStatus {
 
 extension UserProfileImageUpdateStatus: UserProfileImageUpdateProtocol {
     public func updateImage(imageData: Data) {
-        guard let uiMOC = managedObjectContext.zm_userInterface else { return }
-        let editableUser = ZMUser.selfUser(in: uiMOC) as ZMEditableUser
-        editableUser.originalProfileImageData = imageData
-
-        setState(state: .preprocess(image: imageData))
+        managedObjectContext.performGroupedBlock {
+            guard let uiMOC = self.managedObjectContext.zm_userInterface else { return }
+            uiMOC.performGroupedBlock {
+                let editableUser = ZMUser.selfUser(in: uiMOC) as ZMEditableUser
+                editableUser.originalProfileImageData = imageData
+                self.setState(state: .preprocess(image: imageData))
+            }
+        }
     }
 }
 

--- a/Source/UserSession/UserProfileImageUpdateStatus.swift
+++ b/Source/UserSession/UserProfileImageUpdateStatus.swift
@@ -239,6 +239,10 @@ extension UserProfileImageUpdateStatus {
 
 extension UserProfileImageUpdateStatus: UserProfileImageUpdateProtocol {
     public func updateImage(imageData: Data) {
+        guard let uiMOC = managedObjectContext.zm_userInterface else { return }
+        let editableUser = ZMUser.selfUser(in: uiMOC) as ZMEditableUser
+        editableUser.originalProfileImageData = imageData
+
         setState(state: .preprocess(image: imageData))
     }
 }

--- a/Tests/Source/UserSession/UserProfileImageUpdateStatusTests.swift
+++ b/Tests/Source/UserSession/UserProfileImageUpdateStatusTests.swift
@@ -356,6 +356,21 @@ extension UserProfileImageUpdateStatusTests {
         // THEN 
         XCTAssertTrue(self.waitForCustomExpectations(withTimeout: 0.5))
     }
+
+    func testThatItSetsTheOriginalProfileImageDataOnTheSelfUser() {
+        // GIVEN
+        let selfUser = ZMUser.selfUser(in: uiMOC)
+        let oldData = selfUser.originalProfileImageData
+        let newData = mediumJPEGData()
+        XCTAssertNotEqual(oldData, newData)
+
+        // WHEN
+        sut.updateImage(imageData: newData)
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // THEN
+        XCTAssertEqual(selfUser.originalProfileImageData, newData)
+    }
     
     func testThatAfterDownsamplingImageItSetsCorrectState() {
         // GIVEN


### PR DESCRIPTION
# What's in this PR?

Unify the API to change a profile picture. The UI is supposed to call
```swift 
UserProfileImageUpdateStatus.updateImage(imageData: newProfileImageData)
```
in order to upload a new profile image, using this API ensures we update the user profile with v3 and the deprecated method which does not use `/assets/v3`.


