### PR TITLE
Fix tests hanging due to a observer deadlock

### DIFF
--- a/Source/UserSession/BackgroundAPNSPingBackStatus.swift
+++ b/Source/UserSession/BackgroundAPNSPingBackStatus.swift
@@ -156,7 +156,7 @@ extension NSManagedObjectContext : ZMLastNotificationIDStore {
             updateStatus()
         }
 
-        RequestAvailableNotification.notifyNewRequestsAvailable(self)
+        RequestAvailableNotification.notifyNewRequestsAvailable(nil)
     }
 
     @objc(didReceiveEncryptedEvents:originalEvents:hasMore:)

--- a/Tests/Source/UserSession/BackgroundAPNSPingBackStatusTests.swift
+++ b/Tests/Source/UserSession/BackgroundAPNSPingBackStatusTests.swift
@@ -26,18 +26,22 @@ import WireMockTransport
 
 class OperationLoopNewRequestObserver {
     
+    var token : NSObjectProtocol?
     var notifications = [Notification]()
     fileprivate var notificationCenter = NotificationCenter.default
     fileprivate var newRequestNotification = "RequestAvailableNotification"
     
     init() {
-        notificationCenter.addObserver(forName: Notification.Name(rawValue: newRequestNotification), object: nil, queue: .main) { [weak self] note in
+        token = notificationCenter.addObserver(forName: Notification.Name(rawValue: newRequestNotification), object: nil, queue: .main) { [weak self] note in
             self?.notifications.append(note)
         }
     }
     
     deinit {
-        notificationCenter.removeObserver(self)
+        notifications.removeAll()
+        if let token = token {
+            notificationCenter.removeObserver(token)
+        }
     }
 }
 


### PR DESCRIPTION
Adding a observer without retaining the token was causing a deadlock.