### PR TITLE
Remove levels parameter from search, reduce search result size to 10

### DIFF
--- a/Source/UserSession/Search/Internal/ZMSearch.m
+++ b/Source/UserSession/Search/Internal/ZMSearch.m
@@ -322,7 +322,7 @@
         return;
     }
     
-    ZMTransportRequest *request = [ZMSearchRequestCodec searchRequestForQueryString:self.request.query levels:3 fetchLimit:30];
+    ZMTransportRequest *request = [ZMSearchRequestCodec searchRequestForQueryString:self.request.query fetchLimit:10];
     [request setDebugInformationTranscoder:self];
     [request addCompletionHandler:[ZMCompletionHandler handlerOnGroupQueue:self.userInterfaceContext block:^(ZMTransportResponse *response) {
         ZM_STRONG(self);

--- a/Source/UserSession/Search/Internal/ZMSearchRequestCodec.h
+++ b/Source/UserSession/Search/Internal/ZMSearchRequestCodec.h
@@ -26,7 +26,7 @@
 
 @interface ZMSearchRequestCodec : NSObject
 
-+ (ZMTransportRequest *)searchRequestForQueryString:(NSString *)queryString levels:(int)levels fetchLimit:(int)fetchLimit;
++ (ZMTransportRequest *)searchRequestForQueryString:(NSString *)queryString  fetchLimit:(int)fetchLimit;
 + (ZMSearchResult *)searchResultFromTransportResponse:(ZMTransportResponse *)response ignoredIDs:(NSArray *)ignoredIDs userSession:(ZMUserSession *)userSession query:(NSString *)query;
 
 @end

--- a/Source/UserSession/Search/Internal/ZMSearchRequestCodec.m
+++ b/Source/UserSession/Search/Internal/ZMSearchRequestCodec.m
@@ -31,7 +31,7 @@ static NSString * const ZMSearchEndPoint = @"/search/contacts";
 
 @implementation ZMSearchRequestCodec
 
-+ (ZMTransportRequest *)searchRequestForQueryString:(NSString *)queryString levels:(int)levels fetchLimit:(int)fetchLimit;
++ (ZMTransportRequest *)searchRequestForQueryString:(NSString *)queryString  fetchLimit:(int)fetchLimit;
 {
     VerifyAction(queryString != nil, queryString = @"");
     
@@ -43,7 +43,7 @@ static NSString * const ZMSearchEndPoint = @"/search/contacts";
     [set removeCharactersInString:@"=&+"];
     NSString *urlEncodedQuery = [queryString stringByAddingPercentEncodingWithAllowedCharacters:set];
     
-    NSString *path = [NSString stringWithFormat:@"%@?q=%@&l=%d&size=%d", ZMSearchEndPoint, urlEncodedQuery, levels, fetchLimit];
+    NSString *path = [NSString stringWithFormat:@"%@?q=%@&size=%d", ZMSearchEndPoint, urlEncodedQuery, fetchLimit];
     return [ZMTransportRequest requestGetFromPath:path];
     
 }

--- a/Tests/Source/UserSession/Search/ZMSearchDirectoryTests.m
+++ b/Tests/Source/UserSession/Search/ZMSearchDirectoryTests.m
@@ -864,7 +864,7 @@ typedef void (^URLSessionCompletionBlock)(NSData *data, NSURLResponse *response,
 - (void)testThatItSendsASearchRequest
 {
     // given
-    NSString *searchURL = @"/search/contacts?q=Steve%20O'Hara%20%26%20S%C3%B6hne&l=3&size=30";
+    NSString *searchURL = @"/search/contacts?q=Steve%20O'Hara%20%26%20S%C3%B6hne&size=10";
     ZMTransportRequest *expectedRequest = [ZMTransportRequest requestGetFromPath:searchURL];
 
     // expect
@@ -884,7 +884,7 @@ typedef void (^URLSessionCompletionBlock)(NSData *data, NSURLResponse *response,
 - (void)testThatItEncodesAPlusCharacterInTheSearchURL
 {
     // given
-    NSString *searchURL = @"/search/contacts?q=foo%2Bbar@example.com&l=3&size=30";
+    NSString *searchURL = @"/search/contacts?q=foo%2Bbar@example.com&size=10";
     ZMTransportRequest *expectedRequest = [ZMTransportRequest requestGetFromPath:searchURL];
     
     // expect
@@ -907,7 +907,7 @@ typedef void (^URLSessionCompletionBlock)(NSData *data, NSURLResponse *response,
     NSString *croppedString = [@"f" stringByPaddingToLength:200 withString:@"o" startingAtIndex:0];
     NSString *tooLongString = [@"f" stringByPaddingToLength:400 withString:@"o" startingAtIndex:0];
     
-    NSString *searchURL = [NSString stringWithFormat:@"/search/contacts?q=%@&l=3&size=30", croppedString];
+    NSString *searchURL = [NSString stringWithFormat:@"/search/contacts?q=%@&size=10", croppedString];
     ZMTransportRequest *expectedRequest = [ZMTransportRequest requestGetFromPath:searchURL];
     
     // expect
@@ -932,7 +932,7 @@ typedef void (^URLSessionCompletionBlock)(NSData *data, NSURLResponse *response,
     // "The characters slash ("/") and question mark ("?") may represent data within the query component."
     
     // given
-    NSString *searchURL = @"/search/contacts?q=$%26%2B,/:;%3D?@&l=3&size=30";
+    NSString *searchURL = @"/search/contacts?q=$%26%2B,/:;%3D?@&size=10";
     ZMTransportRequest *expectedRequest = [ZMTransportRequest requestGetFromPath:searchURL];
     
     // expect

--- a/Tests/Source/UserSession/Search/ZMSearchRequestCodecTests.m
+++ b/Tests/Source/UserSession/Search/ZMSearchRequestCodecTests.m
@@ -94,10 +94,10 @@
     NSString *queryString = @"search me";
     
     // when
-    ZMTransportRequest *request = [ZMSearchRequestCodec searchRequestForQueryString:queryString levels:1 fetchLimit:9];
+    ZMTransportRequest *request = [ZMSearchRequestCodec searchRequestForQueryString:queryString fetchLimit:9];
     
     // then
-    XCTAssertEqualObjects(request.path, @"/search/contacts?q=search%20me&l=1&size=9");
+    XCTAssertEqualObjects(request.path, @"/search/contacts?q=search%20me&size=9");
 }
 
 - (void)testThatItRemovesInitialAtSymbol
@@ -106,10 +106,10 @@
     NSString *queryString = @"@foo";
     
     // when
-    ZMTransportRequest *request = [ZMSearchRequestCodec searchRequestForQueryString:queryString levels:1 fetchLimit:9];
+    ZMTransportRequest *request = [ZMSearchRequestCodec searchRequestForQueryString:queryString fetchLimit:9];
     
     // then
-    XCTAssertEqualObjects(request.path, @"/search/contacts?q=foo&l=1&size=9");
+    XCTAssertEqualObjects(request.path, @"/search/contacts?q=foo&size=9");
 }
 
 - (void)testThatItDoesNotRemovesNonInitialAtSymbol
@@ -118,10 +118,10 @@
     NSString *queryString = @"boo@foo";
     
     // when
-    ZMTransportRequest *request = [ZMSearchRequestCodec searchRequestForQueryString:queryString levels:1 fetchLimit:9];
+    ZMTransportRequest *request = [ZMSearchRequestCodec searchRequestForQueryString:queryString fetchLimit:9];
     
     // then
-    XCTAssertEqualObjects(request.path, @"/search/contacts?q=boo@foo&l=1&size=9");
+    XCTAssertEqualObjects(request.path, @"/search/contacts?q=boo@foo&size=9");
 }
 
 - (void)testThatItAddsConnectedUsersToSearchResults_UsersInContact


### PR DESCRIPTION
# What's in this PR?

* Remove levels url parameter.
* Reduce requested search result size to 10.