### PR TITLE
Move blacklist checker to SessionManager

### DIFF
--- a/Source/Public/WireSyncEngine.h
+++ b/Source/Public/WireSyncEngine.h
@@ -32,6 +32,7 @@
 #import <WireSyncEngine/ZMOnDemandFlowManager.h>
 
 // PRIVATE
+#import <WireSyncEngine/ZMBlacklistVerificator.h>
 #import <WireSyncEngine/ZMUserSession+Private.h>
 #import <WireSyncEngine/ZMPushRegistrant.h>
 #import <WireSyncEngine/ZMNotifications+UserSession.h>

--- a/Source/Public/ZMUserSession.h
+++ b/Source/Public/ZMUserSession.h
@@ -85,13 +85,6 @@ extern NSString * const ZMTransportRequestLoopNotificationName;
 @property (atomic, readonly) ZMNetworkState networkState;
 @property (atomic) BOOL isNotificationContentHidden;
 
-/**
- Starts session and checks if client version is not in black list.
- Version should be a build number. blackListedBlock is retained and called only if passed version is black listed. The block is 
- called only once, even if the file is downloaded multiple times.
- */
-- (void)startAndCheckClientVersionWithCheckInterval:(NSTimeInterval)interval blackListedBlock:(void (^)())blackListed;
-
 - (void)start;
 
 /// Performs a save in the context

--- a/Source/UserSession/ZMBlacklistVerificator.h
+++ b/Source/UserSession/ZMBlacklistVerificator.h
@@ -24,12 +24,16 @@
 
 @interface ZMBlacklistVerificator : NSObject
 
+NS_ASSUME_NONNULL_BEGIN
+
 - (instancetype)initWithCheckInterval:(NSTimeInterval)checkInterval
                               version:(NSString *)version
-                         workingGroup:(ZMSDispatchGroup *)workingGroup
+                         workingGroup:(ZMSDispatchGroup * _Nullable)workingGroup
                           application:(id<ZMApplication>)application
                     blacklistCallback:(void (^)(BOOL))blacklistCallback;
 
 - (void)teardown;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -68,7 +68,6 @@ static NSString * const AppstoreURL = @"https://itunes.apple.com/us/app/zeta-cli
 @property (nonatomic) ZMBlacklistVerificator *blackList;
 @property (nonatomic) ZMAPNSEnvironment *apnsEnvironment;
 
-@property (nonatomic) BOOL isVersionBlacklisted;
 @property (nonatomic) ZMOnDemandFlowManager *onDemandFlowManager;
 
 @property (nonatomic) ZMPushRegistrant *pushRegistrant;
@@ -435,23 +434,6 @@ ZM_EMPTY_ASSERTING_INIT()
 - (void)setMediaManager:(AVSMediaManager *)delegate;
 {
     NOT_USED(delegate);
-}
-
-- (void)startAndCheckClientVersionWithCheckInterval:(NSTimeInterval)interval blackListedBlock:(void (^)())blackListed;
-{
-    [self start];
-    ZM_WEAK(self);
-    self.blackList = [[ZMBlacklistVerificator alloc] initWithCheckInterval:interval
-                                                                   version:self.appVersion
-                                                              workingGroup:self.syncManagedObjectContext.dispatchGroup
-                                                               application:self.application
-                                                         blacklistCallback:^(BOOL isBlackListed) {
-        ZM_STRONG(self);
-        if (!self.isVersionBlacklisted && isBlackListed && blackListed) {
-            blackListed();
-            self.isVersionBlacklisted = YES;
-        }
-    }];
 }
 
 - (void)start;

--- a/Tests/Source/Integration/IntegrationTest.swift
+++ b/Tests/Source/Integration/IntegrationTest.swift
@@ -414,6 +414,10 @@ extension IntegrationTest {
 
 extension IntegrationTest : SessionManagerDelegate {
     
+    public func sessionManagerDidBlacklistCurrentVersion() {
+        
+    }
+    
     public func sessionManagerCreated(userSession: ZMUserSession) {
         self.userSession = userSession
         

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -46,6 +46,11 @@ class MockLocalStoreProvider: NSObject, LocalStoreProviderProtocol {
 }
 
 class SessionManagerTestDelegate: SessionManagerDelegate {
+    
+    func sessionManagerDidBlacklistCurrentVersion() {
+        
+    }
+
     var unauthenticatedSession : UnauthenticatedSession?
     func sessionManagerCreated(unauthenticatedSession : UnauthenticatedSession) {
         self.unauthenticatedSession = unauthenticatedSession

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		09E393BB1BAB0BB500F3EA1B /* ZMUserSession+OTR.h in Headers */ = {isa = PBXBuildFile; fileRef = 09E393B91BAB0BB500F3EA1B /* ZMUserSession+OTR.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		09E393BE1BAB0C2A00F3EA1B /* ZMUserSession+OTR.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E393BD1BAB0C2A00F3EA1B /* ZMUserSession+OTR.m */; };
 		160195611E30C9CF00ACBFAC /* LocalNotificationDispatcherCallingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160195601E30C9CF00ACBFAC /* LocalNotificationDispatcherCallingTests.swift */; };
+		1602B4611F3B04150061C135 /* ZMBlacklistVerificator.h in Headers */ = {isa = PBXBuildFile; fileRef = F9FD798B19EE9B9A00D70FCD /* ZMBlacklistVerificator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		160C31271E6434500012E4BC /* OperationStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160C31261E6434500012E4BC /* OperationStatus.swift */; };
 		160C31411E6DDFC30012E4BC /* VoiceChannelV3Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160C31401E6DDFC30012E4BC /* VoiceChannelV3Tests.swift */; };
 		160C31441E8049320012E4BC /* ApplicationStatusDirectory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160C31431E8049320012E4BC /* ApplicationStatusDirectory.swift */; };
@@ -2086,6 +2087,7 @@
 				F9B71F471CB29600001DB03F /* ZMBareUser+UserSession.h in Headers */,
 				3E17FA671A6690AA00DFA12F /* ZMPushRegistrant.h in Headers */,
 				54DE26B31BC56E62002B5FBC /* ZMHotFixDirectory.h in Headers */,
+				1602B4611F3B04150061C135 /* ZMBlacklistVerificator.h in Headers */,
 				5430E9251BAA0D9F00395E05 /* WireSyncEngineLogs.h in Headers */,
 				1618B4101DE5FAD4003F015C /* ZMUserSession+Internal.h in Headers */,
 				1EB871501BF502A000AF5CE1 /* ZMUserTranscoder.h in Headers */,


### PR DESCRIPTION
### problem
Since the introduction of the core-data free login blacklisting is not enforced until you've logged in. 

### solution
Move the blacklist checker from `ZMUserSession` to `SessionManager`.

### testing
It would be nice to write a test for blacklist logic inside SessionManager.  In order to do so we should create a protocol for the`ZMBlacklistVerificator` and inject it into the SessionManager. I would do this a follow up PR since I want to continue with the RC.