### PR TITLE
Sanitise request paths for loop tracking, add tests

### DIFF
--- a/Source/Analytics/RequestLoopAnalyticsTracker.swift
+++ b/Source/Analytics/RequestLoopAnalyticsTracker.swift
@@ -25,11 +25,11 @@ import Foundation
         "/typing"
     ]
     
-    weak var analytic : AnalyticsType?
+    weak var analytics: AnalyticsType?
     
     @objc(initWithAnalytics:)
-    public init(with : AnalyticsType) {
-        analytic = with
+    public init(with analytics : AnalyticsType?) {
+        self.analytics = analytics
     }
 
     /// Track a loop at the given path.
@@ -39,10 +39,12 @@ import Foundation
     @objc(tagWithPath:)
     public func tag(with path: String) -> Bool {
         guard nil == ignoredPrefixes.first(where: path.hasPrefix) else { return false }
-        if let analytic = analytic {
-            analytic.tagEvent("request.loop", attributes: ["path": path.sanitizePath() as NSObject])
+        if let analytics = analytics {
+            analytics.tagEvent("request.loop", attributes: ["path": path.sanitizePath() as NSObject])
+            return true
+        } else {
+            return false
         }
-        return true
     }
 }
 

--- a/Source/Analytics/RequestLoopAnalyticsTracker.swift
+++ b/Source/Analytics/RequestLoopAnalyticsTracker.swift
@@ -32,6 +32,10 @@ import Foundation
         analytic = with
     }
 
+    /// Track a loop at the given path.
+    /// The path will be sanitized (UUIDs will be removed).
+    /// - parameter path: The path to track a request loop for.
+    /// - returns: `true` in case the tracking has been performed, `false` otherwise (e.g. when the path was in the ignored paths list).
     @objc(tagWithPath:)
     public func tag(with path: String) -> Bool {
         guard nil == ignoredPrefixes.first(where: path.hasPrefix) else { return false }

--- a/Source/Analytics/RequestLoopAnalyticsTracker.swift
+++ b/Source/Analytics/RequestLoopAnalyticsTracker.swift
@@ -18,7 +18,12 @@
 
 import Foundation
 
+
 @objc public class RequestLoopAnalyticsTracker : NSObject {
+
+    private let ignoredPrefixes = [
+        "/typing"
+    ]
     
     weak var analytic : AnalyticsType?
     
@@ -28,9 +33,39 @@ import Foundation
     }
 
     @objc(tagWithPath:)
-    public func tag(with: String) -> Void {
+    public func tag(with path: String) -> Bool {
+        guard nil == ignoredPrefixes.first(where: path.hasPrefix) else { return false }
         if let analytic = analytic {
-            analytic.tagEvent("request.loop", attributes: ["path": with as NSObject])
+            analytic.tagEvent("request.loop", attributes: ["path": path.sanitizePath() as NSObject])
         }
+        return true
+    }
+}
+
+
+extension String {
+
+    static var uuidRegexp: NSRegularExpression? = {
+        return try? NSRegularExpression(
+            pattern: "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{3,12}",
+            options: .caseInsensitive
+        )
+    }()
+
+    static var clientIdRegexp: NSRegularExpression? = {
+        return try? NSRegularExpression(
+            pattern: "[a-f0-9]{15,16}",
+            options: .caseInsensitive
+        )
+    }()
+
+
+    func sanitizePath()-> String {
+        guard let uuidRegexp = String.uuidRegexp, let clientIdRegexp = String.clientIdRegexp else { return self }
+        let mutableString = NSMutableString(string: self)
+        let template = "{id}"
+        uuidRegexp.replaceMatches(in: mutableString, options: [], range: NSMakeRange(0, mutableString.length), withTemplate: template)
+        clientIdRegexp.replaceMatches(in: mutableString, options: [], range: NSMakeRange(0, mutableString.length), withTemplate: template)
+        return mutableString as String
     }
 }

--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -240,12 +240,10 @@ ZM_EMPTY_ASSERTING_INIT()
     
     RequestLoopAnalyticsTracker *tracker = [[RequestLoopAnalyticsTracker alloc] initWithAnalytics:analytics];
     session.requestLoopDetectionCallback = ^(NSString *path) {
-        if ([path hasSuffix:@"/typing"]) {
+        // TAG analytics
+        if (! [tracker tagWithPath:path]) {
             return;
         }
-
-        //TAG analytics
-        [tracker tagWithPath:path];
         ZMLogWarn(@"Request loop happening at path: %@", path);
         dispatch_async(dispatch_get_main_queue(), ^{
             [[NSNotificationCenter defaultCenter] postNotificationName:ZMTransportRequestLoopNotificationName object:nil userInfo:@{@"path" : path}];

--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -240,7 +240,7 @@ ZM_EMPTY_ASSERTING_INIT()
     
     RequestLoopAnalyticsTracker *tracker = [[RequestLoopAnalyticsTracker alloc] initWithAnalytics:analytics];
     session.requestLoopDetectionCallback = ^(NSString *path) {
-        // TAG analytics
+        // The tracker will return NO in case the path should be ignored.
         if (! [tracker tagWithPath:path]) {
             return;
         }

--- a/Tests/Source/Utility/RequestLoopAnalyticsTrackerTests.swift
+++ b/Tests/Source/Utility/RequestLoopAnalyticsTrackerTests.swift
@@ -71,7 +71,8 @@ class RequestLoopAnalyticsTrackerTests: XCTestCase {
 
 
     func testThatItExcludesIsTyping() {
-        let sut = RequestLoopAnalyticsTracker(with: MockAnalytics())
+        let analytics = MockAnalytics()
+        let sut = RequestLoopAnalyticsTracker(with: analytics)
         XCTAssertFalse(sut.tag(with: "/typing"))
         XCTAssertTrue(sut.tag(with: "/assets/v3"))
     }

--- a/Tests/Source/Utility/RequestLoopAnalyticsTrackerTests.swift
+++ b/Tests/Source/Utility/RequestLoopAnalyticsTrackerTests.swift
@@ -1,0 +1,79 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+import XCTest
+import WireTesting
+@testable import WireSyncEngine
+
+
+class RequestLoopAnalyticsTrackerTests: XCTestCase {
+
+    func testThatItSanitizesUUIDsAndClientIDs() {
+        let paths = [
+            "/notifications?size=500&since=cfb40e1a-1096-11e7-bfff-22000b1081a7&client=95b2471202e2cda9&cancel_fallback=3c41e15a-1098-11e7-bfff-22000b017aef",
+            "/notifications?size=500&since=c57202ca-2b28-11e7-bfff-22000ac3020a&client=cf114edfb492c778&cancel_fallback=cfa5f148-2b28-11e7-bfff-22000a568fd1",
+            "/assets/07430c64-f376-4ecf-a114-85d04848de85?conv_id=49ca25cf-9181-4735-bfc5-1db26b7a49af",
+            "/assets/6a295066-1ca9-43c8-8b9d-8f22c27f292e?conv_id=b453fbe0-d938-4e49-9739-7ea53c74a8ca",
+            "/assets/e821d372-0bec-43e3-9c6a-ecfcfa995bdc?conv_id=70021ba4-487a-4967-b73b-aa950ea3b595",
+            "/conversations/22df105c-75b5-4b42-8d05-25961bfef285/otr/messages",
+            "/conversations/8812f63e-0f88-4249-9758-e8ecf4bf2c42/otr/messages?report_missing=84d29540-8b82-4adb-a4ba-f84adffef7e7",
+            "/assets/67feb2f3-3118-4807-9c40-a4c86235c456?conv_id=dcb383ff-def6-47b6-92c8-bfc88075aba8",
+            "/assets/85b16732-0617-4dd9-a043-c18123d39ea7?conv_id=cdf377c2-21c9-4649-83cb-c03ef54ba354",
+            "/notifications?size=500&since=b610ca0a-0eef-11e7-bfff-22000b1081a7&client=37cbf257edc68492&cancel_fallback=b7b3ac32-0ef0-11e7-bfff-22000b18c377",
+            "/conversations/4ec7f78d-92d4-4adc-acef-a5fd1ce2d05d/otr/messages?report_missing=69607340-332f-44b3-af7e-64d5101935d9",
+            "/assets/793ed60b-6a6f-41f1-be20-fae17fd83148?conv_id=b98cc1a7-ff98-4376-bdbe-0f806e5c4522",
+            "/assets/19ad9766-91e8-4d5a-8f7a-9e9da0a57b19?conv_id=b98cc1a7-ff98-4376-bdbe-0f806e5c4522",
+            "/conversations/58128c2d-8181-45d9-91d5-d4aa31a637f8/otr/messages?report_missing=e3cfe44e-f4a9-4c9a-a759-8b718f3dfaf6",
+            "/assets/v3/3-2-8db1e0ad-77a0-47c8-ad5d-fa479f40872f",
+            "/assets/v3"
+        ]
+
+        let expected = [
+            "/notifications?size=500&since={id}&client={id}&cancel_fallback={id}",
+            "/notifications?size=500&since={id}&client={id}&cancel_fallback={id}",
+            "/assets/{id}?conv_id={id}",
+            "/assets/{id}?conv_id={id}",
+            "/assets/{id}?conv_id={id}",
+            "/conversations/{id}/otr/messages",
+            "/conversations/{id}/otr/messages?report_missing={id}",
+            "/assets/{id}?conv_id={id}",
+            "/assets/{id}?conv_id={id}",
+            "/notifications?size=500&since={id}&client={id}&cancel_fallback={id}",
+            "/conversations/{id}/otr/messages?report_missing={id}",
+            "/assets/{id}?conv_id={id}",
+            "/assets/{id}?conv_id={id}",
+            "/conversations/{id}/otr/messages?report_missing={id}",
+            "/assets/v3/3-2-{id}",
+            "/assets/v3"
+        ]
+
+        zip(expected, paths.map { $0.sanitizePath() }).forEach { (expected, actual) in
+            XCTAssertEqual(actual, expected)
+        }
+    }
+
+
+    func testThatItExcludesIsTyping() {
+        let sut = RequestLoopAnalyticsTracker(with: MockAnalytics())
+        XCTAssertFalse(sut.tag(with: "/typing"))
+        XCTAssertTrue(sut.tag(with: "/assets/v3"))
+    }
+
+}

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -316,6 +316,7 @@
 		BF2A9D581D6B5BDB00FA7DBC /* StoreUpdateEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2A9D571D6B5BDB00FA7DBC /* StoreUpdateEventTests.swift */; };
 		BF2A9D5D1D6B63DB00FA7DBC /* StoreUpdateEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2A9D5A1D6B63DB00FA7DBC /* StoreUpdateEvent.swift */; };
 		BF2A9D611D6C70EA00FA7DBC /* ZMEventModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = BF2A9D5F1D6C70EA00FA7DBC /* ZMEventModel.xcdatamodeld */; };
+		BF325E9D1EC067D600772145 /* RequestLoopAnalyticsTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF325E9C1EC067D600772145 /* RequestLoopAnalyticsTrackerTests.swift */; };
 		BF36DDF11E8BACD400D61310 /* ZMUserSession+OperationLoop.h in Headers */ = {isa = PBXBuildFile; fileRef = BF36DDF01E8BACD400D61310 /* ZMUserSession+OperationLoop.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF36DDF21E8BAE3C00D61310 /* ZMOperationLoop+Background.h in Headers */ = {isa = PBXBuildFile; fileRef = F962A8E819FFC06E00FD0F80 /* ZMOperationLoop+Background.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF44A3511C71D5FC00C6928E /* store127.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = BF44A3501C71D5FC00C6928E /* store127.wiredatabase */; };
@@ -908,6 +909,7 @@
 		BF2A9D571D6B5BDB00FA7DBC /* StoreUpdateEventTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreUpdateEventTests.swift; sourceTree = "<group>"; };
 		BF2A9D5A1D6B63DB00FA7DBC /* StoreUpdateEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StoreUpdateEvent.swift; path = Decoding/StoreUpdateEvent.swift; sourceTree = "<group>"; };
 		BF2A9D601D6C70EA00FA7DBC /* ZMEventModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = ZMEventModel.xcdatamodel; sourceTree = "<group>"; };
+		BF325E9C1EC067D600772145 /* RequestLoopAnalyticsTrackerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestLoopAnalyticsTrackerTests.swift; sourceTree = "<group>"; };
 		BF36DDF01E8BACD400D61310 /* ZMUserSession+OperationLoop.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ZMUserSession+OperationLoop.h"; sourceTree = "<group>"; };
 		BF40AC711D096A0E00287E29 /* AnalyticsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsTests.swift; sourceTree = "<group>"; };
 		BF44A3501C71D5FC00C6928E /* store127.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = store127.wiredatabase; sourceTree = "<group>"; };
@@ -1943,6 +1945,7 @@
 			children = (
 				3E5286BB1AD3DB8A00B1AB1C /* KeySetTests.swift */,
 				BF40AC711D096A0E00287E29 /* AnalyticsTests.swift */,
+				BF325E9C1EC067D600772145 /* RequestLoopAnalyticsTrackerTests.swift */,
 				543ED0001D79E0EE00A9CDF3 /* ApplicationMock.swift */,
 			);
 			path = Utility;
@@ -2415,6 +2418,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BF325E9D1EC067D600772145 /* RequestLoopAnalyticsTrackerTests.swift in Sources */,
 				544BA1361A43401400D3B852 /* ZMCallFlowRequestStrategyTests.m in Sources */,
 				54ADA7631E3B3D8E00B90C7D /* IntegrationTestBase+Encryption.swift in Sources */,
 				F991CE161CB55512004D8465 /* ZMUser+Testing.m in Sources */,


### PR DESCRIPTION
# What's in this PR?

* Sanitise request paths for loop tracking (replace UUIDs and client IDs with `"{id}"`).
* Add tests for `RequestLoopAnalyticsTracker`.