### PR TITLE
Initial sync fixes

### DIFF
--- a/Source/Public/ZMUserSession.h
+++ b/Source/Public/ZMUserSession.h
@@ -123,6 +123,9 @@ extern NSString * const ZMTransportRequestLoopNotificationName;
 
 @property (nonatomic, readonly) NSURL *storeURL;
 
+/// The sync has been completed as least once
+@property (nonatomic, readonly) BOOL hasCompletedInitialSync;
+           
 @end
 
 

--- a/Source/Synchronization/Transcoders/ZMSelfStrategy.m
+++ b/Source/Synchronization/Transcoders/ZMSelfStrategy.m
@@ -299,6 +299,9 @@ NSTimeInterval ZMSelfStrategyPendingValidationRequestInterval = 5;
             }
         }
         
+        // Save to ensure self user is update to date when sync finishes
+        [self.managedObjectContext saveOrRollback];
+        
         if (self.isSyncing) {
             [syncStatus finishCurrentSyncPhaseWithPhase:self.expectedSyncPhase];
         }

--- a/Source/Synchronization/ZMHotFix.m
+++ b/Source/Synchronization/ZMHotFix.m
@@ -78,6 +78,15 @@ NSString * const ZMSkipHotfix = @"ZMSkipHotfix";
         return;
     }
     
+    if (lastSavedVersion == nil) {
+        ZMLogDebug(@"No saved last version. We assume it's a new database and don't apply any HotFix.");
+        [self.syncMOC performGroupedBlock:^{
+            [self saveNewVersion:currentVersionString];
+            [self.syncMOC saveOrRollback];
+        }];
+        return;
+    }
+    
     ZMLogDebug(@"Applying HotFix with last saved version %@, current version %@.", lastSavedVersion.versionString, currentVersion.versionString);
     [self.syncMOC performGroupedBlock:^{
         [self applyFixesSinceVersion:lastSavedVersion];

--- a/Source/UserSession/SyncStatus.swift
+++ b/Source/UserSession/SyncStatus.swift
@@ -132,6 +132,8 @@ extension SyncStatus {
     public func finishCurrentSyncPhase(phase : SyncPhase) {
         precondition(phase == currentSyncPhase, "Finished syncPhase does not match currentPhase")
         
+        zmLog.debug("finished sync phase: \(phase)")
+        
         guard let nextPhase = currentSyncPhase.nextPhase else { return }
         
         if currentSyncPhase.isLastSlowSyncPhase {
@@ -146,8 +148,11 @@ extension SyncStatus {
                 // We need to restart fetching the notification stream since we might be missing notifications
                 currentSyncPhase = .fetchingMissedEvents
                 needsToRestartQuickSync = false
+                zmLog.debug("restarting quick sync since push channel was closed")
                 return
             }
+            
+            zmLog.debug("sync complete")
             syncStateDelegate.didFinishSync()
             managedObjectContext.zm_userInterface.perform{
                 ZMUserSession.notifyInitialSyncCompleted()
@@ -158,6 +163,8 @@ extension SyncStatus {
     
     public func failCurrentSyncPhase(phase : SyncPhase) {
         precondition(phase == currentSyncPhase, "Failed syncPhase does not match currentPhase")
+        
+        zmLog.debug("failed sync phase: \(phase)")
         
         if currentSyncPhase == .fetchingMissedEvents {
             managedObjectContext.zm_lastNotificationID = nil

--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -80,6 +80,7 @@ static NSString * const AppstoreURL = @"https://itunes.apple.com/us/app/zeta-cli
 @property (nonatomic) NSURL *keyStoreURL;
 @property (nonatomic, readwrite) NSURL *sharedContainerURL;
 @property (nonatomic) TopConversationsDirectory *topConversationsDirectory;
+@property (nonatomic) BOOL hasCompletedInitialSync;
 
 
 /// Build number of the Wire app
@@ -740,6 +741,7 @@ ZM_EMPTY_ASSERTING_INIT()
     [self.managedObjectContext performGroupedBlock:^{
         ZM_STRONG(self);
         self.isPerformingSync = NO;
+        self.hasCompletedInitialSync = YES;
         [self changeNetworkStateAndNotify];
         [self notifyThirdPartyServices];
         [self processPendingNotificationActions];

--- a/Tests/Source/Synchronization/ZMHotFixTests.m
+++ b/Tests/Source/Synchronization/ZMHotFixTests.m
@@ -258,6 +258,7 @@
 - (void)testThatItSendsOutResetPushTokenNotificationVersion_40_4
 {
     // given
+    [self saveNewVersion];
     PushTokenNotificationObserver *observer = [[PushTokenNotificationObserver alloc] init];
     
     // when
@@ -290,6 +291,7 @@
 - (void)testThatItRemovesTheSharingExtensionURLs
 {
     // given
+    [self saveNewVersion];
     NSURL *directoryURL = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:[NSUserDefaults groupName]];
     NSURL *imageURL = [directoryURL URLByAppendingPathComponent:@"profile_images"];
     NSURL *conversationUrl = [directoryURL URLByAppendingPathComponent:@"conversations"];
@@ -315,6 +317,7 @@
 - (void)testThatItCopiesTheAPSDecryptionKeysFromKeyChainToSelfClient_41_43
 {
     // given
+    [self saveNewVersion];
     UserClient *userClient = [self createSelfClient];
     NSData *encryptionKey = [NSData randomEncryptionKey];
     NSData *verificationKey = [NSData randomEncryptionKey];
@@ -362,6 +365,7 @@
 - (void)testThatItSetsNeedsToUploadSignalingKeysIfKeysNotPresentInKeyChain_41_43
 {
     // given
+    [self saveNewVersion];
     UserClient *userClient = [self createSelfClient];
     XCTAssertFalse(userClient.needsToUploadSignalingKeys);
     XCTAssertFalse([userClient hasLocalModificationsForKey:@"needsToUploadSignalingKeys"]);
@@ -402,6 +406,7 @@
 - (void)testThatItSetsNotUploadedAssetClientMessagesToFailedAndAlsoExpiresFailedImageMessages_42_11
 {
     // given
+    [self saveNewVersion];
     ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
     conversation.conversationType = ZMConversationTypeOneOnOne;
     
@@ -515,6 +520,7 @@
 - (void)testThatItRemovesPendingConfirmationsForDeletedMessages_54_0_1
 {
     // given
+    [self saveNewVersion];
     [self.syncMOC setPersistentStoreMetadata:@YES forKey:@"HasHistory"];
     
     ZMConversation *oneOnOneConversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
@@ -550,6 +556,7 @@
 
 - (void)testThatItPurgesPinCachesInHostBundle_60_0_0
 {
+    [self saveNewVersion];
     NSFileManager *fileManager = [NSFileManager defaultManager];
     
     // given
@@ -599,6 +606,7 @@
 - (void)testThatItMarksConnectedUsersToBeUpdatedFromTheBackend_62_3_1
 {
     // given
+    [self saveNewVersion];
     ZMUser *connectedUser = [ZMUser insertNewObjectInManagedObjectContext:self.syncMOC];
     connectedUser.connection = [ZMConnection insertNewObjectInManagedObjectContext:self.syncMOC];
     connectedUser.connection.status = ZMConnectionStatusAccepted;
@@ -640,6 +648,7 @@
     // to redownload all users as soon as we support downloading profile pictures using the /v3/ endpoint.
 
     // given
+    [self saveNewVersion];
     ZMUser *connectedUser = [ZMUser insertNewObjectInManagedObjectContext:self.syncMOC];
     connectedUser.connection = [ZMConnection insertNewObjectInManagedObjectContext:self.syncMOC];
     connectedUser.connection.status = ZMConnectionStatusAccepted;

--- a/Tests/Source/Synchronization/ZMHotFixTests.m
+++ b/Tests/Source/Synchronization/ZMHotFixTests.m
@@ -199,16 +199,18 @@
     XCTAssertEqual(self.fakeHotFixDirectory.method2CallCount, 0u);
 }
 
-- (void)testThatItCallsAllMethodsIfThereIsNoLastSavedVersion
+- (void)testThatItDoesntCallAnyMethodsIfThereIsNoLastSavedVersionButUpdateLastSavedVersion
 {
     // when
     [self.sut applyPatchesForCurrentVersion:@"1.0"];
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
-    XCTAssertEqual(self.fakeHotFixDirectory.method1CallCount, 1u);
-    XCTAssertEqual(self.fakeHotFixDirectory.method2CallCount, 1u);
-    XCTAssertEqual(self.fakeHotFixDirectory.method3CallCount, 1u);
+    NSString *newVersion = [self.syncMOC persistentStoreMetadataForKey:@"lastSavedVersion"];
+    XCTAssertEqualObjects(newVersion, @"1.0");
+    XCTAssertEqual(self.fakeHotFixDirectory.method1CallCount, 0u);
+    XCTAssertEqual(self.fakeHotFixDirectory.method2CallCount, 0u);
+    XCTAssertEqual(self.fakeHotFixDirectory.method3CallCount, 0u);
 }
 
 - (void)testThatItRunsFixesOnlyOnce


### PR DESCRIPTION
This PR add new property `hasCompletedInitialSync`. We currently have a similar property in the UI but it's unreliable since it's based on the `initialSyncCompleted` notification which doesn't guarantee the order in which the observers are executed.

Additionally we now also skip applying all hot fixes for on a fresh install and therefore avoids some unnecessary requests.