### PR TITLE
Fixing test failures after mock transport update

### DIFF
--- a/Tests/Source/Data Model/ZMUser+Testing.m
+++ b/Tests/Source/Data Model/ZMUser+Testing.m
@@ -28,7 +28,7 @@
         return;
     }
     
-    if(self.isConnected) {
+    if(self.isSelfUser) {
         FHAssertEqualObjects(failureRecorder, self.emailAddress, user.email);
         FHAssertEqualObjects(failureRecorder, self.phoneNumber, user.phone);
     }

--- a/Tests/Source/Integration/SlowSyncTests.m
+++ b/Tests/Source/Integration/SlowSyncTests.m
@@ -341,14 +341,18 @@
         values = [[mockUser committedValuesForKeys:nil] copy];
     }];
     
+    BOOL emailAndPhoneMatches = YES;
+    if (user.isSelfUser) {
+        FHAssertEqualObjects(failureRecorder, user.emailAddress, values[@"email"]);
+        FHAssertEqualObjects(failureRecorder, user.phoneNumber, values[@"phone"]);
+        emailAndPhoneMatches = (user.emailAddress == values[@"email"] || [user.emailAddress isEqualToString:values[@"email"]]) &&
+                               (user.phoneNumber == values[@"phone"] || [user.phoneNumber isEqualToString:values[@"phone"]]);
+    }
     FHAssertEqualObjects(failureRecorder, user.name, values[@"name"]);
-    FHAssertEqualObjects(failureRecorder, user.emailAddress, values[@"email"]);
-    FHAssertEqualObjects(failureRecorder, user.phoneNumber, values[@"phone"]);
     FHAssertEqual(failureRecorder, user.accentColorValue, (ZMAccentColor) [values[@"accentID"] intValue]);
     
     return ((user.name == values[@"name"] || [user.name isEqualToString:values[@"name"]])
-            && (user.emailAddress == values[@"email"] || [user.emailAddress isEqualToString:values[@"email"]])
-            && (user.phoneNumber == values[@"phone"] || [user.phoneNumber isEqualToString:values[@"phone"]])
+            && emailAndPhoneMatches
             && (user.accentColorValue == (ZMAccentColor) [values[@"accentID"] intValue]));
 }
 

--- a/Tests/Source/Integration/SlowSyncTests.m
+++ b/Tests/Source/Integration/SlowSyncTests.m
@@ -1,4 +1,20 @@
-
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
 
 @import Foundation;
 @import ZMTransport;


### PR DESCRIPTION
Mock transport returns phone and email only for self user. Few methods that check users would fail as it would compare the current data with the response and see that values are missing.