### PR TITLE
Fix checking the wrong return value 

### DIFF
--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -78,12 +78,12 @@ public class AVSWrapper : AVSWrapperType {
     
     public func startCall(conversationId: UUID, video isVideo: Bool) -> Bool {
         let didStart = wcall_start(conversationId.transportString(), (Bool(isVideo) ? 1 : 0))
-        return didStart == 1
+        return didStart == 0
     }
     
     public func answerCall(conversationId: UUID) -> Bool {
         let didAnswer = wcall_answer(conversationId.transportString())
-        return (didAnswer == 1)
+        return didAnswer == 0
     }
     
     public func endCall(conversationId: UUID) {

--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -13,8 +13,9 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// along with this program. If not, see http://www.gnu.org/licenses/.
 //
+
 
 import Foundation
 import avs

--- a/Source/UserSession/CallStateObserver.swift
+++ b/Source/UserSession/CallStateObserver.swift
@@ -120,8 +120,6 @@ private final class CallingSystemMessageGenerator {
         case .terminating(reason: .canceled):
             let caller = callers[conversation] ?? sender
             conversation.appendMissedCallMessage(fromUser: caller, at: Date())
-        case .terminating(reason: .timeout):
-            conversation.appendPerformedCallMessage(with: 0, caller: sender)
         default:
             break
         }

--- a/Tests/Source/Calling/CallStateObserverTests.swift
+++ b/Tests/Source/Calling/CallStateObserverTests.swift
@@ -99,21 +99,6 @@ class CallStateObserverTests : MessagingTest {
         }
     }
     
-    func testThatPerformedCallMessageIsAppendedForCallsThatTimeout() {
-        
-        // given when
-        sut.callCenterDidChange(callState: .terminating(reason: .timeout), conversationId: conversation.remoteIdentifier!, userId: sender.remoteIdentifier!)
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
-        // then
-        if let message =  conversation.messages.lastObject as? ZMSystemMessage {
-            XCTAssertEqual(message.systemMessageType, .performedCall)
-            XCTAssertEqual(message.sender, sender)
-        } else {
-            XCTFail()
-        }
-    }
-    
     func testThatMissedCallMessageIsNotAppendedForCallsOtherCallStates() {
         
         // given


### PR DESCRIPTION
# What's in this PR?

* Fixes comparing the return value of some `wcall` C function to to the wrong value, from the documentation: 
>  Returns 0 if successful

* Do not append additional performed call system message for terminating v3 calls. A `ZMSystemMessage` of type `.missedCalll` is already appended by the SystemMessageCallObserver when the call is terminated (or times out).