### PR TITLE
Fix login integration tests

### DIFF
--- a/Source/Synchronization/Strategies/UserClientRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/UserClientRequestStrategy.swift
@@ -401,6 +401,7 @@ public final class UserClientRequestStrategy: ZMObjectSyncStrategy, ZMObjectStra
                 }
             } else {
                 clientRegistrationStatus?.didDetectCurrentClientDeletion()
+                clientUpdateStatus?.didDetectCurrentClientDeletion()
             }
             
         default: break

--- a/Source/Synchronization/ZMOperationLoop.h
+++ b/Source/Synchronization/ZMOperationLoop.h
@@ -26,6 +26,7 @@
 @class ZMClientRegistrationStatus;
 @class NSManagedObjectContext;
 @class LocalNotificationDispatcher;
+@class AVSMediaManager;
 
 @protocol ZMSyncStateDelegate;
 @protocol ZMTransportData;
@@ -51,7 +52,7 @@ extern NSString * const ZMPushChannelResponseStatusKey;
 - (instancetype)initWithTransportSession:(ZMTransportSession *)transportSession
                            cookieStorage:(ZMPersistentCookieStorage *)cookieStorage
              localNotificationdispatcher:(LocalNotificationDispatcher *)dispatcher
-                            mediaManager:(id<AVSMediaManager>)mediaManager
+                            mediaManager:(AVSMediaManager *)mediaManager
                      onDemandFlowManager:(ZMOnDemandFlowManager *)onDemandFlowManager
                                    uiMOC:(NSManagedObjectContext *)uiMOC
                                  syncMOC:(NSManagedObjectContext *)syncMOC

--- a/Source/Synchronization/ZMOperationLoop.m
+++ b/Source/Synchronization/ZMOperationLoop.m
@@ -73,7 +73,7 @@ static char* const ZMLogTag ZM_UNUSED = "OperationLoop";
 - (instancetype)initWithTransportSession:(ZMTransportSession *)transportSession
                            cookieStorage:(ZMPersistentCookieStorage *)cookieStorage
              localNotificationdispatcher:(LocalNotificationDispatcher *)dispatcher
-                            mediaManager:(id<AVSMediaManager>)mediaManager
+                            mediaManager:(AVSMediaManager *)mediaManager
                      onDemandFlowManager:(ZMOnDemandFlowManager *)onDemandFlowManager
                                    uiMOC:(NSManagedObjectContext *)uiMOC
                                  syncMOC:(NSManagedObjectContext *)syncMOC

--- a/Source/Synchronization/ZMSyncStrategy.h
+++ b/Source/Synchronization/ZMSyncStrategy.h
@@ -38,9 +38,9 @@
 @class BackgroundAPNSPingBackStatus;
 @class ZMAccountStatus;
 @class ZMApplicationStatusDirectory;
+@class AVSMediaManager;
 
 @protocol ZMTransportData;
-@protocol AVSMediaManager;
 @protocol ZMSyncStateDelegate;
 @protocol ZMBackgroundable;
 @protocol ApplicationStateOwner;
@@ -51,7 +51,7 @@
 - (instancetype)initWithSyncManagedObjectContextMOC:(NSManagedObjectContext *)syncMOC
                              uiManagedObjectContext:(NSManagedObjectContext *)uiMOC
                                       cookieStorage:(ZMPersistentCookieStorage *)cookieStorage
-                                       mediaManager:(id<AVSMediaManager>)mediaManager
+                                       mediaManager:(AVSMediaManager *)mediaManager
                                 onDemandFlowManager:(ZMOnDemandFlowManager *)onDemandFlowManager
                                   syncStateDelegate:(id<ZMSyncStateDelegate>)syncStateDelegate
                        localNotificationsDispatcher:(LocalNotificationDispatcher *)localNotificationsDispatcher

--- a/Source/Synchronization/ZMSyncStrategy.m
+++ b/Source/Synchronization/ZMSyncStrategy.m
@@ -118,7 +118,7 @@ ZM_EMPTY_ASSERTING_INIT()
 - (instancetype)initWithSyncManagedObjectContextMOC:(NSManagedObjectContext *)syncMOC
                              uiManagedObjectContext:(NSManagedObjectContext *)uiMOC
                                       cookieStorage:(ZMPersistentCookieStorage *)cookieStorage
-                                       mediaManager:(id<AVSMediaManager>)mediaManager
+                                       mediaManager:(AVSMediaManager *)mediaManager
                                 onDemandFlowManager:(ZMOnDemandFlowManager *)onDemandFlowManager
                                   syncStateDelegate:(id<ZMSyncStateDelegate>)syncStateDelegate
                        localNotificationsDispatcher:(LocalNotificationDispatcher *)localNotificationsDispatcher
@@ -213,7 +213,7 @@ ZM_EMPTY_ASSERTING_INIT()
 }
 
 - (void)createTranscodersWithLocalNotificationsDispatcher:(LocalNotificationDispatcher *)localNotificationsDispatcher
-                                         mediaManager:(id<AVSMediaManager>)mediaManager
+                                         mediaManager:(AVSMediaManager *)mediaManager
                                   onDemandFlowManager:(ZMOnDemandFlowManager *)onDemandFlowManager
 {
     self.eventDecoder = [[EventDecoder alloc] initWithEventMOC:self.eventMOC syncMOC:self.syncMOC];

--- a/Source/UnauthenticatedSession/UnauthenticatedSession.swift
+++ b/Source/UnauthenticatedSession/UnauthenticatedSession.swift
@@ -31,15 +31,16 @@ public class UnauthenticatedSession : NSObject {
     let operationLoop: UnauthenticatedOperationLoop
     weak var delegate: UnauthenticatedSessionDelegate?
     
-    convenience init(authenticationStatus: ZMAuthenticationStatus, transportSession: ZMTransportSession, delegate: UnauthenticatedSessionDelegate? = nil) throws {
+    convenience init(transportSession: ZMTransportSession, delegate: UnauthenticatedSessionDelegate? = nil) throws {
         let model = NSManagedObjectModel()
         let coordinator = NSPersistentStoreCoordinator(managedObjectModel: model)
         try coordinator.addPersistentStore(ofType: NSInMemoryStoreType, configurationName: nil, at: nil, options: nil)
         let moc = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
         moc.createDispatchGroups()
         moc.persistentStoreCoordinator = coordinator
+        let authenticationStatus = ZMAuthenticationStatus(cookieStorage: transportSession.cookieStorage, managedObjectContext: moc)
         
-        self.init(moc: moc, authenticationStatus: authenticationStatus, transportSession: transportSession, delegate: delegate)
+        self.init(moc: moc, authenticationStatus: authenticationStatus!, transportSession: transportSession, delegate: delegate)
     }
     
     init(moc: NSManagedObjectContext, authenticationStatus: ZMAuthenticationStatus, transportSession: ZMTransportSession, delegate: UnauthenticatedSessionDelegate?) {

--- a/Source/UnauthenticatedSession/ZMAuthenticationStatus.h
+++ b/Source/UnauthenticatedSession/ZMAuthenticationStatus.h
@@ -70,7 +70,7 @@ typedef NS_ENUM(NSUInteger, ZMAuthenticationPhase) {
 @property (nonatomic) NSData *profileImageData;
 
 
-- (instancetype)initWithCookieStorage:(ZMPersistentCookieStorage *)cookieStorage;
+- (instancetype)initWithCookieStorage:(ZMPersistentCookieStorage *)cookieStorage managedObjectContext:(NSManagedObjectContext *)managedObjectContext;
 
 - (void)addAuthenticationCenterObserver:(id<ZMAuthenticationStatusObserver>)observer;
 - (void)removeAuthenticationCenterObserver:(id<ZMAuthenticationStatusObserver>)observer;

--- a/Source/UnauthenticatedSession/ZMAuthenticationStatus.m
+++ b/Source/UnauthenticatedSession/ZMAuthenticationStatus.m
@@ -41,10 +41,11 @@ static NSString* ZMLogTag ZM_UNUSED = @"Authentication";
 
 @implementation ZMAuthenticationStatus
 
-- (instancetype)initWithCookieStorage:(ZMPersistentCookieStorage *)cookieStorage;
+- (instancetype)initWithCookieStorage:(ZMPersistentCookieStorage *)cookieStorage managedObjectContext:(NSManagedObjectContext *)managedObjectContext;
 {
     self = [super init];
     if(self) {
+        self.moc = managedObjectContext;
         self.cookieStorage = cookieStorage;
         self.isWaitingForLogin = !self.isLoggedIn;
     }

--- a/Source/UserSession/ClientUpdateStatus.swift
+++ b/Source/UserSession/ClientUpdateStatus.swift
@@ -202,6 +202,10 @@ public enum ClientUpdateError : NSInteger {
         }
     }
     
+    public func didDetectCurrentClientDeletion() {
+        needsToVerifySelfClientOnAuthenticationDidSucceed = false
+    }
+    
     open func didDeleteClient() {
         if isWaitingToDeleteClients && !hasClientsToDelete {
             isWaitingToDeleteClients = false

--- a/Source/UserSession/ZMUserSession+Internal.h
+++ b/Source/UserSession/ZMUserSession+Internal.h
@@ -39,6 +39,7 @@
 @class ClientUpdateStatus;
 @class AVSFlowManager;
 @class ZMCallKitDelegate;
+@class AVSMediaManager;
 
 extern NSString * const ZMAppendAVSLogNotificationName;
 
@@ -88,7 +89,7 @@ extern NSString * const ZMAppendAVSLogNotificationName;
 - (instancetype)initWithTransportSession:(ZMTransportSession *)session
                     userInterfaceContext:(NSManagedObjectContext *)userInterfaceContext
                 syncManagedObjectContext:(NSManagedObjectContext *)syncManagedObjectContext
-                            mediaManager:(id<AVSMediaManager>)mediaManager
+                            mediaManager:(AVSMediaManager *)mediaManager
                          apnsEnvironment:(ZMAPNSEnvironment *)apnsEnvironment
                            operationLoop:(ZMOperationLoop *)operationLoop
                              application:(id<ZMApplication>)application

--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -61,7 +61,6 @@ static NSString * const AppstoreURL = @"https://itunes.apple.com/us/app/zeta-cli
 @interface ZMUserSession ()
 @property (nonatomic) ZMOperationLoop *operationLoop;
 @property (nonatomic) ZMTransportRequest *runningLoginRequest;
-@property (nonatomic) BOOL ownsQueue;
 @property (nonatomic) ZMTransportSession *transportSession;
 @property (nonatomic) NSManagedObjectContext *managedObjectContext;
 @property (nonatomic) NSManagedObjectContext *syncManagedObjectContext;
@@ -201,7 +200,7 @@ ZM_EMPTY_ASSERTING_INIT()
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (instancetype)initWithMediaManager:(id<AVSMediaManager>)mediaManager
+- (instancetype)initWithMediaManager:(AVSMediaManager *)mediaManager
                            analytics:(id<AnalyticsType>)analytics
                     transportSession:(ZMTransportSession *)transportSession
                      apnsEnvironment:(ZMAPNSEnvironment *)apnsEnvironment
@@ -244,7 +243,6 @@ ZM_EMPTY_ASSERTING_INIT()
         };
     }
     
-    
     self = [self initWithTransportSession:transportSession
                      userInterfaceContext:userInterfaceContext
                  syncManagedObjectContext:syncMOC
@@ -254,16 +252,13 @@ ZM_EMPTY_ASSERTING_INIT()
                               application:application
                                appVersion:appVersion
                        appGroupIdentifier:appGroupIdentifier];
-    if (self != nil) {
-        self.ownsQueue = YES;
-    }
     return self;
 }
 
 - (instancetype)initWithTransportSession:(ZMTransportSession *)session
                     userInterfaceContext:(NSManagedObjectContext *)userInterfaceContext
                 syncManagedObjectContext:(NSManagedObjectContext *)syncManagedObjectContext
-                            mediaManager:(id<AVSMediaManager>)mediaManager
+                            mediaManager:(AVSMediaManager *)mediaManager
                          apnsEnvironment:(ZMAPNSEnvironment *)apnsEnvironment
                            operationLoop:(ZMOperationLoop *)operationLoop
                              application:(id<ZMApplication>)application
@@ -400,11 +395,6 @@ ZM_EMPTY_ASSERTING_INIT()
     self.localNotificationDispatcher = nil;
     [self.blackList teardown];
     
-    if(self.ownsQueue) {
-        [self.transportSession tearDown];
-        self.transportSession = nil;
-    }
-    
     __block NSMutableArray *keysToRemove = [NSMutableArray array];
     [self.managedObjectContext.userInfo enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL * ZM_UNUSED stop) {
         if ([obj respondsToSelector:@selector((tearDown))]) {
@@ -520,7 +510,7 @@ ZM_EMPTY_ASSERTING_INIT()
     }];
 }
 
-- (void)setMediaManager:(id <AVSMediaManager>)delegate;
+- (void)setMediaManager:(AVSMediaManager *)delegate;
 {
     NOT_USED(delegate);
 }

--- a/Tests/Source/Synchronization/SynchronizationMocks.swift
+++ b/Tests/Source/Synchronization/SynchronizationMocks.swift
@@ -104,7 +104,7 @@ class MockAuthenticationStatus: ZMAuthenticationStatus {
     init(phase: ZMAuthenticationPhase = .authenticated, cookieString: String = "label", cookieStorage: ZMPersistentCookieStorage? = nil) {
         self.mockPhase = phase
         self.cookieString = cookieString
-        super.init(cookieStorage: cookieStorage)
+        super.init(cookieStorage: cookieStorage, managedObjectContext: nil)
     }
     
     override var currentPhase: ZMAuthenticationPhase {

--- a/Tests/Source/Synchronization/Transcoders/ZMLoginCodeRequestTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMLoginCodeRequestTranscoderTests.m
@@ -39,7 +39,7 @@
 - (void)setUp {
     [super setUp];
     
-    self.authenticationStatus = [[ZMAuthenticationStatus alloc] initWithCookieStorage:nil];
+    self.authenticationStatus = [[ZMAuthenticationStatus alloc] initWithCookieStorage:nil managedObjectContext: self.uiMOC];
     self.sut = [[ZMLoginCodeRequestTranscoder alloc] initWithManagedObjectContext:self.uiMOC authenticationStatus:self.authenticationStatus];
 }
 

--- a/Tests/Source/Synchronization/Transcoders/ZMLoginTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMLoginTranscoderTests.m
@@ -80,7 +80,7 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
     [super setUp];
     
     self.originalLoginTimerInterval = DefaultPendingValidationLoginAttemptInterval;
-    self.authenticationStatus = [[ZMAuthenticationStatus alloc] initWithCookieStorage:[ZMPersistentCookieStorage storageForServerName:@"test"]];
+    self.authenticationStatus = [[ZMAuthenticationStatus alloc] initWithCookieStorage:[ZMPersistentCookieStorage storageForServerName:@"test"] managedObjectContext:nil];
     self.mockClientRegistrationStatus = [OCMockObject niceMockForClass:[ZMClientRegistrationStatus class]];
     
     self.mockLocale = [OCMockObject niceMockForClass:[NSLocale class]];

--- a/Tests/Source/Synchronization/Transcoders/ZMPhoneNumberVerificationTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMPhoneNumberVerificationTranscoderTests.m
@@ -39,7 +39,7 @@
 - (void)setUp {
     [super setUp];
     
-    self.authenticationStatus = [[ZMAuthenticationStatus alloc] initWithCookieStorage:nil];
+    self.authenticationStatus = [[ZMAuthenticationStatus alloc] initWithCookieStorage:nil managedObjectContext:self.uiMOC];
     
     self.sut = [[ZMPhoneNumberVerificationTranscoder alloc] initWithManagedObjectContext:self.uiMOC authenticationStatus:self.authenticationStatus];
 }

--- a/Tests/Source/Synchronization/Transcoders/ZMRegistrationTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMRegistrationTranscoderTests.m
@@ -59,7 +59,7 @@
     (void) [[[classMock stub] andReturn:self.registrationDownstreamSync] syncWithSingleRequestTranscoder:OCMOCK_ANY managedObjectContext:self.uiMOC];
     
     self.cookieStorage = [ZMPersistentCookieStorage storageForServerName:@"com.wearezeta.test-WireSyncEngine"];
-    self.authenticationStatus = [[ZMAuthenticationStatus alloc] initWithCookieStorage:self.cookieStorage];
+    self.authenticationStatus = [[ZMAuthenticationStatus alloc] initWithCookieStorage:self.cookieStorage managedObjectContext:self.uiMOC];
         
     self.sut = (id) [[ZMRegistrationTranscoder alloc] initWithManagedObjectContext:self.uiMOC authenticationStatus:self.authenticationStatus];
     [classMock stopMocking];

--- a/Tests/Source/UserSession/ZMAuthenticationStatusTests.m
+++ b/Tests/Source/UserSession/ZMAuthenticationStatusTests.m
@@ -48,7 +48,7 @@
     [super setUp];
     
     self.cookieStorage = [ZMPersistentCookieStorage storageForServerName:@"foo.bar"];
-    self.sut = [[ZMAuthenticationStatus alloc] initWithCookieStorage:self.cookieStorage];
+    self.sut = [[ZMAuthenticationStatus alloc] initWithCookieStorage:self.cookieStorage managedObjectContext:nil];
     ZM_WEAK(self);
     // If a test fires any notification and it's not listening for it, this will fail
     self.authenticationCallback = ^(id note ZM_UNUSED){

--- a/Tests/Source/UserSession/ZMUserSessionTestsBase.m
+++ b/Tests/Source/UserSession/ZMUserSessionTestsBase.m
@@ -71,7 +71,7 @@
     self.mediaManager = [OCMockObject niceMockForClass:AVSMediaManager.class];
     self.requestAvailableNotification = [OCMockObject mockForClass:ZMRequestAvailableNotification.class];
     
-    self.authenticationStatus = [[ZMAuthenticationStatus alloc] initWithCookieStorage:self.cookieStorage];
+    self.authenticationStatus = [[ZMAuthenticationStatus alloc] initWithCookieStorage:self.cookieStorage managedObjectContext:nil];
     self.clientRegistrationStatus = [[ZMClientRegistrationStatus alloc] initWithManagedObjectContext:self.syncMOC cookieStorage:self.cookieStorage registrationStatusDelegate:nil];
     self.proxiedRequestStatus = [[ProxiedRequestsStatus alloc] initWithRequestCancellation:self.transportSession];
     self.operationStatus = [[ZMOperationStatus alloc] init];

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		1618B4101DE5FAD4003F015C /* ZMUserSession+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 3EC2357F192B617700B72C21 /* ZMUserSession+Internal.h */; };
 		1621D2711D770FB1007108C2 /* ZMSyncStateDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1621D2701D770FB1007108C2 /* ZMSyncStateDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1632C4B21F0E91FE007BE89D /* EmailRegistrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5454A69B1AEFA01D0022AFA4 /* EmailRegistrationTests.m */; };
+		1632C4B31F0FD270007BE89D /* LoginFlowTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 54FC8A0F192CD55000D3C016 /* LoginFlowTests.m */; };
 		1633875C1F066B610015034C /* ZMRegistrationTranscoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 54F8D71919AB541400146664 /* ZMRegistrationTranscoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		163495851F010AF0004E80DB /* UnauthenticatedSession+Registration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163495841F010AF0004E80DB /* UnauthenticatedSession+Registration.swift */; };
 		1634958B1F0254CB004E80DB /* SessionManager+ServerConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1634958A1F0254CB004E80DB /* SessionManager+ServerConnection.swift */; };
@@ -2496,6 +2497,7 @@
 				545434A219AB6975003892D9 /* ZMRegistrationTranscoderTests.m in Sources */,
 				85D85B0D7E5F7D9A55B5E07B /* IntegrationTestBase.m in Sources */,
 				545FC3341A5B003A005EEA26 /* ObjectTranscoderTests.m in Sources */,
+				1632C4B31F0FD270007BE89D /* LoginFlowTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Issues fixed while migrating tests:
* We didn't create an unauthenticated session if you got logged out.
* If your client got deleted we we will receive a event which logs you out. If you tried to log in again the first attempt would fail since we would again detect that your client was deleted.