### PR TITLE
do not call back automatically when acting on a missed call notification

### DIFF
--- a/Source/UserSession/ZMUserSession+Background.m
+++ b/Source/UserSession/ZMUserSession+Background.m
@@ -341,9 +341,8 @@ static NSString *ZMLogTag = @"Push";
 {
     if (note.actionIdentifier == nil || [note.actionIdentifier isEqualToString:ZMCallAcceptAction]) {
         BOOL callIsStillOngoing = (note.conversation.callParticipants.count > 0) || note.conversation.voiceChannel.state == VoiceChannelV2StateIncomingCall;
-        BOOL userWantsToCallBack = ([note.category isEqualToString:ZMMissedCallCategory]);
         
-        if ([WireCallCenter activeCallConversationsInUserSession:self].count == 0 && (callIsStillOngoing || userWantsToCallBack)) {
+        if ([WireCallCenter activeCallConversationsInUserSession:self].count == 0 && callIsStillOngoing) {
             NOT_USED([note.conversation.voiceChannel joinWithVideo:NO userSession:self]);
             [note.conversation.managedObjectContext saveOrRollback];
         }

--- a/Tests/Source/UserSession/ZMUserSessionTests.m
+++ b/Tests/Source/UserSession/ZMUserSessionTests.m
@@ -1280,7 +1280,7 @@
 }
 
 
-- (void)testThatItCalls_DelegateShowConversationAndCallsBack_ZMMissedCallCategory_CallBackAction
+- (void)testThatItCalls_DelegateShowConversationButDoesNotCallBack_ZMMissedCallCategory_CallBackAction
 {
     // given
     [self simulateLoggedInUser];
@@ -1298,7 +1298,7 @@
     }];
     
     // then
-    XCTAssertTrue(conversation.callDeviceIsActive);
+    XCTAssertFalse(conversation.callDeviceIsActive);
 
 }
 


### PR DESCRIPTION
In some cases when a call timed out AVS would notify us about the timeout the next time the app enters the foreground. We would then create a notification (while the applicationStatus is still .background). iOS would then call `application: didReceiveLocalNotification:` which is usually only called when the user either taps on a notification while the app is already running. This in turn causes an automatic callback, because we assume the user actively tapped on the notification. 

To avoid automatic callbacks, missed call notifications now only open the conversation - but do not call back automatically anymore unless the call is still ongoing.