### PR TITLE
Delete keychain items on a fresh install

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -128,6 +128,7 @@ public class SessionManager : NSObject {
                 createSession()
             }
         } else {
+            transportSession.cookieStorage.deleteUserKeychainItems()
             let unauthenticatedSession = UnauthenticatedSession(transportSession: transportSession, delegate: self)
             self.unauthenticatedSession = unauthenticatedSession
             delegate?.sessionManagerCreated(unauthenticatedSession: unauthenticatedSession)


### PR DESCRIPTION
Some devices would retain the cookie in the keychain causing the
login to get stuck. We can't work around this by deleting all keychain
items if we don't have data store. This fix is not necessary in the
upcoming multi account setup.

https://wearezeta.atlassian.net/browse/ZIOS-8844