### PR TITLE
buffer call events until avs is ready

### DIFF
--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -28,7 +28,7 @@ public protocol AVSWrapperType {
     func endCall(conversationId: UUID)
     func rejectCall(conversationId: UUID)
     func close()
-    func received(data: Data, currentTimestamp: Date, serverTimestamp: Date, conversationId: UUID, userId: UUID, clientId: String)
+    func received(callEvent: CallEvent)
     func toggleVideo(conversationID: UUID, active: Bool)
     
     func isVideoCall(conversationId: UUID) -> Bool
@@ -115,12 +115,12 @@ public class AVSWrapper : AVSWrapperType {
         wcall_resp(Int32(httpStatus), "", context)
     }
     
-    public func received(data: Data, currentTimestamp: Date, serverTimestamp: Date, conversationId: UUID, userId: UUID, clientId: String) {
-        data.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) in
-            let currentTime = UInt32(currentTimestamp.timeIntervalSince1970)
-            let serverTime = UInt32(serverTimestamp.timeIntervalSince1970)
+    public func received(callEvent: CallEvent) {
+        callEvent.data.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) in
+            let currentTime = UInt32(callEvent.currentTimestamp.timeIntervalSince1970)
+            let serverTime = UInt32(callEvent.serverTimestamp.timeIntervalSince1970)
             
-            wcall_recv_msg(bytes, data.count, currentTime, serverTime, conversationId.transportString(), userId.transportString(), clientId)
+            wcall_recv_msg(bytes, callEvent.data.count, currentTime, serverTime, callEvent.conversationId.transportString(), callEvent.userId.transportString(), callEvent.clientId)
         }
     }
     

--- a/Tests/Source/Calling/WireCallCenterV3Mock.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Mock.swift
@@ -32,7 +32,7 @@ class MockAVSWrapper : AVSWrapperType {
     var startCallShouldFail : Bool = false
     var mockIsVideoCall : Bool = false
     var hasOngoingCall: Bool = false
-    
+    var receivedCallEvents : [CallEvent] = []
     
     required init(userId: UUID, clientId: String, observer: UnsafeMutableRawPointer?) {
         // do nothing
@@ -68,8 +68,8 @@ class MockAVSWrapper : AVSWrapperType {
         //
     }
     
-    func received(data: Data, currentTimestamp: Date, serverTimestamp: Date, conversationId: UUID, userId: UUID, clientId: String) {
-        //
+    func received(callEvent: CallEvent) {
+        receivedCallEvents.append(callEvent)
     }
     
     func isVideoCall(conversationId: UUID) -> Bool {


### PR DESCRIPTION
When a user is called while his device is offline and the app is killed, they will currently not receive a system message for the missed call once the app restarts. The reason is that we are forwarding the call events from the notification stream to AVS before the readyHandler is called. 

Fix: We are now buffering call events until the readyHandler is called. 

