### PR TITLE
Fix for call config not being fetched in the background

### DIFF
--- a/Source/Calling/ZMCallFlowRequestStrategy.m
+++ b/Source/Calling/ZMCallFlowRequestStrategy.m
@@ -100,7 +100,7 @@ static NSString *ZMLogTag ZM_UNUSED = @"Calling";
 
 - (ZMStrategyConfigurationOption)configuration
 {
-    return ZMStrategyConfigurationOptionAllowsRequestsDuringEventProcessing | ZMStrategyConfigurationOptionAllowsRequestsDuringSync;
+    return ZMStrategyConfigurationOptionAllowsRequestsDuringEventProcessing | ZMStrategyConfigurationOptionAllowsRequestsDuringSync | ZMStrategyConfigurationOptionAllowsRequestsWhileInBackground;
 }
 
 - (void)setUpFlowManagerIfNeeded

--- a/Source/UserSession/OperationStatus.swift
+++ b/Source/UserSession/OperationStatus.swift
@@ -24,6 +24,8 @@ public typealias BackgroundTaskHandler = (_ taskResult: BackgroundTaskResult) ->
 
 let OperationStatusChangedNotification : Notification.Name  = Notification.Name(rawValue: "OperationStatusChangedNotification")
 
+private let zmLog = ZMSLog(tag: "OperationStatus")
+
 @objc(ZMOperationStatusDelegate)
 public protocol OperationStatusDelegate : class {
     
@@ -38,12 +40,27 @@ public enum BackgroundTaskResult : UInt {
     case failed
 }
 
-@objc public enum SyncEngineOperationState : UInt {
+@objc public enum SyncEngineOperationState : UInt, CustomStringConvertible {
     case background
     case backgroundCall
     case backgroundFetch
     case backgroundTask
     case foreground
+    
+    public var description : String {
+        switch self {
+        case .background:
+            return "background"
+        case .backgroundCall:
+            return "backgroundCall"
+        case .backgroundFetch:
+            return "backgroundFetch"
+        case .backgroundTask:
+            return "backgroundTask"
+        case .foreground:
+            return "foreground"
+        }
+    }
 }
 
 @objc(ZMOperationStatus)
@@ -143,6 +160,7 @@ public class OperationStatus : NSObject {
         let newOperationState = calculatedOperationState
         
         if newOperationState != oldOperationState {
+            zmLog.debug("operation state changed from \(oldOperationState) to \(newOperationState)")
             operationState = newOperationState
         }
     }

--- a/Source/UserSession/SyncStatus.swift
+++ b/Source/UserSession/SyncStatus.swift
@@ -16,7 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-@objc public enum SyncPhase : Int {
+@objc public enum SyncPhase : Int, CustomStringConvertible {
     case fetchingLastUpdateEventID
     case fetchingConnections
     case fetchingConversations
@@ -36,7 +36,26 @@
             return false
         }
     }
+    
+    public var description: String {
+        switch self {
+        case .fetchingLastUpdateEventID:
+            return "fetchingLastUpdateEventID"
+        case .fetchingConnections:
+            return "fetchingConnections"
+        case .fetchingConversations:
+            return "fetchingConversations"
+        case .fetchingUsers:
+            return "fetchingUsers"
+        case .fetchingMissedEvents:
+            return "fetchingMissedEvents"
+        case .done:
+            return "done"
+        }
+    }
 }
+
+private let zmLog = ZMSLog(tag: "SyncStatus")
 
 public class SyncStatus : NSObject {
 
@@ -44,6 +63,7 @@ public class SyncStatus : NSObject {
     public internal (set) var currentSyncPhase : SyncPhase = .done {
         didSet {
             if currentSyncPhase != oldValue {
+                zmLog.debug("did change sync phase: \(currentSyncPhase)")
                 previousPhase = oldValue
             }
         }
@@ -116,11 +136,13 @@ extension SyncStatus {
     }
     
     public func updateLastUpdateEventID(eventID : UUID) {
+        zmLog.debug("update last eventID: \(eventID)")
         lastUpdateEventID = eventID
     }
     
     public func persistLastUpdateEventID() {
         guard let lastUpdateEventID = lastUpdateEventID else { return }
+        zmLog.debug("persist last eventID: \(lastUpdateEventID)")
         managedObjectContext.zm_lastNotificationID = lastUpdateEventID
     }
 }

--- a/Tests/Source/Calling/ZMCallFlowRequestStrategyTests.m
+++ b/Tests/Source/Calling/ZMCallFlowRequestStrategyTests.m
@@ -107,7 +107,7 @@ static NSString * const FlowEventName2 = @"conversation.member-join";
 
 - (void)testThatUsesCorrectRequestStrategyConfiguration
 {
-    XCTAssertEqual(self.sut.configuration, ZMStrategyConfigurationOptionAllowsRequestsDuringEventProcessing | ZMStrategyConfigurationOptionAllowsRequestsDuringSync);
+    XCTAssertEqual(self.sut.configuration, ZMStrategyConfigurationOptionAllowsRequestsDuringEventProcessing | ZMStrategyConfigurationOptionAllowsRequestsDuringSync | ZMStrategyConfigurationOptionAllowsRequestsWhileInBackground);
 }
 
 - (void)testThatItReleasesTheFlowForCallDeviceIsActive_No


### PR DESCRIPTION
Also added some debug logs to the `OperationStatus` and `SyncStatus`.