### PR TITLE
Skip team slow sync until new endpoint is defined

### DIFF
--- a/Source/Synchronization/Transcoders/TeamSyncRequestStrategy.swift
+++ b/Source/Synchronization/Transcoders/TeamSyncRequestStrategy.swift
@@ -45,6 +45,8 @@ public final class TeamSyncRequestStrategy: AbstractRequestStrategy, ZMContextCh
     fileprivate var memberSync: ZMRemoteIdentifierObjectSync!
     fileprivate var remotelyDeletedIds: Set<UUID>?
 
+    var skipTeamSync = true
+
     public init(
         withManagedObjectContext managedObjectContext: NSManagedObjectContext,
         applicationStatus: ApplicationStatus,
@@ -72,6 +74,12 @@ public final class TeamSyncRequestStrategy: AbstractRequestStrategy, ZMContextCh
     }
 
     public override func nextRequestIfAllowed() -> ZMTransportRequest? {
+        // Temporaily disable the team slow-sync until th enew endpoint is defined
+        if skipTeamSync && isSyncing {
+            syncStatus?.finishCurrentSyncPhase(phase: expectedSyncPhase)
+            return nil
+        }
+
         if isSyncing && teamListSync.status != .inProgress && memberSync.isDone {
             remotelyDeletedIds = fetchExistingTeamIds()
             teamListSync.resetFetching()

--- a/Tests/Source/Integration/SlowSyncTests+Teams.swift
+++ b/Tests/Source/Integration/SlowSyncTests+Teams.swift
@@ -19,7 +19,7 @@
 
 class SlowSyncTestsTeams: IntegrationTestBase {
 
-    func testThatItFetchesTeamsAndMembersDuringSlowSync() {
+    func DISABLED_testThatItFetchesTeamsAndMembersDuringSlowSync() {
         // Given
         var team: MockTeam!
         var otherMember: MockMember!
@@ -70,7 +70,7 @@ class SlowSyncTestsTeams: IntegrationTestBase {
         }
     }
 
-    func testThatItFetchesTeamConversationsDuringSlowSync() {
+    func DISABLED_testThatItFetchesTeamConversationsDuringSlowSync() {
         // Given
         var team: MockTeam!
         var otherMember: MockMember!

--- a/Tests/Source/Integration/SlowSyncTests.m
+++ b/Tests/Source/Integration/SlowSyncTests.m
@@ -128,7 +128,7 @@
              [ZMTransportRequest requestGetFromPath:@"/connections?size=90"],
              [ZMTransportRequest requestGetFromPath:@"/conversations/ids?size=100"],
              [ZMTransportRequest requestGetFromPath:[NSString stringWithFormat:@"/conversations?ids=%@,%@,%@,%@", self.selfConversation.identifier,self.selfToUser1Conversation.identifier,self.selfToUser2Conversation.identifier,self.groupConversation.identifier]],
-             [ZMTransportRequest requestGetFromPath:@"/teams?size=50"],
+             // [ZMTransportRequest requestGetFromPath:@"/teams?size=50"], See TeamSyncRequestStrategy.skipTeamSync
              [ZMTransportRequest requestGetFromPath:[NSString stringWithFormat:@"/users?ids=%@,%@", self.user1.identifier, self.user2.identifier]],
              [ZMTransportRequest requestGetFromPath:[NSString stringWithFormat:@"/users?ids=%@", self.user3.identifier]],
              [ZMTransportRequest requestWithPath:@"/onboarding/v3" method:ZMMethodPOST payload:@{

--- a/Tests/Source/Integration/TeamTests.swift
+++ b/Tests/Source/Integration/TeamTests.swift
@@ -332,7 +332,8 @@ extension TeamTests {
 
 extension TeamTests {
 
-    func testThatItDeltesARemotelyDeletedTeamAfterPerfomingSlowSyncCausedByMissedEvents() {
+    // See TeamSyncRequestStrategy.skipTeamSync
+    func DISABLED_testThatItDeltesARemotelyDeletedTeamAfterPerfomingSlowSyncCausedByMissedEvents() {
         // Given
         // 1. Insert local team, which will not be returned by mock transport when fetching /teams
         let localOnlyTeamId = UUID.create()

--- a/Tests/Source/Synchronization/Transcoders/TeamSyncRequestStrategyTests.swift
+++ b/Tests/Source/Synchronization/Transcoders/TeamSyncRequestStrategyTests.swift
@@ -31,6 +31,7 @@ final class TeamSyncRequestStrategyTests: MessagingTest {
         mockSyncStatus = MockSyncStatus(managedObjectContext: syncMOC, syncStateDelegate: MockSyncStateDelegate())
         mockApplicationStatus = MockApplicationStatus()
         sut = TeamSyncRequestStrategy(withManagedObjectContext: syncMOC, applicationStatus: mockApplicationStatus, syncStatus: mockSyncStatus)
+        sut.skipTeamSync = false
     }
 
     override func tearDown() {
@@ -107,6 +108,19 @@ final class TeamSyncRequestStrategyTests: MessagingTest {
         XCTAssertTrue(mockSyncStatus.didCallFailCurrentSyncPhase)
     }
 
+    func testThatItAdvancesTheSyncPhase_SkipTeamSync() {
+        // given
+        sut.skipTeamSync = true
+        mockSyncStatus.mockPhase = .fetchingTeams
+        mockApplicationStatus.mockSynchronizationState = .synchronizing
+
+        // when
+        XCTAssertNil(sut.nextRequest())
+
+        // then
+        XCTAssert(mockSyncStatus.didCallFinishCurrentSyncPhase)
+    }
+
     func testThatItCreatesLocalTeamsFromTheResponsePayload() {
         // given
         mockSyncStatus.mockPhase = .fetchingTeams
@@ -162,6 +176,8 @@ final class TeamSyncRequestStrategyTests: MessagingTest {
             syncStatus: mockSyncStatus,
             syncConfiguration: configuration
         )
+
+        sut.skipTeamSync = false
 
         let team1Id = UUID.create(), team2Id = UUID.create(), team3Id = UUID.create()
 


### PR DESCRIPTION
# What's in this PR?

* Disable downloading all teams during slow-sync, this is done by introducing a flag `skipTeamSync` which can easily be removed later.
* With the transition to a multi-account with 0-1 team each model instead of a single account multi-team model we need to delete all local teams for the current account and ensure we don't refetch them for now. As soon as the new endpoint to fetch the single team is ready we can change the path and re-enable fetching this single team during slow-sync (e.g. I assume we will get a team id when fetching `/self` or there will be another dedicated endpoint, after inserting the team locally we can adjust the `TeamSyncRequestStrategy` to refetch local teams and their members).