### PR TITLE
Retain local store provider until store is created

### DIFF
--- a/Source/SessionManager/LocalStoreProvider.swift
+++ b/Source/SessionManager/LocalStoreProvider.swift
@@ -45,15 +45,18 @@ public extension Bundle {
     }
 
     public func createStorageStack(migration: (() -> Void)?, completion: @escaping (LocalStoreProviderProtocol) -> Void) {
+        var strongSelf : LocalStoreProvider? = self
+        
         StorageStack.shared.createManagedObjectContextDirectory(
             accountIdentifier: userIdentifier,
             applicationContainer: sharedContainerDirectory,
             dispatchGroup: dispatchGroup,
             startedMigrationCallback: { migration?() },
-            completionHandler: { [weak self] contextDirectory in
-                guard let `self` = self else { return }
+            completionHandler: { contextDirectory in
+                guard let `self` = strongSelf else { return }
                 self.contextDirectory = contextDirectory
                 completion(self)
+                strongSelf = nil
             }
         )
     }


### PR DESCRIPTION
The `LocalStoreProvider` got deallocated before the store was created when not using an in-memory store because it's created asynchronously. This PR attempts to fix this by having the `LocalStoreProvider` retain itself until its completion block has been executed.