### PR TITLE
REVERT: Require email on second sign in

### DIFF
--- a/Source/Public/NSError+ZMUserSession.h
+++ b/Source/Public/NSError+ZMUserSession.h
@@ -47,11 +47,10 @@ typedef NS_ENUM(NSUInteger, ZMUserSessionErrorCode) {
     /// There is already a recent request to get the activation code for registration/login
     ZMUserSessionCodeRequestIsAlreadyPending = 12,
     /// The user account does not have a password, and a password
-    /// is needed to register a new client.
+    /// is needed to register a new client
     ZMUserSessionNeedsPasswordToRegisterClient = 13,
     /// The user account does not have an email, and an email
     /// is needed to register a new client
-    /// Not supported by the backend any more. The error is generated locally.
     ZMUserSessionNeedsToRegisterEmailToRegisterClient = 14,
     /// Too many clients have been registered for this user,
     /// one needs to be deleted before registering a new one

--- a/Source/Synchronization/Strategies/UserClientRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/UserClientRequestStrategy.swift
@@ -46,9 +46,9 @@ public final class UserClientRequestStrategy: ZMObjectSyncStrategy, ZMObjectStra
     public var minNumberOfRemainingKeys: UInt = 20
     
     fileprivate var insertSyncFilter: NSPredicate {
-        return NSPredicate { object, _ -> Bool in
-            guard let client = object as? UserClient, let user = client.user else { return false }
-            return user.isSelfUser
+        return NSPredicate { [unowned self] object, _ -> Bool in
+            guard let client = object as? UserClient else { return false }
+            return client.user == ZMUser.selfUser(in: self.managedObjectContext)
         }
     }
     
@@ -190,7 +190,7 @@ public final class UserClientRequestStrategy: ZMObjectSyncStrategy, ZMObjectStra
             return false
         }
         if keysToParse.contains(ZMUserClientNeedsToUpdateSignalingKeysKey) {
-            if response.httpStatus == 400, let label = response.payloadLabel(), label == "bad-request" {
+            if response.httpStatus == 400, let label = response.payloadLabel() , label == "bad-request" {
                 // Malformed prekeys uploaded - recreate and retry once per launch
 
                 if didRetryRegisteringSignalingKeys {
@@ -267,17 +267,13 @@ public final class UserClientRequestStrategy: ZMObjectSyncStrategy, ZMObjectStra
     
     public func errorFromFailedInsertResponse(_ response: ZMTransportResponse!) -> NSError {
         var errorCode: ZMUserSessionErrorCode = .unkownError
-        if let response = response, response.result == .permanentError {
+        if let response = response , response.result == .permanentError {
 
             if let errorLabel = response.payload?.asDictionary()?["label"] as? String {
                 switch errorLabel {
                 case "missing-auth":
-                    if let emailAddress = ZMUser.selfUser(in: self.managedObjectContext).emailAddress, !emailAddress.isEmpty {
-                        errorCode = .needsPasswordToRegisterClient
-                    }
-                    else {
-                        errorCode = .invalidCredentials
-                    }
+                    let selfUserHasEmail = (ZMUser.selfUser(in: self.managedObjectContext).emailAddress != nil )
+                    errorCode = selfUserHasEmail ? .needsPasswordToRegisterClient : .needsToRegisterEmailToRegisterClient
                     break
                 case "too-many-clients":
                     errorCode = .canNotRegisterMoreClients

--- a/Source/Synchronization/Transcoders/ZMSelfStrategy.m
+++ b/Source/Synchronization/Transcoders/ZMSelfStrategy.m
@@ -316,7 +316,7 @@ static NSString * const DeletionRequestKey = @"";
         // TODO: Write tests for all cases
         BOOL selfUserHasEmail = (selfUser.emailAddress != nil);
         BOOL needToNotifyAuthState = (clientPhase == ZMClientRegistrationPhaseWaitingForSelfUser) ||
-                                     (clientPhase == ZMClientRegistrationPhaseWaitingForEmailVerfication);
+                                     (clientPhase == ZMClientRegistrationPhaseWaitingForEmailVerfication && selfUserHasEmail);
 
         if (needToNotifyAuthState) {
             [clientStatus didFetchSelfUser];

--- a/Source/UserSession/ZMAuthenticationStatus.h
+++ b/Source/UserSession/ZMAuthenticationStatus.h
@@ -109,6 +109,7 @@ typedef NS_ENUM(NSUInteger, ZMAuthenticationPhase) {
 @interface ZMAuthenticationStatus (CredentialProvider) <ZMCredentialProvider>
 
 - (void)credentialsMayBeCleared;
+- (BOOL)registeredOnThisDeviceOnContext:(NSManagedObjectContext *)moc;
 
 @end
 

--- a/Source/UserSession/ZMAuthenticationStatus.m
+++ b/Source/UserSession/ZMAuthenticationStatus.m
@@ -105,12 +105,12 @@ static NSString* ZMLogTag ZM_UNUSED = @"Authentication";
 
 - (void)setRegisteredOnThisDevice:(BOOL)registeredOnThisDevice
 {
-    [self.moc setRegisteredOnThisDevice:registeredOnThisDevice];
+    [self.moc setPersistentStoreMetadata:@(registeredOnThisDevice) forKey:RegisteredOnThisDeviceKey];
 }
 
 - (BOOL)registeredOnThisDevice
 {
-    return [self.moc isRegisteredOnThisDevice];
+    return [self registeredOnThisDeviceOnContext:self.moc];
 }
 
 - (ZMCompleteRegistrationUser *)registrationUser
@@ -452,25 +452,9 @@ static NSString* ZMLogTag ZM_UNUSED = @"Authentication";
     return nil;
 }
 
-@end
-
-
-
-@implementation NSManagedObjectContext (Registration)
-
-- (void)setRegisteredOnThisDevice:(BOOL)registeredOnThisDevice
+- (BOOL)registeredOnThisDeviceOnContext:(NSManagedObjectContext *)moc;
 {
-    assert(self.zm_isSyncContext);
-    [self setPersistentStoreMetadata:@(registeredOnThisDevice) forKey:RegisteredOnThisDeviceKey];
-    NSManagedObjectContext *uiContext = self.zm_userInterfaceContext;
-    [uiContext performGroupedBlock:^{
-        [uiContext setPersistentStoreMetadata:@(registeredOnThisDevice) forKey:RegisteredOnThisDeviceKey];
-    }];
-}
-
-- (BOOL)isRegisteredOnThisDevice
-{
-    return ((NSNumber *)[self persistentStoreMetadataForKey:RegisteredOnThisDeviceKey]).boolValue;
+    return ((NSNumber *)[moc persistentStoreMetadataForKey:RegisteredOnThisDeviceKey]).boolValue;
 }
 
 @end

--- a/Source/UserSession/ZMAuthenticationStatus_Internal.h
+++ b/Source/UserSession/ZMAuthenticationStatus_Internal.h
@@ -47,10 +47,3 @@
 - (void)setLoginCredentials:(ZMCredentials *)credentials;
 
 @end
-
-
-@interface NSManagedObjectContext (Registration)
-- (void)setRegisteredOnThisDevice:(BOOL)registeredOnThisDevice;
-- (BOOL)isRegisteredOnThisDevice;
-@end
-

--- a/Source/UserSession/ZMClientRegistrationStatus+Internal.h
+++ b/Source/UserSession/ZMClientRegistrationStatus+Internal.h
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-#import "ZMClientRegistrationStatus.h"
 
 @class ZMEmailCredentials;
 
@@ -24,8 +23,5 @@
 
 - (void)credentialsMayBeCleared;
 - (ZMEmailCredentials *)emailCredentials;
-@end
 
-@interface ZMClientRegistrationStatus ()
-- (BOOL)isAddingEmailNecessary;
 @end

--- a/Source/UserSession/ZMClientRegistrationStatus.h
+++ b/Source/UserSession/ZMClientRegistrationStatus.h
@@ -58,8 +58,8 @@ extern NSString *const ZMPersistedClientIdKey;
 @interface ZMClientRegistrationStatus : NSObject <ClientRegistrationDelegate>
 
 - (instancetype)initWithManagedObjectContext:(NSManagedObjectContext *)moc
-                     loginCredentialProvider:(id<ZMCredentialProvider>)loginCredentialProvider
-                    updateCredentialProvider:(id<ZMCredentialProvider>)updateCredentialProvider
+                     loginCredentialProvider:(id<ZMCredentialProvider>) loginCredentialProvider
+                    updateCredentialProvider:(id<ZMCredentialProvider>) updateCredentialProvider
                                       cookie:(ZMCookie *)cookie
                   registrationStatusDelegate:(id<ZMClientRegistrationStatusDelegate>) registrationStatusDelegate;
 
@@ -78,5 +78,6 @@ extern NSString *const ZMPersistedClientIdKey;
 
 @property (nonatomic, readonly) ZMClientRegistrationPhase currentPhase;
 @property (nonatomic, readonly) ZMEmailCredentials *emailCredentials;
+@property (nonatomic, readonly) BOOL hasEmailCredentials;
 
 @end

--- a/Source/UserSession/ZMClientRegistrationStatus.m
+++ b/Source/UserSession/ZMClientRegistrationStatus.m
@@ -32,21 +32,24 @@ NSString *const ZMPersistedClientIdKey = @"PersistedClientId";
 
 static NSString *ZMLogTag ZM_UNUSED = @"Authentication";
 
+
 @interface ZMClientRegistrationStatus ()
 
 @property (nonatomic) NSManagedObjectContext *managedObjectContext;
 @property (nonatomic) BOOL isWaitingForClientsToBeDeleted;
 @property (nonatomic) BOOL isWaitingForUserClients;
 @property (nonatomic) BOOL isWaitingForCredentials;
+@property (nonatomic) BOOL isWaitingForEmailVerification;
 @property (nonatomic) BOOL needsToCheckCredentials;
+
 @property (nonatomic) BOOL needsToVerifySelfClient;
 
-@property (nonatomic, weak) id <ZMCredentialProvider> loginCredentialProvider;
+@property (nonatomic, weak) id<ZMCredentialProvider> loginCredentialProvider;
 @property (nonatomic, weak) id <ZMCredentialProvider> updateCredentialProvider;
 @property (nonatomic, weak) id <ZMClientRegistrationStatusDelegate> registrationStatusDelegate;
 @property (nonatomic) ZMCookie *cookie;
 
-@property (nonatomic) id <ZMClientUpdateObserverToken> clientUpdateToken;
+@property (nonatomic) id<ZMClientUpdateObserverToken> clientUpdateToken;
 @property (nonatomic) BOOL tornDown;
 
 @end
@@ -110,6 +113,7 @@ static NSString *ZMLogTag ZM_UNUSED = @"Authentication";
 
 - (ZMClientRegistrationPhase)currentPhase
 {
+    
     /*
      The flow is as follows
      ZMClientRegistrationPhaseWaitingForLogin
@@ -118,12 +122,6 @@ static NSString *ZMLogTag ZM_UNUSED = @"Authentication";
      ZMClientRegistrationPhaseWaitingForSelfUser
      [We fetch the selfUser]
                 |
-     [User has email address?]      --> NO  --> ZMClientRegistrationPhaseWaitingForEmailVerfication
-                                                [user adds email and password, we fetch user from BE]
-                                            --> ZMClientRegistrationPhaseUnregistered
-                                                [Client is registered]
-                                            --> ZMClientRegistrationPhaseRegistered
-                                    --> YES --> Proceed
      ZMClientRegistrationPhaseUnregistered
      [We try to register the client without the password]
                 |
@@ -136,7 +134,11 @@ static NSString *ZMLogTag ZM_UNUSED = @"Authentication";
                                             --> ZMClientRegistrationPhaseUnregistered
                                                 [User entered correct password ?] -->  YES --> Continue at [User has too many devices]
                                                                                   -->  NO  --> ZMClientRegistrationPhaseWaitingForLogin
-
+                                    --> NO  --> ZMClientRegistrationPhaseWaitingForEmailVerfication 
+                                                [user adds email and password, we fetch user from BE]
+                                            --> ZMClientRegistrationPhaseUnregistered
+                                                [Client is registered]
+                                            --> ZMClientRegistrationPhaseRegistered
      [User has too many deviced?]    --> YES --> ZMClientRegistrationPhaseFetchingClients
                                                 [User selects device to delete]
                                             --> ZMClientRegistrationPhaseWaitingForDeletion
@@ -168,14 +170,14 @@ static NSString *ZMLogTag ZM_UNUSED = @"Authentication";
         return ZMClientRegistrationPhaseFetchingClients;
     }
     
+    // when the user has previously only registered by phone and now wants to register a second device, he needs to register his email address and password first
+    if (self.isWaitingForEmailVerification) {
+        return ZMClientRegistrationPhaseWaitingForEmailVerfication;
+    }
+    
     // when the user
     if (!self.needsToRegisterClient) {
         return ZMClientRegistrationPhaseRegistered;
-    }
-    
-    // when the user has previously only registered by phone and now wants to register a second device, he needs to register his email address and password first
-    if (self.isAddingEmailNecessary) {
-        return ZMClientRegistrationPhaseWaitingForEmailVerfication;
     }
     
     // when the user has too many clients registered already and selected one device to delete
@@ -197,6 +199,11 @@ static NSString *ZMLogTag ZM_UNUSED = @"Authentication";
 - (BOOL)isWaitingForLogin
 {
     return self.cookie.data == nil;
+}
+
+- (BOOL)hasEmailCredentials;
+{
+    return self.emailCredentials.email != nil && self.emailCredentials.password != nil;
 }
 
 - (BOOL)needsToRegisterClient
@@ -223,11 +230,6 @@ static NSString *ZMLogTag ZM_UNUSED = @"Authentication";
     return (selfUser.emailAddress == nil);
 }
 
-- (BOOL)isAddingEmailNecessary
-{
-    return ![self.managedObjectContext isRegisteredOnThisDevice] && self.isWaitingForSelfUserEmail;
-}
-
 - (void)prepareForClientRegistration
 {
     if (!self.needsToRegisterClient) {
@@ -242,8 +244,7 @@ static NSString *ZMLogTag ZM_UNUSED = @"Authentication";
     if ([self needsToCreateNewClientForSelfUser:selfUser]) {
         ZMLogDebug(@"%@", NSStringFromSelector(_cmd));
         [self insertNewClientForSelfUser:selfUser];
-    }
-    else {
+    } else {
         // there is already an unregistered client in the store
         // since there is no change in the managedObject, it will not trigger [ZMRequestAvailableNotification notifyNewRequestsAvailable:] automatically
         // therefore we need to call it here
@@ -276,12 +277,10 @@ static NSString *ZMLogTag ZM_UNUSED = @"Authentication";
 - (void)didFetchSelfUser;
 {
     ZMLogDebug(@"%@", NSStringFromSelector(_cmd));
+    if (self.isWaitingForEmailVerification && !self.isWaitingForSelfUserEmail) {
+        self.isWaitingForEmailVerification = NO;
+    }
     if (self.needsToRegisterClient) {
-        
-        if (self.isAddingEmailNecessary) {
-            [self notifyEmailIsNecessary];
-        }
-        
         [self prepareForClientRegistration];
     }
     else {
@@ -338,6 +337,9 @@ static NSString *ZMLogTag ZM_UNUSED = @"Authentication";
         // set this label to block additional requests while we are waiting for the user to (re-)enter the password
         self.needsToCheckCredentials = YES;
     }
+    if (error.code == ZMUserSessionNeedsToRegisterEmailToRegisterClient) {
+        self.isWaitingForEmailVerification = YES;
+    }
     
     if (error.code == ZMUserSessionCanNotRegisterMoreClients) {
         // Wait and fetch the clients before sending the error
@@ -349,13 +351,6 @@ static NSString *ZMLogTag ZM_UNUSED = @"Authentication";
     }
 }
 
-- (void)notifyEmailIsNecessary
-{
-    NSError *emailMissingError = [[NSError alloc] initWithDomain:ZMUserSessionErrorDomain
-                                                            code:ZMUserSessionNeedsToRegisterEmailToRegisterClient
-                                                        userInfo:nil];
-    [ZMUserSessionAuthenticationNotification notifyAuthenticationDidFail:emailMissingError];
-}
 
 - (void)didFetchClients:(NSArray<NSManagedObjectID *> *)clientIDs;
 {
@@ -406,8 +401,7 @@ static NSString *ZMLogTag ZM_UNUSED = @"Authentication";
     [self.managedObjectContext deleteAndCreateNewEncryptionContext];
 }
 
-- (BOOL)clientIsReadyForRequests
-{
+- (BOOL)clientIsReadyForRequests {
     return self.currentPhase == ZMClientRegistrationPhaseRegistered;
 }
 

--- a/Source/UserSession/ZMUserSession+Registration.m
+++ b/Source/UserSession/ZMUserSession+Registration.m
@@ -32,7 +32,6 @@
 #import "ZMUserSessionRegistrationNotification.h"
 #import "ZMCredentials.h"
 #import "ZMUserSessionRegistrationNotification.h"
-#import "ZMAuthenticationStatus_Internal.h"
 
 @implementation ZMUser (ZMRegistrationUser)
 
@@ -51,9 +50,8 @@
 
 @implementation ZMUserSession (Registration)
 
-- (BOOL)registeredOnThisDevice
-{
-    return [self.managedObjectContext isRegisteredOnThisDevice];
+- (BOOL)registeredOnThisDevice {
+    return [self.authenticationStatus registeredOnThisDeviceOnContext:self.managedObjectContext];
 }
 
 - (void)registerSelfUser:(ZMCompleteRegistrationUser * __unused)registrationUser

--- a/Tests/Source/E2EE/UserClientRequestStrategyTests.swift
+++ b/Tests/Source/E2EE/UserClientRequestStrategyTests.swift
@@ -228,7 +228,7 @@ extension UserClientRequestStrategyTests {
         guard let request = self.sut.nextRequest() else { return XCTFail() }
         let responsePayload = ["code": 403, "message": "Re-authentication via password required", "label": "missing-auth"] as [String : Any]
         let response = ZMTransportResponse(payload: responsePayload as ZMTransportData, httpStatus: 403, transportSessionError: nil)
-        let expectedError = NSError(domain: ZMUserSessionErrorDomain, code: Int(ZMUserSessionErrorCode.invalidCredentials.rawValue), userInfo: nil)
+        let expectedError = NSError(domain: ZMUserSessionErrorDomain, code: Int(ZMUserSessionErrorCode.needsToRegisterEmailToRegisterClient.rawValue), userInfo: nil)
         
         // when
         request.complete(with: response)

--- a/Tests/Source/Integration/LoginFlowTests.m
+++ b/Tests/Source/Integration/LoginFlowTests.m
@@ -592,6 +592,8 @@ extern NSTimeInterval DebugLoginFailureTimerOverride;
         // when trying to register without email credentials, the BE tells us we need credentials
         if(!didRun && [request.path isEqualToString:@"/clients"] && request.method == ZMMethodPOST) {
             didRun = YES;
+            NSDictionary *payload = @{@"label" : @"missing-auth"};
+            return [ZMTransportResponse responseWithPayload:payload HTTPStatus:400 transportSessionError:nil];
         }
         // the user updates the email address (currently does not work in MockTransportsession for some reason)
         if ([request.path isEqualToString:@"/self/email"]) {

--- a/Tests/Source/Integration/UserProfileTests.m
+++ b/Tests/Source/Integration/UserProfileTests.m
@@ -25,23 +25,14 @@
 #import "ZMUserSession.h"
 #import "ZMUserSession+Authentication.h"
 #import "ZMUserSession+Registration.h"
-#import "ZMUserSession+Internal.h"
-
-#import "ZMClientRegistrationStatus+Internal.h"
 
 #import "ZMCredentials.h"
   
 @interface UserProfileTests : IntegrationTestBase
-@property (nonatomic) id clientRegStatusMock;
+
 @end
 
 @implementation UserProfileTests
-
-- (void)tearDown
-{
-    [super tearDown];
-    [self.clientRegStatusMock stopMocking];
-}
 
 - (void)testThatWeCanChangeUsernameAndAccentColorForSelfUser
 {
@@ -393,12 +384,6 @@
 - (BOOL)loginWithPhoneAndRemoveEmail
 {
     NSString *phone = @"+99123456789";
-    
-    if (nil == self.clientRegStatusMock) {
-        self.clientRegStatusMock = [OCMockObject partialMockForObject:self.userSession.clientRegistrationStatus];
-        [[[self.clientRegStatusMock stub] andReturnValue:@(NO)] isAddingEmailNecessary];
-    }
-    
     self.selfUser.email = nil;
     self.selfUser.phone = phone;
     self.selfUser.password = nil;
@@ -412,13 +397,12 @@
 - (void)testThatItCanSetEmailAndPassword
 {
     // given
-    self.registeredOnThisDevice = YES;
     NSString *email = @"foobar@geraterwerwer.dsf.example.com";
     XCTAssertTrue([self loginWithPhoneAndRemoveEmail]);
-    self.selfUser.email = nil;
-    self.selfUser.password = nil;
     ZMEmailCredentials *credentials = [ZMEmailCredentials credentialsWithEmail:email password:@"ds4rgsdg"];
     [self.mockTransportSession resetReceivedRequests];
+    
+    XCTAssertFalse(self.userSession.registeredOnThisDevice);
     
     ZMUser *selfUser = [ZMUser selfUserInUserSession:self.userSession];
     XCTAssertEqualObjects(selfUser.emailAddress, nil);
@@ -431,6 +415,7 @@
     id userObserver = [OCMockObject mockForProtocol:@protocol(ZMUserObserver)];
     id userObserverToken = [UserChangeInfo addObserver:userObserver forBareUser:selfUser];
     [(id<ZMUserObserver>)[userObserver expect] userDidChange:OCMOCK_ANY]; // <- DONE: when receiving this, I know that the email was set
+    
     
     // when
     [self.userSession.userProfile requestSettingEmailAndPasswordWithCredentials:credentials error:nil]; // <- STEP 1
@@ -459,6 +444,8 @@
     XCTAssertTrue([self loginWithPhoneAndRemoveEmail]);
     ZMEmailCredentials *credentials = [ZMEmailCredentials credentialsWithEmail:email password:@"ds4rgsdg"];
     [self.mockTransportSession resetReceivedRequests];
+    
+    XCTAssertFalse(self.userSession.registeredOnThisDevice);
     
     ZMUser *selfUser = [ZMUser selfUserInUserSession:self.userSession];
     XCTAssertEqualObjects(selfUser.emailAddress, nil);
@@ -493,6 +480,8 @@
     XCTAssertTrue([self loginWithPhoneAndRemoveEmail]);
     ZMEmailCredentials *credentials = [ZMEmailCredentials credentialsWithEmail:email password:@"ds4rgsdg"];
     [self.mockTransportSession resetReceivedRequests];
+    
+    XCTAssertFalse(self.userSession.registeredOnThisDevice);
     
     ZMUser *selfUser = [ZMUser selfUserInUserSession:self.userSession];
     XCTAssertEqualObjects(selfUser.emailAddress, nil);
@@ -541,6 +530,8 @@
     ZMEmailCredentials *credentials = [ZMEmailCredentials credentialsWithEmail:email password:@"ds4rgsdg"];
     [self.mockTransportSession resetReceivedRequests];
     
+    XCTAssertFalse(self.userSession.registeredOnThisDevice);
+    
     ZMUser *selfUser = [ZMUser selfUserInUserSession:self.userSession];
     XCTAssertEqualObjects(selfUser.emailAddress, nil);
     
@@ -576,6 +567,8 @@
     ZMEmailCredentials *credentials = [ZMEmailCredentials credentialsWithEmail:email password:@"ds4rgsdg"];
     [self.mockTransportSession resetReceivedRequests];
     
+    XCTAssertFalse(self.userSession.registeredOnThisDevice);
+    
     ZMUser *selfUser = [ZMUser selfUserInUserSession:self.userSession];
     XCTAssertEqualObjects(selfUser.emailAddress, nil);
     
@@ -610,6 +603,8 @@
     XCTAssertTrue([self loginWithPhoneAndRemoveEmail]);
     ZMEmailCredentials *credentials = [ZMEmailCredentials credentialsWithEmail:email password:@"ds4rgsdg"];
     [self.mockTransportSession resetReceivedRequests];
+    
+    XCTAssertFalse(self.userSession.registeredOnThisDevice);
     
     ZMUser *selfUser = [ZMUser selfUserInUserSession:self.userSession];
     XCTAssertEqualObjects(selfUser.emailAddress, nil);

--- a/Tests/Source/Synchronization/Transcoders/ZMLoginTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMLoginTranscoderTests.m
@@ -81,7 +81,7 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
     
     self.originalLoginTimerInterval = DefaultPendingValidationLoginAttemptInterval;
     ZMCookie *cookie = [[ZMCookie alloc] initWithManagedObjectContext:self.uiMOC cookieStorage:[ZMPersistentCookieStorage storageForServerName:@"test"]];
-    self.authenticationStatus = [[ZMAuthenticationStatus alloc] initWithManagedObjectContext:self.syncMOC cookie:cookie];
+    self.authenticationStatus = [[ZMAuthenticationStatus alloc] initWithManagedObjectContext:self.uiMOC cookie:cookie];
     self.mockClientRegistrationStatus = [OCMockObject niceMockForClass:[ZMClientRegistrationStatus class]];
     
     self.mockApplicationStatusDirectory = [OCMockObject niceMockForClass:[ZMApplicationStatusDirectory class]];

--- a/Tests/Source/Synchronization/Transcoders/ZMRegistrationTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMRegistrationTranscoderTests.m
@@ -305,9 +305,7 @@
     [[self.registrationDownstreamSync expect] readyForNextRequest];
     
     // when
-    [self performPretendingUiMocIsSyncMoc:^{
-        [self.sut didReceiveResponse:response forSingleRequest:self.registrationDownstreamSync];
-    }];
+    [self.sut didReceiveResponse:response forSingleRequest:self.registrationDownstreamSync];
     
     // then
     XCTAssertEqualObjects(self.authenticationStatus.loginCredentials.password, password);
@@ -329,11 +327,10 @@
     [[self.registrationDownstreamSync expect] readyForNextRequest];
     
     // when
-    [self performPretendingUiMocIsSyncMoc:^{
-        [self.sut didReceiveResponse:response forSingleRequest:self.registrationDownstreamSync];
-        // then
-        XCTAssertTrue(self.authenticationStatus.registeredOnThisDevice);
-    }];
+    [self.sut didReceiveResponse:response forSingleRequest:self.registrationDownstreamSync];
+    
+    // then
+    XCTAssertTrue(self.authenticationStatus.registeredOnThisDevice);
 }
 
 - (void)testThatItUpdatesTheSelfUserAfterSuccessfullRegistration
@@ -359,9 +356,7 @@
     [[self.registrationDownstreamSync expect] readyForNextRequest];
     
     // when
-    [self performPretendingUiMocIsSyncMoc:^{
-        [self.sut didReceiveResponse:response forSingleRequest:self.registrationDownstreamSync];
-    }];
+    [self.sut didReceiveResponse:response forSingleRequest:self.registrationDownstreamSync];
 
     // then
     ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
@@ -394,9 +389,7 @@
     [[self.registrationDownstreamSync expect] readyForNextRequest];
     
     // when
-    [self performPretendingUiMocIsSyncMoc:^{
-        [self.sut didReceiveResponse:response forSingleRequest:self.registrationDownstreamSync];
-    }];
+    [self.sut didReceiveResponse:response forSingleRequest:self.registrationDownstreamSync];
     
     // then
     ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
@@ -417,9 +410,7 @@
     ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:nil HTTPStatus:400 transportSessionError:nil];
     
     // when
-    [self performPretendingUiMocIsSyncMoc:^{
-        [self.sut didReceiveResponse:response forSingleRequest:self.registrationDownstreamSync];
-    }];
+    [self.sut didReceiveResponse:response forSingleRequest:self.registrationDownstreamSync];
     
     // then
     ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
@@ -450,9 +441,7 @@
     ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:nil HTTPStatus:400 transportSessionError:nil];
     
     // when
-    [self performPretendingUiMocIsSyncMoc:^{
-        [self.sut didReceiveResponse:response forSingleRequest:self.registrationDownstreamSync];
-    }];
+    [self.sut didReceiveResponse:response forSingleRequest:self.registrationDownstreamSync];
     
     // then
     XCTAssertTrue([self waitForCustomExpectationsWithTimeout:0.5]);
@@ -481,9 +470,7 @@
     ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@{@"label":@"invalid-email"} HTTPStatus:400 transportSessionError:nil];
     
     // when
-    [self performPretendingUiMocIsSyncMoc:^{
-        [self.sut didReceiveResponse:response forSingleRequest:self.registrationDownstreamSync];
-    }];
+    [self.sut didReceiveResponse:response forSingleRequest:self.registrationDownstreamSync];
     
     // then
     XCTAssertTrue([self waitForCustomExpectationsWithTimeout:0.5]);
@@ -510,9 +497,7 @@
     ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@{@"label":@"invalid-phone"} HTTPStatus:400 transportSessionError:nil];
     
     // when
-    [self performPretendingUiMocIsSyncMoc:^{
-        [self.sut didReceiveResponse:response forSingleRequest:self.registrationDownstreamSync];
-    }];
+    [self.sut didReceiveResponse:response forSingleRequest:self.registrationDownstreamSync];
     
     // then
     XCTAssertTrue([self waitForCustomExpectationsWithTimeout:0.5]);
@@ -538,12 +523,11 @@
                                                        transportSessionError:nil];
     
     // when
-    [self performPretendingUiMocIsSyncMoc:^{
-        [self.sut didReceiveResponse:response forSingleRequest:self.registrationDownstreamSync];
+    [self.sut didReceiveResponse:response forSingleRequest:self.registrationDownstreamSync];
     
-        // then
-        XCTAssertFalse(self.authenticationStatus.registeredOnThisDevice);
-    }];
+    // then
+    XCTAssertFalse(self.authenticationStatus.registeredOnThisDevice);
+
 }
 
 @end

--- a/Tests/Source/UserSession/ZMAuthenticationStatusTests.m
+++ b/Tests/Source/UserSession/ZMAuthenticationStatusTests.m
@@ -143,9 +143,7 @@
     
     // when
     [self.sut prepareForRegistrationOfUser:regUser];
-    [self performPretendingUiMocIsSyncMoc:^{
-        [self.sut didCompleteRegistrationSuccessfully];
-    }];
+    [self.sut didCompleteRegistrationSuccessfully];
     
     XCTAssertTrue([self waitForCustomExpectationsWithTimeout:0.5]);
 }
@@ -233,9 +231,7 @@
     ZMCredentials *credentials = [ZMEmailCredentials credentialsWithEmail:email password:pass];
     
     // when
-    [self performPretendingUiMocIsSyncMoc:^{
-        [self.sut prepareForLoginWithCredentials:credentials];
-    }];
+    [self.sut prepareForLoginWithCredentials:credentials];
     
     // then
     XCTAssertEqual(self.sut.currentPhase, ZMAuthenticationPhaseLoginWithEmail);
@@ -251,9 +247,8 @@
     ZMCredentials *credentials = [ZMPhoneCredentials credentialsWithPhoneNumber:phone verificationCode:code];
     
     // when
-    [self performPretendingUiMocIsSyncMoc:^{
-        [self.sut prepareForLoginWithCredentials:credentials];
-    }];
+    [self.sut prepareForLoginWithCredentials:credentials];
+    
     // then
     XCTAssertEqual(self.sut.currentPhase, ZMAuthenticationPhaseLoginWithPhone);
     XCTAssertEqual(self.sut.loginCredentials, credentials);
@@ -329,10 +324,8 @@
     };
     
     // when
-    [self performPretendingUiMocIsSyncMoc:^{
-        [self.sut prepareForRegistrationOfUser:[ZMCompleteRegistrationUser registrationUserWithEmail:email password:password]];
-        [self.sut didCompleteRegistrationSuccessfully];
-    }];
+    [self.sut prepareForRegistrationOfUser:[ZMCompleteRegistrationUser registrationUserWithEmail:email password:password]];
+    [self.sut didCompleteRegistrationSuccessfully];
     
     // then
     XCTAssertEqual(self.sut.currentPhase, ZMAuthenticationPhaseLoginWithEmail);
@@ -550,9 +543,7 @@
     NSString *password = @"#$4tewt343$";
     
     // when
-    [self performPretendingUiMocIsSyncMoc:^{
-        [self.sut prepareForLoginWithCredentials:[ZMEmailCredentials credentialsWithEmail:email password:password]];
-    }];
+    [self.sut prepareForLoginWithCredentials:[ZMEmailCredentials credentialsWithEmail:email password:password]];
     [self.sut didFailLoginWithEmail:YES];
     
     // then
@@ -580,9 +571,7 @@
     ZMCredentials *credentials = [ZMEmailCredentials credentialsWithEmail:email password:password];
     
     // when
-    [self performPretendingUiMocIsSyncMoc:^{
-        [self.sut prepareForLoginWithCredentials:credentials];
-    }];
+    [self.sut prepareForLoginWithCredentials:credentials];
     [self.sut didFailLoginWithEmailBecausePendingValidation];
     
     // then
@@ -609,9 +598,7 @@
     NSString *code = @"324543";
     
     // when
-    [self performPretendingUiMocIsSyncMoc:^{
-        [self.sut prepareForLoginWithCredentials:[ZMPhoneCredentials credentialsWithPhoneNumber:phone verificationCode:code]];
-    }];
+    [self.sut prepareForLoginWithCredentials:[ZMPhoneCredentials credentialsWithPhoneNumber:phone verificationCode:code]];
     [self.sut didFailLoginWithPhone:YES];
     
     // then
@@ -639,9 +626,7 @@
     ZMCredentials *credentials = [ZMEmailCredentials credentialsWithEmail:email password:password];
     
     // when
-    [self performPretendingUiMocIsSyncMoc:^{
-        [self.sut prepareForLoginWithCredentials:credentials];
-    }];
+    [self.sut prepareForLoginWithCredentials:credentials];
     [self.sut didTimeoutLoginForCredentials:credentials];
     
     // then
@@ -660,9 +645,7 @@
     ZMCredentials *credentials2 = [ZMPhoneCredentials credentialsWithPhoneNumber:@"+4912345678900" verificationCode:@"123456"];
     
     // when
-    [self performPretendingUiMocIsSyncMoc:^{
-        [self.sut prepareForLoginWithCredentials:credentials1];
-    }];
+    [self.sut prepareForLoginWithCredentials:credentials1];
     [self.sut didTimeoutLoginForCredentials:credentials2];
     
     // then
@@ -690,9 +673,7 @@
 {
     // given
     [self.sut setAuthenticationCookieData:[NSData data]];
-    [self performPretendingUiMocIsSyncMoc:^{
-        [self.sut prepareForLoginWithCredentials:[ZMEmailCredentials credentialsWithEmail:@"foo@example.com" password:@"boo"]];
-    }];
+    [self.sut prepareForLoginWithCredentials:[ZMEmailCredentials credentialsWithEmail:@"foo@example.com" password:@"boo"]];
 
     // then
     XCTAssertNotNil(self.sut.emailCredentials);
@@ -701,9 +682,7 @@
 - (void)testThatItClearsCredentialsIfInPhaseAuthenticated
 {
     // given
-    [self performPretendingUiMocIsSyncMoc:^{
-        [self.sut prepareForLoginWithCredentials:[ZMEmailCredentials credentialsWithEmail:@"foo@example.com" password:@"boo"]];
-    }];
+    [self.sut prepareForLoginWithCredentials:[ZMEmailCredentials credentialsWithEmail:@"foo@example.com" password:@"boo"]];
     [self.sut setAuthenticationCookieData:[NSData data]];
     
     XCTAssertNotNil(self.sut.loginCredentials);
@@ -718,9 +697,7 @@
 - (void)testThatItDoesNotClearCredentialsIfNotAuthenticated
 {
     // given
-    [self performPretendingUiMocIsSyncMoc:^{
-        [self.sut prepareForLoginWithCredentials:[ZMEmailCredentials credentialsWithEmail:@"foo@example.com" password:@"boo"]];
-    }];
+    [self.sut prepareForLoginWithCredentials:[ZMEmailCredentials credentialsWithEmail:@"foo@example.com" password:@"boo"]];
     
     XCTAssertNotNil(self.sut.loginCredentials);
     

--- a/Tests/Source/UserSession/ZMClientRegistrationStatusTests.m
+++ b/Tests/Source/UserSession/ZMClientRegistrationStatusTests.m
@@ -82,7 +82,7 @@
     [[[self.mockCookieStorage stub] andReturn:[NSData data]] authenticationCookieData];
     
     ZMCookie *cookie = [[ZMCookie alloc] initWithManagedObjectContext:self.syncMOC cookieStorage:self.mockCookieStorage];
-    self.sut = [[ZMClientRegistrationStatus alloc] initWithManagedObjectContext:self.syncMOC
+    self.sut = [[ZMClientRegistrationStatus alloc] initWithManagedObjectContext:self.uiMOC
                                                         loginCredentialProvider:self.loginProvider
                                                        updateCredentialProvider:self.updateProvider
                                                                          cookie:cookie
@@ -115,9 +115,9 @@
 - (void)testThatItInsertsANewClientIfThereIsNoneWaitingToBeSynced
 {
     // given
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
+    ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
     selfUser.remoteIdentifier = [NSUUID UUID];
-    UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.syncMOC];
+    UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.uiMOC];
     client.user = selfUser;
     client.remoteIdentifier = @"identifier";
     
@@ -176,9 +176,9 @@
 - (void)testThatItReturns_Registered_IfSelfClientIsSet
 {
     // given
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
+    ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
     selfUser.remoteIdentifier = [NSUUID UUID];
-    [self.syncMOC setPersistentStoreMetadata:@"lala" forKey:ZMPersistedClientIdKey];
+    [self.uiMOC setPersistentStoreMetadata:@"lala" forKey:ZMPersistedClientIdKey];
     
     // then
     XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseRegistered);
@@ -187,7 +187,7 @@
 - (void)testThatItReturns_FetchingClients_WhenReceivingAnErrorWithTooManyClients
 {
     // given
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
+    ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
     selfUser.remoteIdentifier = [NSUUID UUID];
     
     // when
@@ -209,7 +209,6 @@
     [self performPretendingUiMocIsSyncMoc:^{
         ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
         selfUser.remoteIdentifier = NSUUID.createUUID;
-        selfUser.emailAddress = @"email@domain.com";
         
         UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.uiMOC];
         client.remoteIdentifier = @"identifier";
@@ -234,21 +233,23 @@
 - (void)testThatItResets_LocallyModifiedKeys_AfterUserSelectedClientToDelete
 {
     // given
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
-    selfUser.remoteIdentifier = NSUUID.createUUID;
-    
-    UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.syncMOC];
-    client.remoteIdentifier = @"identifier";
-    client.user = selfUser;
-    [client setLocallyModifiedKeys:[NSSet setWithObject:@"numberOfKeysRemaining"]];
-    
-    [self.syncMOC setPersistentStoreMetadata:client.remoteIdentifier forKey:ZMPersistedClientIdKey];
-    
-    // when
-    [self.sut didDetectCurrentClientDeletion];
-    
-    // then
-    XCTAssertFalse([client hasLocalModificationsForKey:@"numberOfKeysRemaining"]);
+    [self performPretendingUiMocIsSyncMoc:^{
+        ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
+        selfUser.remoteIdentifier = NSUUID.createUUID;
+        
+        UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.uiMOC];
+        client.remoteIdentifier = @"identifier";
+        client.user = selfUser;
+        [client setLocallyModifiedKeys:[NSSet setWithObject:@"numberOfKeysRemaining"]];
+        
+        [self.uiMOC setPersistentStoreMetadata:client.remoteIdentifier forKey:ZMPersistedClientIdKey];
+        
+        // when
+        [self.sut didDetectCurrentClientDeletion];
+        
+        // then
+        XCTAssertFalse([client hasLocalModificationsForKey:@"numberOfKeysRemaining"]);
+    }];
 }
 
 - (void)testThatItInvalidatesSelfClientAndDeletesAndRecreatesCryptoBoxOnDidDetectCurrentClientDeletion
@@ -256,7 +257,6 @@
     // given
     ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
     selfUser.remoteIdentifier = [NSUUID UUID];
-    selfUser.emailAddress = @"email@domain.com";
     
     UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.uiMOC];
     client.user = selfUser;
@@ -270,6 +270,21 @@
     // then
     XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseWaitingForDeletion);
 }
+
+- (void)testThatItReturns_WaitingForEmailVerfication_IFError_UserNeedsToRegisterEmail
+{
+    // given
+    ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
+    selfUser.remoteIdentifier = [NSUUID UUID];
+    
+    // when
+    NSError *error = [NSError errorWithDomain:@"ZMUserSession" code:ZMUserSessionNeedsToRegisterEmailToRegisterClient userInfo:nil];
+    [self.sut didFailToRegisterClient:error];
+    
+    // then
+    XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseWaitingForEmailVerfication);
+}
+
 
 - (void)testThatItReturnsYESForNeedsToRegisterClientIfNoClientIdInMetadata
 {
@@ -286,13 +301,13 @@
 - (void)testThatItNotfiesCredentialProviderWhenClientIsRegistered
 {
     //given
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
+    ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
     selfUser.remoteIdentifier = [NSUUID new];
 
     //when
     [self.sut prepareForClientRegistration];
 
-    UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.syncMOC];
+    UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.uiMOC];
     client.remoteIdentifier = [NSUUID createUUID].transportString;
 
     [self.sut didRegisterClient:client];
@@ -326,11 +341,10 @@
 {
     // given
     
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
+    ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
     selfUser.remoteIdentifier = [NSUUID UUID];
-    selfUser.emailAddress = nil;
-    selfUser.phoneNumber = nil;
     
+    [self.sut didFailToRegisterClient:[self needToRegisterEmailError]];
     XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseWaitingForEmailVerfication);
     
     // when
@@ -346,11 +360,10 @@
 {
     // given
     
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
+    ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
     selfUser.remoteIdentifier = [NSUUID UUID];
-    selfUser.emailAddress = nil;
-    selfUser.phoneNumber = nil;
     
+    [self.sut didFailToRegisterClient:[self needToRegisterEmailError]];
     XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseWaitingForEmailVerfication);
     
     // when
@@ -364,9 +377,8 @@
 - (void)testThatItResetsThePhaseToWaitingForLoginIfItNeedsPasswordToRegisterClient
 {
     // given
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
+    ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
     selfUser.remoteIdentifier = [NSUUID UUID];
-    selfUser.emailAddress = @"email@domain.com";
     [[[self.mockCookieStorage stub] andReturn:[NSData data]] authenticationCookieData];
     self.loginProvider.shouldReturnNilCredentials = YES;
     self.updateProvider.shouldReturnNilCredentials = YES;
@@ -414,7 +426,7 @@
 - (void)testThatItNotifiesTheUIIfTheClientWasAlreadyRegisteredBeforeFetchingTheSelfUser
 {
     // given
-    [self.syncMOC setPersistentStoreMetadata:@"brrrrr" forKey:ZMPersistedClientIdKey];
+    [self.uiMOC setPersistentStoreMetadata:@"brrrrr" forKey:ZMPersistedClientIdKey];
     
     // when
     [self.sut didFetchSelfUser];
@@ -428,19 +440,16 @@
 - (void)testThatItNotifiesTheUIIfTheRegistrationFailsWithMissingEmailVerification
 {
     // given
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
-    selfUser.remoteIdentifier = [NSUUID UUID];
-    selfUser.emailAddress = nil;
-    selfUser.phoneNumber = nil;
+    NSError *error = [self needToRegisterEmailError];
     
     // when
-    [self.sut didFetchSelfUser];
+    [self.sut didFailToRegisterClient:error];
     
     // then
     XCTAssertEqual(self.sessionNotifications.count, 1u);
     ZMUserSessionAuthenticationNotification *note = self.sessionNotifications.firstObject;
     XCTAssertEqual(note.type, ZMAuthenticationNotificationAuthenticationDidFail);
-    XCTAssertEqual(note.error.code, [self needToRegisterEmailError].code);
+    XCTAssertEqual(note.error, error);
 }
 
 - (void)testThatItNotifiesTheUIIfTheRegistrationFailsWithMissingPasswordError
@@ -488,14 +497,14 @@
 - (void)testThatItDeletesTheCookieIfFetchingClientsFailedWithError_SelfClientIsInvalid
 {
     // given
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
+    ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
     selfUser.remoteIdentifier = [NSUUID UUID];
     
-    UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.syncMOC];
+    UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.uiMOC];
     client.user = selfUser;
     client.remoteIdentifier = @"identifer";
-    [self.syncMOC saveOrRollback];
-    [self.syncMOC setPersistentStoreMetadata:client.remoteIdentifier forKey:ZMPersistedClientIdKey];
+    [self.uiMOC saveOrRollback];
+    [self.uiMOC setPersistentStoreMetadata:client.remoteIdentifier forKey:ZMPersistedClientIdKey];
 
     XCTAssertNotNil(selfUser.selfClient);
     
@@ -509,7 +518,7 @@
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
-    XCTAssertNil([self.syncMOC persistentStoreMetadataForKey:ZMPersistedClientIdKey]);
+    XCTAssertNil([self.uiMOC persistentStoreMetadataForKey:ZMPersistedClientIdKey]);
     [self.mockCookieStorage verify];
 }
 

--- a/Tests/Source/UserSession/ZMUserSessionAuthenticationTests.m
+++ b/Tests/Source/UserSession/ZMUserSessionAuthenticationTests.m
@@ -163,13 +163,15 @@
     // expectations
     ZMTransportEnqueueResult *r = [ZMTransportEnqueueResult resultDidHaveLessRequestsThanMax:NO didGenerateNonNullRequest:YES];
     [[[self.transportSession stub] andReturn:r] attemptToEnqueueSyncRequestWithGenerator:OCMOCK_ANY];
+//    [[(id) self.authenticationObserver expect] authenticationDidSucceed];
+//    [self verifyMockLater:self.authenticationObserver];
     
     // when
     ZMCredentials *cred = [ZMEmailCredentials credentialsWithEmail:@"someone@example.com" password:@"valid-password"];
     [self.sut loginWithCredentials:cred];
-    WaitForAllGroupsToBeEmpty(0.5);
     
     // then
+//    XCTAssertTrue(self.sut.isLoggedIn);
     XCTAssertTrue(self.sut.authenticationStatus.currentPhase == ZMAuthenticationPhaseAuthenticated);
 }
 


### PR DESCRIPTION
Revert https://github.com/wireapp/wire-ios-sync-engine/pull/375 as a try to fix the missing user credentials.