### PR TITLE
filter out duplicate call member, keep highest connection state

### DIFF
--- a/Tests/Source/Calling/VoiceChannelParticipantV3SnapshotTests.swift
+++ b/Tests/Source/Calling/VoiceChannelParticipantV3SnapshotTests.swift
@@ -1,0 +1,95 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+@testable import WireSyncEngine
+
+class VoiceChannelParticipantV3SnapshotTests : MessagingTest {
+
+    var mockWireCallCenterV3 : WireCallCenterV3Mock!
+
+    override func setUp() {
+        super.setUp()
+        mockWireCallCenterV3 = WireCallCenterV3Mock(userId: UUID(), clientId: "foo", uiMOC: uiMOC)
+    }
+    
+    override func tearDown() {
+        mockWireCallCenterV3 = nil
+        super.tearDown()
+    }
+
+    func testThatItDoesNotCrashWhenInitializedWithDuplicateCallMembers(){
+        // given
+        let userId = UUID()
+        let callMember1 = CallMember(userId: userId, audioEstablished: true)
+        let callMember2 = CallMember(userId: userId, audioEstablished: false)
+
+        // when
+        let sut = WireSyncEngine.VoiceChannelParticipantV3Snapshot(conversationId: UUID(),
+                                                                   selfUserID: UUID(),
+                                                                   members: [callMember1, callMember2])
+        
+        // then
+        // it does not crash and
+        XCTAssertEqual(sut.members.array.count, 1)
+        if let first = sut.members.array.first {
+            XCTAssertTrue(first.audioEstablished)
+        }
+    }
+    
+    func testThatItDoesNotCrashWhenUpdatedWithDuplicateCallMembers(){
+        // given
+        let userId = UUID()
+        let callMember1 = CallMember(userId: userId, audioEstablished: true)
+        let callMember2 = CallMember(userId: userId, audioEstablished: false)
+        let sut = WireSyncEngine.VoiceChannelParticipantV3Snapshot(conversationId: UUID(),
+                                                                   selfUserID: UUID(),
+                                                                   members: [])
+
+        // when
+        sut.callParticipantsChanged(newParticipants: [callMember1, callMember2])
+        
+        // then
+        // it does not crash and
+        XCTAssertEqual(sut.members.array.count, 1)
+        if let first = sut.members.array.first {
+            XCTAssertTrue(first.audioEstablished)
+        }
+    }
+    
+    func testThatItKeepsTheMemberWithAudioEstablished(){
+        // given
+        let userId = UUID()
+        let callMember1 = CallMember(userId: userId, audioEstablished: false)
+        let callMember2 = CallMember(userId: userId, audioEstablished: true)
+        let sut = WireSyncEngine.VoiceChannelParticipantV3Snapshot(conversationId: UUID(),
+                                                                   selfUserID: UUID(),
+                                                                   members: [])
+        
+        // when
+        sut.callParticipantsChanged(newParticipants: [callMember1, callMember2])
+        
+        // then
+        // it does not crash and
+        XCTAssertEqual(sut.members.array.count, 1)
+        if let first = sut.members.array.first {
+            XCTAssertTrue(first.audioEstablished)
+        }
+    }
+}

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -456,6 +456,7 @@
 		F9E577211E77EC6D0065EFE4 /* WireCallCenterV3+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9E577201E77EC6D0065EFE4 /* WireCallCenterV3+Notifications.swift */; };
 		F9F631421DE3524100416938 /* TypingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F631411DE3524100416938 /* TypingStrategy.swift */; };
 		F9F631431DE3534F00416938 /* ZMTyping.h in Headers */ = {isa = PBXBuildFile; fileRef = 3E3C00C91A2358BA00D02D21 /* ZMTyping.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F9F846351ED307F70087C1A4 /* VoiceChannelParticipantV3SnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F846331ED307F10087C1A4 /* VoiceChannelParticipantV3SnapshotTests.swift */; };
 		F9F9F5621D75D62100AE6499 /* RequestStrategyTestBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F9F5611D75D62100AE6499 /* RequestStrategyTestBase.swift */; };
 		F9FD167B1BDFCDAD00725F5C /* ZMClientRegistrationStatus.h in Headers */ = {isa = PBXBuildFile; fileRef = F9FD16791BDFCDAD00725F5C /* ZMClientRegistrationStatus.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F9FD167C1BDFCDAD00725F5C /* ZMClientRegistrationStatus.m in Sources */ = {isa = PBXBuildFile; fileRef = F9FD167A1BDFCDAD00725F5C /* ZMClientRegistrationStatus.m */; };
@@ -1062,6 +1063,7 @@
 		F9E577201E77EC6D0065EFE4 /* WireCallCenterV3+Notifications.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WireCallCenterV3+Notifications.swift"; sourceTree = "<group>"; };
 		F9F11A061A0A630900F1DCEE /* ZMBlacklistVerificatorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMBlacklistVerificatorTest.m; sourceTree = "<group>"; };
 		F9F631411DE3524100416938 /* TypingStrategy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypingStrategy.swift; sourceTree = "<group>"; };
+		F9F846331ED307F10087C1A4 /* VoiceChannelParticipantV3SnapshotTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VoiceChannelParticipantV3SnapshotTests.swift; sourceTree = "<group>"; };
 		F9F9F5611D75D62100AE6499 /* RequestStrategyTestBase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestStrategyTestBase.swift; sourceTree = "<group>"; };
 		F9FD16791BDFCDAD00725F5C /* ZMClientRegistrationStatus.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZMClientRegistrationStatus.h; sourceTree = "<group>"; };
 		F9FD167A1BDFCDAD00725F5C /* ZMClientRegistrationStatus.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMClientRegistrationStatus.m; sourceTree = "<group>"; };
@@ -1333,6 +1335,7 @@
 				F94E39231E4CE2CA0072D71C /* VoiceChannelStateSnapshotTests.swift */,
 				F9CDA3981E9E5CF0001F98A5 /* SystemMessageCallObserverTests.swift */,
 				F95FFBCF1EB8A44D004031CB /* CallSystemMessageGeneratorTests.swift */,
+				F9F846331ED307F10087C1A4 /* VoiceChannelParticipantV3SnapshotTests.swift */,
 			);
 			path = Calling;
 			sourceTree = "<group>";
@@ -2529,6 +2532,7 @@
 				0920C4DA1B305FF500C55728 /* UserSessionGiphyRequestStateTests.swift in Sources */,
 				541918ED195AD9D100A5023D /* SendAndReceiveMessagesTests.m in Sources */,
 				3EA1EC6D19BDE4C800AA1384 /* ZMPushTokenTests.m in Sources */,
+				F9F846351ED307F70087C1A4 /* VoiceChannelParticipantV3SnapshotTests.swift in Sources */,
 				54773ABD1DF093AC00B484AF /* ZMSearchDirectoryAddressBookTests.swift in Sources */,
 				54DE9BEF1DE760A900EFFB9C /* RandomHandleGeneratorTests.swift in Sources */,
 				F9C598AD1A0947B300B1F760 /* ZMBlacklistDownloaderTest.m in Sources */,


### PR DESCRIPTION
When a user joins a group call from two devices, AVS will return two `CallMember` structs with the same userId (but possibly with different audioEstablished flag). We don't expect that and crash. 
We are now filtering the duplicate members and keep the one with the highest connection state (e.g. the one with audioEstablished true). 

It needs to be discussed whether we will need to handle multiple CallMembers for the same user in the future. In that case we need to get the clientID from AVS in order to be able to distinguish the members.