### PR TITLE
Fix broken login flow tests

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -198,7 +198,11 @@ extension SessionManager: ZMAuthenticationObserver {
     }
     
     @objc public func authenticationDidSucceed() {
-        guard self.userSession == nil, let authenticationStatus = self.unauthenticatedSession?.authenticationStatus else { return }
+        guard self.userSession == nil, let authenticationStatus = self.unauthenticatedSession?.authenticationStatus else {
+            RequestAvailableNotification.notifyNewRequestsAvailable(self)
+            return
+        }
+        
         let userSession = ZMUserSession(mediaManager: mediaManager,
                                         analytics: analytics,
                                         transportSession: transportSession,

--- a/Tests/Source/Integration/LoginFlowTests.m
+++ b/Tests/Source/Integration/LoginFlowTests.m
@@ -249,6 +249,7 @@ extern NSTimeInterval DebugLoginFailureTimerOverride;
     
     id authenticationObserver = [OCMockObject mockForProtocol:@protocol(ZMAuthenticationObserver)];
     [[authenticationObserver stub] authenticationDidSucceed];
+    [[authenticationObserver stub] authenticationDidFail:OCMOCK_ANY];
     id token = [ZMUserSessionAuthenticationNotification addObserver:authenticationObserver];
     
     // getting access token fails


### PR DESCRIPTION
The login flow could get stalled if we login after the user session has already been created.