### PR TITLE
Fix liking a message from a push notification

### DIFF
--- a/Source/Public/zmessaging.h
+++ b/Source/Public/zmessaging.h
@@ -69,4 +69,5 @@
 #import <zmessaging/VoiceChannelV2+VideoCalling.h>
 #import <zmessaging/VoiceChannelV2+CallFlow.h>
 #import <zmessaging/ZMAVSBridge.h>
-
+#import <zmessaging/ZMUserSession+OperationLoop.h>
+#import <zmessaging/ZMOperationLoop+Background.h>

--- a/Source/UserSession/ZMUserSession+Background.m
+++ b/Source/UserSession/ZMUserSession+Background.m
@@ -204,6 +204,7 @@ static NSString *ZMLogTag = @"Push";
     }
     if ([identifier isEqualToString:ZMMessageLikeAction]) {
         [self likeMessageForNotification:notification WithCompletionHandler:completionHandler];
+        return;
     }
     
     if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_8_4) {

--- a/Source/UserSession/ZMUserSession+Background.m
+++ b/Source/UserSession/ZMUserSession+Background.m
@@ -194,28 +194,22 @@ static NSString *ZMLogTag = @"Push";
 
 - (void)application:(id<ZMApplication>)application handleActionWithIdentifier:(NSString *)identifier forLocalNotification:(UILocalNotification *)notification responseInfo:(NSDictionary *)responseInfo completionHandler:(void(^)())completionHandler;
 {
+    double version = floor(NSFoundationVersionNumber);
+
     if ([identifier isEqualToString:ZMCallIgnoreAction]){
         [self ignoreCallForNotification:notification withCompletionHandler:completionHandler];
-        return;
     }
-    if ([identifier isEqualToString:ZMConversationMuteAction]) {
+    else if ([identifier isEqualToString:ZMConversationMuteAction]) {
         [self muteConversationForNotification:notification withCompletionHandler:completionHandler];
-        return;
     }
-    if ([identifier isEqualToString:ZMMessageLikeAction]) {
+    else if ([identifier isEqualToString:ZMMessageLikeAction]) {
         [self likeMessageForNotification:notification WithCompletionHandler:completionHandler];
-        return;
     }
-    
-    if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_8_4) {
+    else if ([identifier isEqualToString:ZMConversationDirectReplyAction] && version > NSFoundationVersionNumber_iOS_8_4) {
         NSString *textInput = [responseInfo optionalStringForKey:UIUserNotificationActionResponseTypedTextKey];
-        if ([identifier isEqualToString:ZMConversationDirectReplyAction]) {
-            [self replyToNotification:notification withReply:textInput completionHandler:completionHandler];
-            return;
-        }
+        [self replyToNotification:notification withReply:textInput completionHandler:completionHandler];
     }
-    
-    if (application.applicationState == UIApplicationStateInactive) {
+    else if (application.applicationState == UIApplicationStateInactive) {
         self.pendingLocalNotification = [[ZMStoredLocalNotification alloc] initWithNotification:notification
                                                                            managedObjectContext:self.managedObjectContext
                                                                                actionIdentifier:identifier
@@ -224,7 +218,7 @@ static NSString *ZMLogTag = @"Push";
             [self didEnterEventProcessingState:nil];
         }
     }
-    if (completionHandler != nil) {
+    else if (completionHandler != nil) {
         completionHandler();
     }
 }

--- a/Source/UserSession/ZMUserSession+Internal.h
+++ b/Source/UserSession/ZMUserSession+Internal.h
@@ -78,7 +78,6 @@ extern NSString * const ZMAppendAVSLogNotificationName;
 @interface ZMUserSession (Internal) 
 
 @property (nonatomic, readonly) BOOL isLoggedIn;
-@property (nonatomic, readonly) ZMOperationLoop *operationLoop;
 @property (nonatomic, readonly) NSManagedObjectContext *managedObjectContext;
 @property (nonatomic, readonly) ZMTransportSession *transportSession;
 @property (nonatomic, readonly) NSManagedObjectContext *syncManagedObjectContext;

--- a/Source/UserSession/ZMUserSession+OperationLoop.h
+++ b/Source/UserSession/ZMUserSession+OperationLoop.h
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
+// Copyright (C) 2017 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/Source/UserSession/ZMUserSession+OperationLoop.h
+++ b/Source/UserSession/ZMUserSession+OperationLoop.h
@@ -1,0 +1,26 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+#import "ZMUserSession.h"
+
+@interface ZMUserSession (OperationLoop)
+
+@property (nonatomic, readonly) ZMOperationLoop *operationLoop;
+
+@end

--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -28,6 +28,7 @@
 #import "ZMUserSession+Background.h"
 
 #import "ZMUserSession+Internal.h"
+#import "ZMUserSession+OperationLoop.h"
 #import "ZMSyncStrategy.h"
 #import "NSError+ZMUserSessionInternal.h"
 #import "ZMCredentials.h"

--- a/zmessaging-cocoa.xcodeproj/project.pbxproj
+++ b/zmessaging-cocoa.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 		0932EA4D1AE6952A00D1BFD1 /* ZMAuthenticationStatus.h in Headers */ = {isa = PBXBuildFile; fileRef = 54F7217319A5F0C5009A8AF5 /* ZMAuthenticationStatus.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		093694451BA9633300F36B3A /* UserClientRequestFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 093694441BA9633300F36B3A /* UserClientRequestFactoryTests.swift */; };
 		094CDBED1B84D0A1004AD7BF /* ZMUnauthenticatedBackgroundState.h in Headers */ = {isa = PBXBuildFile; fileRef = 3EDDBB9B1A5ACEDE00A87E06 /* ZMUnauthenticatedBackgroundState.h */; };
-		094CDBEE1B84D0A1004AD7BF /* ZMBackgroundFetch.h in Headers */ = {isa = PBXBuildFile; fileRef = 3E4844BD1A94D74E00EF1E27 /* ZMBackgroundFetch.h */; };
+		094CDBEE1B84D0A1004AD7BF /* ZMBackgroundFetch.h in Headers */ = {isa = PBXBuildFile; fileRef = 3E4844BD1A94D74E00EF1E27 /* ZMBackgroundFetch.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		09531F161AE960E300B8556A /* ZMLoginCodeRequestTranscoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 09531F131AE960E300B8556A /* ZMLoginCodeRequestTranscoder.h */; };
 		09531F181AE960E300B8556A /* ZMLoginCodeRequestTranscoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 09531F141AE960E300B8556A /* ZMLoginCodeRequestTranscoder.m */; };
 		09531F1C1AE9644800B8556A /* ZMLoginCodeRequestTranscoderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 09531F1A1AE9644800B8556A /* ZMLoginCodeRequestTranscoderTests.m */; };
@@ -335,6 +335,8 @@
 		BF2A9D581D6B5BDB00FA7DBC /* StoreUpdateEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2A9D571D6B5BDB00FA7DBC /* StoreUpdateEventTests.swift */; };
 		BF2A9D5D1D6B63DB00FA7DBC /* StoreUpdateEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2A9D5A1D6B63DB00FA7DBC /* StoreUpdateEvent.swift */; };
 		BF2A9D611D6C70EA00FA7DBC /* ZMEventModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = BF2A9D5F1D6C70EA00FA7DBC /* ZMEventModel.xcdatamodeld */; };
+		BF36DDF11E8BACD400D61310 /* ZMUserSession+OperationLoop.h in Headers */ = {isa = PBXBuildFile; fileRef = BF36DDF01E8BACD400D61310 /* ZMUserSession+OperationLoop.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BF36DDF21E8BAE3C00D61310 /* ZMOperationLoop+Background.h in Headers */ = {isa = PBXBuildFile; fileRef = F962A8E819FFC06E00FD0F80 /* ZMOperationLoop+Background.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF44A3511C71D5FC00C6928E /* store127.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = BF44A3501C71D5FC00C6928E /* store127.wiredatabase */; };
 		BF603D201E76DE3B006E59CA /* ZMCommonContactsSearchDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = BF603D1F1E76DE3B006E59CA /* ZMCommonContactsSearchDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF6D5D031C4948830049F712 /* zmessaging124.momd in Resources */ = {isa = PBXBuildFile; fileRef = BF6D5D021C4948830049F712 /* zmessaging124.momd */; };
@@ -958,6 +960,7 @@
 		BF2A9D571D6B5BDB00FA7DBC /* StoreUpdateEventTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreUpdateEventTests.swift; sourceTree = "<group>"; };
 		BF2A9D5A1D6B63DB00FA7DBC /* StoreUpdateEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StoreUpdateEvent.swift; path = Decoding/StoreUpdateEvent.swift; sourceTree = "<group>"; };
 		BF2A9D601D6C70EA00FA7DBC /* ZMEventModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = ZMEventModel.xcdatamodel; sourceTree = "<group>"; };
+		BF36DDF01E8BACD400D61310 /* ZMUserSession+OperationLoop.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ZMUserSession+OperationLoop.h"; sourceTree = "<group>"; };
 		BF40AC711D096A0E00287E29 /* AnalyticsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsTests.swift; sourceTree = "<group>"; };
 		BF40AC7D1D0990A900287E29 /* ClusterizerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClusterizerTests.swift; sourceTree = "<group>"; };
 		BF44A3501C71D5FC00C6928E /* store127.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = store127.wiredatabase; sourceTree = "<group>"; };
@@ -1664,6 +1667,7 @@
 				F9FD798019EE73C500D70FCD /* VersionBlacklist */,
 				A9BABE5E19BA1EF300E9E5A3 /* Search */,
 				3EC2357F192B617700B72C21 /* ZMUserSession+Internal.h */,
+				BF36DDF01E8BACD400D61310 /* ZMUserSession+OperationLoop.h */,
 				54BAF1BC19212EBA008042FB /* ZMUserSession.m */,
 				549AEA3C1D6365C1003C0BEC /* ZMUserSession+AddressBook.swift */,
 				3E4F728219EC0D76002FE184 /* ZMUserSession+Background.m */,
@@ -2196,6 +2200,7 @@
 				8795A3D51B2EDE030047A067 /* ZMAVSBridge.h in Headers */,
 				165D3A291E1D43870052E654 /* VoiceChannelV2+Testing.h in Headers */,
 				F98EDCF41D82B924001E65CB /* ZMSpellOutSmallNumbersFormatter.h in Headers */,
+				BF36DDF11E8BACD400D61310 /* ZMUserSession+OperationLoop.h in Headers */,
 				F95706551DE5D6D50087442C /* ZMUserIDsForSearchDirectoryTable.h in Headers */,
 				094CDBEE1B84D0A1004AD7BF /* ZMBackgroundFetch.h in Headers */,
 				F98EDCDA1D82B913001E65CB /* ZMLocalNotification+Internal.h in Headers */,
@@ -2233,6 +2238,7 @@
 				87ADCE3B1DA6539F00CC06DC /* ZMCallKitDelegate.h in Headers */,
 				546E73EC1ADFD9F200AFF9BE /* ZMUserSessionAuthenticationNotification.h in Headers */,
 				546E73F21ADFDDFE00AFF9BE /* ZMUserSessionRegistrationNotification.h in Headers */,
+				BF36DDF21E8BAE3C00D61310 /* ZMOperationLoop+Background.h in Headers */,
 				16DCAD671B0F9447008C1DD9 /* NSURL+LaunchOptions.h in Headers */,
 				544BA1241A433DE400D3B852 /* ZMUserSession+Background.h in Headers */,
 				09531F161AE960E300B8556A /* ZMLoginCodeRequestTranscoder.h in Headers */,


### PR DESCRIPTION
# What's in this PR?

* We did not return after the call to kick off the like action, which could result in the completion handler being called too early.
* More importantly we did not start a proper background task on the `ZMOperationLoop`.
* Shuffled around some properties and include some files in the public header to expose the operation loop and relevant methods to Swift.
