### PR TITLE
Move LocalStoreProvider creation into static function

### DIFF
--- a/Source/Synchronization/ZMSyncStrategy.m
+++ b/Source/Synchronization/ZMSyncStrategy.m
@@ -134,7 +134,7 @@ ZM_EMPTY_ASSERTING_INIT()
         self.uiMOC = storeProvider.contextDirectory.uiContext;
         self.hotFix = [[ZMHotFix alloc] initWithSyncMOC:self.syncMOC];
 
-        self.eventMOC = [NSManagedObjectContext createEventContextWithSharedContainerURL:storeProvider.sharedContainerDirectory userIdentifier:storeProvider.userIdentifier];
+        self.eventMOC = [NSManagedObjectContext createEventContextWithSharedContainerURL:storeProvider.applicationContainer userIdentifier:storeProvider.userIdentifier];
         [self.eventMOC addGroup:self.syncMOC.dispatchGroup];
         
         self.applicationStatusDirectory = [[ZMApplicationStatusDirectory alloc] initWithManagedObjectContext:self.syncMOC

--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -193,8 +193,8 @@ ZM_EMPTY_ASSERTING_INIT()
         }];
         self.managedObjectContext.zm_syncContext = self.syncManagedObjectContext;
         
-        NSURL *cacheLocation = [NSFileManager.defaultManager cachesURLForAccountWith:storeProvider.userIdentifier in:storeProvider.sharedContainerDirectory];
-        [self.class moveCachesIfNeededForAccountWith:storeProvider.userIdentifier in:storeProvider.sharedContainerDirectory];
+        NSURL *cacheLocation = [NSFileManager.defaultManager cachesURLForAccountWith:storeProvider.userIdentifier in:storeProvider.applicationContainer];
+        [self.class moveCachesIfNeededForAccountWith:storeProvider.userIdentifier in:storeProvider.applicationContainer];
         
         UserImageLocalCache *userImageCache = [[UserImageLocalCache alloc] initWithLocation:cacheLocation];
         self.managedObjectContext.zm_userImageCache = userImageCache;
@@ -263,7 +263,7 @@ ZM_EMPTY_ASSERTING_INIT()
         }];
         [self enableBackgroundFetch];
 
-        self.storedDidSaveNotifications = [[ContextDidSaveNotificationPersistence alloc] initWithSharedContainerURL:self.storeProvider.sharedContainerDirectory];
+        self.storedDidSaveNotifications = [[ContextDidSaveNotificationPersistence alloc] initWithSharedContainerURL:self.storeProvider.applicationContainer];
         
         if ([self.class useCallKit]) {
             CXProvider *provider = [[CXProvider alloc] initWithConfiguration:[ZMCallKitDelegate providerConfiguration]];
@@ -380,7 +380,7 @@ ZM_EMPTY_ASSERTING_INIT()
 
 - (NSURL *)sharedContainerURL
 {
-    return self.storeProvider.sharedContainerDirectory;
+    return self.storeProvider.applicationContainer;
 }
 
 - (void)didRequestToOpenSyncConversation:(NSNotification *)note

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -99,12 +99,14 @@ class SessionManagerTests: IntegrationTest {
         account.cookieStorage().authenticationCookieData = NSData.secureRandomData(ofLength: 16)
         manager.addAndSelect(account)
 
-        let provider = LocalStoreProvider(sharedContainerDirectory: sharedContainer, userIdentifier: currentUserIdentifier)
         var completed = false
-        provider.createStorageStack(migration: nil) { configuration in
-            completed = true
-        }
-
+        LocalStoreProvider.createStack(
+            applicationContainer: sharedContainer,
+            userIdentifier: currentUserIdentifier,
+            dispatchGroup: dispatchGroup,
+            completion: { _ in completed = true }
+        )
+        
         XCTAssert(wait(withTimeout: 0.5) { completed })
 
         // when

--- a/Tests/Source/UserSession/ZMUserSessionTestsBase.h
+++ b/Tests/Source/UserSession/ZMUserSessionTestsBase.h
@@ -55,7 +55,7 @@
 @interface MockLocalStoreProvider : NSObject <LocalStoreProviderProtocol>
 
 @property (nonatomic, copy) NSUUID *userIdentifier;
-@property (nonatomic, copy) NSURL *sharedContainerDirectory;
+@property (nonatomic, copy) NSURL *applicationContainer;
 @property (nonatomic, strong) ManagedObjectContextDirectory *contextDirectory;
 
 - (instancetype)initWithSharedContainerDirectory:(NSURL *)sharedContainerDirectory userIdentifier:(NSUUID *)userIdentifier contextDirectory:(ManagedObjectContextDirectory *)contextDirectory;

--- a/Tests/Source/UserSession/ZMUserSessionTestsBase.m
+++ b/Tests/Source/UserSession/ZMUserSessionTestsBase.m
@@ -30,7 +30,7 @@
     self = [super init];
     if (self) {
         self.userIdentifier = userIdentifier;
-        self.sharedContainerDirectory = sharedContainerDirectory;
+        self.applicationContainer = sharedContainerDirectory;
         self.contextDirectory = contextDirectory;
     }
     return self;


### PR DESCRIPTION
# What's in this PR?

The `LocalStoreProvider` object is not retained in the `SessionManager` (neither should or was `self`in any of the involved completion handlers), but only used to invoke the `create...` method method on it which in turn will pass a complete instance of `LocalStoreProvider` in its completion handler. This instance is then passed to the user session init. This API design had a couple of shortcomings which are addressed in this PR.

Before this change an instance of `LocalStoreProvider` was created with its `contextDirectory` set to `nil`. After invoking the async `create...` method on that object the completion handler was called passing on the object itself with the directory set. This PR converts the `create...` method to be a `static` one. The completion handler still hands over a `LocalStoreProvider` instance, but now there is a guarantee that every instance will always hold a `ManagedObjectContextDirectory`.