### PR TITLE
Ensure we delete teams we did not receive a deletion event for

### DIFF
--- a/Tests/Source/Integration/TeamTests.swift
+++ b/Tests/Source/Integration/TeamTests.swift
@@ -319,8 +319,7 @@ extension TeamTests {
     func testThatYouCanRemoveAMemberFromATeamConversation_SelfIsMember(){
     
     }
-    
-    
+
     func testThatYouCanNotAddAMemberToATeamConversation_SelfIsGuest(){
         
     }
@@ -328,4 +327,39 @@ extension TeamTests {
     func testThatYouCanNOTRemoveAMemberFromATeamConversation_SelfIsGuest(){
     
     }
+
+}
+
+// MARK : Remotely Deleted Team
+
+extension TeamTests {
+
+    func testThatItDeltesARemotelyDeletedTeamAfterPerfomingSlowSyncCausedByMissedEvents() {
+        // Given
+        // 1. Insert local team, which will not be returned by mock transport when fetching /teams
+        let localOnlyTeamId = UUID.create()
+        let localOnlyTeam = Team.insertNewObject(in: uiMOC)
+        localOnlyTeam.remoteIdentifier = localOnlyTeamId
+        XCTAssert(uiMOC.saveOrRollback())
+
+        // 2. Force a slow sync by returning a 404 when hitting /notifications
+        mockTransportSession.responseGeneratorBlock = { request in
+            if request.path.hasPrefix("/notifications") && !request.path.contains("cancel_fallback") {
+                defer { self.mockTransportSession.responseGeneratorBlock = nil }
+                return ZMTransportResponse(payload: nil, httpStatus: 404, transportSessionError: nil)
+            }
+            return nil
+        }
+
+        // When
+        XCTAssert(logInAndWaitForSyncToBeComplete())
+        XCTAssert(waitForEverythingToBeDone())
+
+        // Then
+        // Assert that the local team got deleted after trying to refetch it AFTER the slow sync was performed.
+        // FIXME: The team is not deleted on uiMOC at this point,
+        // check if we are missing a save or not propagating the changes correctly here?
+        XCTAssertNil(Team.fetch(withRemoteIdentifier: localOnlyTeamId, in: syncMOC))
+    }
+
 }

--- a/Tests/Source/Integration/TeamTests.swift
+++ b/Tests/Source/Integration/TeamTests.swift
@@ -357,9 +357,8 @@ extension TeamTests {
 
         // Then
         // Assert that the local team got deleted after trying to refetch it AFTER the slow sync was performed.
-        // FIXME: The team is not deleted on uiMOC at this point,
-        // check if we are missing a save or not propagating the changes correctly here?
-        XCTAssertNil(Team.fetch(withRemoteIdentifier: localOnlyTeamId, in: syncMOC))
+        let team = Team.fetch(withRemoteIdentifier: localOnlyTeamId, in: uiMOC)
+        XCTAssert(team == nil || team!.isDeleted)
     }
 
 }


### PR DESCRIPTION
# What's in this PR?

It can happen that a user is offline for longer than 4 weeks, in this case said user will miss events and we will perform a slow sync. In the case the user got removed from a team that the user already has locally in that period, we want to ensure that we delete that team from the client.
The `/teams` request will only return the teams the user is still a member in of course, so we fetch all local teams and mark them as `needsToBeUpdatedFromBackend`, we reset this flag for all teams we fetch during the slow sync, (we just fetched them so there is no need to do it again after the slow sync completed). After the slow sync we will try to fetch the deleted teams and receive a 4xx response and delete the team locally.