### PR TITLE
Injecting store details

### DIFF
--- a/Source/Public/ZMUserSession.h
+++ b/Source/Public/ZMUserSession.h
@@ -42,6 +42,7 @@
 @protocol ZMThirdPartyServicesDelegate;
 @protocol UserProfileImageUpdateProtocol;
 @protocol ZMApplication;
+@protocol LocalStoreProviderProtocol;
 @class TopConversationsDirectory;
 
 @protocol ZMAVSLogObserver <NSObject>
@@ -64,27 +65,11 @@ extern NSString * const ZMTransportRequestLoopNotificationName;
 @interface ZMUserSession : NSObject <ZMManagedObjectContextProvider>
 
 /**
- Returns YES if data store needs to be migrated.
- */
-+ (BOOL)needsToPrepareLocalStoreUsingAppGroupIdentifier:(NSString *)appGroupIdentifier;
-
-/**
- Should be called <b>before</b> using ZMUserSession when applications is started if +needsToPrepareLocalStore returns YES. 
-    It will intialize persistent store and perform migration (if needed) on background thread.
-    When it's done it will call completionHandler on an arbitrary thread. It is the responsability of the caller to switch to the desired thread.
-    The local store is not ready to be used (and the ZMUserSession is not ready to be initialized) until the completionHandler has been called.
- */
-+ (void)prepareLocalStoreUsingAppGroupIdentifier:(NSString *)appGroupIdentifier completion:(void (^)())completionHandler;
-
-/// Whether the local store is ready to be opened. If it returns false, the user session can't be started yet
-+ (BOOL)storeIsReady;
-
-/**
  Intended initializer to be used by the UI
  @param mediaManager: The media manager delegate
  @param analytics: An object conforming to the @c AnalyticsType protocol that can be used to track events on the sync engine
  @param appVersion: The application version (build number)
- @param appGroupIdentifier: The identifier of the shared application group container that should be used to store databases etc.
+ @param storeProvider: An object conforming to the @c LocalStoreProviderProtocol that provides information about local store locations etc.
 */
 - (instancetype)initWithMediaManager:(AVSMediaManager *)mediaManager
                            analytics:(id<AnalyticsType>)analytics
@@ -93,7 +78,7 @@ extern NSString * const ZMTransportRequestLoopNotificationName;
                          application:(id<ZMApplication>)application
                               userId:(NSUUID *)uuid
                           appVersion:(NSString *)appVersion
-                  appGroupIdentifier:(NSString *)appGroupIdentifier;
+                       storeProvider:(id<LocalStoreProviderProtocol>)storeProvider;
 
 @property (nonatomic, weak) id<ZMRequestsToOpenViewsDelegate> requestToOpenViewDelegate;
 @property (nonatomic, weak) id<ZMThirdPartyServicesDelegate> thirdPartyServicesDelegate;
@@ -137,9 +122,6 @@ extern NSString * const ZMTransportRequestLoopNotificationName;
 @property (nonatomic, readonly) NSURL *sharedContainerURL;
 
 @property (nonatomic, readonly) NSURL *storeURL;
-
-+ (NSURL *)sharedContainerDirectoryForApplicationGroup:(NSString *)appGroupIdentifier;
-+ (NSURL *)storeURLForAppGroupIdentifier:(NSString *)appGroupIdentifier;
 
 @end
 

--- a/Source/SessionManager/LocalStoreProvider.swift
+++ b/Source/SessionManager/LocalStoreProvider.swift
@@ -1,0 +1,50 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+public protocol LocalStoreProviderProtocol {
+    func storeExists(forAppGroupIdentifier appGroupIdentifier:String) -> Bool
+    func storeURL(forAppGroupIdentifier appGroupIdentifier: String) -> URL
+    func needsToPrepareLocalStore(usingAppGroupIdentifier appGroupIdentifier: String) -> Bool
+    func prepareLocalStore(usingAppGroupIdentifier appGroupIdentifier: String, completion completionHandler: (() -> ()))
+}
+
+class LocalStoreProvider {
+    
+}
+
+extension LocalStoreProvider: LocalStoreProviderProtocol {
+    func storeURL(forAppGroupIdentifier appGroupIdentifier: String) -> URL {
+        fatalError()
+    }
+    
+    func storeExists(forAppGroupIdentifier appGroupIdentifier:String) -> Bool {
+        let storeURL = self.storeURL(forAppGroupIdentifier: appGroupIdentifier)
+        return NSManagedObjectContext.storeExists(at: storeURL)
+    }
+    
+    func needsToPrepareLocalStore(usingAppGroupIdentifier appGroupIdentifier: String) -> Bool {
+        fatalError()
+    }
+    
+    func prepareLocalStore(usingAppGroupIdentifier appGroupIdentifier: String, completion completionHandler: (() -> ())) {
+        fatalError()
+    }
+
+}

--- a/Source/SessionManager/LocalStoreProvider.swift
+++ b/Source/SessionManager/LocalStoreProvider.swift
@@ -48,6 +48,9 @@ protocol FileManagerProtocol: class {
 
 extension FileManager: FileManagerProtocol {}
 
+
+/// Encapsulates all storage related data and methods. LocalStoreProviderProtocol protocol
+/// is used instead of concrete class to let us inject a custom implementation in tests
 @objc public class LocalStoreProvider: NSObject {
     
     public let appGroupIdentifier: String

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -31,7 +31,6 @@ public protocol SessionManagerDelegate : class {
 
 @objc
 public class SessionManager : NSObject {
-    public let localStoreProvider: LocalStoreProviderProtocol
     public let appVersion: String
     public let mediaManager: AVSMediaManager
     public var analytics: AnalyticsType?
@@ -64,7 +63,7 @@ public class SessionManager : NSObject {
                                                   sharedContainerIdentifier: nil)
         let localStoreProvider = LocalStoreProvider()
         
-        self.init(localStoreProvider: localStoreProvider,
+        self.init(storeProvider: localStoreProvider,
                   appVersion: appVersion,
                   transportSession: transportSession,
                   mediaManager: mediaManager,
@@ -75,7 +74,7 @@ public class SessionManager : NSObject {
         
     }
     
-    public init(localStoreProvider: LocalStoreProviderProtocol,
+    public init(storeProvider: LocalStoreProviderProtocol,
                 appVersion: String,
                 transportSession: ZMTransportSession,
                 apnsEnvironment: ZMAPNSEnvironment? = nil,
@@ -83,14 +82,12 @@ public class SessionManager : NSObject {
                 analytics: AnalyticsType?,
                 delegate: SessionManagerDelegate?,
                 application: ZMApplication,
-                launchOptions: [UIApplicationLaunchOptionsKey : Any],
-                storeProvider: LocalStoreProviderProtocol = LocalStoreProvider()
+                launchOptions: [UIApplicationLaunchOptionsKey : Any]
                 ) {
         
         SessionManager.enableLogsByEnvironmentVariable()
         self.storeProvider = storeProvider
         
-        self.localStoreProvider = localStoreProvider
         self.appVersion = appVersion
         self.apnsEnvironment = apnsEnvironment
         self.application = application

--- a/Source/UserSession/ZMUserSession+Internal.h
+++ b/Source/UserSession/ZMUserSession+Internal.h
@@ -94,7 +94,7 @@ extern NSString * const ZMAppendAVSLogNotificationName;
                            operationLoop:(ZMOperationLoop *)operationLoop
                              application:(id<ZMApplication>)application
                               appVersion:(NSString *)appVersion
-                      appGroupIdentifier:(NSString *)appGroupIdentifier;
+                           storeProvider:(id<LocalStoreProviderProtocol>)storeProvider;
 
 @property (nonatomic) ZMPushRegistrant *pushRegistrant;
 @property (nonatomic) ZMApplicationRemoteNotification *applicationRemoteNotification;

--- a/Tests/Source/Integration/IntegrationTest.swift
+++ b/Tests/Source/Integration/IntegrationTest.swift
@@ -129,7 +129,7 @@ extension IntegrationTest {
         
         let storeProvider = WireSyncEngine.LocalStoreProvider()
 
-        sessionManager = SessionManager(localStoreProvider: storeProvider,
+        sessionManager = SessionManager(storeProvider: storeProvider,
                                         appVersion: "0.0.0",
                                         transportSession: transportSession,
                                         apnsEnvironment: apnsEnvironment,

--- a/Tests/Source/Integration/IntegrationTest.swift
+++ b/Tests/Source/Integration/IntegrationTest.swift
@@ -122,15 +122,14 @@ extension IntegrationTest {
     @objc
     func createSessionManager() {
         
-        guard let bundleIdentifier = Bundle.init(for: type(of: self)).bundleIdentifier,
-              let mediaManager = mediaManager,
+        guard let mediaManager = mediaManager,
               let application = application,
               let transportSession = transportSession
         else { XCTFail(); return }
         
-        let groupIdentifier = "group.\(bundleIdentifier)"
-        
-        sessionManager = SessionManager(appGroupIdentifier: groupIdentifier,
+        let storeProvider = WireSyncEngine.LocalStoreProvider()
+
+        sessionManager = SessionManager(localStoreProvider: storeProvider,
                                         appVersion: "0.0.0",
                                         transportSession: transportSession,
                                         apnsEnvironment: apnsEnvironment,

--- a/Tests/Source/SessionManager/LocalStoreProviderTests.swift
+++ b/Tests/Source/SessionManager/LocalStoreProviderTests.swift
@@ -1,0 +1,177 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import WireSyncEngine
+
+typealias FileManagerProtocol = WireSyncEngine.FileManagerProtocol
+
+class MockFileManager: FileManagerProtocol {
+    var containerURL: URL?
+    var calledGroupIdentifier: String?
+    func containerURL(forSecurityApplicationGroupIdentifier groupIdentifier: String) -> URL? {
+        calledGroupIdentifier = groupIdentifier
+        return containerURL
+    }
+
+    var urlsForDirectory = [URL]()
+    var calledDomainMask: FileManager.SearchPathDomainMask?
+    var calledDirectory: FileManager.SearchPathDirectory?
+    func urls(for directory: FileManager.SearchPathDirectory, in domainMask: FileManager.SearchPathDomainMask) -> [URL] {
+        calledDirectory = directory
+        calledDomainMask = domainMask
+        return urlsForDirectory
+    }
+}
+
+class LocalStoreProviderTests: ZMTBaseTest {
+    
+    var sut: LocalStoreProvider!
+    var fileManager: MockFileManager!
+    var appGroupIdentifier: String!
+    var bundleIdentifier: String!
+    
+    override func setUp() {
+        super.setUp()
+        fileManager = MockFileManager()
+        bundleIdentifier = "com.some.app"
+        appGroupIdentifier = "group." + bundleIdentifier
+        sut = LocalStoreProvider(bundleIdentifier: bundleIdentifier, appGroupIdentifier: appGroupIdentifier, fileManager: fileManager)
+    }
+    
+    override func tearDown() {
+        sut = nil
+        fileManager = nil
+        appGroupIdentifier = nil
+        super.tearDown()
+    }
+}
+
+// MARK: - Initialization
+extension LocalStoreProviderTests {
+    
+    func testThatItHasGroupIdentifierFromMainBundle() {
+        // given
+        let groupIdentifier = "group.\(Bundle.main.bundleIdentifier!)"
+        
+        // when
+        let sut = LocalStoreProvider()
+        
+        // then
+        XCTAssertEqual(sut.appGroupIdentifier, groupIdentifier)
+    }
+    
+    func testThatItIsInitializedWithDefaultFileManager() {
+        // given
+        let defaultFileManager: FileManagerProtocol = FileManager.default
+        
+        // when
+        let sut = LocalStoreProvider()
+
+        // then
+        XCTAssert(sut.fileManager === defaultFileManager)
+    }
+}
+
+// MARK: - Properties
+extension LocalStoreProviderTests {
+
+    func testThatSharedContainerDirectoryIsProvidedFromFileManager() {
+        // given
+        fileManager.containerURL = URL(fileURLWithPath: "some/file/path")
+        XCTAssertNotNil(fileManager.containerURL)
+        
+        // when
+        let containerURL = sut.sharedContainerDirectory
+        
+        // then
+        XCTAssertEqual(containerURL, fileManager.containerURL)
+        XCTAssertEqual(fileManager.calledGroupIdentifier, appGroupIdentifier)
+    }
+    
+    func testItFallsBackToUserDocumentsDirectoryIfSharedContainerIsNotAvailable() {
+        // given
+        fileManager.containerURL = nil
+        let documentsDirectory = URL(fileURLWithPath: "path/to/documents")
+        fileManager.urlsForDirectory = [documentsDirectory]
+        
+        // when
+        var containerURL: URL?
+        performIgnoringZMLogError {
+            containerURL = self.sut.sharedContainerDirectory
+        }
+        
+        // then
+        XCTAssertEqual(containerURL, documentsDirectory)
+        XCTAssertEqual(fileManager.calledDomainMask, .userDomainMask)
+        XCTAssertEqual(fileManager.calledDirectory, .documentDirectory)
+    }
+    
+    func testThatCachesAreNilWhenContainerIsNil() {
+        // given
+        fileManager.containerURL = nil
+        
+        // then
+        XCTAssertNil(sut.cachesURL)
+    }
+    
+    func testThatCachesIsInSharedContainer_Library_Caches() {
+        // given
+        let containerURL = URL(fileURLWithPath: "some/file/path")
+        let cachesURL = containerURL.appendingPathComponent("Library/Caches/")
+        fileManager.containerURL = containerURL
+        XCTAssertNotNil(fileManager.containerURL)
+        
+        // when
+        XCTAssertEqual(sut.cachesURL, cachesURL)
+        
+        // then
+        XCTAssertEqual(fileManager.calledGroupIdentifier, appGroupIdentifier)
+    }
+
+    func testThatKeyStoreIsInSharedContainer() {
+        // given
+        let containerURL = URL(fileURLWithPath: "some/file/path")
+        fileManager.containerURL = containerURL
+        XCTAssertNotNil(fileManager.containerURL)
+
+        // then
+        XCTAssertEqual(sut.keyStoreURL, containerURL)
+    }
+    
+    func testThatKeyStoreIsNilWhenContainerIsNil() {
+        // given
+        fileManager.containerURL = nil
+        
+        // then
+        performIgnoringZMLogError {
+            XCTAssertNil(self.sut.keyStoreURL)
+        }
+    }
+    
+    func testThatStoreURLIsInSharedContainer_bundleId() {
+        // given
+        let containerURL = URL(fileURLWithPath: "some/file/path")
+        let storeURL = containerURL.appendingPathComponent("\(bundleIdentifier!)/store.wiredatabase")
+        fileManager.containerURL = containerURL
+        XCTAssertNotNil(fileManager.containerURL)
+        
+        // then
+        XCTAssertEqual(sut.storeURL, storeURL)
+    }
+}

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -1,0 +1,24 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+import WireTesting
+
+class SessionManagerTests: ZMTBaseTest {
+        
+}

--- a/Tests/Source/UserSession/BackgroundAPNSConfirmationStatusTests.swift
+++ b/Tests/Source/UserSession/BackgroundAPNSConfirmationStatusTests.swift
@@ -58,8 +58,9 @@ class BackgroundAPNSConfirmationStatusTests : MessagingTest {
         fakeBGActivityFactory.tearDown()
         sut.tearDown()
         sut = nil
+        fakeBGActivityFactory.mainGroupQueue = nil
+        fakeBGActivityFactory.tearDown()
         fakeBGActivityFactory = nil
-        FakeBackgroundActivityFactory.tearDownInstance()
         super.tearDown()
     }
     

--- a/Tests/Source/UserSession/BackgroundAPNSPingBackStatusTests.swift
+++ b/Tests/Source/UserSession/BackgroundAPNSPingBackStatusTests.swift
@@ -184,8 +184,9 @@ class BackgroundAPNSPingBackStatusTests: MessagingTest {
     
     override func tearDown() {
         observer = nil
-        BackgroundActivityFactory.tearDownInstance()
         sut = nil
+        BackgroundActivityFactory.sharedInstance().mainGroupQueue = nil
+        BackgroundActivityFactory.sharedInstance().application = nil
         authenticationProvider = nil
         super.tearDown()
     }

--- a/Tests/Source/UserSession/ZMUserSessionTests.m
+++ b/Tests/Source/UserSession/ZMUserSessionTests.m
@@ -19,6 +19,7 @@
 
 @import PushKit;
 @import WireMockTransport;
+@import WireSyncEngine;
 
 #include "ZMUserSessionTestsBase.h"
 #import "ZMPushToken.h"
@@ -34,8 +35,6 @@
 - (void)simulateLoggedInUser;
 
 @end
-
-
 
 @implementation ZMUserSessionTests
 
@@ -85,6 +84,8 @@
     id userAgent = [OCMockObject mockForClass:ZMUserAgent.class];
     [[[userAgent expect] classMethod] setWireAppVersion:version];
     
+    id<LocalStoreProviderProtocol> storeProvider = [[LocalStoreProvider alloc] init];
+    
     // when
     ZMUserSession *session = [[ZMUserSession alloc] initWithMediaManager:nil
                                                                analytics:nil
@@ -93,7 +94,7 @@
                                                              application:[UIApplication sharedApplication]
                                                                   userId:nil
                                                               appVersion:version
-                                                      appGroupIdentifier:self.groupIdentifier];
+                                                           storeProvider:storeProvider];
     XCTAssertNotNil(session);
     
     // then
@@ -224,6 +225,7 @@
     id pushChannel = [OCMockObject niceMockForProtocol:@protocol(ZMPushChannel)];
     id transportSession = [OCMockObject niceMockForClass:ZMTransportSession.class];
     id cookieStorage = [OCMockObject niceMockForClass:ZMPersistentCookieStorage.class];
+    id<LocalStoreProviderProtocol> storeProvider = [[LocalStoreProvider alloc] init];
     
     // expect
     [[pushChannel expect] setClientID:userClient.remoteIdentifier];
@@ -239,7 +241,7 @@
                                                                    operationLoop:nil
                                                                      application:self.application
                                                                       appVersion:@"00000"
-                                                              appGroupIdentifier:self.groupIdentifier];
+                                                                   storeProvider:storeProvider];
     [userSession didRegisterUserClient:userClient];
     
     // then
@@ -516,6 +518,7 @@
 - (void)testThatItSetsItselfAsADelegateOfTheTransportSessionAndForwardsUserClientID
 {
     // given
+    id<LocalStoreProviderProtocol> storeProvider = [[LocalStoreProvider alloc] init];
     id transportSession = [OCMockObject mockForClass:ZMTransportSession.class];
     id pushChannel = [OCMockObject mockForProtocol:@protocol(ZMPushChannel)];
     
@@ -550,7 +553,7 @@
                                                                    operationLoop:nil
                                                                      application:self.application
                                                                       appVersion:@"00000"
-                                                              appGroupIdentifier:self.groupIdentifier];
+                                                                   storeProvider:storeProvider];
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then

--- a/Tests/Source/UserSession/ZMUserSessionTestsBase.m
+++ b/Tests/Source/UserSession/ZMUserSessionTestsBase.m
@@ -20,6 +20,7 @@
 #import <Foundation/Foundation.h>
 #include "ZMUserSessionTestsBase.h"
 #import "WireSyncEngine_iOS_Tests-Swift.h"
+@import WireSyncEngine;
 
 @implementation ThirdPartyServices
 
@@ -91,6 +92,8 @@
     [[[self.apnsEnvironment stub] andReturn:@"APNS"] transportTypeForTokenType:ZMAPNSTypeNormal];
     [[[self.apnsEnvironment stub] andReturn:@"APNS_VOIP"] transportTypeForTokenType:ZMAPNSTypeVoIP];
     
+    id<LocalStoreProviderProtocol> storeProvider = [[LocalStoreProvider alloc] init];
+    
     self.sut = [[ZMUserSession alloc] initWithTransportSession:self.transportSession
                                           userInterfaceContext:self.uiMOC
                                       syncManagedObjectContext:self.syncMOC
@@ -99,7 +102,7 @@
                                                  operationLoop:self.operationLoop
                                                    application:self.application
                                                     appVersion:@"00000"
-                                            appGroupIdentifier:self.groupIdentifier];
+                                                 storeProvider:storeProvider];
     self.sut.thirdPartyServicesDelegate = self.thirdPartyServices;
     
     WaitForAllGroupsToBeEmpty(0.5);

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -317,6 +317,8 @@
 		CE99C4A01D378C5D0001D297 /* MockLinkPreviewDetector.m in Sources */ = {isa = PBXBuildFile; fileRef = CE99C49F1D378C5D0001D297 /* MockLinkPreviewDetector.m */; };
 		CEE02E461DDA0F4D00BA2BE2 /* avs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE5DC1A01DDA09F000D24DBA /* avs.framework */; };
 		CEF2DE7F1DB778F300451642 /* RequestLoopAnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF2DE7E1DB778F300451642 /* RequestLoopAnalyticsTracker.swift */; };
+		F159F4141F1E3134001B7D80 /* SessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F159F4131F1E3134001B7D80 /* SessionManagerTests.swift */; };
+		F159F4161F1E4C4C001B7D80 /* LocalStoreProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F159F4151F1E4C4C001B7D80 /* LocalStoreProvider.swift */; };
 		F170AF211E78013A0033DC33 /* UserImageAssetUpdateStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F170AF1F1E7800CF0033DC33 /* UserImageAssetUpdateStrategyTests.swift */; };
 		F190E0AA1E8D517A003E81F8 /* UserProfileImageV3Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F190E0A81E8D516D003E81F8 /* UserProfileImageV3Tests.swift */; };
 		F190E0DD1E8E7C9D003E81F8 /* SlowSyncTests+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = F190E0DB1E8E7BA1003E81F8 /* SlowSyncTests+Swift.swift */; };
@@ -886,6 +888,8 @@
 		CE99C49F1D378C5D0001D297 /* MockLinkPreviewDetector.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MockLinkPreviewDetector.m; sourceTree = "<group>"; };
 		CE99C4A11D37ACC60001D297 /* Ono.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Ono.framework; path = Carthage/Build/iOS/Ono.framework; sourceTree = "<group>"; };
 		CEF2DE7E1DB778F300451642 /* RequestLoopAnalyticsTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestLoopAnalyticsTracker.swift; sourceTree = "<group>"; };
+		F159F4131F1E3134001B7D80 /* SessionManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionManagerTests.swift; sourceTree = "<group>"; };
+		F159F4151F1E4C4C001B7D80 /* LocalStoreProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalStoreProvider.swift; sourceTree = "<group>"; };
 		F170AF1F1E7800CF0033DC33 /* UserImageAssetUpdateStrategyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserImageAssetUpdateStrategyTests.swift; sourceTree = "<group>"; };
 		F190E0A81E8D516D003E81F8 /* UserProfileImageV3Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserProfileImageV3Tests.swift; sourceTree = "<group>"; };
 		F190E0DB1E8E7BA1003E81F8 /* SlowSyncTests+Swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SlowSyncTests+Swift.swift"; sourceTree = "<group>"; };
@@ -1369,6 +1373,7 @@
 				A9EAE00A19DBF24100FD386C /* Utility */,
 				54CEC9BB19AB34CE006817BB /* Registration */,
 				5474C7EB1921303400185A3A /* UserSession */,
+				F159F4121F1E310C001B7D80 /* SessionManager */,
 				5474C7DD1921303400185A3A /* Data Model */,
 				85D850FC5E45F9F688A64419 /* Synchronization */,
 				54FC8A0E192CD52800D3C016 /* Integration */,
@@ -1904,6 +1909,14 @@
 			name = "DB Fixture 1.24";
 			sourceTree = "<group>";
 		};
+		F159F4121F1E310C001B7D80 /* SessionManager */ = {
+			isa = PBXGroup;
+			children = (
+				F159F4131F1E3134001B7D80 /* SessionManagerTests.swift */,
+			);
+			path = SessionManager;
+			sourceTree = "<group>";
+		};
 		F19F1D121EFBC17A00275E27 /* UnauthenticatedSession */ = {
 			isa = PBXGroup;
 			children = (
@@ -1926,6 +1939,7 @@
 		F19F1D361EFBF60A00275E27 /* SessionManager */ = {
 			isa = PBXGroup;
 			children = (
+				F159F4151F1E4C4C001B7D80 /* LocalStoreProvider.swift */,
 				F19F1D371EFBF61800275E27 /* SessionManager.swift */,
 				16FF474B1F0D54B20044C491 /* SessionManager+Logs.swift */,
 				1634958A1F0254CB004E80DB /* SessionManager+ServerConnection.swift */,
@@ -2446,6 +2460,7 @@
 				54DE9BEF1DE760A900EFFB9C /* RandomHandleGeneratorTests.swift in Sources */,
 				F9C598AD1A0947B300B1F760 /* ZMBlacklistDownloaderTest.m in Sources */,
 				BFE53F551D5A2F7000398378 /* DeleteMessagesTests.swift in Sources */,
+				F159F4141F1E3134001B7D80 /* SessionManagerTests.swift in Sources */,
 				16A702D01E92998100B8410D /* ApplicationStatusDirectoryTests.swift in Sources */,
 				093694451BA9633300F36B3A /* UserClientRequestFactoryTests.swift in Sources */,
 				F94F6B331E54B9C000D46A29 /* CallingRequestStrategyTests.swift in Sources */,
@@ -2624,6 +2639,7 @@
 				3EDBFD781A65200F0095E2DD /* ZMPushRegistrant.swift in Sources */,
 				F98EDCEF1D82B924001E65CB /* UILocalNotification+UserInfo.m in Sources */,
 				F98EDCF01D82B924001E65CB /* ZMLocalNotificationLocalization+Components.swift in Sources */,
+				F159F4161F1E4C4C001B7D80 /* LocalStoreProvider.swift in Sources */,
 				1660AA0D1ECDB0250056D403 /* SearchTask.swift in Sources */,
 				F9245BED1CBF95A8009D1E85 /* ZMHotFixDirectory+Swift.swift in Sources */,
 				54991D5A1DEDD07E007E282F /* AddressBookIOS9.swift in Sources */,

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -319,6 +319,7 @@
 		CEF2DE7F1DB778F300451642 /* RequestLoopAnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF2DE7E1DB778F300451642 /* RequestLoopAnalyticsTracker.swift */; };
 		F159F4141F1E3134001B7D80 /* SessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F159F4131F1E3134001B7D80 /* SessionManagerTests.swift */; };
 		F159F4161F1E4C4C001B7D80 /* LocalStoreProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F159F4151F1E4C4C001B7D80 /* LocalStoreProvider.swift */; };
+		F159F4191F1F8B02001B7D80 /* LocalStoreProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F159F4181F1F8B02001B7D80 /* LocalStoreProviderTests.swift */; };
 		F170AF211E78013A0033DC33 /* UserImageAssetUpdateStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F170AF1F1E7800CF0033DC33 /* UserImageAssetUpdateStrategyTests.swift */; };
 		F190E0AA1E8D517A003E81F8 /* UserProfileImageV3Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F190E0A81E8D516D003E81F8 /* UserProfileImageV3Tests.swift */; };
 		F190E0DD1E8E7C9D003E81F8 /* SlowSyncTests+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = F190E0DB1E8E7BA1003E81F8 /* SlowSyncTests+Swift.swift */; };
@@ -890,6 +891,7 @@
 		CEF2DE7E1DB778F300451642 /* RequestLoopAnalyticsTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestLoopAnalyticsTracker.swift; sourceTree = "<group>"; };
 		F159F4131F1E3134001B7D80 /* SessionManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionManagerTests.swift; sourceTree = "<group>"; };
 		F159F4151F1E4C4C001B7D80 /* LocalStoreProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalStoreProvider.swift; sourceTree = "<group>"; };
+		F159F4181F1F8B02001B7D80 /* LocalStoreProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalStoreProviderTests.swift; sourceTree = "<group>"; };
 		F170AF1F1E7800CF0033DC33 /* UserImageAssetUpdateStrategyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserImageAssetUpdateStrategyTests.swift; sourceTree = "<group>"; };
 		F190E0A81E8D516D003E81F8 /* UserProfileImageV3Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserProfileImageV3Tests.swift; sourceTree = "<group>"; };
 		F190E0DB1E8E7BA1003E81F8 /* SlowSyncTests+Swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SlowSyncTests+Swift.swift"; sourceTree = "<group>"; };
@@ -1913,6 +1915,7 @@
 			isa = PBXGroup;
 			children = (
 				F159F4131F1E3134001B7D80 /* SessionManagerTests.swift */,
+				F159F4181F1F8B02001B7D80 /* LocalStoreProviderTests.swift */,
 			);
 			path = SessionManager;
 			sourceTree = "<group>";
@@ -2490,6 +2493,7 @@
 				54DFB8F01B30649000F1C736 /* GiphyTests.m in Sources */,
 				164B8C211E254AD00060AB26 /* WireCallCenterV3Mock.swift in Sources */,
 				54C2F69B1A6FA988003D09D9 /* ZMLocalNotificationForExpiredMessageTest.m in Sources */,
+				F159F4191F1F8B02001B7D80 /* LocalStoreProviderTests.swift in Sources */,
 				F170AF211E78013A0033DC33 /* UserImageAssetUpdateStrategyTests.swift in Sources */,
 				F95ECF511B94BD05009F91BA /* ZMHotFixTests.m in Sources */,
 				F9410F681DE4BE42007451FF /* PushTokenStrategyTests.swift in Sources */,


### PR DESCRIPTION
It was tricky to test storage related behaviour (migration, store doesn't exist etc.), so I added a protocol that encapsulates the data and methods used for this. This is then injected to session manager/user session and enables us to easily mock the behaviour in tests.

This will unfortunately conflict with https://github.com/wireapp/wire-ios-sync-engine/pull/466, but at same time IMHO make it slightly simpler.