### PR TITLE
Always include local seach for connected users

### DIFF
--- a/Source/UserSession/Search/Internal/ZMSearch.m
+++ b/Source/UserSession/Search/Internal/ZMSearch.m
@@ -380,7 +380,7 @@
 {
     ZMSearchResult *combined = [[ZMSearchResult alloc] init];
     
-    [combined addUsersInContacts:  remoteResult.usersInContacts  ?: localResult.usersInContacts];
+    [combined addUsersInContacts: localResult.usersInContacts];
     [combined addUsersInDirectory: remoteResult.usersInDirectory ?: localResult.usersInDirectory];
     [combined addGroupConversations:localResult.groupConversations];
     


### PR DESCRIPTION
- The bug is introduced due to the recent changes on the backend.
- We can safely assume that we can search locally for the connections.