### PR TITLE
Fix phone registration tests

### DIFF
--- a/Source/Public/WireSyncEngine.h
+++ b/Source/Public/WireSyncEngine.h
@@ -66,3 +66,4 @@
 #import <WireSyncEngine/ZMLoginCodeRequestTranscoder.h>
 #import <WireSyncEngine/ZMRegistrationTranscoder.h>
 #import <WireSyncEngine/ZMPhoneNumberVerificationTranscoder.h>
+#import <WireSyncEngine/ZMHotFix.h>

--- a/Source/Public/ZMUserSession.h
+++ b/Source/Public/ZMUserSession.h
@@ -33,10 +33,10 @@
 @class ZMCallKitDelegate;
 @class CallingRequestStrategy;
 @class AVSMediaManager;
+@class ZMAPNSEnvironment;
 
 @protocol UserProfile;
 @protocol AnalyticsType;
-//@protocol AVSMediaManager;
 @protocol ZMNetworkAvailabilityObserver;
 @protocol ZMRequestsToOpenViewsDelegate;
 @protocol ZMThirdPartyServicesDelegate;
@@ -88,6 +88,7 @@ extern NSString * const ZMTransportRequestLoopNotificationName;
 - (instancetype)initWithMediaManager:(AVSMediaManager *)mediaManager
                            analytics:(id<AnalyticsType>)analytics
                     transportSession:(ZMTransportSession *)transportSession
+                     apnsEnvironment:(ZMAPNSEnvironment *)apnsEnvironment
                               userId:(NSUUID *)uuid
                           appVersion:(NSString *)appVersion
                   appGroupIdentifier:(NSString *)appGroupIdentifier;

--- a/Source/SessionManager/SessionManager+Logs.swift
+++ b/Source/SessionManager/SessionManager+Logs.swift
@@ -16,17 +16,16 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
+import Foundation
 
-@import WireUtilities;
-@import WireTransport;
-@import WireDataModel;
-
-#import "ZMUserSession.h"
-
-@interface ZMUserSession (Private)
-
-@property (nonatomic, readonly) ZMTransportSession *transportSession;
-
-- (void)tearDown;
-
-@end
+extension SessionManager {
+    
+    static func enableLogsByEnvironmentVariable() {
+        if let tags = ProcessInfo.processInfo.environment["ZMLOG_TAGS"] {
+            for tag in (tags.characters.split { $0 == "," }.map { String($0) }) {
+                ZMSLog.set(level: .debug, tag: tag)
+            }
+        }
+    }
+    
+}

--- a/Source/Synchronization/Transcoders/ZMLastUpdateEventIDTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMLastUpdateEventIDTranscoder.m
@@ -130,15 +130,19 @@
 {
     NOT_USED(sync);
     SyncStatus *status = self.syncStatus;
+    
+    NSUUID *lastNotificationID = [[response.payload asDictionary] optionalUuidForKey:@"id"];
+    
     if(response.payload == nil) {
         if (status.isSyncing) {
             [status failCurrentSyncPhaseWithPhase:self.expectedSyncPhase];
         }
         return;
     }
-    
-    NSUUID *lastNotificationID = [[response.payload asDictionary] optionalUuidForKey:@"id"];
-    if(lastNotificationID != nil) {
+    else if (response.HTTPStatus == 404 && status.currentSyncPhase == self.expectedSyncPhase) {
+        [status finishCurrentSyncPhaseWithPhase:self.expectedSyncPhase];
+    }
+    else if (lastNotificationID != nil) {
         self.lastUpdateEventID = lastNotificationID;
         if (status.currentSyncPhase == self.expectedSyncPhase) {
             [status updateLastUpdateEventIDWithEventID:lastNotificationID];

--- a/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
@@ -360,7 +360,7 @@ previouslyReceivedEventIDsCollection:(id<PreviouslyReceivedEventIDsCollection>)e
         [syncStatus failCurrentSyncPhaseWithPhase:self.expectedSyncPhase];
     }
     
-    if (!self.listPaginator.hasMoreToFetch && self.lastUpdateEventID != nil && self.isSyncing) {
+    if (!self.listPaginator.hasMoreToFetch && self.isSyncing) {
         
         // The fetch of the notification stream was initiated after the push channel was established
         // so we must restart the fetching to be sure that we haven't missed any notifications.

--- a/Source/UserSession/ZMUserSession+Internal.h
+++ b/Source/UserSession/ZMUserSession+Internal.h
@@ -95,8 +95,6 @@ extern NSString * const ZMAppendAVSLogNotificationName;
                               appVersion:(NSString *)appVersion
                       appGroupIdentifier:(NSString *)appGroupIdentifier;
 
-- (void)tearDown;
-
 @property (nonatomic) ZMPushRegistrant *pushRegistrant;
 @property (nonatomic) ZMApplicationRemoteNotification *applicationRemoteNotification;
 @property (nonatomic) ZMStoredLocalNotification *pendingLocalNotification;

--- a/Source/UserSession/ZMUserSession+Logs.swift
+++ b/Source/UserSession/ZMUserSession+Logs.swift
@@ -20,18 +20,6 @@
 import Foundation
 import WireDataModel
 
-extension ZMUserSession {
-
-    @objc public static func enableLogsByEnvironmentVariable()
-    {
-        if let tags = ProcessInfo.processInfo.environment["ZMLOG_TAGS"] {
-            for tag in (tags.characters.split { $0 == "," }.map { String($0) }) {
-                ZMSLog.set(level: .debug, tag: tag)
-            }
-        }
-    }
-}
-
 // MARK: - Error on context save debugging
 
 public enum ContextType : String {

--- a/Tests/Source/Integration/IntegrationTest.h
+++ b/Tests/Source/Integration/IntegrationTest.h
@@ -28,6 +28,8 @@
 @class AVSMediaManager;
 @class ZMAPNSEnvironment;
 @class UnauthenticatedSession;
+@class MockUser;
+@class MockConversation;
 
 @interface IntegrationTest : ZMTBaseTest
 
@@ -41,5 +43,8 @@
 @property (nonatomic, nullable) UnauthenticatedSession *unauthenticatedSession;
 @property (nonatomic, readonly) BOOL useInMemoryStore;
 @property (nonatomic, readonly) BOOL useRealKeychain;
+
+@property (nonatomic, nullable) MockUser *selfUser;
+@property (nonatomic, nullable) MockConversation *selfConversation;
 
 @end

--- a/Tests/Source/Integration/IntegrationTest.h
+++ b/Tests/Source/Integration/IntegrationTest.h
@@ -1,0 +1,45 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+#import <XCTest/XCTest.h>
+
+@import WireTesting;
+
+@class SessionManager;
+@class ZMTransportSession;
+@class MockTransportSession;
+@class ApplicationMock;
+@class ZMUserSession;
+@class AVSMediaManager;
+@class ZMAPNSEnvironment;
+@class UnauthenticatedSession;
+
+@interface IntegrationTest : ZMTBaseTest
+
+@property (nonatomic, nullable) SessionManager *sessionManager;
+@property (nonatomic, nullable) MockTransportSession *mockTransportSession;
+@property (nonatomic, readonly, nullable) ZMTransportSession *transportSession;
+@property (nonatomic, nullable) AVSMediaManager *mediaManager;
+@property (nonatomic, nullable) ZMAPNSEnvironment *apnsEnvironment;
+@property (nonatomic, nullable) ApplicationMock *application;
+@property (nonatomic, nullable) ZMUserSession *userSession;
+@property (nonatomic, nullable) UnauthenticatedSession *unauthenticatedSession;
+@property (nonatomic, readonly) BOOL useInMemoryStore;
+@property (nonatomic, readonly) BOOL useRealKeychain;
+
+@end

--- a/Tests/Source/Integration/IntegrationTest.m
+++ b/Tests/Source/Integration/IntegrationTest.m
@@ -1,0 +1,85 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+#import <XCTest/XCTest.h>
+
+@import avs;
+
+#import "IntegrationTest.h"
+#import "WireSyncEngine_iOS_Tests-Swift.h"
+
+
+@interface IntegrationTest ()
+
+@property (nonatomic, nullable) id mockMediaManager;
+@property (nonatomic, nullable) id mockAPNSEnvironment;
+
+@end
+
+
+@implementation IntegrationTest
+
+- (void)setUp {
+    [super setUp];
+    
+    self.mockMediaManager = [OCMockObject niceMockForClass:AVSMediaManager.class];
+    
+    id mockAPNSEnvironment = [OCMockObject niceMockForClass:[ZMAPNSEnvironment class]];
+    [[[mockAPNSEnvironment stub] andReturn:@"com.wire.production"] appIdentifier];
+    [[[mockAPNSEnvironment stub] andReturn:@"APNS"] transportTypeForTokenType:ZMAPNSTypeNormal];
+    [[[mockAPNSEnvironment stub] andReturn:@"APNS_VOIP"] transportTypeForTokenType:ZMAPNSTypeVoIP];
+    self.mockAPNSEnvironment = mockAPNSEnvironment;
+    
+    [self _setUp];
+}
+
+- (void)tearDown {
+    [self _tearDown];
+    
+    self.mockMediaManager = nil;
+    self.mockAPNSEnvironment = nil;
+    
+    [super tearDown];
+}
+
+- (BOOL)useInMemoryStore
+{
+    return YES;
+}
+
+- (BOOL)useRealKeychain
+{
+    return NO;
+}
+
+- (ZMTransportSession *)transportSession
+{
+    return (ZMTransportSession *)self.mockTransportSession;
+}
+
+- (AVSMediaManager *)mediaManager
+{
+    return self.mockMediaManager;
+}
+
+- (ZMAPNSEnvironment *)apnsEnvironment
+{
+    return self.mockAPNSEnvironment;
+}
+
+@end

--- a/Tests/Source/Integration/IntegrationTest.swift
+++ b/Tests/Source/Integration/IntegrationTest.swift
@@ -23,6 +23,9 @@ import WireTesting
 
 extension IntegrationTest {
     
+    static let SelfUserEmail = "myself@user.example.com"
+    static let SelfUserPassword = "fgf0934';$@#%"
+    
     @objc
     func _setUp() {
         resetKeychain()
@@ -72,6 +75,28 @@ extension IntegrationTest {
                                         delegate: self,
                                         application: application,
                                         launchOptions: [:])
+    }
+    
+    @objc
+    func createDefaultUsersAndConversations() {
+        
+        mockTransportSession?.performRemoteChanges({ session in
+            let selfUser = session.insertSelfUser(withName: "The Self User")
+            selfUser.email = IntegrationTest.SelfUserEmail
+            selfUser.password = IntegrationTest.SelfUserPassword
+            selfUser.phone = ""
+            selfUser.accentID = 2
+            session.addProfilePicture(to: selfUser)
+            session.addV3ProfilePicture(to: selfUser)
+            
+            let selfConversation = session.insertSelfConversation(withSelfUser: selfUser)
+            selfConversation.identifier = selfUser.identifier
+            
+            self.selfUser = selfUser
+            self.selfConversation = selfConversation
+        })
+        
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
     }
     
 }

--- a/Tests/Source/Integration/IntegrationTest.swift
+++ b/Tests/Source/Integration/IntegrationTest.swift
@@ -1,0 +1,106 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireTesting
+
+@testable import WireSyncEngine
+
+extension IntegrationTest {
+    
+    @objc
+    func _setUp() {
+        resetKeychain()
+        
+        NSManagedObjectContext.setUseInMemoryStore(useInMemoryStore)
+        
+        application = ApplicationMock()
+        mockTransportSession = MockTransportSession(dispatchGroup: self.dispatchGroup)
+        WireCallCenterV3Factory.wireCallCenterClass = WireCallCenterV3IntegrationMock.self;
+        ZMCallFlowRequestStrategyInternalFlowManagerOverride = MockFlowManager()
+        
+        createSessionManager()
+    }
+    
+    @objc
+    func _tearDown() {
+        ZMCallFlowRequestStrategyInternalFlowManagerOverride = nil
+        userSession = nil
+        unauthenticatedSession = nil
+        mockTransportSession?.tearDown()
+        mockTransportSession = nil
+        sessionManager = nil
+    }
+    
+    func resetKeychain() {
+        ZMPersistentCookieStorage.setDoNotPersistToKeychain(!useRealKeychain)
+        let cookieStorage = ZMPersistentCookieStorage()
+        cookieStorage.deleteUserKeychainItems()
+    }
+    
+    func createSessionManager() {
+        
+        guard let bundleIdentifier = Bundle.init(for: type(of: self)).bundleIdentifier,
+              let mediaManager = mediaManager,
+              let application = application,
+              let transportSession = transportSession
+        else { XCTFail(); return }
+        
+        let groupIdentifier = "group.\(bundleIdentifier)"
+        
+        sessionManager = SessionManager(appGroupIdentifier: groupIdentifier,
+                                        appVersion: "0.0.0",
+                                        transportSession: transportSession,
+                                        apnsEnvironment: apnsEnvironment,
+                                        mediaManager: mediaManager,
+                                        analytics: nil,
+                                        delegate: self,
+                                        application: application,
+                                        launchOptions: [:])
+    }
+    
+}
+
+extension IntegrationTest : SessionManagerDelegate {
+    
+    public func sessionManagerCreated(userSession: ZMUserSession) {
+        self.userSession = userSession
+        
+        userSession.syncManagedObjectContext.performGroupedBlockAndWait {
+            userSession.syncManagedObjectContext.setPersistentStoreMetadata(NSNumber(value: true), key: ZMSkipHotfix)
+            userSession.syncManagedObjectContext.add(self.dispatchGroup)
+        }
+        
+        userSession.managedObjectContext.performGroupedBlockAndWait {
+            userSession.managedObjectContext.add(self.dispatchGroup)
+        }
+        
+        userSession.managedObjectContext.performGroupedBlock {
+            userSession.start()
+        }
+    }
+    
+    public func sessionManagerCreated(unauthenticatedSession: UnauthenticatedSession) {
+        self.unauthenticatedSession = unauthenticatedSession
+    }
+    
+    public func sessionManagerWillStartMigratingLocalStore() {
+        
+    }
+    
+}

--- a/Tests/Source/Integration/IntegrationTestBase.m
+++ b/Tests/Source/Integration/IntegrationTestBase.m
@@ -27,7 +27,6 @@
 #import "ZMUserSession+Authentication.h"
 #import "ZMUserSession+Registration.h"
 #import "ZMCredentials.h"
-#import <WireSyncEngine/ZMAuthenticationStatus+Testing.h>
 #import <WireSyncEngine/WireSyncEngine-Swift.h>
 #import "ZMCallFlowRequestStrategy.h"
 #import "ZMOperationLoop+Private.h"
@@ -444,7 +443,7 @@ NSString * const SelfUserPassword = @"fgf0934';$@#%";
         didSucceed = YES;
     }] authenticationDidSucceed];
 
-    id token = [self.userSession addAuthenticationObserver:authenticationObserver];
+    id token = [ZMUserSessionAuthenticationNotification addObserver:authenticationObserver];
 //    [self.userSession loginWithCredentials:credentials]; // TODO jacob
     
     BOOL done = [self waitOnMainLoopUntilBlock:^BOOL{
@@ -461,7 +460,7 @@ NSString * const SelfUserPassword = @"fgf0934';$@#%";
 
     }
     
-    [self.userSession removeAuthenticationObserverForToken:token];
+    [ZMUserSessionAuthenticationNotification removeObserverForToken:token];
     return done;
 }
 

--- a/Tests/Source/Integration/PhoneRegistrationTests.m
+++ b/Tests/Source/Integration/PhoneRegistrationTests.m
@@ -233,61 +233,66 @@
     XCTAssertEqual(self.mockTransportSession.receivedRequests.count, 3u);
 }
 
-//- (void)testThatItLogsInWithAPhoneNumberIfThePhoneNumberIsAlreadyRegisteredToAnotherUser
-//{
-//    // given
-//    NSString *phone = @"+4912345678900";
-//    NSString *code = self.mockTransportSession.phoneVerificationCodeForLogin;
-//    
-//    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
-//        NOT_USED(session);
-//        self.selfUser.phone = phone;
-//    }];
-//    
-//    // expect
-//    [[self.authenticationObserver expect] loginCodeRequestDidSucceed];
-//    [[self.authenticationObserver expect] authenticationDidSucceed];
-//    
-//    // when
-//    [self.unauthenticatedSession requestPhoneVerificationCodeForRegistration:phone];
-//    WaitForAllGroupsToBeEmpty(0.5);
-//    [self.unauthenticatedSession verifyPhoneNumberForRegistration:phone verificationCode:code];
-//    WaitForAllGroupsToBeEmpty(0.5);
-//    
-//    // then
-//    ZMUser *selfUser = [ZMUser selfUserInUserSession:self.userSession];
-//    XCTAssertEqualObjects(selfUser.name, selfUser.name);
-//    XCTAssertEqualObjects(selfUser.phoneNumber, phone);
-//    XCTAssertEqual(selfUser.accentColorValue, selfUser.accentColorValue);
-//    
-//}
+- (void)testThatItLogsInWithAPhoneNumberIfThePhoneNumberIsAlreadyRegisteredToAnotherUser
+{
+    // given
+    [self createDefaultUsersAndConversations];
+    
+    NSString *phone = @"+4912345678900";
+    NSString *code = self.mockTransportSession.phoneVerificationCodeForLogin;
+    
+    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+        NOT_USED(session);
+        self.selfUser.phone = phone;
+    }];
+    
+    // expect
+    [[self.authenticationObserver expect] loginCodeRequestDidSucceed];
+    [[self.authenticationObserver expect] authenticationDidSucceed];
+    [[self.authenticationObserver expect] authenticationDidSucceed]; // client was registered
+    
+    // when
+    [self.unauthenticatedSession requestPhoneVerificationCodeForRegistration:phone];
+    WaitForAllGroupsToBeEmpty(0.5);
+    [self.unauthenticatedSession verifyPhoneNumberForRegistration:phone verificationCode:code];
+    WaitForAllGroupsToBeEmpty(0.5);
+    
+    // then
+    ZMUser *selfUser = [ZMUser selfUserInUserSession:self.userSession];
+    XCTAssertEqualObjects(selfUser.name, selfUser.name);
+    XCTAssertEqualObjects(selfUser.phoneNumber, phone);
+    XCTAssertEqual(selfUser.accentColorValue, selfUser.accentColorValue);
+    
+}
 
-//- (void)testThatItReturnsAPhoneVerificationFailureWithAlreadyRegisteredPhoneNumber
-//{
-//    // given
-//    NSString *phone = @"+4912345678900";
-//    NSString *code = self.mockTransportSession.invalidPhoneVerificationCode;
-//    
-//    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
-//        NOT_USED(session);
-//        self.selfUser.phone = phone;
-//    }];
-//    
-//    // expect
-//    [[self.authenticationObserver expect] loginCodeRequestDidSucceed];
-//    [[self.registrationObserver expect] registrationDidFail:[OCMArg checkWithBlock:^BOOL(NSError *error) {
-//        XCTAssertEqual(error.code, (int) ZMUserSessionPhoneNumberIsAlreadyRegistered);
-//        XCTAssertEqualObjects(error.domain, ZMUserSessionErrorDomain);
-//        return YES;
-//    }]];
-//    
-//    // when
-//    [self.unauthenticatedSession requestPhoneVerificationCodeForRegistration:phone];
-//    WaitForAllGroupsToBeEmpty(0.5);
-//    [self.unauthenticatedSession verifyPhoneNumberForRegistration:phone verificationCode:code];
-//    WaitForAllGroupsToBeEmpty(0.5);
-//
-//}
+- (void)testThatItReturnsAPhoneVerificationFailureWithAlreadyRegisteredPhoneNumber
+{
+    // given
+    [self createDefaultUsersAndConversations];
+    
+    NSString *phone = @"+4912345678900";
+    NSString *code = self.mockTransportSession.invalidPhoneVerificationCode;
+    
+    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+        NOT_USED(session);
+        self.selfUser.phone = phone;
+    }];
+    
+    // expect
+    [[self.authenticationObserver expect] loginCodeRequestDidSucceed];
+    [[self.registrationObserver expect] registrationDidFail:[OCMArg checkWithBlock:^BOOL(NSError *error) {
+        XCTAssertEqual(error.code, (int) ZMUserSessionPhoneNumberIsAlreadyRegistered);
+        XCTAssertEqualObjects(error.domain, ZMUserSessionErrorDomain);
+        return YES;
+    }]];
+    
+    // when
+    [self.unauthenticatedSession requestPhoneVerificationCodeForRegistration:phone];
+    WaitForAllGroupsToBeEmpty(0.5);
+    [self.unauthenticatedSession verifyPhoneNumberForRegistration:phone verificationCode:code];
+    WaitForAllGroupsToBeEmpty(0.5);
+
+}
 
 - (void)testThatWeCanAskForThePhoneRegistrationCodeTwice
 {

--- a/Tests/Source/Integration/UserProfileTests.m
+++ b/Tests/Source/Integration/UserProfileTests.m
@@ -131,7 +131,7 @@
     WaitForAllGroupsToBeEmpty(0.5);
     
     id authenticationObserver = [OCMockObject mockForProtocol:@protocol(ZMAuthenticationObserver)];
-    id authenticationObserverToken = [self.userSession addAuthenticationObserver:authenticationObserver];
+    id authenticationObserverToken = [ZMUserSessionAuthenticationNotification addObserver:authenticationObserver];
     
     // expect
     [[authenticationObserver expect] authenticationDidSucceed];
@@ -142,7 +142,7 @@
     
     // then
     [authenticationObserver verify];
-    [self.userSession removeAuthenticationObserverForToken:authenticationObserverToken];
+    [ZMUserSessionAuthenticationNotification removeObserverForToken:authenticationObserverToken];
 }
 
 @end

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationSetTests.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationSetTests.swift
@@ -57,9 +57,9 @@ class MockEventNotification : MockLocalNotification, EventNotification {
     var eventTypeUnderTest : ZMUpdateEventType?
     var ignoresSilencedState : Bool { return false }
     var eventType : ZMUpdateEventType { return eventTypeUnderTest ?? .unknown }
-    unowned var application: Application
+    unowned var application: ZMApplication
     unowned var managedObjectContext: NSManagedObjectContext
-    required init?(events: [ZMUpdateEvent], conversation: ZMConversation?, managedObjectContext: NSManagedObjectContext, application: Application?) {
+    required init?(events: [ZMUpdateEvent], conversation: ZMConversation?, managedObjectContext: NSManagedObjectContext, application: ZMApplication?) {
         self.managedObjectContext = managedObjectContext
         self.application = application!
         super.init(conversationID: conversation?.remoteIdentifier)

--- a/Tests/Source/Synchronization/Transcoders/ZMRegistrationTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMRegistrationTranscoderTests.m
@@ -326,7 +326,7 @@
     [self performPretendingUiMocIsSyncMoc:^{
         [self.sut didReceiveResponse:response forSingleRequest:self.registrationDownstreamSync];
         // then
-        XCTAssertTrue(self.authenticationStatus.registeredOnThisDevice);
+        XCTAssertTrue(self.authenticationStatus.completedRegistration);
     }];
 }
 
@@ -536,7 +536,7 @@
         [self.sut didReceiveResponse:response forSingleRequest:self.registrationDownstreamSync];
     
         // then
-        XCTAssertFalse(self.authenticationStatus.registeredOnThisDevice);
+        XCTAssertFalse(self.authenticationStatus.completedRegistration);
     }];
 }
 

--- a/Tests/Source/Test-Bridging-Header.h
+++ b/Tests/Source/Test-Bridging-Header.h
@@ -24,6 +24,6 @@
 #import "MessagingTest+EventFactory.h"
 #import "ConversationTestsBase.h"
 #import "ZMLocalNotificationForEventTest.h"
-@import CallKit;
 #import "ZMCallKitDelegateTests+Mocking.h"
 #import "ZMCallKitDelegate+TypeConformance.h"
+#import "IntegrationTest.h"

--- a/Tests/Source/UserSession/ZMAuthenticationStatusTests.m
+++ b/Tests/Source/UserSession/ZMAuthenticationStatusTests.m
@@ -24,7 +24,6 @@
 #import "MessagingTest.h"
 #import "ZMUserSessionAuthenticationNotification.h"
 #import "ZMUserSessionRegistrationNotification.h"
-#import "ZMAuthenticationStatus+Testing.h"
 #import "ZMCredentials.h"
 #import "NSError+ZMUserSessionInternal.h"
 #import <WireSyncEngine/WireSyncEngine-Swift.h>

--- a/Tests/Source/UserSession/ZMUserSessionTests.m
+++ b/Tests/Source/UserSession/ZMUserSessionTests.m
@@ -89,6 +89,7 @@
     ZMUserSession *session = [[ZMUserSession alloc] initWithMediaManager:nil
                                                                analytics:nil
                                                         transportSession:transportSession
+                                                         apnsEnvironment:nil
                                                                   userId:nil
                                                               appVersion:version
                                                       appGroupIdentifier:self.groupIdentifier];

--- a/Tests/Source/Utility/ApplicationMock.swift
+++ b/Tests/Source/Utility/ApplicationMock.swift
@@ -49,7 +49,7 @@ import WireSyncEngine
 }
 
 // MARK: - Application protocol
-extension ApplicationMock : Application {
+extension ApplicationMock : ZMApplication {
     
     public func scheduleLocalNotification(_ notification: UILocalNotification) {
         self.scheduledLocalNotifications.append(notification)

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -85,6 +85,10 @@
 		16F5F16C1E4092C00062F0AE /* NSManagedObjectContext+CTCallCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16F5F16B1E4092C00062F0AE /* NSManagedObjectContext+CTCallCenter.swift */; };
 		16F6BB0C1ED5824B009EA803 /* ZMUserSession+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 16F6BB0B1ED58242009EA803 /* ZMUserSession+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		16F6BB381EDEA659009EA803 /* SearchResult+AddressBook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16F6BB371EDEA659009EA803 /* SearchResult+AddressBook.swift */; };
+		16FF47441F0BF5C70044C491 /* IntegrationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16FF47431F0BF5C70044C491 /* IntegrationTest.swift */; };
+		16FF47451F0C06EA0044C491 /* PhoneRegistrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5454A69F1AEFA0A70022AFA4 /* PhoneRegistrationTests.m */; };
+		16FF47471F0CD58A0044C491 /* IntegrationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 16FF47461F0CD58A0044C491 /* IntegrationTest.m */; };
+		16FF474C1F0D54B20044C491 /* SessionManager+Logs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16FF474B1F0D54B20044C491 /* SessionManager+Logs.swift */; };
 		1E16CE871BF4BC5F00336616 /* ProtocolBuffers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E16CE861BF4BC5F00336616 /* ProtocolBuffers.framework */; };
 		1E16CE881BF4BC5F00336616 /* ProtocolBuffers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E16CE861BF4BC5F00336616 /* ProtocolBuffers.framework */; };
 		1EB871501BF502A000AF5CE1 /* ZMUserTranscoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 54F8D6EC19AB535700146664 /* ZMUserTranscoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -353,7 +357,7 @@
 		F94F6B331E54B9C000D46A29 /* CallingRequestStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F94F6B321E54B9C000D46A29 /* CallingRequestStrategyTests.swift */; };
 		F95706541DE5D1CC0087442C /* SearchUserImageStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F95706531DE5D1CC0087442C /* SearchUserImageStrategy.swift */; };
 		F95706591DE5F6D40087442C /* SearchUserImageStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F95706581DE5F6D40087442C /* SearchUserImageStrategyTests.swift */; };
-		F95ECF4E1B94A553009F91BA /* ZMHotFix.h in Headers */ = {isa = PBXBuildFile; fileRef = F95ECF4C1B94A553009F91BA /* ZMHotFix.h */; };
+		F95ECF4E1B94A553009F91BA /* ZMHotFix.h in Headers */ = {isa = PBXBuildFile; fileRef = F95ECF4C1B94A553009F91BA /* ZMHotFix.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F95ECF511B94BD05009F91BA /* ZMHotFixTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F95ECF501B94BD05009F91BA /* ZMHotFixTests.m */; };
 		F95FFBD11EB8A478004031CB /* CallSystemMessageGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F95FFBCF1EB8A44D004031CB /* CallSystemMessageGeneratorTests.swift */; };
 		F9644AEA1E83CDD100A1887B /* CallingV3Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9644AE91E83CDD100A1887B /* CallingV3Tests.swift */; };
@@ -575,6 +579,10 @@
 		16F5F16B1E4092C00062F0AE /* NSManagedObjectContext+CTCallCenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+CTCallCenter.swift"; sourceTree = "<group>"; };
 		16F6BB0B1ED58242009EA803 /* ZMUserSession+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ZMUserSession+Private.h"; sourceTree = "<group>"; };
 		16F6BB371EDEA659009EA803 /* SearchResult+AddressBook.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SearchResult+AddressBook.swift"; sourceTree = "<group>"; };
+		16FF47431F0BF5C70044C491 /* IntegrationTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntegrationTest.swift; sourceTree = "<group>"; };
+		16FF47461F0CD58A0044C491 /* IntegrationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IntegrationTest.m; sourceTree = "<group>"; };
+		16FF47481F0CD6610044C491 /* IntegrationTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IntegrationTest.h; sourceTree = "<group>"; };
+		16FF474B1F0D54B20044C491 /* SessionManager+Logs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SessionManager+Logs.swift"; sourceTree = "<group>"; };
 		1E16CE861BF4BC5F00336616 /* ProtocolBuffers.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ProtocolBuffers.framework; path = Carthage/Build/iOS/ProtocolBuffers.framework; sourceTree = "<group>"; };
 		3E05F247192A4F8900F22D80 /* NSError+ZMUserSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSError+ZMUserSession.h"; sourceTree = "<group>"; };
 		3E05F250192A4FBD00F22D80 /* UserSessionErrorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UserSessionErrorTests.m; sourceTree = "<group>"; };
@@ -1669,6 +1677,9 @@
 				F9644AE91E83CDD100A1887B /* CallingV3Tests.swift */,
 				85D85A150524EE3BE658A112 /* IntegrationTestBase.h */,
 				85D85FD47DF54EE1F532B5BE /* IntegrationTestBase.m */,
+				16FF47481F0CD6610044C491 /* IntegrationTest.h */,
+				16FF47461F0CD58A0044C491 /* IntegrationTest.m */,
+				16FF47431F0BF5C70044C491 /* IntegrationTest.swift */,
 				54ADA7611E3B3CBE00B90C7D /* IntegrationTestBase+Encryption.swift */,
 				163BB8111EE1A65A00DF9384 /* IntegrationTestBase+Search.swift */,
 				3E288A6919C859210031CFCE /* NotificationObservers.h */,
@@ -1919,6 +1930,7 @@
 			isa = PBXGroup;
 			children = (
 				F19F1D371EFBF61800275E27 /* SessionManager.swift */,
+				16FF474B1F0D54B20044C491 /* SessionManager+Logs.swift */,
 				1634958A1F0254CB004E80DB /* SessionManager+ServerConnection.swift */,
 			);
 			path = SessionManager;
@@ -2349,6 +2361,7 @@
 				54A170691B300717001B41A5 /* ProxiedRequestStrategyTests.swift in Sources */,
 				1660AA111ECE3C1C0056D403 /* SearchTaskTests.swift in Sources */,
 				F95706591DE5F6D40087442C /* SearchUserImageStrategyTests.swift in Sources */,
+				16FF47441F0BF5C70044C491 /* IntegrationTest.swift in Sources */,
 				098CFBBB1B7B9C94000B02B1 /* BaseTestSwiftHelpers.swift in Sources */,
 				543ED0011D79E0EE00A9CDF3 /* ApplicationMock.swift in Sources */,
 				878F63E51EF91E7C006E819B /* HotFixDuplicatesTests.swift in Sources */,
@@ -2439,12 +2452,14 @@
 				093694451BA9633300F36B3A /* UserClientRequestFactoryTests.swift in Sources */,
 				F94F6B331E54B9C000D46A29 /* CallingRequestStrategyTests.swift in Sources */,
 				545643D61C62C1A800A2129C /* ConversationTestsBase.m in Sources */,
+				16FF47451F0C06EA0044C491 /* PhoneRegistrationTests.m in Sources */,
 				3E26BED51A4037370071B4C9 /* IsTypingTests.m in Sources */,
 				54E4DD0F1DE4A9C500FEF192 /* UserHandleTests.swift in Sources */,
 				F9DAC54F1C2035660001F11E /* ConversationStatusStrategyTests.swift in Sources */,
 				164C29A31ECF437E0026562A /* SearchRequestTests.swift in Sources */,
 				54F7217E19A62225009A8AF5 /* ZMUpdateEventsBufferTests.m in Sources */,
 				546F815C1E685F6E00775059 /* LocalNotificationDispatcherTests.swift in Sources */,
+				16FF47471F0CD58A0044C491 /* IntegrationTest.m in Sources */,
 				5474C80A1921309400185A3A /* MessagingTest.m in Sources */,
 				872C99531DB525A1006A3BDE /* ZMCallKitDelegateTests.swift in Sources */,
 				160195611E30C9CF00ACBFAC /* LocalNotificationDispatcherCallingTests.swift in Sources */,
@@ -2537,6 +2552,7 @@
 				F1A94BD21F010287003083D9 /* UnauthenticatedSession+Login.swift in Sources */,
 				54A170651B300696001B41A5 /* ProxiedRequestStrategy.swift in Sources */,
 				160C31441E8049320012E4BC /* ApplicationStatusDirectory.swift in Sources */,
+				16FF474C1F0D54B20044C491 /* SessionManager+Logs.swift in Sources */,
 				1659114D1DEF1DA3007FA847 /* ZMLocalNotificationForCallState.swift in Sources */,
 				F19F1D281EFBC34E00275E27 /* ZMUserSessionRegistrationNotification.m in Sources */,
 				5478A1411DEC4048006F7268 /* UserProfile.swift in Sources */,


### PR DESCRIPTION
Since the `ZMUserSession` has been replaced by the `SessionManager` as the entry point to SE we also need to update our integration tests to reflect that. Modifying the existing `IntegrationTestBase` was difficult since it inherits from `MessagingTest` which relies heavily on MOCs.

I therefore decided to create a `IntegrationTest` base class which tries to remain as close as possible to a real setup. The class is defined in obj-c but the implementation is in swift because obj-c classes can't inherit from swift classes.