### PR TITLE
Discard notifications for other users

### DIFF
--- a/Source/Synchronization/ZMOperationLoop+Background.h
+++ b/Source/Synchronization/ZMOperationLoop+Background.h
@@ -28,4 +28,6 @@
 /// Process the payload of the remote notification. This may cause a @c UILocalNotification to be displayed.
 - (void)saveEventsAndSendNotificationForPayload:(NSDictionary *)payload fetchCompletionHandler:(ZMPushResultHandler)completionHandler source:(ZMPushNotficationType)source;
 
+/// Checks if notification refers to the current user.
+- (BOOL)notificationIsForCurrentUser:(NSDictionary *)userInfo;
 @end

--- a/Source/Synchronization/ZMOperationLoop.h
+++ b/Source/Synchronization/ZMOperationLoop.h
@@ -39,7 +39,7 @@ extern NSString * const ZMPushChannelResponseStatusKey;
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithTransportSession:(ZMTransportSession *)transportSession
                            cookieStorage:(ZMPersistentCookieStorage *)cookieStorage
-             localNotificationdispatcher:(LocalNotificationDispatcher *)dispatcher
+             localNotificationDispatcher:(LocalNotificationDispatcher *)dispatcher
                             mediaManager:(AVSMediaManager *)mediaManager
                              flowManager:(id<FlowManagerType>)flowManager
                            storeProvider:(id<LocalStoreProviderProtocol>)storeProvider

--- a/Source/Synchronization/ZMOperationLoop.m
+++ b/Source/Synchronization/ZMOperationLoop.m
@@ -72,7 +72,7 @@ static char* const ZMLogTag ZM_UNUSED = "OperationLoop";
 
 - (instancetype)initWithTransportSession:(ZMTransportSession *)transportSession
                            cookieStorage:(ZMPersistentCookieStorage *)cookieStorage
-             localNotificationdispatcher:(LocalNotificationDispatcher *)dispatcher
+             localNotificationDispatcher:(LocalNotificationDispatcher *)dispatcher
                             mediaManager:(AVSMediaManager *)mediaManager
                              flowManager:(id<FlowManagerType>)flowManager
                            storeProvider:(id<LocalStoreProviderProtocol>)storeProvider

--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -230,7 +230,7 @@ ZM_EMPTY_ASSERTING_INIT()
     
             self.operationLoop = operationLoop ?: [[ZMOperationLoop alloc] initWithTransportSession:session
                                                                                       cookieStorage:session.cookieStorage
-                                                                        localNotificationdispatcher:self.localNotificationDispatcher
+                                                                        localNotificationDispatcher:self.localNotificationDispatcher
                                                                                        mediaManager:mediaManager
                                                                                 flowManager:flowManager
                                                                                       storeProvider:storeProvider

--- a/Tests/Source/Synchronization/ZMOperationLoopTests.m
+++ b/Tests/Source/Synchronization/ZMOperationLoopTests.m
@@ -1017,6 +1017,47 @@
     [self.pingBackStatus verify];
 }
 
+- (void)testThatItUsesTheNotificationWithoutUserID
+{
+    // GIVEN
+    NSDictionary *pushPayload =  @{@"aps" : @{},
+                                   @"data" : @{
+                                           @"type" : @"notice"
+                                           }
+                                   };
+    // WHEN & THEN
+    XCTAssertTrue([self.sut notificationIsForCurrentUser:pushPayload]);
+}
+
+- (void)testThatItUsesTheNotificationForCurrentUser
+{
+    // GIVEN
+    ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
+    selfUser.remoteIdentifier = [NSUUID UUID];
+    
+    NSDictionary *pushPayload =  @{@"aps" : @{},
+                                   @"data" : @{
+                                           @"user": selfUser.remoteIdentifier.transportString,
+                                           @"type" : @"notice"
+                                           }
+                                   };
+    // WHEN & THEN
+    XCTAssertTrue([self.sut notificationIsForCurrentUser:pushPayload]);
+}
+
+- (void)testThatItIgnoresTheNotificationForOtherUser
+{
+    // GIVEN
+    NSDictionary *pushPayload =  @{@"aps" : @{},
+                                   @"data" : @{
+                                           @"user": [NSUUID UUID].transportString,
+                                           @"type" : @"notice"
+                                           }
+                                   };
+    // WHEN & THEN
+    XCTAssertFalse([self.sut notificationIsForCurrentUser:pushPayload]);
+}
+
 - (NSArray *)messageAddPayloadWithNonces:(NSArray <NSUUID *>*)nonces
 {
     return [nonces mapWithBlock:^NSDictionary *(NSUUID *nonce) {


### PR DESCRIPTION
# Issue

With the coming support of multiple users registering for the same push token the backend is going to include the user id into the incoming notification payload. In the future we are going to forward those notifications to the proper sync engine.

Currently the incoming notification could potentially be for the other user too, but we have no sync engine running for that user.

# Solution

We are going to temporarily discard the notifications that are coming not for the current user.