### PR TITLE
Fixing flaky calling test

### DIFF
--- a/Tests/Source/Integration/CallingV3Tests.swift
+++ b/Tests/Source/Integration/CallingV3Tests.swift
@@ -793,12 +793,13 @@ extension CallingV3Tests {
         let user = conversationUnderTest.connectedUser!
         
         XCTAssertNotEqualWithAccuracy(conversationUnderTest.lastModifiedDate!.timeIntervalSince1970, Date().timeIntervalSince1970, 1.0)
+        let lastModified = conversationUnderTest.lastModifiedDate!
         
         // when
         otherStartCall(user: user)
         
         // then
-        XCTAssertEqualWithAccuracy(conversationUnderTest.lastModifiedDate!.timeIntervalSince1970, Date().timeIntervalSince1970, accuracy: 1.0)
+        XCTAssertGreaterThan(conversationUnderTest.lastModifiedDate!, lastModified)
     }
     
 }

--- a/Tests/Source/Integration/CallingV3Tests.swift
+++ b/Tests/Source/Integration/CallingV3Tests.swift
@@ -792,14 +792,16 @@ extension CallingV3Tests {
         XCTAssertTrue(logInAndWaitForSyncToBeComplete())
         let user = conversationUnderTest.connectedUser!
         
-        XCTAssertNotEqualWithAccuracy(conversationUnderTest.lastModifiedDate!.timeIntervalSince1970, Date().timeIntervalSince1970, 1.0)
-        let lastModified = conversationUnderTest.lastModifiedDate!
+        // Time gets truncated to integer values under the hood, doing the same to avoid false positives
+        let timeIntervalBeforeCall = TimeInterval(UInt32(Date().timeIntervalSince1970))
+        XCTAssertLessThan(conversationUnderTest.lastModifiedDate!.timeIntervalSince1970, timeIntervalBeforeCall)
         
         // when
         otherStartCall(user: user)
         
         // then
-        XCTAssertGreaterThan(conversationUnderTest.lastModifiedDate!, lastModified)
+        let modified = conversationUnderTest.lastModifiedDate!.timeIntervalSince1970
+        XCTAssertGreaterThanOrEqual(modified, timeIntervalBeforeCall)
     }
     
 }

--- a/Tests/Source/Integration/IntegrationTestBase.m
+++ b/Tests/Source/Integration/IntegrationTestBase.m
@@ -123,6 +123,8 @@ NSString * const SelfUserPassword = @"fgf0934';$@#%";
     [BackgroundActivityFactory tearDownInstance];
     [LinkPreviewDetectorHelper tearDown];
     
+    self.mockObjectIDToRemoteID = nil;
+    self.mockFlowManager = nil;
     self.conversationChangeObserver = nil;
     self.userChangeObserver = nil;
     self.messageChangeObserver = nil;

--- a/Tests/Source/MessagingTest.m
+++ b/Tests/Source/MessagingTest.m
@@ -170,6 +170,10 @@
     [self resetState];
     [MessagingTest deleteAllFilesInCache];
     [self removeCachesInSharedContainer];
+    _application = nil;
+    self.groupIdentifier = nil;
+    self.storeURL = nil;
+    self.keyStoreURL = nil;
     [super tearDown];
     Require([self waitForAllGroupsToBeEmptyWithTimeout:5]);
 }


### PR DESCRIPTION
Been bothering us for some time. The date passed to AVS gets truncated to integers which can lead to problems if we compare last modified date to current date.