### PR TITLE
Fix /typing exclusion

### DIFF
--- a/Source/Analytics/RequestLoopAnalyticsTracker.swift
+++ b/Source/Analytics/RequestLoopAnalyticsTracker.swift
@@ -21,7 +21,7 @@ import Foundation
 
 @objc public class RequestLoopAnalyticsTracker : NSObject {
 
-    private let ignoredPrefixes = [
+    private let ignoredSuffixes = [
         "/typing"
     ]
     
@@ -38,7 +38,7 @@ import Foundation
     /// - returns: `true` in case the tracking has been performed, `false` otherwise (e.g. when the path was in the ignored paths list).
     @objc(tagWithPath:)
     public func tag(with path: String) -> Bool {
-        guard nil == ignoredPrefixes.first(where: path.hasPrefix) else { return false }
+        guard nil == ignoredSuffixes.first(where: path.hasSuffix) else { return false }
         if let analytics = analytics {
             analytics.tagEvent("request.loop", attributes: ["path": path.sanitizePath() as NSObject])
             return true

--- a/Tests/Source/Utility/RequestLoopAnalyticsTrackerTests.swift
+++ b/Tests/Source/Utility/RequestLoopAnalyticsTrackerTests.swift
@@ -73,7 +73,8 @@ class RequestLoopAnalyticsTrackerTests: XCTestCase {
     func testThatItExcludesIsTyping() {
         let analytics = MockAnalytics()
         let sut = RequestLoopAnalyticsTracker(with: analytics)
-        XCTAssertFalse(sut.tag(with: "/typing"))
+        let typingPath = "/conversations/58128c2d-8181-45d9-91d5-d4aa31a637f8/typing"
+        XCTAssertFalse(sut.tag(with: typingPath))
         XCTAssertTrue(sut.tag(with: "/assets/v3"))
     }
 


### PR DESCRIPTION
# What's in this PR?

* Fix `conversations/{id}/typing` exclusion.