### PR TITLE
Fix leaks in TypingStrategy

### DIFF
--- a/Source/Synchronization/Strategies/TypingStrategy.swift
+++ b/Source/Synchronization/Strategies/TypingStrategy.swift
@@ -66,8 +66,8 @@ public class TypingStrategy : NSObject {
         self.clientRegistrationDelegate = clientRegistrationDelegate
         self.typing = typing ?? ZMTyping(userInterfaceManagedObjectContext: uiContext, syncManagedObjectContext: syncContext)
         super.init()
-        NotificationCenter.default.addObserver(forName: Notification.Name(rawValue:ZMTypingNotificationName), object: nil, queue: nil, using: addConversationForNextRequest)
-        NotificationCenter.default.addObserver(forName: Notification.Name(rawValue:ZMConversationClearTypingNotificationName), object: nil, queue: nil, using: shouldClearTypingForConversation)
+        NotificationCenter.default.addObserver(self, selector: #selector(addConversationForNextRequest), name: Notification.Name(rawValue: ZMTypingNotificationName), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(shouldClearTypingForConversation), name: Notification.Name(rawValue: ZMConversationClearTypingNotificationName), object: nil)
     }
     
     public func tearDown() {
@@ -81,7 +81,7 @@ public class TypingStrategy : NSObject {
         assert(tornDown, "Need to tearDown TypingStrategy")
     }
     
-    fileprivate func addConversationForNextRequest(note : Notification) {
+    fileprivate dynamic func addConversationForNextRequest(note : Notification) {
         guard let conversation = note.object as? ZMConversation, conversation.remoteIdentifier != nil
         else { return }
         
@@ -89,10 +89,9 @@ public class TypingStrategy : NSObject {
         let clearIsTyping = (note.userInfo?[ClearIsTypingKey] as? NSNumber)?.boolValue ?? false
         
         add(conversation:conversation, isTyping:isTyping, clearIsTyping:clearIsTyping)
-        RequestAvailableNotification.notifyNewRequestsAvailable(self)
     }
     
-    fileprivate func shouldClearTypingForConversation(note: Notification) {
+    fileprivate dynamic func shouldClearTypingForConversation(note: Notification) {
         guard let conversation = note.object as? ZMConversation, conversation.remoteIdentifier != nil
         else { return }
         

--- a/Tests/Source/Synchronization/Strategies/TypingStrategyTests.swift
+++ b/Tests/Source/Synchronization/Strategies/TypingStrategyTests.swift
@@ -88,13 +88,13 @@ class TypingStrategyTests : MessagingTest {
     }
     
     override func tearDown() {
-        self.conversationA = nil;
-        self.userA = nil;
+        self.conversationA = nil
+        self.userA = nil
         
         self.sut.tearDown()
         XCTAssertTrue(typing.didTearDown)
-        self.typing = nil;
-        self.sut = nil;
+        self.typing = nil
+        self.sut = nil
         
         ZMTypingDefaultTimeout = originalTimeout;
         super.tearDown()
@@ -337,7 +337,7 @@ extension TypingStrategyTests {
         var result = [ZMTransportRequest?]()
         let conversation = insertUIConversation()
         
-        isTyping.forEach{
+        isTyping.forEach {
             TypingStrategy.notifyTranscoderThatUser(isTyping: $0, in: conversation)
             XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
             if delay == .delay {
@@ -361,7 +361,7 @@ extension TypingStrategyTests {
     
     func testThatItDoesReturn_OnlyOne_RequestsWhenReceiving_AnotherIdentical_TypingNotification() {
         // when
-        let (conversation, requests) = requestsForSendingNotifications(isTyping:[true, true], delay:.noDelay)
+        let (conversation, requests) = requestsForSendingNotifications(isTyping:[true, true], delay: .noDelay)
         XCTAssertEqual(requests.count, 2)
         let request1 = requests.first!
         let request2 = requests.last!


### PR DESCRIPTION
# What's in this PR?

* When debugging the flaky `TypingStrategyTests` I noticed that the amount of `TypingStrategies` being alive is the same as the amount of tests that have previously run.
* When running the whole test suite there are a lot of tests running before the `TypingStrategyTests`, which means there could be hundreds of leaked `TypingStrategy`s, as the `isTyping` request generation is time sensitive this could be the root cause of the flakiness (e.g. when the huge amount of leaked strategies receive the notification first then the actual sut in the tests might get it too late).
* The `TypingStrategy` was never torn down in tests. The problem was that we were using the `NotificationCenter` block API to add observers, but were not holding on to the observer tokens and deregistering them in `tearDown`. We were also passing a function pointer, which is nice syntactic sugar but also has the caveat that it captures `self` strongly in the case the function is an instance member. We now use the selector API.
* This also removes an unnecessary call to `RequestAvailableNotification.notifyNewRequestsAvailable(self)` in `addConversationForNextRequest`, as it is already called internally form within a `performGroupedBlock`.