### PR TITLE
Remove redundant code

### DIFF
--- a/Source/Synchronization/Transcoders/TeamSyncRequestStrategy.swift
+++ b/Source/Synchronization/Transcoders/TeamSyncRequestStrategy.swift
@@ -136,8 +136,6 @@ extension TeamSyncRequestStrategy: ZMSimpleListRequestPaginatorSync {
             guard let id = (payload["id"] as? String).flatMap(UUID.init) else { return nil }
             let team = Team.fetchOrCreate(with: id, create: true, in: managedObjectContext, created: nil)
             team?.update(with: payload)
-            // See `markExistingTeamsAsNeedingToBeDownloaded`
-            team?.needsToBeUpdatedFromBackend = false
             return team
         }
 


### PR DESCRIPTION
# What's in this PR?

* After changing the logic to delete local teams not returned from the `/teams` endpoint instead of trying to refetch them (and then delete them in case of a 4xx response) some code resetting the flag to fetch them was still left in the code.