### PR TITLE
Invalidate CallKit provider when tearing down a user session

### DIFF
--- a/Source/Calling/ZMCallKitDelegate.h
+++ b/Source/Calling/ZMCallKitDelegate.h
@@ -45,6 +45,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)reportCallWithUUID:(NSUUID *)UUID endedAtDate:(nullable NSDate *)dateEnded reason:(NSUInteger)endedReason;
 - (void)reportOutgoingCallWithUUID:(NSUUID *)UUID startedConnectingAtDate:(nullable NSDate *)dateStartedConnecting;
 - (void)reportOutgoingCallWithUUID:(NSUUID *)UUID connectedAtDate:(nullable NSDate *)dateConnected;
+
+/// Invalidates the provider and completes all active calls with an error.
+- (void)invalidate;
 @end
 
 /// Needed to unbound @c ZMCallKitDelegate from OS CallKit implementation (for testing).
@@ -66,6 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Finds the appropriate conversation described by the list of @c INPerson objects.
 + (nullable instancetype)resolveConversationForPersons:(NSArray<INPerson *> *)persons
                                              inContext:(NSManagedObjectContext *)context;
+
 @end
 
 

--- a/Source/Calling/ZMCallKitDelegate.m
+++ b/Source/Calling/ZMCallKitDelegate.m
@@ -196,6 +196,7 @@ NS_ASSUME_NONNULL_END
 
 - (void)dealloc
 {
+    [self.provider invalidate];
     [WireCallCenterV3 removeObserverWithToken:self.callStateObserverToken];
     [WireCallCenterV3 removeObserverWithToken:self.missedCallsObserverToken];
     [[NSNotificationCenter defaultCenter] removeObserver:self];

--- a/Tests/Source/Calling/ZMCallKitDelegateTests.swift
+++ b/Tests/Source/Calling/ZMCallKitDelegateTests.swift
@@ -24,8 +24,6 @@ import Intents
 @available(iOS 10.0, *)
 class MockCallKitProvider: NSObject, CallKitProviderType {
 
-
-
     required init(configuration: CXProviderConfiguration) {
         
     }
@@ -61,6 +59,12 @@ class MockCallKitProvider: NSObject, CallKitProviderType {
     func reportOutgoingCall(with UUID: UUID, startedConnectingAt dateStartedConnecting: Date?) {
         timesReportOutgoingCallStartedConnectingCalled += 1
     }
+    
+    public var isInvalidated : Bool = false
+    func invalidate() {
+        isInvalidated = true
+    }
+
 }
 
 @available(iOS 10.0, *)
@@ -249,6 +253,21 @@ class ZMCallKitDelegateTest: MessagingTest {
         
         // then
         XCTAssertEqual(configuration.ringtoneSound, customSoundName + ".m4a")
+    }
+    
+    func testThatItInvalidatesTheProviderOnDealloc() {
+        // given
+        sut = ZMCallKitDelegate(callKitProvider: self.callKitProvider,
+                          callController: self.callKitController,
+                          flowManager: FlowManagerMock(),
+                          userSession: self.mockUserSession,
+                          mediaManager: nil)
+        
+        // when
+        sut = nil
+        
+        // then
+        XCTAssertTrue(callKitProvider.isInvalidated)
     }
     
     // Public API - outgoing calls


### PR DESCRIPTION
It wasn't possible to receive or make calls after switching accounts, this seems to be caused by us not invalidating the old CallKit provider.