### PR TITLE
fix/handle search

### DIFF
--- a/Source/UserSession/Search/SearchTask.swift
+++ b/Source/UserSession/Search/SearchTask.swift
@@ -234,19 +234,23 @@ extension SearchTask {
                     return
                 }
                 
-                if let prevResult = self?.result, let firstResult = self?.result.directory.first {
-                    if !prevResult.directory.contains(firstResult) {
-                        self?.result = SearchResult(
-                            contacts: prevResult.contacts,
-                            teamMembers: prevResult.teamMembers,
-                            addressBook: prevResult.addressBook,
-                            directory: result.directory + prevResult.directory,
-                            conversations: prevResult.conversations
-                        )
+                if let user = result.directory.first {
+                    if let prevResult = self?.result {
+                        // prepend result to prevResult only if it doesn't contain it
+                        if !prevResult.directory.contains(user) {
+                            self?.result = SearchResult(
+                                contacts: prevResult.contacts,
+                                teamMembers: prevResult.teamMembers,
+                                addressBook: prevResult.addressBook,
+                                directory: result.directory + prevResult.directory,
+                                conversations: prevResult.conversations
+                            )
+                        }
+                    } else {
+                        self?.result = result
                     }
-                } else {
-                    self?.result = result
                 }
+                
             }))
             
             request.add(ZMTaskCreatedHandler(on: self.context, block: { [weak self] (taskIdentifier) in


### PR DESCRIPTION
## Problem:
I overlooked a small error in an if condition when checking the results of a handle search request. I was trying to unpack the first directory element of the previous search result instead of the current search result.

Also, I split `if let` statements because the current result should overwrite `self.result` only if there doesn't exist a previous result, not if there is a previous result but no new result.