### PR TITLE
Always using user remote identifier as CallKit handle

### DIFF
--- a/Source/Calling/ZMCallKitDelegate.m
+++ b/Source/Calling/ZMCallKitDelegate.m
@@ -97,46 +97,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 NS_ASSUME_NONNULL_END
 
-@implementation ZMUser (Handle)
-
-- (CXHandle *)callKitHandle
-{
-    if (0 != self.phoneNumber.length) {
-        return [[CXHandle alloc] initWithType:CXHandleTypePhoneNumber value:self.phoneNumber];
-    }
-    else if (0 != self.emailAddress.length) {
-        return [[CXHandle alloc] initWithType:CXHandleTypeEmailAddress value:self.emailAddress];
-    }
-    else if (nil != self.oneToOneConversation.remoteIdentifier) {
-        return [[CXHandle alloc] initWithType:CXHandleTypeGeneric value:self.oneToOneConversation.remoteIdentifier.transportString];
-    }
-    else {
-        RequireString(1, "Cannot create CXHandle: user has neither email nor phone number");
-    }
-    return nil;
-}
-
-@end
-
 @implementation ZMConversation (Handle)
 
 - (CXHandle *)callKitHandle
 {
-    switch (self.conversationType) {
-        case ZMConversationTypeOneOnOne:
-        case ZMConversationTypeConnection:
-            return self.connectedUser.callKitHandle;
-            break;
-        case ZMConversationTypeGroup:
-            return [[CXHandle alloc] initWithType:CXHandleTypeGeneric value:self.remoteIdentifier.transportString];
-            break;
-        default:
-            RequireString(1, "Cannot create CXHandle: conversation type is invalid");
-            return nil;
-            break;
-    }
-    
-    return nil;
+    return [[CXHandle alloc] initWithType:CXHandleTypeGeneric value:self.remoteIdentifier.transportString];
 }
 
 - (NSString *)localizedCallerNameWithCallFromUser:(ZMUser *)user

--- a/Tests/Source/Calling/ZMCallKitDelegateTests.swift
+++ b/Tests/Source/Calling/ZMCallKitDelegateTests.swift
@@ -267,8 +267,8 @@ class ZMCallKitDelegateTest: MessagingTest {
         let action = self.callKitController.requestedTransactions.first!.actions.first! as! CXStartCallAction
 
         XCTAssertEqual(action.callUUID, conversation.remoteIdentifier)
-        XCTAssertEqual(action.handle.type, .emailAddress)
-        XCTAssertEqual(action.handle.value, user.emailAddress)
+        XCTAssertEqual(action.handle.type, .generic)
+        XCTAssertEqual(action.handle.value, conversation.remoteIdentifier?.transportString())
     }
     
     func testThatItReportsTheStartCallRequest_groupConversation() {
@@ -306,8 +306,8 @@ class ZMCallKitDelegateTest: MessagingTest {
         let action = self.callKitController.requestedTransactions.first!.actions.first! as! CXStartCallAction
         
         XCTAssertEqual(action.callUUID, conversation.remoteIdentifier)
-        XCTAssertEqual(action.handle.type, .emailAddress)
-        XCTAssertEqual(action.handle.value, otherUser.emailAddress)
+        XCTAssertEqual(action.handle.type, .generic)
+        XCTAssertEqual(action.handle.value, conversation.remoteIdentifier?.transportString())
         XCTAssertTrue(action.isVideo)
     }
     
@@ -359,8 +359,8 @@ class ZMCallKitDelegateTest: MessagingTest {
         
         let action = self.callKitController.requestedTransactions.last!.actions.last! as! CXStartCallAction
         XCTAssertEqual(action.callUUID, conversation.remoteIdentifier)
-        XCTAssertEqual(action.handle.type, .emailAddress)
-        XCTAssertEqual(action.handle.value, otherUser.emailAddress)
+        XCTAssertEqual(action.handle.type, .generic)
+        XCTAssertEqual(action.handle.value, conversation.remoteIdentifier?.transportString())
         XCTAssertTrue(action.isVideo)
     }
     


### PR DESCRIPTION
We don't have email and phone number of other users and with SMB the 1to1 conversation might not be available, so always using user remote identifier as CallKit handle.