### PR TITLE
Fix conversation creation payload

### DIFF
--- a/Source/Synchronization/Transcoders/ZMConversationTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMConversationTranscoder.m
@@ -43,6 +43,8 @@ static NSString *const UserInfoRemovedValueKey = @"removed";
 static NSString *const ConversationInfoArchivedValueKey = @"archived";
 
 static NSString *const ConversationTeamKey = @"team";
+static NSString *const ConversationTeamIdKey = @"teamid";
+static NSString *const ConversationTeamManagedKey = @"managed";
 
 @interface ZMConversationTranscoder () <ZMSimpleListRequestPaginatorSync>
 
@@ -688,7 +690,10 @@ static NSString *const ConversationTeamKey = @"team";
     }
 
     if (insertedConversation.team.remoteIdentifier != nil) {
-        payload[ConversationTeamKey] = insertedConversation.team.remoteIdentifier.transportString;
+        payload[ConversationTeamKey] = @{
+                             ConversationTeamIdKey: insertedConversation.team.remoteIdentifier.transportString,
+                             ConversationTeamManagedKey: @NO // FIXME:
+                             };
     }
     
     request = [ZMTransportRequest requestWithPath:ConversationsPath method:ZMMethodPOST payload:payload];

--- a/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.m
@@ -1523,10 +1523,12 @@ static NSString *const CONVERSATION_ID_REQUEST_PREFIX = @"/conversations?ids=";
     NSSet *expected = [users mapWithBlock:^NSString *(ZMUser *user) { return user.remoteIdentifier.transportString; }].set;
     XCTAssertEqualObjects([NSSet setWithArray:request.payload[@"users"]], expected);
     XCTAssertEqualObjects(request.payload[@"name"], name);
+    NSDictionary *teamPayload = request.payload[@"team"];
     Team *team = [ZMUser selfUserInContext:self.syncMOC].teams.anyObject;
     XCTAssertNotNil(team);
 
-    XCTAssertEqualObjects(request.payload[@"team"], team.remoteIdentifier.transportString);
+    XCTAssertEqualObjects(teamPayload[@"teamid"], team.remoteIdentifier.transportString);
+    XCTAssertEqualObjects(teamPayload[@"managed"], @NO);
 }
 
 - (ZMTransportRequest *)requestForConversationCreationWithTeamAndUsers:(NSArray <ZMUser *> *)users modifier:(void (^)(ZMConversation *conversation))modifier

--- a/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.m
@@ -1493,9 +1493,11 @@ static NSString *const CONVERSATION_ID_REQUEST_PREFIX = @"/conversations?ids=";
 
         NSSet *expected = [users mapWithBlock:^NSString *(ZMUser *user) { return user.remoteIdentifier.transportString; }].set;
         XCTAssertEqualObjects([NSSet setWithArray:request.payload[@"users"]], expected);
+        NSDictionary *teamPayload = request.payload[@"team"];
         Team *team = [ZMUser selfUserInContext:self.syncMOC].teams.anyObject;
         XCTAssertNotNil(team);
-        XCTAssertEqualObjects(request.payload[@"team"], team.remoteIdentifier.transportString);
+        XCTAssertEqualObjects(teamPayload[@"teamid"], team.remoteIdentifier.transportString);
+        XCTAssertEqualObjects(teamPayload[@"managed"], @NO);
     }];
 }
 


### PR DESCRIPTION
# What's in this PR?

* While the payload when getting a team conversation does not include an object containing the `managed` we still need to include it when creating a team conversation.