### PR TITLE
process actions directly if sync done & pushChannel is open

### DIFF
--- a/Source/UserSession/ZMUserSession+Background.m
+++ b/Source/UserSession/ZMUserSession+Background.m
@@ -187,6 +187,9 @@ static NSString *ZMLogTag = @"Push";
                                                                                actionIdentifier:nil
                                                                                       textInput:nil];
     }
+    if (self.didStartInitialSync && !self.isPerformingSync && self.pushChannelIsOpen) {
+        [self processPendingNotificationActions];
+    }
 }
 
 - (void)application:(id<ZMApplication>)application handleActionWithIdentifier:(NSString *)identifier forLocalNotification:(UILocalNotification *)notification responseInfo:(NSDictionary *)responseInfo completionHandler:(void(^)())completionHandler;
@@ -217,10 +220,12 @@ static NSString *ZMLogTag = @"Push";
                                                                            managedObjectContext:self.managedObjectContext
                                                                                actionIdentifier:identifier
                                                                                       textInput:nil];
-        if (self.didStartInitialSync && !self.isPerformingSync) {
-            [self processPendingNotificationActions];
-        }
     }
+    
+    if (self.didStartInitialSync && !self.isPerformingSync && self.pushChannelIsOpen) {
+        [self processPendingNotificationActions];
+    }
+    
     if (completionHandler != nil) {
         completionHandler();
     }


### PR DESCRIPTION
Previously when acting on an APNS, the app would be launched, we would perform a quicksync and only then perform the action (e.g. accepting an incoming call). The reason for this is that the notifications might be outdated and the incoming call might have already ended. By performing the sync before the action, we would have the actual state of the call and would not for example accidentally call back in an already ended call.

Due to changes in the handling of call APNS, we are now already performing a sync when receiving a call APNS. When the app launches due to an action on an APNS (swipe or tap) it would wait forever for the sync to be complete and therefore not perform the actions (until the next quicksync).

We are now checking if the sync is already done and if the pushChannel is open. And if that's the case, perform the action immediately, otherwise wait for the callBack that the sync is done.