### PR TITLE
Fix core data multithreading assertion when setting context type on eventMOC

### DIFF
--- a/Source/Synchronization/NSManagedObjectContext+EventDecoder.swift
+++ b/Source/Synchronization/NSManagedObjectContext+EventDecoder.swift
@@ -34,8 +34,9 @@ extension NSManagedObjectContext {
         let managedObjectContext = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
         managedObjectContext.persistentStoreCoordinator = eventPersistentStoreCoordinator
         managedObjectContext.createDispatchGroups()
-        managedObjectContext.isEventMOC = true
-        
+        managedObjectContext.performGroupedBlock {
+            managedObjectContext.isEventMOC = true
+        }
         addPersistentStore(eventPersistentStoreCoordinator!, appGroupIdentifier: appGroupIdentifier)
         return managedObjectContext
     }


### PR DESCRIPTION
# What's in this PR?

* Fix core data multithreading assertion when setting context type on eventMOC.