### PR TITLE
Fixed tests for new binding argument

### DIFF
--- a/Source/Synchronization/Strategies/TeamDownloadRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/TeamDownloadRequestStrategy.swift
@@ -71,7 +71,7 @@ extension TeamDownloadRequestStrategy: ZMDownstreamTranscoder {
             let team = object as? Team,
             let payload = response.payload?.asDictionary() as? [String: Any] else { return }
         
-        guard let isBound = payload["binding"] as? Bool, isBound == true else {
+        if let isBound = payload["binding"] as? Bool, !isBound {
             managedObjectContext.delete(team)
             return
         }

--- a/Tests/Source/Synchronization/Strategies/TeamDownloadRequestStrategyTests.swift
+++ b/Tests/Source/Synchronization/Strategies/TeamDownloadRequestStrategyTests.swift
@@ -57,7 +57,7 @@ class TeamDownloadRequestStrategyTests: MessagingTest {
             "name": "Wire GmbH",
             "icon": "",
             "icon_key": "",
-            "binding" : (isBound ? 1: 0)
+            "binding" : (isBound ? true: false)
         ]
     }
     


### PR DESCRIPTION
Also changed logic for checking if the team is `binding`, so if the payload cannot be parsed the team would not be deleted.