### PR TITLE
Fixed assert breaking tests

### DIFF
--- a/Source/Synchronization/Transcoders/ZMLastUpdateEventIDTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMLastUpdateEventIDTranscoder.m
@@ -130,7 +130,9 @@
     NOT_USED(sync);
     SyncStatus *status = self.syncStatus;
     if(response.payload == nil) {
-        [status failCurrentSyncPhaseWithPhase:self.expectedSyncPhase];
+        if (status.isSyncing) {
+            [status failCurrentSyncPhaseWithPhase:self.expectedSyncPhase];
+        }
         return;
     }
     
@@ -139,7 +141,10 @@
         self.lastUpdateEventID = lastNotificationID;
         if (status.currentSyncPhase == self.expectedSyncPhase) {
             [status updateLastUpdateEventIDWithEventID:lastNotificationID];
-            [status finishCurrentSyncPhaseWithPhase:self.expectedSyncPhase];
+            
+            if (status.isSyncing) {
+                [status finishCurrentSyncPhaseWithPhase:self.expectedSyncPhase];
+            }
         }
     }
     

--- a/Source/Synchronization/Transcoders/ZMLastUpdateEventIDTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMLastUpdateEventIDTranscoder.m
@@ -141,10 +141,7 @@
         self.lastUpdateEventID = lastNotificationID;
         if (status.currentSyncPhase == self.expectedSyncPhase) {
             [status updateLastUpdateEventIDWithEventID:lastNotificationID];
-            
-            if (status.isSyncing) {
-                [status finishCurrentSyncPhaseWithPhase:self.expectedSyncPhase];
-            }
+            [status finishCurrentSyncPhaseWithPhase:self.expectedSyncPhase];
         }
     }
     

--- a/Source/UserSession/SyncStatus.swift
+++ b/Source/UserSession/SyncStatus.swift
@@ -130,10 +130,8 @@ public class SyncStatus : NSObject {
 extension SyncStatus {
     
     public func finishCurrentSyncPhase(phase : SyncPhase) {
-        guard phase == currentSyncPhase else {
-            zmLog.error("Finished syncPhase does not match currentPhase")
-            return
-        }
+        precondition(phase == currentSyncPhase, "Finished syncPhase does not match currentPhase")
+        
         guard let nextPhase = currentSyncPhase.nextPhase else { return }
         
         if currentSyncPhase.isLastSlowSyncPhase {
@@ -159,10 +157,7 @@ extension SyncStatus {
     }
     
     public func failCurrentSyncPhase(phase : SyncPhase) {
-        guard phase == currentSyncPhase else {
-            zmLog.error("Finished syncPhase does not match currentPhase")
-            return
-        }
+        precondition(phase == currentSyncPhase, "Failed syncPhase does not match currentPhase")
         
         if currentSyncPhase == .fetchingMissedEvents {
             currentSyncPhase = hasPersistedLastEventID ? SyncPhase.fetchingLastUpdateEventID.nextPhase! : .fetchingLastUpdateEventID

--- a/Source/UserSession/SyncStatus.swift
+++ b/Source/UserSession/SyncStatus.swift
@@ -130,7 +130,10 @@ public class SyncStatus : NSObject {
 extension SyncStatus {
     
     public func finishCurrentSyncPhase(phase : SyncPhase) {
-        assert(phase == currentSyncPhase, "Finished syncPhase does not match currentPhase")
+        guard phase == currentSyncPhase else {
+            zmLog.error("Finished syncPhase does not match currentPhase")
+            return
+        }
         guard let nextPhase = currentSyncPhase.nextPhase else { return }
         
         if currentSyncPhase.isLastSlowSyncPhase {
@@ -156,7 +159,10 @@ extension SyncStatus {
     }
     
     public func failCurrentSyncPhase(phase : SyncPhase) {
-        assert(phase == currentSyncPhase, "Finished syncPhase does not match currentPhase")
+        guard phase == currentSyncPhase else {
+            zmLog.error("Finished syncPhase does not match currentPhase")
+            return
+        }
         
         if currentSyncPhase == .fetchingMissedEvents {
             currentSyncPhase = hasPersistedLastEventID ? SyncPhase.fetchingLastUpdateEventID.nextPhase! : .fetchingLastUpdateEventID

--- a/Tests/Source/Synchronization/Transcoders/ZMLastUpdateEventIDTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMLastUpdateEventIDTranscoderTests.m
@@ -258,15 +258,17 @@
 
 - (void)testThatTheLastUpdateEventIDIsNotPersistedIfTheResponseIsAPermanentError
 {
-    // given
-    ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:nil HTTPStatus:400 transportSessionError:nil];
-    [self.sut didReceiveResponse:response forSingleRequest:self.downstreamSync];
-    
-    // expect
-    [[(id)self.directory.missingUpdateEventsTranscoder reject] setLastUpdateEventID:OCMOCK_ANY];
-    
-    // when
-    [self.sut persistLastUpdateEventID];
+    [self performIgnoringZMLogError:^{
+        // given
+        ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:nil HTTPStatus:400 transportSessionError:nil];
+        [self.sut didReceiveResponse:response forSingleRequest:self.downstreamSync];
+        
+        // expect
+        [[(id)self.directory.missingUpdateEventsTranscoder reject] setLastUpdateEventID:OCMOCK_ANY];
+        
+        // when
+        [self.sut persistLastUpdateEventID];        
+    }];
 }
 
 - (void)testThatItEncodesTheRightRequestWithoutClient

--- a/Tests/Source/Synchronization/Transcoders/ZMLastUpdateEventIDTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMLastUpdateEventIDTranscoderTests.m
@@ -258,17 +258,15 @@
 
 - (void)testThatTheLastUpdateEventIDIsNotPersistedIfTheResponseIsAPermanentError
 {
-    [self performIgnoringZMLogError:^{
-        // given
-        ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:nil HTTPStatus:400 transportSessionError:nil];
-        [self.sut didReceiveResponse:response forSingleRequest:self.downstreamSync];
-        
-        // expect
-        [[(id)self.directory.missingUpdateEventsTranscoder reject] setLastUpdateEventID:OCMOCK_ANY];
-        
-        // when
-        [self.sut persistLastUpdateEventID];        
-    }];
+    // given
+    ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:nil HTTPStatus:400 transportSessionError:nil];
+    [self.sut didReceiveResponse:response forSingleRequest:self.downstreamSync];
+    
+    // expect
+    [[(id)self.directory.missingUpdateEventsTranscoder reject] setLastUpdateEventID:OCMOCK_ANY];
+    
+    // when
+    [self.sut persistLastUpdateEventID];
 }
 
 - (void)testThatItEncodesTheRightRequestWithoutClient


### PR DESCRIPTION
- Replaced the assert with `ZMLogError`.

Idea for the future improvement: 
Create the precondition method that checks the condition and fails the test but crash on production.