### PR TITLE
Add a HotFix to enforce a slow sync when updating sync-engine to v88

### DIFF
--- a/Source/Synchronization/ZMHotFixDirectory+Swift.swift
+++ b/Source/Synchronization/ZMHotFixDirectory+Swift.swift
@@ -106,4 +106,8 @@ extension ZMHotFixDirectory {
         ZMUser.selfUser(in: context).needsToBeUpdatedFromBackend = true
         context.enqueueDelayedSave()
     }
+
+    public static func restartSlowSync() {
+        NotificationCenter.default.post(name: .ForceSlowSync, object: nil)
+    }
 }

--- a/Source/Synchronization/ZMHotFixDirectory.m
+++ b/Source/Synchronization/ZMHotFixDirectory.m
@@ -107,6 +107,14 @@ static NSString* ZMLogTag ZM_UNUSED = @"HotFix";
                      patchCode:^(NSManagedObjectContext *context) {
                          [ZMHotFixDirectory refetchConnectedUsers:context];
                      }],
+
+                    /// We need to force a slow sync with the introduction of Teams, as users might have missed
+                    /// update events when being added to teams or team conversations.
+                    [ZMHotFixPatch
+                     patchWithVersion:@"88.0.0"
+                     patchCode:^(__unused NSManagedObjectContext *context) {
+                         [ZMHotFixDirectory restartSlowSync];
+                     }],
                     ];
     });
     return patches;

--- a/Source/UserSession/SyncStatus.swift
+++ b/Source/UserSession/SyncStatus.swift
@@ -65,6 +65,16 @@
 
 private let zmLog = ZMSLog(tag: "SyncStatus")
 
+
+extension Notification.Name {
+
+    public static var ForceSlowSync = {
+        Notification.Name("restartSlowSyncNotificationName")
+    }()
+    
+}
+
+
 public class SyncStatus : NSObject {
 
     fileprivate var previousPhase : SyncPhase = .done
@@ -99,8 +109,13 @@ public class SyncStatus : NSObject {
         super.init()
         
         currentSyncPhase = hasPersistedLastEventID ? .fetchingMissedEvents : .fetchingLastUpdateEventID
-        
         self.syncStateDelegate.didStartSync()
+        NotificationCenter.default.addObserver(self, selector: #selector(forceSlowSync), name: .ForceSlowSync, object: nil)
+    }
+
+    public func forceSlowSync() {
+        currentSyncPhase = .fetchingLastUpdateEventID
+        syncStateDelegate.didStartSync()
     }
 }
 

--- a/Source/UserSession/SyncStatus.swift
+++ b/Source/UserSession/SyncStatus.swift
@@ -44,15 +44,7 @@
     }
 
     var nextPhase: SyncPhase? {
-        switch self {
-        case .fetchingLastUpdateEventID: return .fetchingTeams
-        case .fetchingTeams: return .fetchingConnections
-        case .fetchingConnections: return .fetchingConversations
-        case .fetchingConversations: return .fetchingUsers
-        case .fetchingUsers: return .fetchingMissedEvents
-        case .fetchingMissedEvents: return .done
-        case .done: return nil
-        }
+        return SyncPhase(rawValue: rawValue + 1)
     }
     
     public var description: String {

--- a/Tests/Source/UserSession/SyncStatusTests.swift
+++ b/Tests/Source/UserSession/SyncStatusTests.swift
@@ -347,7 +347,7 @@ extension SyncStatusTests {
         sut.forceSlowSync()
 
         // then
-        XCTAssertEqual(sut.currentSyncPhase, .fetchingLastUpdateEventID)
+        XCTAssertEqual(sut.currentSyncPhase, .fetchingTeams)
         XCTAssertTrue(sut.isSyncing)
     }
 
@@ -362,7 +362,7 @@ extension SyncStatusTests {
         NotificationCenter.default.post(name: .ForceSlowSync, object: nil)
 
         // then
-        XCTAssertEqual(sut.currentSyncPhase, .fetchingLastUpdateEventID)
+        XCTAssertEqual(sut.currentSyncPhase, .fetchingTeams)
         XCTAssertTrue(sut.isSyncing)
     }
 

--- a/Tests/Source/UserSession/SyncStatusTests.swift
+++ b/Tests/Source/UserSession/SyncStatusTests.swift
@@ -335,7 +335,37 @@ extension SyncStatusTests {
         // then
         XCTAssertEqual(sut.currentSyncPhase, .fetchingMissedEvents)
     }
-    
+
+    func testThatItRestartsSlowSyncWhenRestartSlowSyncIsCalled(){
+        // given
+        uiMOC.zm_lastNotificationID = UUID.timeBasedUUID() as UUID
+        sut = SyncStatus(managedObjectContext: uiMOC, syncStateDelegate: mockSyncDelegate)
+        sut.finishCurrentSyncPhase()
+        XCTAssertEqual(sut.currentSyncPhase, .done)
+
+        // when
+        sut.forceSlowSync()
+
+        // then
+        XCTAssertEqual(sut.currentSyncPhase, .fetchingLastUpdateEventID)
+        XCTAssertTrue(sut.isSyncing)
+    }
+
+    func testThatItRestartsSlowSyncWhenRestartSlowSyncNotificationIsFired(){
+        // given
+        uiMOC.zm_lastNotificationID = UUID.timeBasedUUID() as UUID
+        sut = SyncStatus(managedObjectContext: uiMOC, syncStateDelegate: mockSyncDelegate)
+        sut.finishCurrentSyncPhase()
+        XCTAssertEqual(sut.currentSyncPhase, .done)
+
+        // when
+        NotificationCenter.default.post(name: .ForceSlowSync, object: nil)
+
+        // then
+        XCTAssertEqual(sut.currentSyncPhase, .fetchingLastUpdateEventID)
+        XCTAssertTrue(sut.isSyncing)
+    }
+
     func testThatItDoesNotRestartsQuickSyncWhenPushChannelIsClosed(){
         // given
         uiMOC.zm_lastNotificationID = UUID.timeBasedUUID() as UUID


### PR DESCRIPTION
# What's in this PR?

* Users might receive team related update events while not being able to parse them because they didn't update yet. To work around this we now force a slow sync in a HotFix to refetch all teams and all (team) conversations which might have been added before updating.