### PR TITLE
Do not set account image for accounts with team

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -393,7 +393,7 @@ extension SessionManager {
             if let userName = selfUser.name {
                 account.userName = userName
             }
-            if let userProfileImage = selfUser.imageSmallProfileData {
+            if let userProfileImage = selfUser.imageSmallProfileData, team == nil {
                 account.imageData = userProfileImage
             }
             accountManager.add(account)

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -165,12 +165,15 @@ class SessionManagerTests_Teams: IntegrationTest {
         XCTAssert(login())
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
+        let _ = MockAsset(in: mockTransportSession.managedObjectContext, forID: selfUser.previewProfileAssetIdentifier!)
+        
         // then
         guard let sharedContainer = Bundle.main.appGroupIdentifier.map(FileManager.sharedContainerDirectory) else { return XCTFail() }
         let manager = AccountManager(sharedDirectory: sharedContainer)
         guard let account = manager.accounts.first, manager.accounts.count == 1 else { XCTFail("Should have one account"); return }
         XCTAssertEqual(account.userIdentifier.transportString(), self.selfUser.identifier)
         XCTAssertEqual(account.teamName, teamName)
+        XCTAssertNil(account.imageData)
     }
     
     func testThatItUpdatesAccountAfterTeamNameChanges() {


### PR DESCRIPTION
- Team accounts should use team image, even if it's not available yet.