### PR TITLE
show missed call notification when using CallKit

### DIFF
--- a/Source/UserSession/CallStateObserver.swift
+++ b/Source/UserSession/CallStateObserver.swift
@@ -86,8 +86,7 @@ extension CallStateObserver : WireCallCenterCallStateObserver, WireCallCenterMis
             
             let systemMessage = self.systemMessageGenerator.appendSystemMessageIfNeeded(callState: callState, conversation: conversation, user: user, timeStamp: timeStamp)
             if systemMessage?.systemMessageType == .missedCall
-                && callState == .terminating(reason: .normal)
-                && conversation.conversationType == .group
+                && (callState == .terminating(reason: .canceled) || callState == .terminating(reason: .normal) && conversation.conversationType == .group)
             {
                 // group calls we didn't join, end with reason .normal. We should still insert a missed call in this case.
                 // since the systemMessageGenerator keeps track whether we joined or not, we can use it to decide whether we should show a missed call APNS


### PR DESCRIPTION
## Problem
With CallKit and notifications enabled, the user was not receiving any notifications that they had missed a call. More specifically, when A calls B, and B does not pickup and eventually A cancels or the call times out, then B will have no notification that A ever called.

## Solution
When observing the call state, we were only generating a missed call notification when the user missed a group call that was terminated normally. We now generate the notification if the previous condition is true **OR** the call was canceled (from the sender side).