### PR TITLE
Fix slow sync tests

### DIFF
--- a/Source/Synchronization/Transcoders/ZMLastUpdateEventIDTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMLastUpdateEventIDTranscoder.m
@@ -133,13 +133,7 @@
     
     NSUUID *lastNotificationID = [[response.payload asDictionary] optionalUuidForKey:@"id"];
     
-    if(response.payload == nil) {
-        if (status.isSyncing) {
-            [status failCurrentSyncPhaseWithPhase:self.expectedSyncPhase];
-        }
-        return;
-    }
-    else if (response.HTTPStatus == 404 && status.currentSyncPhase == self.expectedSyncPhase) {
+    if (response.HTTPStatus == 404 && status.currentSyncPhase == self.expectedSyncPhase) {
         [status finishCurrentSyncPhaseWithPhase:self.expectedSyncPhase];
     }
     else if (lastNotificationID != nil) {

--- a/Tests/Source/Integration/SlowSyncTests.m
+++ b/Tests/Source/Integration/SlowSyncTests.m
@@ -336,13 +336,6 @@
     // given
     XCTAssertTrue([self login]);
     
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
-        NOT_USED(session);
-        ZMGenericMessage *message = [ZMGenericMessage messageWithText:@"Hello, Test!" nonce:NSUUID.createUUID.transportString expiresAfter:nil];
-        [self.groupConversation encryptAndInsertDataFromClient:self.user1.clients.anyObject toClient:self.selfUser.clients.anyObject data:message.data];
-    }];
-    WaitForAllGroupsToBeEmpty(0.5);
-    
     [self.mockTransportSession resetReceivedRequests];
 
     // make /notifications fail


### PR DESCRIPTION
Some of the tests were getting into a request loop because of incorrectly handled case when payload is nil