### PR TITLE
Do not create APNS when shouldRing is false for incoming call

### DIFF
--- a/Source/Notifications/Push notifications/Notification Types/ZMLocalNotificationForCallState.swift
+++ b/Source/Notifications/Push notifications/Notification Types/ZMLocalNotificationForCallState.swift
@@ -97,8 +97,9 @@ final public class ZMLocalNotificationForCallState : ZMLocalNotification {
         switch callState {
         case .terminating(reason: .anweredElsewhere), .terminating(reason: .normal):
             return false
-        case .incoming,
-             .terminating,
+        case .incoming(video: _, shouldRing: let shouldRing):
+            return shouldRing
+        case .terminating,
              .none where numberOfMissedCalls > 0:
             return true
         default:

--- a/Tests/Source/Calling/CallStateObserverTests.swift
+++ b/Tests/Source/Calling/CallStateObserverTests.swift
@@ -162,7 +162,7 @@ class CallStateObserverTests : MessagingTest {
     
     func testThatCallStatesAreForwardedToTheNotificationDispatcher() {
         // given when
-        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: false), conversationId: conversation.remoteIdentifier!, userId: sender.remoteIdentifier!, timeStamp: nil)
+        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: true), conversationId: conversation.remoteIdentifier!, userId: sender.remoteIdentifier!, timeStamp: nil)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then

--- a/Tests/Source/Notifications/PushNotifications/LocalNotificationDispatcherCallingTests.swift
+++ b/Tests/Source/Notifications/PushNotifications/LocalNotificationDispatcherCallingTests.swift
@@ -56,7 +56,7 @@ class LocalNotificationDispatcherCallingTests : MessagingTest {
     
     func testThatIncomingCallCreatesCallingNotification() {
         // when
-        sut.process(callState: .incoming(video: false, shouldRing: false), in: conversation, sender: sender)
+        sut.process(callState: .incoming(video: false, shouldRing: true), in: conversation, sender: sender)
         
         // then
         XCTAssertEqual(sut.callingNotifications.notifications.count, 1)
@@ -79,7 +79,7 @@ class LocalNotificationDispatcherCallingTests : MessagingTest {
     
     func testThatIncomingCallIsReplacedByCanceledCallNotification() {
         // given 
-        sut.process(callState: .incoming(video: false, shouldRing: false), in: conversation, sender: sender)
+        sut.process(callState: .incoming(video: false, shouldRing: true), in: conversation, sender: sender)
         XCTAssertEqual(sut.callingNotifications.notifications.count, 1)
         XCTAssertEqual(application.scheduledLocalNotifications.count, 1)
         let incomingCallNotification = application.scheduledLocalNotifications.first!
@@ -95,7 +95,7 @@ class LocalNotificationDispatcherCallingTests : MessagingTest {
     
     func testThatIncomingCallIsClearedWhenCallIsAnsweredElsewhere() {
         // given
-        sut.process(callState: .incoming(video: false, shouldRing: false), in: conversation, sender: sender)
+        sut.process(callState: .incoming(video: false, shouldRing: true), in: conversation, sender: sender)
         XCTAssertEqual(sut.callingNotifications.notifications.count, 1)
         XCTAssertEqual(application.scheduledLocalNotifications.count, 1)
         let incomingCallNotification = application.scheduledLocalNotifications.first!

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationForCallEventTests.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationForCallEventTests.swift
@@ -43,15 +43,16 @@ class ZMLocalNotificationForCallStateTests : MessagingTest {
         }
     }
     
-    
     func testIncomingAudioCall() {
         
         // given
         let note = ZMLocalNotificationForCallState(conversation: conversation, sender: sender)
-        note.update(forCallState: .incoming(video: false, shouldRing: false))
+        note.update(forCallState: .incoming(video: false, shouldRing: true))
         
         // when
-        let uiNote = note.notifications.first!
+        guard let uiNote = note.notifications.first else {
+            return XCTFail("Did not create notification")
+        }
         
         // then
         XCTAssertEqual(uiNote.alertBody, "Callie is calling")
@@ -59,19 +60,41 @@ class ZMLocalNotificationForCallStateTests : MessagingTest {
         XCTAssertEqual(uiNote.soundName, ZMCustomSound.notificationRingingSoundName())
     }
     
+    func testIncomingAudioCall_ShouldRing_False() {
+        
+        // given
+        let note = ZMLocalNotificationForCallState(conversation: conversation, sender: sender)
+        note.update(forCallState: .incoming(video: false, shouldRing: false))
+        
+        // when
+        XCTAssertEqual(note.notifications.count, 0)
+    }
+    
     func testIncomingVideoCall() {
+        
+        // given
+        let note = ZMLocalNotificationForCallState(conversation: conversation, sender: sender)
+        note.update(forCallState: .incoming(video: true, shouldRing: true))
+        
+        // when
+        guard let uiNote = note.notifications.first else {
+            return XCTFail("Did not create notification")
+        }
+        
+        // then
+        XCTAssertEqual(uiNote.alertBody, "Callie is video calling")
+        XCTAssertEqual(uiNote.category, ZMIncomingCallCategory)
+        XCTAssertEqual(uiNote.soundName, ZMCustomSound.notificationRingingSoundName())
+    }
+    
+    func testIncomingVideoCall_ShouldRing_False() {
         
         // given
         let note = ZMLocalNotificationForCallState(conversation: conversation, sender: sender)
         note.update(forCallState: .incoming(video: true, shouldRing: false))
         
         // when
-        let uiNote = note.notifications.first!
-        
-        // then
-        XCTAssertEqual(uiNote.alertBody, "Callie is video calling")
-        XCTAssertEqual(uiNote.category, ZMIncomingCallCategory)
-        XCTAssertEqual(uiNote.soundName, ZMCustomSound.notificationRingingSoundName())
+        XCTAssertEqual(note.notifications.count, 0)
     }
     
     func testCanceledCall() {


### PR DESCRIPTION
When a user has two clients (A and B) and calls from A, we currently create an APNS on B about an incoming call. AVS has the flag shouldRing set to false in this case. 

We should therefore not create an APNS when the flag shouldRing is false.