### PR TITLE
Fix CoreData multithreading violation when sending a reply from a notification

### DIFF
--- a/Source/UserSession/ZMUserSession+Background.m
+++ b/Source/UserSession/ZMUserSession+Background.m
@@ -407,14 +407,16 @@ static NSString *ZMLogTag = @"Push";
     }
     ZMBackgroundActivity *activity = [[BackgroundActivityFactory sharedInstance] backgroundActivityWithName:@"DirectReply Action Handler"];
     ZMConversation *conversation = [notification conversationInManagedObjectContext:self.managedObjectContext];
+
     if (conversation != nil) {
         ZM_WEAK(self);
         [self.operationLoop.syncStrategy.applicationStatusDirectory.operationStatus startBackgroundTaskWithCompletionHandler:^(ZMBackgroundTaskResult result) {
             ZM_STRONG(self);
             self.messageReplyObserverToken = nil;
-            [self.managedObjectContext performGroupedBlock: ^{
+            [self.syncManagedObjectContext performGroupedBlock: ^{
                 if (result == ZMBackgroundTaskResultFailed) {
-                    [self.localNotificationDispatcher didFailToSendMessageIn:conversation];
+                    ZMConversation *syncConversation = [notification conversationInManagedObjectContext:self.syncManagedObjectContext];
+                    [self.localNotificationDispatcher didFailToSendMessageIn:syncConversation];
                 }
                 [activity endActivity];
                 if (completionHandler != nil) {


### PR DESCRIPTION
# What's in this PR?

* We were passing a conversation from the UI context to the `LocalNotificationDispatcher`. The dispatcher internally only operates on the sync context.
* There is still another issue regarding the reply logic, we currently add a message observer to get notified whether the message was sent successfully or not. However, this observer does never fire at the moment, resulting in our background task timeout timer firing and finishing the background task with a result of `ZMBackgroundTaskResultFailed`. This bug is the cause for us always showing a `"Message failed to send"` notification when replying from a notification (this does not apply to liking from a notification as we are not showing any failure notifications in that case). I am still investigating the reason why the observer does not fire in this case, the fix will come in a separate PR.