### PR TITLE
Fix calling tests failing due to changed logic

### DIFF
--- a/Tests/Source/Integration/CallingTests.m
+++ b/Tests/Source/Integration/CallingTests.m
@@ -496,7 +496,7 @@
 }
 
 
-- (void)testThatItDoesNotCreateASystemMessageWhenTheCallIsEndedWithoutBeingMissed
+- (void)testThatItCreatesASystemMessageWhenACallEnds
 {
     // given
     XCTAssertTrue([self logInAndWaitForSyncToBeComplete]);
@@ -513,10 +513,16 @@
         [self.mockConversationUnderTest callEndedEventFromUser:self.user2 selfUser:self.selfUser];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
-        
     
-    // we DO NOT receive a systemMessage
-    XCTAssertEqual(oneToOneConversation.messages.count, messageCount);
+    
+    // then
+    // we receive a systemMessage that we missed a call
+    {
+        XCTAssertEqual(oneToOneConversation.messages.count, messageCount+1u);
+        id<ZMConversationMessage> systemMessage = oneToOneConversation.messages.lastObject;
+        XCTAssertNotNil(systemMessage.systemMessageData);
+        XCTAssertEqual(systemMessage.systemMessageData.systemMessageType, ZMSystemMessageTypeMissedCall);
+    }
 }
 
 


### PR DESCRIPTION
The design of missed calls changed and we do create a missed call system message also in this case now.

logic changed in: https://github.com/wireapp/wire-ios-data-model/pull/234