### PR TITLE
Fix retain cycle in user profile observer

### DIFF
--- a/Source/UserSession/UserProfileUpdateNotifications.swift
+++ b/Source/UserSession/UserProfileUpdateNotifications.swift
@@ -109,8 +109,9 @@ extension UserProfileUpdateStatus {
                                                       object: nil,
                                                       queue: OperationQueue.main)
         {
-            (anynote: Notification) in
-            guard let note = anynote.userInfo?[UserProfileUpdateNotification.userInfoKey] as? UserProfileUpdateNotification else {
+            [weak observer] (anynote: Notification) in
+            guard let note = anynote.userInfo?[UserProfileUpdateNotification.userInfoKey] as? UserProfileUpdateNotification,
+                  let observer = observer else {
                 return
             }
             switch note.type {

--- a/Tests/Source/UserSession/UserProfileUpdateStatusTests.swift
+++ b/Tests/Source/UserSession/UserProfileUpdateStatusTests.swift
@@ -58,7 +58,7 @@ class UserProfileUpdateStatusTests : MessagingTest {
 }
 
 extension UserProfileUpdateStatusTests {
-    func testThatItDoesNotReatinObserver() {
+    func testThatItDoesNotRetainObserver() {
         // GIVEN
         var observer: TestUserProfileUpdateObserver? = TestUserProfileUpdateObserver()
         

--- a/Tests/Source/UserSession/UserProfileUpdateStatusTests.swift
+++ b/Tests/Source/UserSession/UserProfileUpdateStatusTests.swift
@@ -57,6 +57,25 @@ class UserProfileUpdateStatusTests : MessagingTest {
     }
 }
 
+extension UserProfileUpdateStatusTests {
+    func testThatItDoesNotReatinObserver() {
+        // GIVEN
+        var observer: TestUserProfileUpdateObserver? = TestUserProfileUpdateObserver()
+        
+        // WHEN
+        let _ = self.sut.add(observer: observer!)
+        
+        weak var weakObserver = observer
+        
+        autoreleasepool {
+            observer = nil
+        }
+        
+        // THEN
+        XCTAssertNil(weakObserver)
+    }
+}
+
 // MARK: - Changing email
 extension UserProfileUpdateStatusTests {
     func testThatItReturnsErrorWhenPreparingForEmailChangeAndUserUserHasNoEmail() {


### PR DESCRIPTION
# Issue

Automatic retaining closure capture strikes the memory again.