### PR TITLE
Fix: crash when unarchiving objects saved before framework rename

### DIFF
--- a/Source/Notifications/Push notifications/Helpers/SessionTracker.swift
+++ b/Source/Notifications/Push notifications/Helpers/SessionTracker.swift
@@ -136,29 +136,29 @@ public final class Session : NSObject, NSCoding, NSCopying {
     }
     
     open func encode(with aCoder: NSCoder) {
-        aCoder.encode(callStarted, forKey: "callStarted")
-        aCoder.encode(othersJoined, forKey: "othersJoined")
-        aCoder.encode(selfUserJoined, forKey: "selfUserJoined")
-        aCoder.encode(callEnded, forKey: "callEnded")
-        aCoder.encode(isVideo, forKey: "isVideo")
-        aCoder.encode(lastSequence, forKey: "lastSequence")
-        aCoder.encode(sessionID, forKey: "sessionID")
-        aCoder.encode(initiatorID, forKey: "iniatorID")
-        aCoder.encode(conversationID, forKey: "conversationID")
+        aCoder.encode(callStarted, forKey: #keyPath(callStarted))
+        aCoder.encode(othersJoined, forKey: #keyPath(othersJoined))
+        aCoder.encode(selfUserJoined, forKey: #keyPath(selfUserJoined))
+        aCoder.encode(callEnded, forKey: #keyPath(callEnded))
+        aCoder.encode(isVideo, forKey: #keyPath(isVideo))
+        aCoder.encode(lastSequence, forKey: #keyPath(lastSequence))
+        aCoder.encode(sessionID, forKey: #keyPath(sessionID))
+        aCoder.encode(initiatorID, forKey: #keyPath(initiatorID))
+        aCoder.encode(conversationID, forKey: #keyPath(conversationID))
     }
     
     convenience required public init?(coder aDecoder: NSCoder) {
-        guard let sessionID = aDecoder.decodeObject(forKey: "sessionID") as? String,
-        let initiatorID = aDecoder.decodeObject(forKey: "initiatorID") as? UUID,
-        let conversationID = aDecoder.decodeObject(forKey: "conversationID") as? UUID else {return nil}
+        guard let sessionID = aDecoder.decodeObject(forKey: #keyPath(sessionID)) as? String,
+            let initiatorID = aDecoder.decodeObject(forKey: #keyPath(initiatorID)) as? UUID,
+            let conversationID = aDecoder.decodeObject(forKey: #keyPath(conversationID)) as? UUID else {return nil}
         
         self.init(sessionID: sessionID, conversationID: conversationID, initiatorID: initiatorID)
-        self.callStarted = aDecoder.decodeBool(forKey: "callStarted")
-        self.othersJoined = aDecoder.decodeBool(forKey: "othersJoined")
-        self.selfUserJoined = aDecoder.decodeBool(forKey: "selfUserJoined")
-        self.callEnded = aDecoder.decodeBool(forKey: "callEnded")
-        self.isVideo = aDecoder.decodeBool(forKey: "isVideo")
-        self.lastSequence = aDecoder.decodeInteger(forKey: "lastSequence")
+        self.callStarted = aDecoder.decodeBool(forKey: #keyPath(callStarted))
+        self.othersJoined = aDecoder.decodeBool(forKey: #keyPath(othersJoined))
+        self.selfUserJoined = aDecoder.decodeBool(forKey: #keyPath(selfUserJoined))
+        self.callEnded = aDecoder.decodeBool(forKey: #keyPath(callEnded))
+        self.isVideo = aDecoder.decodeBool(forKey: #keyPath(isVideo))
+        self.lastSequence = aDecoder.decodeInteger(forKey: #keyPath(lastSequence))
     }
     
     open func copy(with zone: NSZone?) -> Any {

--- a/Tests/Source/Notifications/PushNotifications/SessionTrackerTest.swift
+++ b/Tests/Source/Notifications/PushNotifications/SessionTrackerTest.swift
@@ -140,7 +140,6 @@ class SessionTests : SessionBaseTest {
     }
 }
 
-
 class SessionTrackerTest : SessionBaseTest {
     
     var sut: SessionTracker!
@@ -208,5 +207,21 @@ class SessionTrackerTest : SessionBaseTest {
         XCTAssertEqual(sut.sessions.count, 1)
         XCTAssertEqual(sut.sessions.first?.sessionID, "session1")
     }
+    
+    func testThatItUnarchivesSessionFromBeforeProjectRenameWithoutCrashing() {
+        // given
+        NSKeyedArchiver.setClassName("zmessaging.Session", for: Session.self) // Class name before the project rename
+        let event = callStateEvent(in: conversation, joinedUsers: [sender], videoSendingUsers: [], sequence: 1, session: "session1")
+        sut.addEvent(event!)
+
+        // when
+        NSKeyedArchiver.setClassName("WireSyncEngine.Session", for: Session.self) // Class name after project rename
+        sut = SessionTracker(managedObjectContext: uiMOC)
+        
+        // then
+        XCTAssertEqual(sut.sessions.count, 1)
+        XCTAssertEqual(sut.sessions.first?.sessionID, "session1")
+    }
+    
 }
 

--- a/Tests/Source/Notifications/PushNotifications/SessionTrackerTest.swift
+++ b/Tests/Source/Notifications/PushNotifications/SessionTrackerTest.swift
@@ -194,5 +194,19 @@ class SessionTrackerTest : SessionBaseTest {
         XCTAssertEqual(session1?.currentState, Session.State.incoming)
         XCTAssertEqual(session2?.currentState, Session.State.sessionEnded)
     }
+    
+    func testThatItRestoresOldSessions() {
+        // given
+        let event = callStateEvent(in: conversation, joinedUsers: [sender], videoSendingUsers: [], sequence: 1, session: "session1")
+        sut.addEvent(event!)
+
+        // when
+        sut = SessionTracker(managedObjectContext: uiMOC)
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        // then
+        XCTAssertEqual(sut.sessions.count, 1)
+        XCTAssertEqual(sut.sessions.first?.sessionID, "session1")
+    }
 }
 


### PR DESCRIPTION
For Swift classes `NSKeyedArchiver` encodes class names with format `moduleName.className`. In an unfortunate case that it can't find this class it throws an (ObjC) exception. 
We recently renamed the project to `WireSyncEngine` and this causes problems if we have saved sessions on disk.

In addition there was a bug in `SessionTracker` (mistyped key ` "iniatorID"` instead of ` "initiatorID"`) that prevented any sessions to be read from disk altogether.