### PR TITLE
Fix call APNS after app is killed

### DIFF
--- a/Tests/Source/Calling/ZMFlowSyncTests.m
+++ b/Tests/Source/Calling/ZMFlowSyncTests.m
@@ -565,6 +565,36 @@ static NSString * const FlowEventName2 = @"conversation.member-join";
     XCTAssertTrue(request.shouldCompress);
 }
 
+- (void)testThatItAllowsRequestForCallsConfigWhenPushChannelIsClosed
+{
+    // given
+    [[[self.internalFlowManager stub] andReturnValue:@YES] isReady];
+    [self simulatePushChannelClose];
+    [self.sut requestWithPath:@"/calls/config" method:@"GET" mediaType:nil content:nil context:nil];
+    WaitForAllGroupsToBeEmpty(0.5);
+    
+    // when
+    ZMTransportRequest *request = [self.sut nextRequest];
+    
+    // then
+    XCTAssertEqual(request.path, @"/calls/config");
+}
+
+- (void)testThatItRejectsRequestWhenPushChannelIsClosed
+{
+    // given
+    [[[self.internalFlowManager stub] andReturnValue:@YES] isReady];
+    [self simulatePushChannelClose];
+    [self.sut requestWithPath:@"/calls/foo" method:@"GET" mediaType:nil content:nil context:nil];
+    WaitForAllGroupsToBeEmpty(0.5);
+    
+    // when
+    ZMTransportRequest *request = [self.sut nextRequest];
+    
+    // then
+    XCTAssertNil(request);
+}
+
 @end
 
 


### PR DESCRIPTION
When we receive a call after having killed the app we didn't display incoming
call notification because AVS wasn't ready to process calling messages. The
reason for this is that we weren't sending the calls/config request which AVS
needs to complete before it can do anything.

This PR allows this request to be made at all times. Previously it wasn't
made since the push channel wasn't open.

https://wearezeta.atlassian.net/browse/ZIOS-8282