### PR TITLE
Fail login immediately when offline

### DIFF
--- a/Source/UnauthenticatedSession/UnauthenticatedOperationLoop.swift
+++ b/Source/UnauthenticatedSession/UnauthenticatedOperationLoop.swift
@@ -22,11 +22,11 @@ import WireMessageStrategy
 
 class UnauthenticatedOperationLoop: NSObject {
     
-    let transportSession: ZMTransportSession
+    let transportSession: TransportSession
     let requestStrategies: [RequestStrategy]
     let operationQueue : ZMSGroupQueue
     
-    init(transportSession: ZMTransportSession, operationQueue: ZMSGroupQueue, requestStrategies: [RequestStrategy]) {
+    init(transportSession: TransportSession, operationQueue: ZMSGroupQueue, requestStrategies: [RequestStrategy]) {
         self.transportSession = transportSession
         self.requestStrategies = requestStrategies
         self.operationQueue = operationQueue
@@ -41,7 +41,7 @@ class UnauthenticatedOperationLoop: NSObject {
 
 extension UnauthenticatedOperationLoop: RequestAvailableObserver {
     func newRequestsAvailable() {
-        self.transportSession.attemptToEnqueueSyncRequest { () -> ZMTransportRequest? in
+        self.transportSession.attemptToEnqueueSyncRequestWithGenerator { () -> ZMTransportRequest? in
             let request = (self.requestStrategies as NSArray).nextRequest()
             
             request?.add(ZMCompletionHandler(on: self.operationQueue, block: {_ in

--- a/Source/UnauthenticatedSession/UnauthenticatedSession+Login.swift
+++ b/Source/UnauthenticatedSession/UnauthenticatedSession+Login.swift
@@ -41,7 +41,7 @@ extension UnauthenticatedSession {
             delegate?.session(session: self, updatedCredentials: credentials)
         } else if credentials.isInvalid {
             ZMUserSessionAuthenticationNotification.notifyAuthenticationDidFail(NSError.userSessionErrorWith(.needsCredentials, userInfo: nil))
-        } else if !self.operationLoop.transportSession.reachability.mayBeReachable {
+        } else if !self.operationLoop.transportSession.reachabilityProvider.mayBeReachable {
             ZMUserSessionAuthenticationNotification.notifyAuthenticationDidFail(NSError.userSessionErrorWith(.networkError, userInfo:nil))
         } else {
             self.authenticationStatus.prepareForLogin(with: credentials)

--- a/Source/UnauthenticatedSession/UnauthenticatedSession+Login.swift
+++ b/Source/UnauthenticatedSession/UnauthenticatedSession+Login.swift
@@ -41,6 +41,8 @@ extension UnauthenticatedSession {
             delegate?.session(session: self, updatedCredentials: credentials)
         } else if credentials.isInvalid {
             ZMUserSessionAuthenticationNotification.notifyAuthenticationDidFail(NSError.userSessionErrorWith(.needsCredentials, userInfo: nil))
+        } else if !self.operationLoop.transportSession.reachability.mayBeReachable {
+            ZMUserSessionAuthenticationNotification.notifyAuthenticationDidFail(NSError.userSessionErrorWith(.networkError, userInfo:nil))
         } else {
             self.authenticationStatus.prepareForLogin(with: credentials)
         }

--- a/Source/UnauthenticatedSession/ZMAuthenticationStatus.m
+++ b/Source/UnauthenticatedSession/ZMAuthenticationStatus.m
@@ -178,8 +178,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"Authentication";
 
 - (void)startLoginTimer
 {
-    [self.loginTimer cancel];
-    self.loginTimer = nil;
+    [self stopLoginTimer];
     self.loginTimer = [ZMTimer timerWithTarget:self];
     self.loginTimer.userInfo = @{ TimerInfoOriginalCredentialsKey : self.loginCredentials };
     [self.loginTimer fireAfterTimeInterval:(DebugLoginFailureTimerOverride > 0 ?: 60 )];

--- a/Tests/Source/MessagingTest.m
+++ b/Tests/Source/MessagingTest.m
@@ -50,6 +50,18 @@
 #import <WireSyncEngine/WireSyncEngine-Swift.h>
 #import "WireSyncEngine_iOS_Tests-Swift.h"
 
+@interface MockTransportSession (Reachability)
+@property (nonatomic, readonly) ZMReachability *reachability;
+@end
+
+@implementation MockTransportSession (Reachability)
+
+- (ZMReachability *)reachability
+{
+    return nil;
+}
+
+@end
 
 @interface MessagingTest () 
 

--- a/Tests/Source/MessagingTest.m
+++ b/Tests/Source/MessagingTest.m
@@ -50,6 +50,8 @@
 #import <WireSyncEngine/WireSyncEngine-Swift.h>
 #import "WireSyncEngine_iOS_Tests-Swift.h"
 
+static ZMReachability *sharedReachabilityMock = nil;
+
 @interface MockTransportSession (Reachability)
 @property (nonatomic, readonly) ZMReachability *reachability;
 @end
@@ -58,7 +60,12 @@
 
 - (ZMReachability *)reachability
 {
-    return nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedReachabilityMock = OCMClassMock(ZMReachability.class);
+        [[[(id)sharedReachabilityMock stub] andReturnValue:[NSNumber numberWithBool:YES]] mayBeReachable];
+    });
+    return sharedReachabilityMock;
 }
 
 @end

--- a/Tests/Source/UserSession/UnauthenticatedSessionTests.swift
+++ b/Tests/Source/UserSession/UnauthenticatedSessionTests.swift
@@ -1,0 +1,104 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import WireSyncEngine
+
+final class TestTransportSession: TransportSession {
+    public var reachabilityProvider: ReachabilityProvider
+    public var testReachability: TestReachability
+    public var cookieStorage = ZMPersistentCookieStorage()
+    
+    init() {
+        testReachability = TestReachability()
+        reachabilityProvider = testReachability
+    }
+    
+    public func attemptToEnqueueSyncRequestWithGenerator(_ generator: @escaping ZMTransportRequestGenerator) -> ZMTransportEnqueueResult {
+        return ZMTransportEnqueueResult(didHaveLessRequestsThanMax: true, didGenerateNonNullRequest: false)
+    }
+}
+
+final class TestReachability: ReachabilityProvider {
+    public var mayBeReachable: Bool = true
+}
+
+final class TestAuthenticationObserver: NSObject, ZMAuthenticationObserver {
+    public var authenticationDidSucceedEvents: Int = 0
+    public var authenticationDidFailEvents: [Error] = []
+    
+    private var observationToken: ZMAuthenticationObserverToken! = nil
+    
+    override init() {
+        super.init()
+        observationToken = ZMUserSessionAuthenticationNotification.addObserver(self)
+    }
+    
+    deinit {
+        ZMUserSessionAuthenticationNotification.removeObserver(for: observationToken)
+    }
+    
+    func authenticationDidSucceed() {
+        authenticationDidSucceedEvents = authenticationDidSucceedEvents + 1
+    }
+    
+    func authenticationDidFail(_ error: Error) {
+        authenticationDidFailEvents.append(error)
+    }
+}
+
+public final class UnauthenticatedSessionTests: XCTestCase {
+    var transportSession: TestTransportSession!
+    var sut: UnauthenticatedSession!
+    
+    public override func setUp() {
+        super.setUp()
+        transportSession = TestTransportSession()
+        sut = UnauthenticatedSession(transportSession: transportSession, delegate: nil)
+    }
+    
+    public override func tearDown() {
+        super.tearDown()
+        sut = nil
+        transportSession = nil
+    }
+    
+    func testThatDuringLoginItThrowsErrorWhenNoCredentials() {
+        let observer = TestAuthenticationObserver()
+        // given
+        transportSession.testReachability.mayBeReachable = false
+        // when
+        sut.login(with: ZMCredentials())
+        // then
+        XCTAssertEqual(observer.authenticationDidSucceedEvents, 0)
+        XCTAssertEqual(observer.authenticationDidFailEvents.count, 1)
+        XCTAssertEqual(observer.authenticationDidFailEvents[0].localizedDescription, NSError.userSessionErrorWith(.needsCredentials, userInfo:nil).localizedDescription)
+    }
+    
+    func testThatDuringLoginItThrowsErrorWhenOffline() {
+        let observer = TestAuthenticationObserver()
+        // given
+        transportSession.testReachability.mayBeReachable = false
+        // when
+        sut.login(with: ZMEmailCredentials(email: "my@mail.com", password: "my-password"))
+        // then
+        XCTAssertEqual(observer.authenticationDidSucceedEvents, 0)
+        XCTAssertEqual(observer.authenticationDidFailEvents.count, 1)
+        XCTAssertEqual(observer.authenticationDidFailEvents[0].localizedDescription, NSError.userSessionErrorWith(.networkError, userInfo:nil).localizedDescription)
+    }
+}

--- a/Tests/Source/UserSession/UnauthenticatedSessionTests.swift
+++ b/Tests/Source/UserSession/UnauthenticatedSessionTests.swift
@@ -73,9 +73,9 @@ public final class UnauthenticatedSessionTests: XCTestCase {
     }
     
     public override func tearDown() {
-        super.tearDown()
         sut = nil
         transportSession = nil
+        super.tearDown()
     }
     
     func testThatDuringLoginItThrowsErrorWhenNoCredentials() {

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -269,6 +269,7 @@
 		872C99601DB6722C006A3BDE /* ZMCallKitDelegateTests+Mocking.m in Sources */ = {isa = PBXBuildFile; fileRef = 872C995F1DB6722C006A3BDE /* ZMCallKitDelegateTests+Mocking.m */; };
 		874F142D1C16FD9700C15118 /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874F142C1C16FD9700C15118 /* Device.swift */; };
 		87508EA01D08264000162483 /* ZMSound.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87508E9F1D08264000162483 /* ZMSound.swift */; };
+		8766853C1F2A1AA00031081B /* UnauthenticatedSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8766853A1F2A1A860031081B /* UnauthenticatedSessionTests.swift */; };
 		878F63E51EF91E7C006E819B /* HotFixDuplicatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878F63E41EF91E7C006E819B /* HotFixDuplicatesTests.swift */; };
 		8795A3D51B2EDE030047A067 /* ZMAVSBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 8795A3D21B2EDE030047A067 /* ZMAVSBridge.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8795A3D71B2EDE030047A067 /* ZMAVSBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 8795A3D31B2EDE030047A067 /* ZMAVSBridge.m */; };
@@ -809,6 +810,7 @@
 		872C995F1DB6722C006A3BDE /* ZMCallKitDelegateTests+Mocking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ZMCallKitDelegateTests+Mocking.m"; sourceTree = "<group>"; };
 		874F142C1C16FD9700C15118 /* Device.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Device.swift; sourceTree = "<group>"; };
 		87508E9F1D08264000162483 /* ZMSound.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMSound.swift; sourceTree = "<group>"; };
+		8766853A1F2A1A860031081B /* UnauthenticatedSessionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnauthenticatedSessionTests.swift; sourceTree = "<group>"; };
 		878F63E41EF91E7C006E819B /* HotFixDuplicatesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HotFixDuplicatesTests.swift; sourceTree = "<group>"; };
 		8795A3D21B2EDE030047A067 /* ZMAVSBridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZMAVSBridge.h; sourceTree = "<group>"; };
 		8795A3D31B2EDE030047A067 /* ZMAVSBridge.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMAVSBridge.m; sourceTree = "<group>"; };
@@ -1448,6 +1450,7 @@
 				F9D1CD131DF6C131002F6E80 /* SyncStatusTests.swift */,
 				160C31491E82AC170012E4BC /* OperationStatusTests.swift */,
 				16A702CF1E92998100B8410D /* ApplicationStatusDirectoryTests.swift */,
+				8766853A1F2A1A860031081B /* UnauthenticatedSessionTests.swift */,
 			);
 			path = UserSession;
 			sourceTree = "<group>";
@@ -2397,6 +2400,7 @@
 				549AEA3F1D636EF3003C0BEC /* AddressBookUploadRequestStrategyTest.swift in Sources */,
 				F96C8E8A1D7F6F8C004B6D87 /* ZMLocalNotificationForSystemMessageTests.swift in Sources */,
 				F925468E1C63B61000CE2D7C /* MessagingTest+EventFactory.m in Sources */,
+				8766853C1F2A1AA00031081B /* UnauthenticatedSessionTests.swift in Sources */,
 				09D7A88A1AE7E591008F190C /* ZMPhoneNumberVerificationTranscoderTests.m in Sources */,
 				542DFEE81DDCA4FD000F5B95 /* UserProfileUpdateRequestStrategyTests.swift in Sources */,
 				548241F01AB09C1500E0ED07 /* APNSTests.m in Sources */,


### PR DESCRIPTION
# Issue

On automation it was noticed that the login error is not always appearing. The error is produced by the timer in `ZMAuthenticationStatus`. I checked the timer and it worked correctly.

The improvement proposed here is to fail the login if the device appears to be offline.