### PR TITLE
Feature/block suspended account

### DIFF
--- a/Source/Public/NSError+ZMUserSession.h
+++ b/Source/Public/NSError+ZMUserSession.h
@@ -65,7 +65,9 @@ typedef NS_ENUM(NSUInteger, ZMUserSessionErrorCode) {
     /// The last user identity (email or phone number) cannot be removed.
     ZMUserSessionLastUserIdentityCantBeDeleted = 19,
     /// Access token expired and could not be renewed
-    ZMUserSessionAccessTokenExpired = 20
+    ZMUserSessionAccessTokenExpired = 20,
+    /// The user account is suspended and may not be logged in
+    ZMUserSessionAccountSuspended = 21
 };
 
 FOUNDATION_EXPORT NSString * const ZMUserSessionErrorDomain;

--- a/Source/Synchronization/Transcoders/ZMLoginTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMLoginTranscoder.m
@@ -222,7 +222,11 @@ NSTimeInterval DefaultPendingValidationLoginAttemptInterval = 5;
         [self.userInfoParser parseUserInfoFromResponse:response];
     }
     else if (response.result == ZMTransportResponseStatusPermanentError) {
-        if (sync == self.timedDownstreamSync) {
+        
+        if ([self isResponseForSuspendedAccount:response]) {
+            [authenticationStatus didFailLoginBecauseAccountSuspended];
+        }
+        else if (sync == self.timedDownstreamSync) {
             
             if([self isResponseForPendingEmailActionvation:response]) {
                 if (self.isWaitingForEmailVerification) {
@@ -259,6 +263,12 @@ NSTimeInterval DefaultPendingValidationLoginAttemptInterval = 5;
 {
     NSString *label = [response.payload asDictionary][@"label"];
     return [label isEqualToString:@"pending-activation"];
+}
+
+- (BOOL)isResponseForSuspendedAccount:(ZMTransportResponse *)response
+{
+    NSString *label = [response.payload asDictionary][@"label"];
+    return response.HTTPStatus == 403 && [label isEqualToString:@"suspended"];
 }
 
 @end

--- a/Source/UnauthenticatedSession/ZMAuthenticationStatus.h
+++ b/Source/UnauthenticatedSession/ZMAuthenticationStatus.h
@@ -101,6 +101,7 @@ typedef NS_ENUM(NSUInteger, ZMAuthenticationPhase) {
 - (void)didFailLoginWithPhone:(BOOL)invalidCredentials;
 - (void)didFailLoginWithEmailBecausePendingValidation;
 - (void)didFailLoginWithEmail:(BOOL)invalidCredentials;
+- (void)didFailLoginBecauseAccountSuspended;
 - (void)didTimeoutLoginForCredentials:(ZMCredentials *)credentials;
 
 @end

--- a/Source/UnauthenticatedSession/ZMAuthenticationStatus.m
+++ b/Source/UnauthenticatedSession/ZMAuthenticationStatus.m
@@ -378,6 +378,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"Authentication";
     ZMLogDebug(@"%@", NSStringFromSelector(_cmd));
     NSError *error = [NSError userSessionErrorWithErrorCode:ZMUserSessionAccountSuspended userInfo:nil];
     [ZMUserSessionAuthenticationNotification notifyAuthenticationDidFail:error];
+    [self resetLoginAndRegistrationStatus];
     ZMLogDebug(@"current phase: %lu", (unsigned long)self.currentPhase);
 }
 

--- a/Source/UnauthenticatedSession/ZMAuthenticationStatus.m
+++ b/Source/UnauthenticatedSession/ZMAuthenticationStatus.m
@@ -373,6 +373,14 @@ static NSString* ZMLogTag ZM_UNUSED = @"Authentication";
     ZMLogDebug(@"current phase: %lu", (unsigned long)self.currentPhase);
 }
 
+- (void)didFailLoginBecauseAccountSuspended
+{
+    ZMLogDebug(@"%@", NSStringFromSelector(_cmd));
+    NSError *error = [NSError userSessionErrorWithErrorCode:ZMUserSessionAccountSuspended userInfo:nil];
+    [ZMUserSessionAuthenticationNotification notifyAuthenticationDidFail:error];
+    ZMLogDebug(@"current phase: %lu", (unsigned long)self.currentPhase);
+}
+
 - (void)cancelWaitingForEmailVerification
 {
     ZMLogDebug(@"%@", NSStringFromSelector(_cmd));

--- a/Tests/Source/Synchronization/Transcoders/ZMLoginTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMLoginTranscoderTests.m
@@ -425,6 +425,39 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
     }];
 }
 
+- (void)testThatItCallsAuthenticationFailOnPhoneLoginWithSuspendedAccount
+{
+    // given
+    NSDictionary *content = @{@"code":@403,
+                              @"message":@"Account suspended.",
+                              @"label":@"suspended"};
+    [self.authenticationStatus prepareForLoginWithCredentials:[ZMPhoneCredentials credentialsWithPhoneNumber:@"+4912345678" verificationCode:@"123456"]];
+    ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:content HTTPStatus:403 transportSessionError:nil];
+    
+    // when
+    [self expectAuthenticationFailedWithError:ZMUserSessionAccountSuspended after:^{
+        [[self.sut nextRequest] completeWithResponse:response];
+        WaitForAllGroupsToBeEmpty(0.5);
+    }];
+}
+
+
+- (void)testThatItCallsAuthenticationFailOnEmailLoginWithSuspendedAccount
+{
+    // given
+    NSDictionary *content = @{@"code":@403,
+                              @"message":@"Account suspended.",
+                              @"label":@"suspended"};
+    [self.authenticationStatus prepareForLoginWithCredentials:[ZMEmailCredentials credentialsWithEmail:@"foo@example.com" password:@"12345678"]];
+    ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:content HTTPStatus:403 transportSessionError:nil];
+    
+    // when
+    [self expectAuthenticationFailedWithError:ZMUserSessionAccountSuspended after:^{
+        [[self.sut nextRequest] completeWithResponse:response];
+        WaitForAllGroupsToBeEmpty(0.5);
+    }];
+}
+
 -(void)testThatItInvalidatesTheCredentialsOnLoginErrorWhenLoggingWithEmail
 {
     // given


### PR DESCRIPTION
When attempting to sign in with a *suspended* account, backend will return the error code `403` with  label `suspended`. This PR adds the new error type and checks for it in the request response and sends the appropriate notification.