### PR TITLE
guard against registering for remote notifications when using simulator

### DIFF
--- a/Source/UserSession/ZMUserSession+Background.m
+++ b/Source/UserSession/ZMUserSession+Background.m
@@ -136,6 +136,12 @@ static NSString *ZMLogTag = @"Push";
 - (void)setupPushNotificationsForApplication:(id<ZMApplication>)application
 {
     [application registerForRemoteNotifications];
+    
+#if TARGET_OS_SIMULATOR
+    ZMLogInfo(@"Skipping request for remote notification permission on simulator.");
+    return;
+    
+#else
     NSSet *categories = [NSSet setWithArray:@[
                                               self.replyCategory,
                                               self.replyCategoryIncludingLike,
@@ -147,6 +153,7 @@ static NSString *ZMLogTag = @"Push";
                                                                                                  UIUserNotificationTypeAlert |
                                                                                                  UIUserNotificationTypeBadge)
                                                                                      categories:categories]];
+#endif
 }
 
 

--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -56,6 +56,8 @@ NSString * const ZMFlowManagerDidBecomeAvailableNotification = @"ZMFlowManagerDi
 
 static NSString * const AppstoreURL = @"https://itunes.apple.com/us/app/zeta-client/id930944768?ls=1&mt=8";
 
+static NSString *ZMLogTag = @"Push";
+
 
 @interface ZMUserSession ()
 @property (nonatomic) ZMOperationLoop *operationLoop;
@@ -437,6 +439,11 @@ ZM_EMPTY_ASSERTING_INIT()
 
 - (void)registerForRemoteNotifications
 {
+#if TARGET_OS_SIMULATOR
+    ZMLogInfo(@"Skipping remote notification registration for simulator.");
+    return;
+    
+#else
     [self.managedObjectContext performGroupedBlock:^{
         // Refresh the Voip token if needed
         NSData *actualToken = self.pushRegistrant.pushToken;
@@ -448,6 +455,7 @@ ZM_EMPTY_ASSERTING_INIT()
         // Request the current token, the rest is taken care of
         [self setupPushNotificationsForApplication:self.application];
     }];
+#endif
 }
 
 - (void)resetPushTokens

--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -56,8 +56,6 @@ NSString * const ZMFlowManagerDidBecomeAvailableNotification = @"ZMFlowManagerDi
 
 static NSString * const AppstoreURL = @"https://itunes.apple.com/us/app/zeta-client/id930944768?ls=1&mt=8";
 
-static NSString *ZMLogTag = @"Push";
-
 
 @interface ZMUserSession ()
 @property (nonatomic) ZMOperationLoop *operationLoop;
@@ -439,11 +437,6 @@ ZM_EMPTY_ASSERTING_INIT()
 
 - (void)registerForRemoteNotifications
 {
-#if TARGET_OS_SIMULATOR
-    ZMLogInfo(@"Skipping remote notification registration for simulator.");
-    return;
-    
-#else
     [self.managedObjectContext performGroupedBlock:^{
         // Refresh the Voip token if needed
         NSData *actualToken = self.pushRegistrant.pushToken;
@@ -455,7 +448,6 @@ ZM_EMPTY_ASSERTING_INIT()
         // Request the current token, the rest is taken care of
         [self setupPushNotificationsForApplication:self.application];
     }];
-#endif
 }
 
 - (void)resetPushTokens


### PR DESCRIPTION
## Problem
When registering for remote notifications, we were not checking if the app was being run on the device, which has no push notifications.

## Solution
Before registering for notifications, we now check if the simulator is being used, if so, we log a message and return early.