### PR TITLE
Finish .fetchingUsers sync phase manually if there are no local users

### DIFF
--- a/Source/Synchronization/Transcoders/ZMUserTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMUserTranscoder.m
@@ -72,10 +72,16 @@ NSUInteger const ZMUserTranscoderNumberOfUUIDsPerRequest = 1600 / 25; // UUID as
             [userIds addObject:user.remoteIdentifier];
         }
     }
-    
-    [self.remoteIDObjectSync addRemoteIdentifiersThatNeedDownload:userIds];
-}
 
+    // If there are no users (in case we just created an account),
+    // we move on to the next sync phase manually.
+    if (userIds.count == 0) {
+        self.didStartSyncing = NO;
+        [self.syncStatus finishCurrentSyncPhaseWithPhase:self.expectedSyncPhase];
+    } else {
+        [self.remoteIDObjectSync addRemoteIdentifiersThatNeedDownload:userIds];
+    }
+}
 
 - (SyncPhase)expectedSyncPhase
 {

--- a/Tests/Source/Synchronization/Transcoders/ZMUserTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMUserTranscoderTests.m
@@ -526,7 +526,7 @@ static NSString *const USER_PATH_WITH_QUERY = @"/users?ids=";
     
     ZMTransportRequest *request = [self.sut nextRequest];
     XCTAssertNotNil(request);
-    ZMTransportResponse *response =[self successResponseForUsersRequest:request];
+    ZMTransportResponse *response = [self successResponseForUsersRequest:request];
     
     // when
     [request completeWithResponse:response];
@@ -534,6 +534,21 @@ static NSString *const USER_PATH_WITH_QUERY = @"/users?ids=";
     
     // then
     XCTAssertFalse(self.mockSyncStatus.didCallFinishCurrentSyncPhase);
+}
+
+- (void)testThatTheCurrentSyncPhaseIsFinishedWhenThereAreNoLocalUsersToBeFetched
+{
+    // given
+    self.mockSyncStatus.mockPhase = SyncPhaseFetchingUsers;
+
+    // when
+    ZMTransportRequest *request = [self.sut nextRequest];
+    XCTAssertNil(request);
+
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    // then
+    XCTAssertTrue(self.mockSyncStatus.didCallFinishCurrentSyncPhase);
 }
 
 - (void)testThatItDoesNotClearNeedsToBeUpdatedFromBackendWhenItIsUpdatedFromPushChannelData


### PR DESCRIPTION
# What's in this PR?

* After not fetching the self user in the`.fetchingUsers` sync phase with the introduction of the `.fetchingSelfUser` sync phase we failed to advance the current phase in the case that there are no local users. This will always be the case for users who just registered. See c6b80ed421f7f44944c9485ae6de27c68d50c560 for reference.