### PR TITLE
Update call system message logic

### DIFF
--- a/Source/UserSession/CallStateObserver.swift
+++ b/Source/UserSession/CallStateObserver.swift
@@ -120,7 +120,7 @@ private final class CallingSystemMessageGenerator {
             let caller = callers[conversation] ?? sender
             conversation.appendMissedCallMessage(fromUser: caller, at: Date())
         case .terminating(reason: .timeout):
-            conversation.appendMissedCallMessage(fromUser: sender, at: Date())
+            conversation.appendPerformedCallMessage(with: 0, caller: sender)
         default:
             break
         }

--- a/Tests/Source/Calling/CallStateObserverTests.swift
+++ b/Tests/Source/Calling/CallStateObserverTests.swift
@@ -99,7 +99,7 @@ class CallStateObserverTests : MessagingTest {
         }
     }
     
-    func testThatMissedCallMessageIsAppendedForCallsThatTimeout() {
+    func testThatPerformedCallMessageIsAppendedForCallsThatTimeout() {
         
         // given when
         sut.callCenterDidChange(callState: .terminating(reason: .timeout), conversationId: conversation.remoteIdentifier!, userId: sender.remoteIdentifier!)
@@ -107,7 +107,7 @@ class CallStateObserverTests : MessagingTest {
         
         // then
         if let message =  conversation.messages.lastObject as? ZMSystemMessage {
-            XCTAssertEqual(message.systemMessageType, .missedCall)
+            XCTAssertEqual(message.systemMessageType, .performedCall)
             XCTAssertEqual(message.sender, sender)
         } else {
             XCTFail()


### PR DESCRIPTION
This PR contains two changes

1. We didn't insert a call system message when you canceled an outgoing call
2. The rules for when to insert a missed call vs. performed call has changed.

The rules are now the following
missed call system message: only inserted for unanswered incoming calls
performed call system message: inserted for all outgoing calls and for connected incoming calls.

https://wearezeta.atlassian.net/browse/ZIOS-8313