### PR TITLE
Fixed call config race condition

### DIFF
--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -421,7 +421,7 @@ public struct CallEvent {
     /// establishedDate - Date of when the call was established (Participants can talk to each other). This property is only valid when the call state is .established.
     public private(set) var establishedDate : Date?
     
-    public weak var transport : WireCallCenterTransport? = nil
+    fileprivate weak var transport : WireCallCenterTransport? = nil
     
     /// Used to collect incoming events (e.g. from fetching the notification stream) until AVS is ready to process them
     var bufferedEvents : [CallEvent]  = []
@@ -465,11 +465,12 @@ public struct CallEvent {
         avsWrapper.close()
     }
     
-    public required init(userId: UUID, clientId: String, avsWrapper: AVSWrapperType? = nil, uiMOC: NSManagedObjectContext, flowManager: FlowManagerType, analytics: AnalyticsType? = nil) {
+    public required init(userId: UUID, clientId: String, avsWrapper: AVSWrapperType? = nil, uiMOC: NSManagedObjectContext, flowManager: FlowManagerType, analytics: AnalyticsType? = nil, transport: WireCallCenterTransport) {
         self.selfUserId = userId
         self.uiMOC = uiMOC
         self.flowManager = flowManager
         self.analytics = analytics
+        self.transport = transport
         
         super.init()
         
@@ -492,7 +493,7 @@ public struct CallEvent {
     }
     
     fileprivate func requestCallConfig() {
-        zmLog.debug("\(self): requestCallConfig()")
+        zmLog.debug("\(self): requestCallConfig(), transport = \(String(describing: transport))")
         transport?.requestCallConfig(completionHandler: { [weak self] (config, httpStatusCode) in
             guard let `self` = self else { return }
             zmLog.debug("\(self): self.avsWrapper.update with \(String(describing: config))")

--- a/Source/Calling/WireCallCenterV3Factory.swift
+++ b/Source/Calling/WireCallCenterV3Factory.swift
@@ -24,11 +24,11 @@ public class WireCallCenterV3Factory : NSObject {
     
     public static var wireCallCenterClass : WireCallCenterV3.Type = WireCallCenterV3.self
     
-    public class func callCenter(withUserId userId: UUID, clientId: String, uiMOC: NSManagedObjectContext, flowManager: FlowManagerType, analytics: AnalyticsType? = nil) -> WireCallCenterV3 {
+    public class func callCenter(withUserId userId: UUID, clientId: String, uiMOC: NSManagedObjectContext, flowManager: FlowManagerType, analytics: AnalyticsType? = nil, transport: WireCallCenterTransport) -> WireCallCenterV3 {
         if let wireCallCenter =  WireCallCenterV3Factory.wireCallCenterClass.activeInstance {
             return wireCallCenter
         } else {
-            return WireCallCenterV3Factory.wireCallCenterClass.init(userId: userId, clientId: clientId, uiMOC: uiMOC, flowManager: flowManager, analytics: analytics)
+            return WireCallCenterV3Factory.wireCallCenterClass.init(userId: userId, clientId: clientId, uiMOC: uiMOC, flowManager: flowManager, analytics: analytics, transport: transport)
         }
     }
     

--- a/Tests/Source/Calling/CallStateObserverTests.swift
+++ b/Tests/Source/Calling/CallStateObserverTests.swift
@@ -177,7 +177,7 @@ class CallStateObserverTests : MessagingTest {
     
     func testThatWeKeepTheWebsocketOpenOnOutgoingCalls() {
         // expect
-        mockCallCenter = WireCallCenterV3Mock(userId: UUID.create(), clientId: "1234567", uiMOC: uiMOC, flowManager: FlowManagerMock())
+        mockCallCenter = WireCallCenterV3Mock(userId: UUID.create(), clientId: "1234567", uiMOC: uiMOC, flowManager: FlowManagerMock(), transport: WireCallCenterTransportMock())
         mockCallCenter?.mockNonIdleCalls = [conversation.remoteIdentifier! : .incoming(video: false, shouldRing: true)]
         
         expectation(forNotification: CallStateObserver.CallInProgressNotification.rawValue, object: nil) { (note) -> Bool in
@@ -198,7 +198,7 @@ class CallStateObserverTests : MessagingTest {
     
     func testThatWeSendNotificationWhenCallTerminates() {
         // given
-        mockCallCenter = WireCallCenterV3Mock(userId: UUID.create(), clientId: "1234567", uiMOC: uiMOC, flowManager: FlowManagerMock())
+        mockCallCenter = WireCallCenterV3Mock(userId: UUID.create(), clientId: "1234567", uiMOC: uiMOC, flowManager: FlowManagerMock(), transport: WireCallCenterTransportMock())
         mockCallCenter?.mockNonIdleCalls = [conversation.remoteIdentifier! : .incoming(video: false, shouldRing: true)]
         sut.callCenterDidChange(voiceChannelState: .incomingCall, conversation: conversation, callingProtocol: .version3)
         

--- a/Tests/Source/Calling/CallSystemMessageGeneratorTests.swift
+++ b/Tests/Source/Calling/CallSystemMessageGeneratorTests.swift
@@ -45,7 +45,7 @@ class CallSystemMessageGeneratorTests : MessagingTest {
         clientID = "foo"
         
         sut = WireSyncEngine.CallSystemMessageGenerator()
-        mockWireCallCenterV3 = WireCallCenterV3Mock(userId: selfUserID, clientId: clientID, uiMOC: uiMOC, flowManager: FlowManagerMock())
+        mockWireCallCenterV3 = WireCallCenterV3Mock(userId: selfUserID, clientId: clientID, uiMOC: uiMOC, flowManager: FlowManagerMock(), transport: WireCallCenterTransportMock())
     }
     
     override func tearDown() {

--- a/Tests/Source/Calling/VoiceChannelParticipantV3SnapshotTests.swift
+++ b/Tests/Source/Calling/VoiceChannelParticipantV3SnapshotTests.swift
@@ -28,7 +28,7 @@ class VoiceChannelParticipantV3SnapshotTests : MessagingTest {
     override func setUp() {
         super.setUp()
         mockFlowManager = FlowManagerMock()
-        mockWireCallCenterV3 = WireCallCenterV3Mock(userId: UUID(), clientId: "foo", uiMOC: uiMOC, flowManager: mockFlowManager)
+        mockWireCallCenterV3 = WireCallCenterV3Mock(userId: UUID(), clientId: "foo", uiMOC: uiMOC, flowManager: mockFlowManager, transport: WireCallCenterTransportMock())
     }
     
     override func tearDown() {

--- a/Tests/Source/Calling/VoiceChannelV3Tests.swift
+++ b/Tests/Source/Calling/VoiceChannelV3Tests.swift
@@ -38,7 +38,7 @@ class VoiceChannelV3Tests : MessagingTest {
         conversation = ZMConversation.insertNewObject(in: self.syncMOC)
         conversation?.remoteIdentifier = UUID.create()
         
-        wireCallCenterMock = WireCallCenterV3Mock(userId: selfUser.remoteIdentifier!, clientId: selfClient.remoteIdentifier!, uiMOC: uiMOC, flowManager: FlowManagerMock())
+        wireCallCenterMock = WireCallCenterV3Mock(userId: selfUser.remoteIdentifier!, clientId: selfClient.remoteIdentifier!, uiMOC: uiMOC, flowManager: FlowManagerMock(), transport: WireCallCenterTransportMock())
         
         sut = VoiceChannelV3(conversation: conversation!)
     }

--- a/Tests/Source/Calling/WireCallCenterV3Mock.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Mock.swift
@@ -95,9 +95,9 @@ public class WireCallCenterV3IntegrationMock : WireCallCenterV3 {
     
     public let mockAVSWrapper : MockAVSWrapper
     
-    public required init(userId: UUID, clientId: String, avsWrapper: AVSWrapperType? = nil, uiMOC: NSManagedObjectContext, flowManager: FlowManagerType, analytics: AnalyticsType? = nil) {
+    public required init(userId: UUID, clientId: String, avsWrapper: AVSWrapperType? = nil, uiMOC: NSManagedObjectContext, flowManager: FlowManagerType, analytics: AnalyticsType? = nil, transport: WireCallCenterTransport) {
         mockAVSWrapper = MockAVSWrapper(userId: userId, clientId: clientId, observer: nil)
-        super.init(userId: userId, clientId: clientId, avsWrapper: mockAVSWrapper, uiMOC: uiMOC, flowManager: flowManager)
+        super.init(userId: userId, clientId: clientId, avsWrapper: mockAVSWrapper, uiMOC: uiMOC, flowManager: flowManager, transport: transport)
     }
     
 }
@@ -153,9 +153,9 @@ public class WireCallCenterV3Mock : WireCallCenterV3 {
         return mockNonIdleCalls
     }
     
-    public required init(userId: UUID, clientId: String, avsWrapper: AVSWrapperType? = nil, uiMOC: NSManagedObjectContext, flowManager: FlowManagerType, analytics: AnalyticsType? = nil) {
+    public required init(userId: UUID, clientId: String, avsWrapper: AVSWrapperType? = nil, uiMOC: NSManagedObjectContext, flowManager: FlowManagerType, analytics: AnalyticsType? = nil, transport: WireCallCenterTransport) {
         mockAVSWrapper = MockAVSWrapper(userId: userId, clientId: clientId, observer: nil)
-        super.init(userId: userId, clientId: clientId, avsWrapper: mockAVSWrapper, uiMOC: uiMOC, flowManager: flowManager)
+        super.init(userId: userId, clientId: clientId, avsWrapper: mockAVSWrapper, uiMOC: uiMOC, flowManager: flowManager, transport: transport)
     }
 
     public func update(callState : CallState, conversationId: UUID, userId: UUID? = nil) {

--- a/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -43,6 +43,7 @@ class WireCallCenterV3Tests: MessagingTest {
     var sut : WireCallCenterV3!
     var selfUserID : UUID!
     var clientID: String!
+    var mockTransport = WireCallCenterTransportMock()
     
     override func setUp() {
         super.setUp()
@@ -50,7 +51,7 @@ class WireCallCenterV3Tests: MessagingTest {
         clientID = "foo"
         flowManager = FlowManagerMock()
         mockAVSWrapper = MockAVSWrapper(userId: selfUserID, clientId: clientID, observer: nil)
-        sut = WireCallCenterV3(userId: selfUserID, clientId: clientID, avsWrapper: mockAVSWrapper, uiMOC: uiMOC, flowManager: flowManager)
+        sut = WireCallCenterV3(userId: selfUserID, clientId: clientID, avsWrapper: mockAVSWrapper, uiMOC: uiMOC, flowManager: flowManager, transport: mockTransport)
     }
     
     override func tearDown() {
@@ -474,9 +475,7 @@ extension WireCallCenterV3Tests {
     
     func testThatCallConfigRequestsAreForwaredToTransportAndAVS() {
         // given
-        let mockTransport = WireCallCenterTransportMock()
         mockTransport.mockCallConfigResponse = ("call_config", 200)
-        sut.transport = mockTransport
         let context = Unmanaged.passUnretained(self.sut).toOpaque()
         
         // when

--- a/Tests/Source/Calling/ZMCallKitDelegateTests.swift
+++ b/Tests/Source/Calling/ZMCallKitDelegateTests.swift
@@ -194,7 +194,7 @@ class ZMCallKitDelegateTest: MessagingTest {
         let configuration = ZMCallKitDelegate.providerConfiguration()
         self.callKitProvider = MockCallKitProvider(configuration: configuration)
         self.callKitController = MockCallKitCallController()
-        self.mockWireCallCenterV3 = WireCallCenterV3Mock(userId: selfUser.remoteIdentifier!, clientId: "123", uiMOC: uiMOC, flowManager: flowManager)
+        self.mockWireCallCenterV3 = WireCallCenterV3Mock(userId: selfUser.remoteIdentifier!, clientId: "123", uiMOC: uiMOC, flowManager: flowManager, transport: WireCallCenterTransportMock())
         self.mockWireCallCenterV3.overridenCallingProtocol = .version2
         
         self.sut = ZMCallKitDelegate(callKitProvider: self.callKitProvider,

--- a/Tests/Source/UserSession/ZMUserSessionTestsBase+Calling.swift
+++ b/Tests/Source/UserSession/ZMUserSessionTestsBase+Calling.swift
@@ -26,7 +26,7 @@ extension ZMUserSessionTestsBase {
     @objc
     public func createCallCenter() -> WireCallCenterV3Mock {
         let selfUser = ZMUser.selfUser(in: self.syncMOC)
-        return WireCallCenterV3Factory.callCenter(withUserId: selfUser.remoteIdentifier!, clientId: selfUser.selfClient()!.remoteIdentifier!, uiMOC: uiMOC, flowManager: FlowManagerMock()) as! WireCallCenterV3Mock
+        return WireCallCenterV3Factory.callCenter(withUserId: selfUser.remoteIdentifier!, clientId: selfUser.selfClient()!.remoteIdentifier!, uiMOC: uiMOC, flowManager: FlowManagerMock(), transport: WireCallCenterTransportMock()) as! WireCallCenterV3Mock
     }
     
     @objc


### PR DESCRIPTION
# Issue

When the `WireCallCenterV3` is created we initialize the wcall in the init, and wcall is dispatching immediately asynchronously the callback to download the call config. The `transport` is necessary to download the call config, but it is assigned only after the `WireCallCenterV3.init` is done. This creates the race condition, where it could happen that the async callback from AVS could arrive before the init is done, so the transport is not assigned yet.

# Solution

Pass transport as an init argument, to guarantee that it is set when any callback is called.