### PR TITLE
Relax constraint on finding unknown files in the Caches directory

### DIFF
--- a/Source/UserSession/FileRelocator.swift
+++ b/Source/UserSession/FileRelocator.swift
@@ -60,7 +60,7 @@ extension ZMUserSession {
                 }
             }
         } else if result.unassigned.count > 0 {
-            fatal("Caches folder contains items that have not been assigned to an account. Items should always be assigned to an account. Use `FileManager.cachesURLForAccount(with accountIdentifier:, in sharedContainerURL:)` to get the default Cache location for the current account")
+            requireInternal(false, "Caches folder contains items that have not been assigned to an account. Items should always be assigned to an account. Use `FileManager.cachesURLForAccount(with accountIdentifier:, in sharedContainerURL:)` to get the default Cache location for the current account")
         }
     }
     


### PR DESCRIPTION
It's dangerous to crash the app on detecting any unknown files in the Caches directory since potentially
they could be created by the system. This PR will change the fatal to only crash on internal builds.