### PR TITLE
Fetch selfUser at the end of slowSync

### DIFF
--- a/Source/Synchronization/Transcoders/TeamSyncRequestStrategy.swift
+++ b/Source/Synchronization/Transcoders/TeamSyncRequestStrategy.swift
@@ -90,7 +90,7 @@ public final class TeamSyncRequestStrategy: AbstractRequestStrategy, ZMContextCh
 
     fileprivate func finishSyncIfCompleted() {
         guard isSyncing, memberSync.isDone, !teamListSync.hasMoreToFetch else { return }
-        syncStatus?.finishCurrentSyncPhase()
+        syncStatus?.finishCurrentSyncPhase(phase: expectedSyncPhase)
 
         // Delete local teams not on the remote anymore
         guard let deletedTeamIds = remotelyDeletedIds else { return }
@@ -100,8 +100,12 @@ public final class TeamSyncRequestStrategy: AbstractRequestStrategy, ZMContextCh
         remotelyDeletedIds = nil
     }
 
+    fileprivate var expectedSyncPhase : SyncPhase {
+        return .fetchingTeams;
+    }
+    
     fileprivate var isSyncing: Bool {
-        return syncStatus?.currentSyncPhase == .fetchingTeams
+        return syncStatus?.currentSyncPhase == expectedSyncPhase
     }
 
     private func fetchExistingTeamIds() -> Set<UUID> {
@@ -142,7 +146,7 @@ extension TeamSyncRequestStrategy: ZMSimpleListRequestPaginatorSync {
         memberSync.addRemoteIdentifiersThatNeedDownload(remoteIds)
 
         if response.result == .permanentError && isSyncing {
-            syncStatus?.failCurrentSyncPhase()
+            syncStatus?.failCurrentSyncPhase(phase: expectedSyncPhase)
         }
 
         finishSyncIfCompleted()
@@ -185,7 +189,7 @@ extension TeamSyncRequestStrategy: ZMRemoteIdentifierObjectTranscoder {
         }
 
         if response.result == .permanentError && isSyncing {
-            syncStatus?.failCurrentSyncPhase()
+            syncStatus?.failCurrentSyncPhase(phase: expectedSyncPhase)
         }
 
         finishSyncIfCompleted()

--- a/Source/Synchronization/Transcoders/ZMConnectionTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMConnectionTranscoder.m
@@ -71,9 +71,15 @@ NSUInteger ZMConnectionTranscoderPageSize = 90;
     return ZMStrategyConfigurationOptionAllowsRequestsDuringSync | ZMStrategyConfigurationOptionAllowsRequestsDuringEventProcessing;
 }
 
+
+- (SyncPhase)expectedSyncPhase
+{
+    return SyncPhaseFetchingConnections;
+}
+
 - (BOOL)isSyncing
 {
-    return self.syncStatus.currentSyncPhase == SyncPhaseFetchingConnections;
+    return self.syncStatus.currentSyncPhase == self.expectedSyncPhase;
 }
 
 - (ZMTransportRequest *)nextRequestIfAllowed
@@ -317,7 +323,7 @@ NSUInteger ZMConnectionTranscoderPageSize = 90;
     SyncStatus *syncStatus = self.syncStatus;
     
     if (!self.conversationsListSync.hasMoreToFetch && self.isSyncing) {
-        [syncStatus finishCurrentSyncPhase];
+        [syncStatus finishCurrentSyncPhaseWithPhase:self.expectedSyncPhase];
     }
     
     return allUIDs.lastObject;
@@ -328,7 +334,7 @@ NSUInteger ZMConnectionTranscoderPageSize = 90;
     SyncStatus *syncStatus = self.syncStatus;
     
     if (response.result == ZMTransportResponseStatusPermanentError && self.isSyncing) {
-        [syncStatus failCurrentSyncPhase];
+        [syncStatus failCurrentSyncPhaseWithPhase:self.expectedSyncPhase];
     }
     return NO;
 }

--- a/Source/Synchronization/Transcoders/ZMConversationTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMConversationTranscoder.m
@@ -155,7 +155,7 @@ static NSString *const ConversationTeamManagedKey = @"managed";
     
     
     if (response.result == ZMTransportResponseStatusPermanentError && self.isSyncing) {
-        [self.syncStatus failCurrentSyncPhase];
+        [self.syncStatus failCurrentSyncPhaseWithPhase:self.expectedSyncPhase];
     }
     
     [self finishSyncIfCompleted];
@@ -166,13 +166,18 @@ static NSString *const ConversationTeamManagedKey = @"managed";
 - (void)finishSyncIfCompleted
 {
     if (!self.listPaginator.hasMoreToFetch && self.remoteIDSync.isDone && self.isSyncing) {
-        [self.syncStatus finishCurrentSyncPhase];
+        [self.syncStatus finishCurrentSyncPhaseWithPhase:self.expectedSyncPhase];
     }
+}
+
+- (SyncPhase)expectedSyncPhase
+{
+    return SyncPhaseFetchingConversations;
 }
 
 - (BOOL)isSyncing
 {
-    return self.syncStatus.currentSyncPhase == SyncPhaseFetchingConversations;
+    return self.syncStatus.currentSyncPhase == self.expectedSyncPhase;
 }
 
 - (ZMTransportRequest *)nextRequestIfAllowed
@@ -951,7 +956,7 @@ static NSString *const ConversationTeamManagedKey = @"managed";
     }
     
     if (response.result == ZMTransportResponseStatusPermanentError && self.isSyncing) {
-        [self.syncStatus failCurrentSyncPhase];
+        [self.syncStatus failCurrentSyncPhaseWithPhase:self.expectedSyncPhase];
     }
     
     [self finishSyncIfCompleted];

--- a/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
@@ -294,9 +294,14 @@ previouslyReceivedEventIDsCollection:(id<PreviouslyReceivedEventIDsCollection>)e
     }
 }
 
+- (SyncPhase)expectedSyncPhase
+{
+    return SyncPhaseFetchingMissedEvents;
+}
+
 - (BOOL)isSyncing
 {
-    return self.syncStatus.currentSyncPhase == SyncPhaseFetchingMissedEvents;
+    return self.syncStatus.currentSyncPhase == self.expectedSyncPhase;
 }
 
 - (NSArray <NSURLQueryItem *> *)additionalQueryItems
@@ -349,7 +354,7 @@ previouslyReceivedEventIDsCollection:(id<PreviouslyReceivedEventIDsCollection>)e
     [self appendPotentialGapSystemMessageIfNeededWithResponse:response];
     
     if (response.result == ZMTransportResponseStatusPermanentError && self.isSyncing){
-        [syncStatus failCurrentSyncPhase];
+        [syncStatus failCurrentSyncPhaseWithPhase:self.expectedSyncPhase];
     }
     
     if (!self.listPaginator.hasMoreToFetch && self.lastUpdateEventID != nil && self.isSyncing) {
@@ -357,7 +362,7 @@ previouslyReceivedEventIDsCollection:(id<PreviouslyReceivedEventIDsCollection>)e
         // The fetch of the notification stream was initiated after the push channel was established
         // so we must restart the fetching to be sure that we haven't missed any notifications.
         if (syncStatus.pushChannelEstablishedDate.timeIntervalSinceReferenceDate < self.listPaginator.lastResetFetchDate.timeIntervalSinceReferenceDate) {
-            [syncStatus finishCurrentSyncPhase];
+            [syncStatus finishCurrentSyncPhaseWithPhase:self.expectedSyncPhase];
         }
     }
     

--- a/Source/Synchronization/Transcoders/ZMSelfStrategy+Internal.h
+++ b/Source/Synchronization/Transcoders/ZMSelfStrategy+Internal.h
@@ -30,6 +30,7 @@ extern NSTimeInterval ZMSelfStrategyPendingValidationRequestInterval;
 - (instancetype)initWithManagedObjectContext:(NSManagedObjectContext *)moc
                            applicationStatus:(id<ZMApplicationStatus>)applicationStatus
                     clientRegistrationStatus:(ZMClientRegistrationStatus *)clientRegistrationStatus
+                                  syncStatus:(SyncStatus *)syncStatus
                           upstreamObjectSync:(ZMUpstreamModifiedObjectSync *)upstreamObjectSync NS_DESIGNATED_INITIALIZER;
 
 

--- a/Source/Synchronization/Transcoders/ZMSelfStrategy.h
+++ b/Source/Synchronization/Transcoders/ZMSelfStrategy.h
@@ -24,6 +24,7 @@
 @class ZMUpstreamModifiedObjectSync;
 @class ZMClientRegistrationStatus;
 @class ZMApplicationStatusDirectory;
+@class SyncStatus;
 
 @interface ZMSelfStrategy : ZMAbstractRequestStrategy <ZMContextChangeTrackerSource>
 
@@ -34,7 +35,8 @@
 
 - (instancetype)initWithManagedObjectContext:(NSManagedObjectContext *)moc
                            applicationStatus:(id<ZMApplicationStatus>)appplicationStatus
-                    clientRegistrationStatus:(ZMClientRegistrationStatus *)clientRegistrationStatus;
+                    clientRegistrationStatus:(ZMClientRegistrationStatus *)clientRegistrationStatus
+                                  syncStatus:(SyncStatus *)syncStatus;
 
 - (void)tearDown;
 

--- a/Source/Synchronization/Transcoders/ZMSelfStrategy.m
+++ b/Source/Synchronization/Transcoders/ZMSelfStrategy.m
@@ -51,6 +51,7 @@ NSTimeInterval ZMSelfStrategyPendingValidationRequestInterval = 5;
 @property (nonatomic) ZMSingleRequestSync *downstreamSelfUserSync;
 @property (nonatomic) NSPredicate *needsToBeUdpatedFromBackend;
 @property (nonatomic, weak) ZMClientRegistrationStatus *clientStatus;
+@property (nonatomic, weak) SyncStatus *syncStatus;
 
 @end
 
@@ -67,6 +68,7 @@ NSTimeInterval ZMSelfStrategyPendingValidationRequestInterval = 5;
 - (instancetype)initWithManagedObjectContext:(NSManagedObjectContext *)moc
                            applicationStatus:(id<ZMApplicationStatus>)applicationStatus
                     clientRegistrationStatus:(ZMClientRegistrationStatus *)clientRegistrationStatus
+                                  syncStatus:(SyncStatus *)syncStatus
 {
     NSArray<NSString *> *keysToSync = @[NameKey, AccentColorValueKey, SmallProfileRemoteIdentifierDataKey, MediumRemoteIdentifierDataKey, PreviewProfileAssetIdentifierKey, CompleteProfileAssetIdentifierKey];
     
@@ -76,17 +78,19 @@ NSTimeInterval ZMSelfStrategyPendingValidationRequestInterval = 5;
                                                         keysToSync:keysToSync
                                                         managedObjectContext:moc];
     
-    return [self initWithManagedObjectContext:moc applicationStatus:applicationStatus clientRegistrationStatus:clientRegistrationStatus upstreamObjectSync:upstreamObjectSync];
+    return [self initWithManagedObjectContext:moc applicationStatus:applicationStatus clientRegistrationStatus:clientRegistrationStatus syncStatus: syncStatus upstreamObjectSync:upstreamObjectSync];
 }
 
 - (instancetype)initWithManagedObjectContext:(NSManagedObjectContext *)moc
                            applicationStatus:(id<ZMApplicationStatus>)applicationStatus
                     clientRegistrationStatus:(ZMClientRegistrationStatus *)clientRegistrationStatus
+                                  syncStatus:(SyncStatus *)syncStatus
                           upstreamObjectSync:(ZMUpstreamModifiedObjectSync *)upstreamObjectSync
 {
     self = [super initWithManagedObjectContext:moc applicationStatus:applicationStatus];
     if(self) {
         self.clientStatus = clientRegistrationStatus;
+        self.syncStatus = syncStatus;
         self.upstreamObjectSync = upstreamObjectSync;
         if (self.upstreamObjectSync == nil) {
             NSArray<NSString *> *keysToSync = @[NameKey, AccentColorValueKey, SmallProfileRemoteIdentifierDataKey, MediumRemoteIdentifierDataKey];
@@ -117,16 +121,28 @@ NSTimeInterval ZMSelfStrategyPendingValidationRequestInterval = 5;
     [self.timedDownstreamSync invalidate];
 }
 
+- (SyncPhase)expectedSyncPhase
+{
+    return SyncPhaseFetchingSelfUser;
+}
+
+- (BOOL)isSyncing
+{
+    return self.syncStatus.currentSyncPhase == self.expectedSyncPhase;
+}
+
 - (ZMTransportRequest *)nextRequestIfAllowed;
 {
     ZMClientRegistrationStatus *clientStatus = self.clientStatus;
+    ZMUser *selfUser = [ZMUser selfUserInContext:self.managedObjectContext];
+    
     if (clientStatus.currentPhase == ZMClientRegistrationPhaseWaitingForEmailVerfication) {
         [self.timedDownstreamSync readyForNextRequestIfNotBusy];
         return [self.timedDownstreamSync nextRequest];
     }
     
     if (clientStatus.currentPhase == ZMClientRegistrationPhaseWaitingForSelfUser) {
-        ZMUser *selfUser = [ZMUser selfUserInContext:self.managedObjectContext];
+        
         if (! selfUser.needsToBeUpdatedFromBackend) {
             selfUser.needsToBeUpdatedFromBackend = YES;
             [self.downstreamSelfUserSync readyForNextRequestIfNotBusy];
@@ -137,6 +153,15 @@ NSTimeInterval ZMSelfStrategyPendingValidationRequestInterval = 5;
     }
     else if (clientStatus.currentPhase == ZMClientRegistrationPhaseRegistered) {
         return [@[self.downstreamSelfUserSync, self.upstreamObjectSync] nextRequest];
+    }
+    else if (self.isSyncing) {
+        if (self.downstreamSelfUserSync.status != ZMSingleRequestInProgress) {
+            selfUser.needsToBeUpdatedFromBackend = YES;
+            [self.downstreamSelfUserSync readyForNextRequestIfNotBusy];
+        }
+        if (selfUser.needsToBeUpdatedFromBackend) {
+            return [self.downstreamSelfUserSync nextRequest];
+        }
     }
     return nil;
 }
@@ -304,7 +329,8 @@ static NSString * const DeletionRequestKey = @"";
 {
     NOT_USED(sync);
     ZMUser *selfUser = [ZMUser selfUserInContext:self.managedObjectContext];
-
+    SyncStatus *syncStatus = self.syncStatus;
+    
     if (response.result == ZMTransportResponseStatusSuccess) {
         
         ZMClientRegistrationStatus *clientStatus = self.clientStatus;
@@ -332,6 +358,12 @@ static NSString * const DeletionRequestKey = @"";
                 self.timedDownstreamSync.timeInterval = 0;
             }
         }
+        
+        if (self.isSyncing) {
+            [syncStatus finishCurrentSyncPhaseWithPhase:self.expectedSyncPhase];
+        }
+    } else if (self.isSyncing) {
+        [syncStatus failCurrentSyncPhaseWithPhase:self.expectedSyncPhase];
     }
 }
 

--- a/Source/Synchronization/Transcoders/ZMSelfStrategy.m
+++ b/Source/Synchronization/Transcoders/ZMSelfStrategy.m
@@ -108,7 +108,7 @@ NSTimeInterval ZMSelfStrategyPendingValidationRequestInterval = 5;
 
 - (ZMStrategyConfigurationOption)configuration
 {
-    return ZMStrategyConfigurationOptionAllowsRequestsDuringEventProcessing | ZMStrategyConfigurationOptionAllowsRequestsWhileUnauthenticated;
+    return ZMStrategyConfigurationOptionAllowsRequestsDuringEventProcessing | ZMStrategyConfigurationOptionAllowsRequestsWhileUnauthenticated | ZMStrategyConfigurationOptionAllowsRequestsDuringSync;
 }
 
 - (NSArray *)contextChangeTrackers
@@ -151,9 +151,6 @@ NSTimeInterval ZMSelfStrategyPendingValidationRequestInterval = 5;
             return [self.downstreamSelfUserSync nextRequest];
         }
     }
-    else if (clientStatus.currentPhase == ZMClientRegistrationPhaseRegistered) {
-        return [@[self.downstreamSelfUserSync, self.upstreamObjectSync] nextRequest];
-    }
     else if (self.isSyncing) {
         if (self.downstreamSelfUserSync.status != ZMSingleRequestInProgress) {
             selfUser.needsToBeUpdatedFromBackend = YES;
@@ -162,6 +159,9 @@ NSTimeInterval ZMSelfStrategyPendingValidationRequestInterval = 5;
         if (selfUser.needsToBeUpdatedFromBackend) {
             return [self.downstreamSelfUserSync nextRequest];
         }
+    }
+    else if (clientStatus.currentPhase == ZMClientRegistrationPhaseRegistered) {
+        return [@[self.downstreamSelfUserSync, self.upstreamObjectSync] nextRequest];
     }
     return nil;
 }

--- a/Source/Synchronization/Transcoders/ZMSelfStrategy.m
+++ b/Source/Synchronization/Transcoders/ZMSelfStrategy.m
@@ -351,7 +351,7 @@ static NSString * const DeletionRequestKey = @"";
         if (self.isSyncing) {
             [syncStatus finishCurrentSyncPhaseWithPhase:self.expectedSyncPhase];
         }
-    } else if (self.isSyncing) {
+    } else if (response.result == ZMTransportResponseStatusPermanentError && self.isSyncing) {
         [syncStatus failCurrentSyncPhaseWithPhase:self.expectedSyncPhase];
     }
 }

--- a/Source/Synchronization/Transcoders/ZMSelfStrategy.m
+++ b/Source/Synchronization/Transcoders/ZMSelfStrategy.m
@@ -140,19 +140,8 @@ NSTimeInterval ZMSelfStrategyPendingValidationRequestInterval = 5;
         [self.timedDownstreamSync readyForNextRequestIfNotBusy];
         return [self.timedDownstreamSync nextRequest];
     }
-    
-    if (clientStatus.currentPhase == ZMClientRegistrationPhaseWaitingForSelfUser) {
-        
+    if (clientStatus.currentPhase == ZMClientRegistrationPhaseWaitingForSelfUser || self.isSyncing) {
         if (! selfUser.needsToBeUpdatedFromBackend) {
-            selfUser.needsToBeUpdatedFromBackend = YES;
-            [self.downstreamSelfUserSync readyForNextRequestIfNotBusy];
-        }
-        if (selfUser.needsToBeUpdatedFromBackend) {
-            return [self.downstreamSelfUserSync nextRequest];
-        }
-    }
-    else if (self.isSyncing) {
-        if (self.downstreamSelfUserSync.status != ZMSingleRequestInProgress) {
             selfUser.needsToBeUpdatedFromBackend = YES;
             [self.downstreamSelfUserSync readyForNextRequestIfNotBusy];
         }

--- a/Source/Synchronization/Transcoders/ZMUserTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMUserTranscoder.m
@@ -82,9 +82,15 @@ NSUInteger const ZMUserTranscoderNumberOfUUIDsPerRequest = 1600 / 25; // UUID as
     [self.remoteIDObjectSync addRemoteIdentifiersThatNeedDownload:userIds];
 }
 
+
+- (SyncPhase)expectedSyncPhase
+{
+    return SyncPhaseFetchingUsers;
+}
+
 - (BOOL)isSyncing
 {
-    return self.syncStatus.currentSyncPhase == SyncPhaseFetchingUsers;
+    return self.syncStatus.currentSyncPhase == self.expectedSyncPhase;
 }
 
 - (ZMTransportRequest *)nextRequestIfAllowed
@@ -267,7 +273,7 @@ NSUInteger const ZMUserTranscoderNumberOfUUIDsPerRequest = 1600 / 25; // UUID as
             
             if (self.remoteIDObjectSync.isDone && self.isSyncing) {
                 self.didStartSyncing = NO;
-                [syncStatus finishCurrentSyncPhase];
+                [syncStatus finishCurrentSyncPhaseWithPhase:self.expectedSyncPhase];
             }
             break;
         }
@@ -276,7 +282,7 @@ NSUInteger const ZMUserTranscoderNumberOfUUIDsPerRequest = 1600 / 25; // UUID as
             [self updateUsersFromPayload:nil expectedRemoteIdentifiers:remoteIdentifiers];
             if (self.isSyncing) {
                 self.didStartSyncing = NO;
-                [syncStatus failCurrentSyncPhase];
+                [syncStatus failCurrentSyncPhaseWithPhase:self.expectedSyncPhase];
             }
             break;
         }

--- a/Source/Synchronization/Transcoders/ZMUserTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMUserTranscoder.m
@@ -73,12 +73,6 @@ NSUInteger const ZMUserTranscoderNumberOfUUIDsPerRequest = 1600 / 25; // UUID as
         }
     }
     
-    // also self
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.managedObjectContext];
-    if (selfUser.remoteIdentifier != nil) {
-        [userIds addObject:selfUser.remoteIdentifier];
-    }
-    
     [self.remoteIDObjectSync addRemoteIdentifiersThatNeedDownload:userIds];
 }
 

--- a/Source/Synchronization/ZMSyncStrategy.m
+++ b/Source/Synchronization/ZMSyncStrategy.m
@@ -236,7 +236,7 @@ ZM_EMPTY_ASSERTING_INIT()
     self.eventDecoder = [[EventDecoder alloc] initWithEventMOC:self.eventMOC syncMOC:self.syncMOC];
     self.connectionTranscoder = [[ZMConnectionTranscoder alloc] initWithManagedObjectContext:self.syncMOC applicationStatus:self.applicationStatusDirectory syncStatus:self.applicationStatusDirectory.syncStatus];
     self.userTranscoder = [[ZMUserTranscoder alloc] initWithManagedObjectContext:self.syncMOC applicationStatus:self.applicationStatusDirectory syncStatus:self.applicationStatusDirectory.syncStatus];
-    self.selfStrategy = [[ZMSelfStrategy alloc] initWithManagedObjectContext:self.syncMOC applicationStatus:self.applicationStatusDirectory clientRegistrationStatus:self.applicationStatusDirectory.clientRegistrationStatus];
+    self.selfStrategy = [[ZMSelfStrategy alloc] initWithManagedObjectContext:self.syncMOC applicationStatus:self.applicationStatusDirectory clientRegistrationStatus:self.applicationStatusDirectory.clientRegistrationStatus syncStatus:self.applicationStatusDirectory.syncStatus];
     self.conversationTranscoder = [[ZMConversationTranscoder alloc] initWithSyncStrategy:self applicationStatus:self.applicationStatusDirectory syncStatus:self.applicationStatusDirectory.syncStatus];
     self.systemMessageEventConsumer = [[SystemMessageEventsConsumer alloc] initWithMoc:self.syncMOC localNotificationDispatcher:localNotificationsDispatcher];
     self.clientMessageTranscoder = [[ClientMessageTranscoder alloc] initIn:self.syncMOC localNotificationDispatcher:localNotificationsDispatcher applicationStatus:self.applicationStatusDirectory];

--- a/Source/UserSession/SyncStatus.swift
+++ b/Source/UserSession/SyncStatus.swift
@@ -22,11 +22,12 @@
     case fetchingConnections
     case fetchingConversations
     case fetchingUsers
+    case fetchingSelfUser
     case fetchingMissedEvents
     case done
     
     var isLastSlowSyncPhase : Bool {
-        return self == .fetchingUsers
+        return self == .fetchingSelfUser
     }
     
     var isSyncing : Bool {
@@ -36,7 +37,8 @@
              .fetchingConnections,
              .fetchingTeams,
              .fetchingUsers,
-             .fetchingConversations:
+             .fetchingConversations,
+             .fetchingSelfUser:
             return true
         case .done:
             return false
@@ -59,6 +61,8 @@
             return "fetchingTeams"
         case .fetchingUsers:
             return "fetchingUsers"
+        case .fetchingSelfUser:
+            return "fetchingSelfUser"
         case .fetchingMissedEvents:
             return "fetchingMissedEvents"
         case .done:
@@ -125,7 +129,8 @@ public class SyncStatus : NSObject {
 // MARK: Slow Sync
 extension SyncStatus {
     
-    public func finishCurrentSyncPhase() {
+    public func finishCurrentSyncPhase(phase : SyncPhase) {
+        guard phase == currentSyncPhase else { return }
         guard let nextPhase = currentSyncPhase.nextPhase else { return }
         
         if currentSyncPhase.isLastSlowSyncPhase {
@@ -150,7 +155,9 @@ extension SyncStatus {
         RequestAvailableNotification.notifyNewRequestsAvailable(self)
     }
     
-    public func failCurrentSyncPhase() {
+    public func failCurrentSyncPhase(phase : SyncPhase) {
+        guard phase == currentSyncPhase else { return }
+        
         if currentSyncPhase == .fetchingMissedEvents {
             currentSyncPhase = hasPersistedLastEventID ? SyncPhase.fetchingLastUpdateEventID.nextPhase! : .fetchingLastUpdateEventID
             needsToRestartQuickSync = false

--- a/Source/UserSession/SyncStatus.swift
+++ b/Source/UserSession/SyncStatus.swift
@@ -130,7 +130,7 @@ public class SyncStatus : NSObject {
 extension SyncStatus {
     
     public func finishCurrentSyncPhase(phase : SyncPhase) {
-        guard phase == currentSyncPhase else { return }
+        assert(phase == currentSyncPhase, "Finished syncPhase does not match currentPhase")
         guard let nextPhase = currentSyncPhase.nextPhase else { return }
         
         if currentSyncPhase.isLastSlowSyncPhase {
@@ -156,7 +156,7 @@ extension SyncStatus {
     }
     
     public func failCurrentSyncPhase(phase : SyncPhase) {
-        guard phase == currentSyncPhase else { return }
+        assert(phase == currentSyncPhase, "Finished syncPhase does not match currentPhase")
         
         if currentSyncPhase == .fetchingMissedEvents {
             currentSyncPhase = hasPersistedLastEventID ? SyncPhase.fetchingLastUpdateEventID.nextPhase! : .fetchingLastUpdateEventID

--- a/Tests/Source/Integration/SlowSyncTests.m
+++ b/Tests/Source/Integration/SlowSyncTests.m
@@ -412,6 +412,17 @@
     XCTAssertEqual(self.userSession.networkState, ZMNetworkStateOnline);
 }
 
+
+- (void)testThatItHasTheSelfUserEmailAfterTheSlowSync
+{
+    // given
+    XCTAssertTrue([self logInAndWaitForSyncToBeComplete]);
+    
+    // then
+    XCTAssertNotNil([[ZMUser selfUserInUserSession:self.userSession] emailAddress]);
+}
+
+
 - (ZMUser *)findUserWithUUID:(NSString *)UUIDString inMoc:(NSManagedObjectContext *)moc {
     ZMUser *user = [ZMUser userWithRemoteID:[UUIDString UUID] createIfNeeded:NO inContext:moc];
     XCTAssertNotNil(user);

--- a/Tests/Source/Integration/SlowSyncTests.m
+++ b/Tests/Source/Integration/SlowSyncTests.m
@@ -122,6 +122,7 @@
     return @[
              [[ZMTransportRequest alloc] initWithPath:ZMLoginURL method:ZMMethodPOST payload:@{@"email":[self.selfUser.email copy], @"password":[self.selfUser.password copy], @"label": self.userSession.authenticationStatus.cookieLabel} authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken],
              [ZMTransportRequest requestGetFromPath:@"/self"],
+             [ZMTransportRequest requestGetFromPath:@"/self"], // second request during slow sync
              [ZMTransportRequest requestGetFromPath:@"/clients"],
              [ZMTransportRequest requestGetFromPath:[NSString stringWithFormat:@"/notifications/last?client=%@",  [ZMUser selfUserInContext:self.syncMOC].selfClient.remoteIdentifier]],
              [ZMTransportRequest requestGetFromPath:@"/connections?size=90"],

--- a/Tests/Source/Integration/SlowSyncTests.m
+++ b/Tests/Source/Integration/SlowSyncTests.m
@@ -129,7 +129,7 @@
              [ZMTransportRequest requestGetFromPath:@"/conversations/ids?size=100"],
              [ZMTransportRequest requestGetFromPath:[NSString stringWithFormat:@"/conversations?ids=%@,%@,%@,%@", self.selfConversation.identifier,self.selfToUser1Conversation.identifier,self.selfToUser2Conversation.identifier,self.groupConversation.identifier]],
              [ZMTransportRequest requestGetFromPath:@"/teams?size=50"],
-             [ZMTransportRequest requestGetFromPath:[NSString stringWithFormat:@"/users?ids=%@,%@,%@", self.selfUser.identifier, self.user1.identifier, self.user2.identifier]],
+             [ZMTransportRequest requestGetFromPath:[NSString stringWithFormat:@"/users?ids=%@,%@", self.user1.identifier, self.user2.identifier]],
              [ZMTransportRequest requestGetFromPath:[NSString stringWithFormat:@"/users?ids=%@", self.user3.identifier]],
              [ZMTransportRequest requestWithPath:@"/onboarding/v3" method:ZMMethodPOST payload:@{
                                                                                                                 @"cards" : @[],

--- a/Tests/Source/Synchronization/SynchronizationMocks.swift
+++ b/Tests/Source/Synchronization/SynchronizationMocks.swift
@@ -228,16 +228,16 @@ public class MockSyncStatus : SyncStatus {
         }
     }
     
-    public override func failCurrentSyncPhase() {
+    public override func failCurrentSyncPhase(phase: SyncPhase) {
         didCallFailCurrentSyncPhase = true
         
-        super.failCurrentSyncPhase()
+        super.failCurrentSyncPhase(phase: phase)
     }
     
-    public override func finishCurrentSyncPhase() {
+    public override func finishCurrentSyncPhase(phase: SyncPhase) {
         didCallFinishCurrentSyncPhase = true
         
-        super.finishCurrentSyncPhase()
+        super.finishCurrentSyncPhase(phase: phase)
     }
 }
 

--- a/Tests/Source/Synchronization/Transcoders/ZMSelfTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMSelfTranscoderTests.m
@@ -33,6 +33,7 @@
 @property (nonatomic) ZMUpstreamModifiedObjectSync *upstreamObjectSync;
 @property (nonatomic) id mockClientRegistrationStatus;
 @property (nonatomic) id requestSync;
+@property (nonatomic) id syncStatus;
 
 @property (nonatomic) ZMClientRegistrationStatus *realClientRegistrationStatus;
 @property (nonatomic) NSTimeInterval originalRequestInterval;
@@ -49,6 +50,8 @@
     
     self.requestSync = [OCMockObject mockForClass:ZMSingleRequestSync.class];
     self.mockClientRegistrationStatus = [OCMockObject niceMockForClass:[ZMClientRegistrationStatus class]];
+    self.syncStatus = [OCMockObject niceMockForClass:[SyncStatus class]];
+    
     self.mockApplicationStatus.mockSynchronizationState = ZMSynchronizationStateEventProcessing;
     self.upstreamObjectSync = [OCMockObject niceMockForClass:ZMUpstreamModifiedObjectSync.class];
     [self.syncMOC performBlockAndWait:^{
@@ -58,6 +61,7 @@
     self.sut = (id) [[ZMSelfStrategy alloc] initWithManagedObjectContext:self.syncMOC
                                                        applicationStatus:self.mockApplicationStatus
                                                 clientRegistrationStatus:self.mockClientRegistrationStatus
+                                                              syncStatus:self.syncStatus
                                                             upstreamObjectSync:self.upstreamObjectSync];
     
     WaitForAllGroupsToBeEmpty(0.5);
@@ -65,6 +69,7 @@
 
 - (void)tearDown
 {
+    self.syncStatus = nil;
     self.requestSync = nil;
     [self.mockClientRegistrationStatus stopMocking];
     self.mockClientRegistrationStatus = nil;
@@ -582,7 +587,8 @@
     //let it create an actual ZMUpstreamSync, not a mocked one
     self.sut = (id) [[ZMSelfStrategy alloc] initWithManagedObjectContext:self.syncMOC
                                                        applicationStatus:self.mockApplicationStatus
-                                                clientRegistrationStatus:self.mockClientRegistrationStatus];
+                                                clientRegistrationStatus:self.mockClientRegistrationStatus
+                                                              syncStatus:self.syncStatus];
 }
 
 - (void)testThatItResetsTheProfileImageWithBlock:(void(^)(ZMUser *user))block;

--- a/Tests/Source/Synchronization/ZMSyncStrategyTests.m
+++ b/Tests/Source/Synchronization/ZMSyncStrategyTests.m
@@ -115,7 +115,7 @@
 
     id selfStrategy = [OCMockObject niceMockForClass:ZMSelfStrategy.class];
     [[[[selfStrategy expect] andReturn:selfStrategy] classMethod] alloc];
-    (void) [(ZMSelfStrategy *)[[selfStrategy expect] andReturn:selfStrategy] initWithManagedObjectContext:self.syncMOC applicationStatus:OCMOCK_ANY clientRegistrationStatus:OCMOCK_ANY];
+    (void) [(ZMSelfStrategy *)[[selfStrategy expect] andReturn:selfStrategy] initWithManagedObjectContext:self.syncMOC applicationStatus:OCMOCK_ANY clientRegistrationStatus:OCMOCK_ANY syncStatus:OCMOCK_ANY];
     [[selfStrategy stub] contextChangeTrackers];
     [[selfStrategy expect] tearDown];
 

--- a/Tests/Source/UserSession/SyncStatusTests.swift
+++ b/Tests/Source/UserSession/SyncStatusTests.swift
@@ -82,27 +82,31 @@ class SyncStatusTests : MessagingTest {
         // given
         XCTAssertEqual(sut.currentSyncPhase, .fetchingLastUpdateEventID)
         // when
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingLastUpdateEventID)
         // then
         XCTAssertEqual(sut.currentSyncPhase, .fetchingTeams)
         // when
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingTeams)
         // then
         XCTAssertEqual(sut.currentSyncPhase, .fetchingConnections)
         // when
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingConnections)
         // then
         XCTAssertEqual(sut.currentSyncPhase, .fetchingConversations)
         // when
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingConversations)
         // then
         XCTAssertEqual(sut.currentSyncPhase, .fetchingUsers)
         // when
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingUsers)
+        // then
+        XCTAssertEqual(sut.currentSyncPhase, .fetchingSelfUser)
+        // when
+        sut.finishCurrentSyncPhase(phase: .fetchingSelfUser)
         // then
         XCTAssertEqual(sut.currentSyncPhase, .fetchingMissedEvents)
         // when
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingMissedEvents)
         // then
         XCTAssertEqual(sut.currentSyncPhase, .done)
     }
@@ -114,24 +118,29 @@ class SyncStatusTests : MessagingTest {
         XCTAssertNil(uiMOC.zm_lastNotificationID)
 
         // when
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingLastUpdateEventID)
         // then
         XCTAssertNil(uiMOC.zm_lastNotificationID)
         // when
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingTeams)
         // then
         XCTAssertNil(uiMOC.zm_lastNotificationID)
         // when
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingConnections)
         // then
         XCTAssertNil(uiMOC.zm_lastNotificationID)
         // when
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingConversations)
         // then
         XCTAssertNil(uiMOC.zm_lastNotificationID)
         XCTAssertEqual(sut.currentSyncPhase, .fetchingUsers)
         // when
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingUsers)
+        // then
+        XCTAssertNil(uiMOC.zm_lastNotificationID)
+        XCTAssertEqual(sut.currentSyncPhase, .fetchingSelfUser)
+        // when
+        sut.finishCurrentSyncPhase(phase: .fetchingSelfUser)
         // then
         XCTAssertNotNil(uiMOC.zm_lastNotificationID)
 
@@ -145,24 +154,27 @@ class SyncStatusTests : MessagingTest {
         // when
         XCTAssertEqual(sut.currentSyncPhase, .fetchingLastUpdateEventID)
         // when
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingLastUpdateEventID)
         // then
         XCTAssertEqual(sut.currentSyncPhase, .fetchingTeams)
         // when
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingTeams)
         // then
         XCTAssertEqual(sut.currentSyncPhase, .fetchingConnections)
         // when
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingConnections)
         // then
         XCTAssertEqual(sut.currentSyncPhase, .fetchingConversations)
         // when
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingConversations)
         // then
         XCTAssertEqual(sut.currentSyncPhase, .fetchingUsers)
         // when
-        sut.finishCurrentSyncPhase()
-        
+        sut.finishCurrentSyncPhase(phase: .fetchingUsers)
+        // then
+        XCTAssertEqual(sut.currentSyncPhase, .fetchingSelfUser)
+        // when
+        sut.finishCurrentSyncPhase(phase: .fetchingSelfUser)
         // then
         XCTAssertNotNil(uiMOC.zm_lastNotificationID)
     }
@@ -173,29 +185,29 @@ class SyncStatusTests : MessagingTest {
         XCTAssertFalse(mockSyncDelegate.didCallFinishSync)
         
         // when
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingLastUpdateEventID)
         // then
         XCTAssertFalse(mockSyncDelegate.didCallFinishSync)
         // when
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingTeams)
         // then
         XCTAssertFalse(mockSyncDelegate.didCallFinishSync)
         // when
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingConnections)
         // then
         XCTAssertFalse(mockSyncDelegate.didCallFinishSync)
         // when
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingConversations)
         // then
         XCTAssertFalse(mockSyncDelegate.didCallFinishSync)
         // when
-        XCTAssertEqual(sut.currentSyncPhase, .fetchingUsers)
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingUsers)
         // then
         XCTAssertFalse(mockSyncDelegate.didCallFinishSync)
         // when
-        sut.finishCurrentSyncPhase()
-        
+        sut.finishCurrentSyncPhase(phase: .fetchingSelfUser)
+        // when
+        sut.finishCurrentSyncPhase(phase: .fetchingMissedEvents)
         
         // then
         XCTAssertTrue(mockSyncDelegate.didCallFinishSync)
@@ -214,13 +226,13 @@ class SyncStatusTests : MessagingTest {
     func testThatItDoesNotNotifyTheStateDelegateWhenAlreadySyncing(){
         // given
         mockSyncDelegate.didCallStartSync = false
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingLastUpdateEventID)
         XCTAssertEqual(sut.currentSyncPhase, .fetchingTeams)
         
         XCTAssertFalse(mockSyncDelegate.didCallStartSync)
         
         // when
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingTeams)
         
         // then
         XCTAssertFalse(mockSyncDelegate.didCallStartSync)
@@ -231,7 +243,7 @@ class SyncStatusTests : MessagingTest {
         // given
         uiMOC.zm_lastNotificationID = UUID.timeBasedUUID() as UUID
         sut = SyncStatus(managedObjectContext: uiMOC, syncStateDelegate: mockSyncDelegate)
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingMissedEvents)
         XCTAssertEqual(sut.currentSyncPhase, .done)
         mockSyncDelegate.didCallStartSync = false
 
@@ -252,7 +264,7 @@ class SyncStatusTests : MessagingTest {
         XCTAssertFalse(observer.didNotify)
 
         // when
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingMissedEvents)
         XCTAssert(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then
@@ -271,7 +283,7 @@ extension SyncStatusTests {
         // given
         uiMOC.zm_lastNotificationID = UUID.timeBasedUUID() as UUID
         sut = SyncStatus(managedObjectContext: uiMOC, syncStateDelegate: mockSyncDelegate)
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingMissedEvents)
         XCTAssertEqual(sut.currentSyncPhase, .done)
         
         // when
@@ -307,7 +319,7 @@ extension SyncStatusTests {
         XCTAssertTrue(sut.needsToRestartQuickSync)
         
         // and when
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingMissedEvents)
         
         // then
         XCTAssertEqual(sut.currentSyncPhase, .fetchingMissedEvents)
@@ -330,7 +342,7 @@ extension SyncStatusTests {
         // and when
         sut.pushChannelDidClose()
         sut.pushChannelDidOpen()
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingMissedEvents)
         
         // then
         XCTAssertEqual(sut.currentSyncPhase, .fetchingMissedEvents)
@@ -340,7 +352,7 @@ extension SyncStatusTests {
         // given
         uiMOC.zm_lastNotificationID = UUID.timeBasedUUID() as UUID
         sut = SyncStatus(managedObjectContext: uiMOC, syncStateDelegate: mockSyncDelegate)
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingMissedEvents)
         XCTAssertEqual(sut.currentSyncPhase, .done)
 
         // when
@@ -355,7 +367,7 @@ extension SyncStatusTests {
         // given
         uiMOC.zm_lastNotificationID = UUID.timeBasedUUID() as UUID
         sut = SyncStatus(managedObjectContext: uiMOC, syncStateDelegate: mockSyncDelegate)
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingMissedEvents)
         XCTAssertEqual(sut.currentSyncPhase, .done)
 
         // when
@@ -382,7 +394,7 @@ extension SyncStatusTests {
         
         // and when
         sut.pushChannelDidClose()
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingMissedEvents)
         
         // then
         XCTAssertEqual(sut.currentSyncPhase, .done)
@@ -395,7 +407,7 @@ extension SyncStatusTests {
         XCTAssertEqual(sut.currentSyncPhase, .fetchingMissedEvents)
         
         // when
-        sut.failCurrentSyncPhase()
+        sut.failCurrentSyncPhase(phase: .fetchingMissedEvents)
         
         // then
         XCTAssertEqual(sut.currentSyncPhase, .fetchingTeams)
@@ -411,7 +423,7 @@ extension SyncStatusTests {
         
         // when
         sut.updateLastUpdateEventID(eventID: newID)
-        sut.failCurrentSyncPhase()
+        sut.failCurrentSyncPhase(phase: .fetchingMissedEvents)
         
         // then
         XCTAssertEqual(uiMOC.zm_lastNotificationID, oldID)
@@ -428,28 +440,31 @@ extension SyncStatusTests {
         
         // when
         sut.updateLastUpdateEventID(eventID: newID)
-        sut.failCurrentSyncPhase()
+        sut.failCurrentSyncPhase(phase: .fetchingMissedEvents)
         
         // then
         XCTAssertNotEqual(uiMOC.zm_lastNotificationID, newID)
         XCTAssertEqual(sut.currentSyncPhase, .fetchingTeams)
         
         // and when
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingTeams)
         // then
         XCTAssertNotEqual(uiMOC.zm_lastNotificationID, newID)
         // when
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingConnections)
         // then
         XCTAssertNotEqual(uiMOC.zm_lastNotificationID, newID)
         // when
-        sut.finishCurrentSyncPhase()
+        sut.finishCurrentSyncPhase(phase: .fetchingConversations)
         // then
         XCTAssertNotEqual(uiMOC.zm_lastNotificationID, newID)
         // when
         XCTAssertEqual(sut.currentSyncPhase, .fetchingUsers)
-        sut.finishCurrentSyncPhase()
-
+        sut.finishCurrentSyncPhase(phase: .fetchingUsers)
+        // when
+        XCTAssertEqual(sut.currentSyncPhase, .fetchingSelfUser)
+        sut.finishCurrentSyncPhase(phase: .fetchingSelfUser)
+        
         // then
         XCTAssertEqual(uiMOC.zm_lastNotificationID, newID)
         XCTAssertNotEqual(uiMOC.zm_lastNotificationID, oldID)

--- a/Tests/Source/UserSession/SyncStatusTests.swift
+++ b/Tests/Source/UserSession/SyncStatusTests.swift
@@ -56,6 +56,15 @@ class SyncStatusTests : MessagingTest {
         super.tearDown()
     }
     
+    func testThatItDoesNotChangePhaseIfCallingPhaseIsNotCurrentPhase(){
+        // given
+        XCTAssertEqual(sut.currentSyncPhase, .fetchingLastUpdateEventID)
+        // when
+        sut.finishCurrentSyncPhase(phase: .fetchingTeams)
+        // then
+        XCTAssertEqual(sut.currentSyncPhase, .fetchingLastUpdateEventID)
+    }
+    
     func testThatWhenIntializingWithoutLastEventIDItStartsInStateFetchingLastUpdateEventID(){
         // given
         uiMOC.zm_lastNotificationID = nil


### PR DESCRIPTION
When fetching users during slowSync, the user payload does not contain an email address thereby deleting the selfUser's email address. During slowSync we should therefore also fetch the selfUser at the end.

Also changed: The slowSync strategies are now calling back the slowSyncStatus callBack with their respective phase - This way we avoid entering a wrong phase before the current phase has completed.

