### PR TITLE
Only upload address book in case there is no team

### DIFF
--- a/Source/UserSession/ZMUserSession+AddressBook.swift
+++ b/Source/UserSession/ZMUserSession+AddressBook.swift
@@ -18,6 +18,8 @@
 
 import Foundation
 
+private let log = ZMSLog(tag: "AddressBook")
+
 // MARK: - Upload observer
 let failedToAccessAddressBookNotificationName = "ZMUserSessionFailedToAccessAddressBook"
 
@@ -48,10 +50,20 @@ extension ZMUserSession {
 
 // MARK: - Address book upload
 extension ZMUserSession {
-    
+
+    /// Asynchronously uploads the next chunk of the address book unless the user is in a team
+    public func uploadAddressBookIfAllowed() {
+        if ZMUser.selfUser(inUserSession: self).hasTeam {
+            log.error("Uploading contacts for an account with team is a forbidden operation")
+        } else {
+            uploadAddressBook()
+        }
+    }
+
     /// Asynchronously uploads the next chunk of the address book
-    public func uploadAddressBook() {
+    private func uploadAddressBook() {
         AddressBook.markAddressBookAsNeedingToBeUploaded(self.managedObjectContext)
         self.managedObjectContext.forceSaveOrRollback()
     }
+
 }


### PR DESCRIPTION
# What's in this PR?

* Add new public method to only upload contacts if there is no team `uploadAddressBookIfAllowed`, this check is more a fail-safe and we should still check this condition beforehand.
* This method will log an error as I would still suggest it being a programmer error to end up in a situation were we already asked the user for permissions as well as called to upload the contacts without checking if they belong to a team.