### PR TITLE
always notify conversationList updated voiceChannelState

### DIFF
--- a/Source/Calling/WireCallCenterV2.swift
+++ b/Source/Calling/WireCallCenterV2.swift
@@ -236,7 +236,13 @@ public class WireCallCenterV2 : NSObject {
         let changedConversations = changedObjects.flatMap({ $0 as? ZMConversation })
         
         for conversation in changedConversations {
-            updateVoiceChannelState(forConversation: conversation)
+            if updateVoiceChannelState(forConversation: conversation) {
+                NotificationDispatcher.notifyNonCoreDataChanges(
+                    objectID: conversation.objectID,
+                    changedKeys: [ZMConversationListIndicatorKey],
+                    uiContext: context
+                )
+            }
             
             if participantSnapshot?.conversation == conversation {
                 participantSnapshot?.recalculateSet()
@@ -246,6 +252,7 @@ public class WireCallCenterV2 : NSObject {
     
     @objc
     public func callStateDidChange(conversations: Set<ZMConversation>) {
+        
         conversations.forEach{
             if updateVoiceChannelState(forConversation: $0), let context = $0.managedObjectContext {
                 NotificationDispatcher.notifyNonCoreDataChanges(

--- a/Tests/Source/Integration/CallingTests.m
+++ b/Tests/Source/Integration/CallingTests.m
@@ -1391,7 +1391,7 @@
     XCTAssertTrue([self logInAndWaitForSyncToBeComplete]);
     
     ZMConversation *conversation = self.conversationUnderTest;
-    [ZMCallTimer setTestCallTimeout: 0.2];
+    [ZMCallTimer setTestCallTimeout: 0.5];
     
     // when other user calls
     [self otherJoinCall];
@@ -1461,7 +1461,7 @@
     self.useGroupConversation = YES;
     
     ZMConversation *conversation = self.conversationUnderTest;
-    [ZMCallTimer setTestCallTimeout: 0.2];
+    [ZMCallTimer setTestCallTimeout: 0.5];
     
     // when selfUser calls
     [self selfJoinCall];


### PR DESCRIPTION
The bug happens in this scenario:
1) User is in a call
2) User ends the call (callDeviceIsActive is set to false)
3) At the same time there is another change in the conversation on the ui, e.g unreadCount / lastReadTimestamp causing a NSManagedObjectsDidChange notification to be fired
4) The stateSnapshot updates due to the notification, but does not notify the NotificationDispatcher (that's the bug)
5) The callState is merged. If the state in the stateSnapshot changes, the NotificationDispatcher notifies about the conversationList. Since the stateSnapshot has already been updated, we do not notify the dispatcher here

Step 4) is now also notifying the dispatcher

