### PR TITLE
Set lastModifiedDate for incoming call

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 github "wireapp/wire-ios-message-strategy" ~> 33.0.0
-github "wireapp/avs-ios-binaries" ~> 3.4.101
+github "wireapp/avs-ios-binaries" ~> 3.4.103
 

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "wireapp/PINCache" "2.3-swift3.1"
-github "wireapp/avs-ios-binaries" "3.4.101"
+github "wireapp/avs-ios-binaries" "3.4.103"
 github "wireapp/libPhoneNumber-iOS" "0.9.2-swift3.1"
 github "wireapp/ocmock" "v3.3.2"
 github "wireapp/ono" "1.4.0"

--- a/Source/Calling/WireCallCenter.swift
+++ b/Source/Calling/WireCallCenter.swift
@@ -123,7 +123,7 @@ class VoiceChannelStateObserverToken : NSObject, WireCallCenterV2CallStateObserv
         })
     }
     
-    func callCenterDidChange(callState: CallState, conversationId: UUID, userId: UUID?) {
+    func callCenterDidChange(callState: CallState, conversationId: UUID, userId: UUID?, timeStamp: Date?) {
         guard let conversation = ZMConversation(remoteID: conversationId, createIfNeeded: false, in: context) else { return }
         let voiceChannelState = callState.voiceChannelState(securityLevel: conversation.securityLevel)
         observer?.callCenterDidChange(voiceChannelState: voiceChannelState, conversation: conversation, callingProtocol: .version3)

--- a/Source/Calling/WireCallCenterV3+Notifications.swift
+++ b/Source/Calling/WireCallCenterV3+Notifications.swift
@@ -55,7 +55,7 @@ struct WireCallCenterV3VideoNotification : SelfPostingNotification {
 /// MARK - Call state observer
 
 public protocol WireCallCenterCallStateObserver : class {
-    func callCenterDidChange(callState: CallState, conversationId: UUID, userId: UUID?)
+    func callCenterDidChange(callState: CallState, conversationId: UUID, userId: UUID?, timeStamp: Date?)
 }
 
 public struct WireCallCenterCallStateNotification : SelfPostingNotification {
@@ -64,6 +64,7 @@ public struct WireCallCenterCallStateNotification : SelfPostingNotification {
     let callState : CallState
     let conversationId : UUID
     let userId : UUID?
+    let messageTime : Date?
 }
 
 
@@ -121,7 +122,7 @@ extension WireCallCenterV3 {
     public class func addCallStateObserver(observer: WireCallCenterCallStateObserver) -> WireCallCenterObserverToken  {
         return NotificationCenter.default.addObserver(forName: WireCallCenterCallStateNotification.notificationName, object: nil, queue: .main) { [weak observer] (note) in
             if let note = note.userInfo?[WireCallCenterCallStateNotification.userInfoKey] as? WireCallCenterCallStateNotification {
-                observer?.callCenterDidChange(callState: note.callState, conversationId: note.conversationId, userId: note.userId)
+                observer?.callCenterDidChange(callState: note.callState, conversationId: note.conversationId, userId: note.userId, timeStamp: note.messageTime)
             }
         }
     }

--- a/Source/Calling/ZMCallKitDelegate+WireCallCenter.swift
+++ b/Source/Calling/ZMCallKitDelegate+WireCallCenter.swift
@@ -76,7 +76,7 @@ public class CallObserver : NSObject, VoiceChannelStateObserver {
 
 extension ZMCallKitDelegate : WireCallCenterCallStateObserver, WireCallCenterMissedCallObserver {
     
-    public func callCenterDidChange(callState: CallState, conversationId: UUID, userId: UUID?) {
+    public func callCenterDidChange(callState: CallState, conversationId: UUID, userId: UUID?, timeStamp: Date?) {
         guard let conversation = ZMConversation(remoteID: conversationId, createIfNeeded: false, in: userSession.managedObjectContext) else {
             return
         }

--- a/Tests/Source/Calling/CallStateObserverTests.swift
+++ b/Tests/Source/Calling/CallStateObserverTests.swift
@@ -70,8 +70,8 @@ class CallStateObserverTests : MessagingTest {
     func testThatMissedCallMessageIsAppendedForCanceledCallByReceiver() {
         
         // given when
-        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: false), conversationId: conversation.remoteIdentifier!, userId: sender.remoteIdentifier!)
-        sut.callCenterDidChange(callState: .terminating(reason: .canceled), conversationId: conversation.remoteIdentifier!, userId: receiver.remoteIdentifier!)
+        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: false), conversationId: conversation.remoteIdentifier!, userId: sender.remoteIdentifier!, timeStamp: nil)
+        sut.callCenterDidChange(callState: .terminating(reason: .canceled), conversationId: conversation.remoteIdentifier!, userId: receiver.remoteIdentifier!, timeStamp: nil)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then
@@ -86,8 +86,8 @@ class CallStateObserverTests : MessagingTest {
     func testThatMissedCallMessageIsAppendedForCanceledCallBySender() {
         
         // given when
-        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: false), conversationId: conversation.remoteIdentifier!, userId: sender.remoteIdentifier!)
-        sut.callCenterDidChange(callState: .terminating(reason: .canceled), conversationId: conversation.remoteIdentifier!, userId: sender.remoteIdentifier!)
+        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: false), conversationId: conversation.remoteIdentifier!, userId: sender.remoteIdentifier!, timeStamp: nil)
+        sut.callCenterDidChange(callState: .terminating(reason: .canceled), conversationId: conversation.remoteIdentifier!, userId: sender.remoteIdentifier!, timeStamp: nil)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then
@@ -117,7 +117,7 @@ class CallStateObserverTests : MessagingTest {
         
         // when
         for callState in ignoredCallStates {
-            sut.callCenterDidChange(callState: callState, conversationId: conversation.remoteIdentifier!, userId: sender.remoteIdentifier!)
+            sut.callCenterDidChange(callState: callState, conversationId: conversation.remoteIdentifier!, userId: sender.remoteIdentifier!, timeStamp: nil)
         }
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
@@ -151,7 +151,7 @@ class CallStateObserverTests : MessagingTest {
     
     func testThatCallStatesAreForwardedToTheNotificationDispatcher() {
         // given when
-        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: false), conversationId: conversation.remoteIdentifier!, userId: sender.remoteIdentifier!)
+        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: false), conversationId: conversation.remoteIdentifier!, userId: sender.remoteIdentifier!, timeStamp: nil)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then
@@ -169,7 +169,7 @@ class CallStateObserverTests : MessagingTest {
         }
         
         // given when
-        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: false), conversationId: conversation.remoteIdentifier!, userId: sender.remoteIdentifier!)
+        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: false), conversationId: conversation.remoteIdentifier!, userId: sender.remoteIdentifier!, timeStamp: nil)
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
     }
     
@@ -184,7 +184,7 @@ class CallStateObserverTests : MessagingTest {
         }
         
         // given when
-        sut.callCenterDidChange(callState: .outgoing, conversationId: conversation.remoteIdentifier!, userId: sender.remoteIdentifier!)
+        sut.callCenterDidChange(callState: .outgoing, conversationId: conversation.remoteIdentifier!, userId: sender.remoteIdentifier!, timeStamp: nil)
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
     }
     
@@ -199,7 +199,7 @@ class CallStateObserverTests : MessagingTest {
         }
         
         // given when
-        sut.callCenterDidChange(callState: .terminating(reason: .normal), conversationId: conversation.remoteIdentifier!, userId: sender.remoteIdentifier!)
+        sut.callCenterDidChange(callState: .terminating(reason: .normal), conversationId: conversation.remoteIdentifier!, userId: sender.remoteIdentifier!, timeStamp: nil)
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
     }
     

--- a/Tests/Source/Calling/WireCallCenterV3Mock.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Mock.swift
@@ -153,7 +153,7 @@ public class WireCallCenterV3Mock : WireCallCenterV3 {
 
     public func update(callState : CallState, conversationId: UUID, userId: UUID? = nil) {
         self.mockAVSCallState = callState
-        WireCallCenterCallStateNotification(callState: callState, conversationId: conversationId, userId: userId).post()
+        WireCallCenterCallStateNotification(callState: callState, conversationId: conversationId, userId: userId, messageTime: nil).post()
     }
 
     var mockInitiator : ZMUser?

--- a/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -73,40 +73,44 @@ class WireCallCenterV3Tests: MessagingTest {
     func testThatTheIncomingCallHandlerPostsTheRightNotification_IsVideo(){
         checkThatItPostsNotification(expectedCallState: .incoming(video: true, shouldRing: false)) { (conversationIdRef, userIdRef, context) in
             WireSyncEngine.incomingCallHandler(conversationId: conversationIdRef,
-                                userId: userIdRef,
-                                isVideoCall: 1,
-                                shouldRing: 0,
-                                contextRef: context)
+                                               messageTime: 0,
+                                               userId: userIdRef,
+                                               isVideoCall: 1,
+                                               shouldRing: 0,
+                                               contextRef: context)
         }
     }
     
     func testThatTheIncomingCallHandlerPostsTheRightNotification(){
         checkThatItPostsNotification(expectedCallState: .incoming(video: false, shouldRing: false)) { (conversationIdRef, userIdRef, context) in
             WireSyncEngine.incomingCallHandler(conversationId: conversationIdRef,
-                                userId: userIdRef,
-                                isVideoCall: 0,
-                                shouldRing: 0,
-                                contextRef: context)
+                                               messageTime: 0,
+                                               userId: userIdRef,
+                                               isVideoCall: 0,
+                                               shouldRing: 0,
+                                               contextRef: context)
         }
     }
     
     func testThatTheIncomingCallHandlerPostsTheRightNotification_IsVideo_ShouldRing(){
         checkThatItPostsNotification(expectedCallState: .incoming(video: true, shouldRing: true)) { (conversationIdRef, userIdRef, context) in
             WireSyncEngine.incomingCallHandler(conversationId: conversationIdRef,
-                                userId: userIdRef,
-                                isVideoCall: 1,
-                                shouldRing: 1,
-                                contextRef: context)
+                                               messageTime: 0,
+                                               userId: userIdRef,
+                                               isVideoCall: 1,
+                                               shouldRing: 1,
+                                               contextRef: context)
         }
     }
     
     func testThatTheIncomingCallHandlerPostsTheRightNotification_ShouldRing(){
         checkThatItPostsNotification(expectedCallState: .incoming(video: false, shouldRing: true)) { (conversationIdRef, userIdRef, context) in
             WireSyncEngine.incomingCallHandler(conversationId: conversationIdRef,
-                                userId: userIdRef,
-                                isVideoCall: 0,
-                                shouldRing: 1,
-                                contextRef: context)
+                                               messageTime: 0,
+                                               userId: userIdRef,
+                                               isVideoCall: 0,
+                                               shouldRing: 1,
+                                               contextRef: context)
         }
     }
     
@@ -178,7 +182,7 @@ class WireCallCenterV3Tests: MessagingTest {
         let userIdRef = userId.transportString().cString(using: .utf8)
         let context = Unmanaged.passUnretained(self.sut).toOpaque()
         
-        WireSyncEngine.incomingCallHandler(conversationId: conversationIdRef, userId: userIdRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
+        WireSyncEngine.incomingCallHandler(conversationId: conversationIdRef, messageTime: 0, userId: userIdRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // expect
@@ -207,7 +211,7 @@ class WireCallCenterV3Tests: MessagingTest {
         let userIdRef = userId.transportString().cString(using: .utf8)
         let context = Unmanaged.passUnretained(self.sut).toOpaque()
         
-        WireSyncEngine.incomingCallHandler(conversationId: conversationIdRef, userId: userIdRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
+        WireSyncEngine.incomingCallHandler(conversationId: conversationIdRef, messageTime: 0, userId: userIdRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // expect
@@ -433,7 +437,7 @@ extension WireCallCenterV3Tests {
         let context = Unmanaged.passUnretained(self.sut).toOpaque()
 
         // when
-        WireSyncEngine.incomingCallHandler(conversationId: conversationIdRef, userId: userIdRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
+        WireSyncEngine.incomingCallHandler(conversationId: conversationIdRef, messageTime: 0, userId: userIdRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then
@@ -469,7 +473,7 @@ extension WireCallCenterV3Tests {
         let context = Unmanaged.passUnretained(self.sut).toOpaque()
 
         // when
-        WireSyncEngine.incomingCallHandler(conversationId: conversationIdRef, userId: userIdRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
+        WireSyncEngine.incomingCallHandler(conversationId: conversationIdRef, messageTime: 0, userId: userIdRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then

--- a/Tests/Source/Calling/ZMCallKitDelegateTests.swift
+++ b/Tests/Source/Calling/ZMCallKitDelegateTests.swift
@@ -774,7 +774,7 @@ class ZMCallKitDelegateTest: MessagingTest {
         let otherUser = self.otherUser(moc: self.uiMOC)
         
         // when
-        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: true), conversationId: conversation.remoteIdentifier!, userId: otherUser.remoteIdentifier!)
+        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: true), conversationId: conversation.remoteIdentifier!, userId: otherUser.remoteIdentifier!, timeStamp: nil)
         
         // then
         XCTAssertEqual(self.callKitProvider.timesReportNewIncomingCallCalled, 1)
@@ -790,7 +790,7 @@ class ZMCallKitDelegateTest: MessagingTest {
         let otherUser = self.otherUser(moc: self.uiMOC)
         
         // when
-        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: true), conversationId: conversation.remoteIdentifier!, userId: otherUser.remoteIdentifier!)
+        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: true), conversationId: conversation.remoteIdentifier!, userId: otherUser.remoteIdentifier!, timeStamp: nil)
         
         // then
         XCTAssertEqual(self.callKitProvider.timesReportNewIncomingCallCalled, 0)
@@ -805,7 +805,7 @@ class ZMCallKitDelegateTest: MessagingTest {
         let otherUser = self.otherUser(moc: self.uiMOC)
         
         // when
-        sut.callCenterDidChange(callState: .terminating(reason: .normal), conversationId: conversation.remoteIdentifier!, userId: otherUser.remoteIdentifier!)
+        sut.callCenterDidChange(callState: .terminating(reason: .normal), conversationId: conversation.remoteIdentifier!, userId: otherUser.remoteIdentifier!, timeStamp: nil)
         
         // then
         XCTAssertEqual(self.callKitProvider.timesReportNewIncomingCallCalled, 0)
@@ -821,7 +821,7 @@ class ZMCallKitDelegateTest: MessagingTest {
         let otherUser = self.otherUser(moc: self.uiMOC)
         
         // when
-        sut.callCenterDidChange(callState: .terminating(reason: .lostMedia), conversationId: conversation.remoteIdentifier!, userId: otherUser.remoteIdentifier!)
+        sut.callCenterDidChange(callState: .terminating(reason: .lostMedia), conversationId: conversation.remoteIdentifier!, userId: otherUser.remoteIdentifier!, timeStamp: nil)
         
         // then
         XCTAssertEqual(self.callKitProvider.lastEndedReason, UInt(CXCallEndedReason.failed.rawValue))
@@ -833,7 +833,7 @@ class ZMCallKitDelegateTest: MessagingTest {
         let otherUser = self.otherUser(moc: self.uiMOC)
         
         // when
-        sut.callCenterDidChange(callState: .terminating(reason: .timeout), conversationId: conversation.remoteIdentifier!, userId: otherUser.remoteIdentifier!)
+        sut.callCenterDidChange(callState: .terminating(reason: .timeout), conversationId: conversation.remoteIdentifier!, userId: otherUser.remoteIdentifier!, timeStamp: nil)
         
         // then
         XCTAssertEqual(self.callKitProvider.lastEndedReason, UInt(CXCallEndedReason.unanswered.rawValue))
@@ -845,7 +845,7 @@ class ZMCallKitDelegateTest: MessagingTest {
         let otherUser = self.otherUser(moc: self.uiMOC)
         
         // when
-        sut.callCenterDidChange(callState: .terminating(reason: .anweredElsewhere), conversationId: conversation.remoteIdentifier!, userId: otherUser.remoteIdentifier!)
+        sut.callCenterDidChange(callState: .terminating(reason: .anweredElsewhere), conversationId: conversation.remoteIdentifier!, userId: otherUser.remoteIdentifier!, timeStamp: nil)
         
         // then
         XCTAssertEqual(self.callKitProvider.lastEndedReason, UInt(CXCallEndedReason.answeredElsewhere.rawValue))
@@ -857,7 +857,7 @@ class ZMCallKitDelegateTest: MessagingTest {
         let selfUser = ZMUser.selfUser(in: self.uiMOC)
         
         // when
-        sut.callCenterDidChange(callState: .terminating(reason: .normal), conversationId: conversation.remoteIdentifier!, userId: selfUser.remoteIdentifier!)
+        sut.callCenterDidChange(callState: .terminating(reason: .normal), conversationId: conversation.remoteIdentifier!, userId: selfUser.remoteIdentifier!, timeStamp: nil)
         
         // then
         XCTAssertEqual(self.callKitProvider.timesReportCallEndedAtCalled, 0)

--- a/Tests/Source/Integration/CallingV3Tests.swift
+++ b/Tests/Source/Integration/CallingV3Tests.swift
@@ -129,7 +129,7 @@ class CallingV3Tests : IntegrationTestBase {
         (WireCallCenterV3.activeInstance as! WireCallCenterV3Mock).mockAVSCallState = .incoming(video: isVideoCall, shouldRing: shouldRing)
 
         let userIdRef = user.remoteIdentifier!.transportString().cString(using: .utf8)
-        WireSyncEngine.incomingCallHandler(conversationId: conversationIdRef, userId: userIdRef, isVideoCall: isVideoCall ? 1 : 0, shouldRing: shouldRing ? 1 : 0, contextRef: wireCallCenterRef)
+        WireSyncEngine.incomingCallHandler(conversationId: conversationIdRef, messageTime: UInt32(Date().timeIntervalSince1970), userId: userIdRef, isVideoCall: isVideoCall ? 1 : 0, shouldRing: shouldRing ? 1 : 0, contextRef: wireCallCenterRef)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
     }
     
@@ -780,6 +780,20 @@ extension CallingV3Tests {
         // the conversation is unarchived
         XCTAssertEqual(conversationUnderTest.messages.count, messageCount+1)
         XCTAssertFalse(conversationUnderTest.isArchived)
+    }
+    
+    func testThatItUpdatesTheLastModifiedDateOfTheConversationWithTheIncomingCallTimestamp(){
+        // given
+        XCTAssertTrue(logInAndWaitForSyncToBeComplete())
+        let user = conversationUnderTest.connectedUser!
+        
+        XCTAssertNotEqualWithAccuracy(conversationUnderTest.lastModifiedDate!.timeIntervalSince1970, Date().timeIntervalSince1970, 1.0)
+        
+        // when
+        otherStartCall(user: user)
+        
+        // then
+        XCTAssertEqualWithAccuracy(conversationUnderTest.lastModifiedDate!.timeIntervalSince1970, Date().timeIntervalSince1970, accuracy: 1.0)
     }
     
 }


### PR DESCRIPTION
To move incoming calls up in the conversation list (e.g. when the call is muted and there is no call overlay), we need to update the lastModifiedDate for the conversation using the message timeStamp of the incoming call.

Note: ideally we should also use the message timestamp for the closed call to insert a missed call message (we are currently using the local time). An API change for AVS is requested.