### PR TITLE
do not report calls to callKit in silenced conversations

### DIFF
--- a/Source/Calling/ZMCallKitDelegate+WireCallCenter.swift
+++ b/Source/Calling/ZMCallKitDelegate+WireCallCenter.swift
@@ -88,7 +88,7 @@ extension ZMCallKitDelegate : WireCallCenterCallStateObserver, WireCallCenterMis
                 let user = ZMUser(remoteID: userId, createIfNeeded: false, in: userSession.managedObjectContext) else {
                     break
             }
-            if shouldRing {
+            if shouldRing && !conversation.isSilenced {
                 indicateIncomingCall(from: user, in: conversation, video: video)
             }
         case let .terminating(reason: reason) where !(reason == .normal && userId == ZMUser.selfUser(inUserSession: userSession).remoteIdentifier):
@@ -123,7 +123,9 @@ extension ZMCallKitDelegate : VoiceChannelStateObserver {
     
         if voiceChannelState == .incomingCall {
             guard let user = conversation.voiceChannelRouter?.v2.participants.firstObject as? ZMUser else { return }
-            indicateIncomingCall(from: user, in: conversation, video: conversation.voiceChannelRouter?.v2.isVideoCall ?? false)
+            if !conversation.isSilenced {
+                indicateIncomingCall(from: user, in: conversation, video: conversation.voiceChannelRouter?.v2.isVideoCall ?? false)
+            }
         }
         
         if voiceChannelState == .selfIsJoiningActiveChannel {

--- a/Source/UserSession/CallStateObserver.swift
+++ b/Source/UserSession/CallStateObserver.swift
@@ -80,9 +80,10 @@ extension CallStateObserver : WireCallCenterCallStateObserver, WireCallCenterMis
         guard let uiMOC = self.managedObjectContext.zm_userInterface else { return }
         uiMOC.performGroupedBlock {
             guard let uiConv = (try? uiMOC.existingObject(with: convObjectID)) as? ZMConversation else { return }
+            
             switch callState {
             case .incoming(video: _, shouldRing: let shouldRing):
-                uiConv.isIgnoringCallV3 = !shouldRing
+                uiConv.isIgnoringCallV3 = uiConv.isSilenced || !shouldRing
                 uiConv.isCallDeviceActiveV3 = false
             case .terminating, .none:
                 uiConv.isCallDeviceActiveV3 = false


### PR DESCRIPTION
**Motivation for this PR**
Incoming calls in muted conversations are not supposed to activate CallKit nor show the internal call UI.

**Also included in this PR:** 
If you are trying to answer a call with callKit and the the callController does not have a call for the conversation yet, the answer would fail with UnknownCallUUID error. 
Solution: When we receive this error we request starting a new call.

Likewise if we try to create a new call, but the callUUID already exists, it currently fails with callUUIDAlreadyExists error code. 
Solution: When we receive this error we request answering the existing call.
