### PR TITLE
Remove NSNotificationCenter based notifications

### DIFF
--- a/Source/Calling/ZMCallFlowRequestStrategy.m
+++ b/Source/Calling/ZMCallFlowRequestStrategy.m
@@ -62,7 +62,7 @@ static NSString *ZMLogTag ZM_UNUSED = @"Calling";
         
         ZM_WEAK(self);
         self.pushChannelObserverToken = [NotificationInContext addObserverWithName:ZMOperationLoop.pushChannelStateChangeNotificationName
-                                           context:self.managedObjectContext
+                                           context:self.managedObjectContext.zm_userInterfaceContext
                                             object:nil
                                              queue:nil
                                              using:^(NotificationInContext * note) {

--- a/Source/Calling/ZMCallFlowRequestStrategy.m
+++ b/Source/Calling/ZMCallFlowRequestStrategy.m
@@ -35,6 +35,7 @@ static NSString *ZMLogTag ZM_UNUSED = @"Calling";
 @property (nonatomic, readonly, weak) NSManagedObjectContext *uiManagedObjectContext;
 @property (nonatomic, strong) dispatch_queue_t avsLogQueue;
 @property (nonatomic, readonly, weak) id<ZMApplication> application;
+@property (nonatomic) id pushChannelObserverToken;
 
 @end
 
@@ -59,7 +60,15 @@ static NSString *ZMLogTag ZM_UNUSED = @"Calling";
         self.flowManager = flowManager;
         self.flowManager.delegate = self;
         
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(pushChannelDidChange:) name:ZMPushChannelStateChangeNotificationName object:nil];
+        ZM_WEAK(self);
+        self.pushChannelObserverToken = [NotificationInContext addObserverWithName:ZMOperationLoop.pushChannelStateChangeNotificationName
+                                           context:self.managedObjectContext
+                                            object:nil
+                                             queue:nil
+                                             using:^(NotificationInContext * note) {
+                                                 ZM_STRONG(self);
+                                                 [self pushChannelDidChange:note];
+                                             }];
         self.pushChannelIsOpen = NO;
         self.avsLogQueue = dispatch_queue_create("AVSLog", DISPATCH_QUEUE_SERIAL);
     }
@@ -77,7 +86,7 @@ static NSString *ZMLogTag ZM_UNUSED = @"Calling";
 - (void)tearDown;
 {
     self.flowManager = nil;
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    self.pushChannelObserverToken = nil;
     [self.application unregisterObserverForStateChange:self];
 }
 
@@ -93,7 +102,7 @@ static NSString *ZMLogTag ZM_UNUSED = @"Calling";
     });
 }
 
-- (void)pushChannelDidChange:(NSNotification *)note
+- (void)pushChannelDidChange:(NotificationInContext *)note
 {
     BOOL newValue = [note.userInfo[ZMPushChannelIsOpenKey] boolValue];
     self.pushChannelIsOpen = newValue;

--- a/Source/Synchronization/Transcoders/ZMLoginTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMLoginTranscoder.m
@@ -93,7 +93,6 @@ NSTimeInterval DefaultPendingValidationLoginAttemptInterval = 5;
 
 - (void)tearDown
 {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
     [self.timedDownstreamSync invalidate];
 }
 

--- a/Source/Synchronization/Transcoders/ZMRegistrationTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMRegistrationTranscoder.m
@@ -35,6 +35,7 @@
 @property (nonatomic, readonly) ZMSingleRequestSync *registrationSync;
 @property (nonatomic, weak) ZMAuthenticationStatus *authenticationStatus;
 @property (nonatomic, weak) id<ZMSGroupQueue> groupQueue;
+@property (nonatomic) id authenticationObserverToken;
 
 @end
 
@@ -57,7 +58,7 @@
         self.userInfoParser = userInfoParser;
         _registrationSync = [ZMSingleRequestSync syncWithSingleRequestTranscoder:self groupQueue:groupQueue];
         self.authenticationStatus = authenticationStatus;
-        [authenticationStatus addAuthenticationCenterObserver:self];
+        self.authenticationObserverToken = [authenticationStatus addAuthenticationCenterObserver:self];
     }
     return self;
 }

--- a/Source/Synchronization/ZMOperationLoop+Notifications.swift
+++ b/Source/Synchronization/ZMOperationLoop+Notifications.swift
@@ -1,0 +1,25 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension ZMOperationLoop {
+    
+    public static let pushChannelStateChangeNotificationName = Notification.Name(rawValue: "ZMPushChannelStateChangeNotificationName")
+    
+}

--- a/Source/Synchronization/ZMOperationLoop.h
+++ b/Source/Synchronization/ZMOperationLoop.h
@@ -28,7 +28,6 @@
 
 @class ZMPersistentCookieStorage;
 
-extern NSString * const ZMPushChannelStateChangeNotificationName;
 extern NSString * const ZMPushChannelIsOpenKey;
 extern NSString * const ZMPushChannelResponseStatusKey;
 

--- a/Source/Synchronization/ZMOperationLoop.m
+++ b/Source/Synchronization/ZMOperationLoop.m
@@ -34,7 +34,6 @@
 #import "WireSyncEngineLogs.h"
 #import <WireSyncEngine/WireSyncEngine-Swift.h>
 
-NSString * const ZMPushChannelStateChangeNotificationName = @"ZMPushChannelStateChangeNotification";
 NSString * const ZMPushChannelIsOpenKey = @"pushChannelIsOpen";
 NSString * const ZMPushChannelResponseStatusKey = @"responseStatus";
 
@@ -334,14 +333,25 @@ static char* const ZMLogTag ZM_UNUSED = "OperationLoop";
 - (void)pushChannelDidClose:(ZMPushChannelConnection *)channel withResponse:(NSHTTPURLResponse *)response;
 {
     NOT_USED(response);
-    [[NSNotificationCenter defaultCenter] postNotificationName:ZMPushChannelStateChangeNotificationName object:self userInfo:@{ZMPushChannelIsOpenKey : @(NO), ZMPushChannelResponseStatusKey : @(response.statusCode)}];
+    [[[NotificationInContext alloc] initWithName:ZMOperationLoop.pushChannelStateChangeNotificationName
+                                         context:self.syncMOC.zm_userInterfaceContext
+                                          object:self userInfo:@{
+                                                                 ZMPushChannelIsOpenKey : @(NO),
+                                                                 ZMPushChannelResponseStatusKey : @(response.statusCode)
+                                                                 }] post];
     [self.syncStrategy didInterruptUpdateEventsStream];
     [ZMRequestAvailableNotification notifyNewRequestsAvailable:channel];
 }
 
 - (void)pushChannelDidOpen:(ZMPushChannelConnection *)channel withResponse:(NSHTTPURLResponse *)response;
 {
-    [[NSNotificationCenter defaultCenter] postNotificationName:ZMPushChannelStateChangeNotificationName object:self userInfo:@{ZMPushChannelIsOpenKey : @(YES), ZMPushChannelResponseStatusKey : @(response.statusCode)}];
+    [[[NotificationInContext alloc] initWithName:ZMOperationLoop.pushChannelStateChangeNotificationName
+                                         context:self.syncMOC.zm_userInterfaceContext
+                                          object:self userInfo: @{
+                                                                  ZMPushChannelIsOpenKey : @(YES),
+                                                                  ZMPushChannelResponseStatusKey : @(response.statusCode)
+                                                  }
+      ] post];
     [self.syncStrategy didEstablishUpdateEventsStream];
     [ZMRequestAvailableNotification notifyNewRequestsAvailable:channel];
 }

--- a/Source/UnauthenticatedSession/ZMAuthenticationStatus.h
+++ b/Source/UnauthenticatedSession/ZMAuthenticationStatus.h
@@ -71,8 +71,7 @@ typedef NS_ENUM(NSUInteger, ZMAuthenticationPhase) {
 
 - (instancetype)initWithGroupQueue:(id<ZMSGroupQueue>)groupQueue;
 
-- (void)addAuthenticationCenterObserver:(id<ZMAuthenticationStatusObserver>)observer;
-- (void)removeAuthenticationCenterObserver:(id<ZMAuthenticationStatusObserver>)observer;
+- (id)addAuthenticationCenterObserver:(id<ZMAuthenticationStatusObserver>)observer;
 
 - (void)prepareForRegistrationOfUser:(ZMCompleteRegistrationUser *)user;
 - (void)prepareForLoginWithCredentials:(ZMCredentials *)credentials;

--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -46,11 +46,11 @@
 #import "ZMCallKitDelegate+TypeConformance.h"
 
 NSString * const ZMPhoneVerificationCodeKey = @"code";
-NSString * const ZMLaunchedWithPhoneVerificationCodeNotificationName = @"ZMLaunchedWithPhoneVerificationCode";
+NSNotificationName const ZMLaunchedWithPhoneVerificationCodeNotificationName = @"ZMLaunchedWithPhoneVerificationCode";
 NSNotificationName const ZMRequestToOpenSyncConversationNotificationName = @"ZMRequestToOpenSyncConversation";
-NSString * const ZMAppendAVSLogNotificationName = @"ZMAppendAVSLogNotification";
-NSString * const ZMUserSessionResetPushTokensNotificationName = @"ZMUserSessionResetPushTokensNotification";
-NSString * const ZMTransportRequestLoopNotificationName = @"ZMTransportRequestLoopNotificationName";
+NSString * const ZMAppendAVSLogNotificationName = @"AVSLogMessageNotification";
+NSNotificationName const ZMUserSessionResetPushTokensNotificationName = @"ZMUserSessionResetPushTokensNotification";
+NSNotificationName const ZMTransportRequestLoopNotificationName = @"ZMTransportRequestLoopNotificationName";
 
 static NSString * const AppstoreURL = @"https://itunes.apple.com/us/app/zeta-client/id930944768?ls=1&mt=8";
 
@@ -803,7 +803,7 @@ static NSString * const IsOfflineKey = @"IsOfflineKey";
 + (id<ZMAVSLogObserverToken>)addAVSLogObserver:(id<ZMAVSLogObserver>)observer;
 {
     ZM_WEAK(observer);
-    return (id<ZMAVSLogObserverToken>)[[NSNotificationCenter defaultCenter] addObserverForName:@"AVSLogMessageNotification"
+    return (id<ZMAVSLogObserverToken>)[[NSNotificationCenter defaultCenter] addObserverForName:ZMAppendAVSLogNotificationName
                                                                                         object:nil
                                                                                          queue:nil
                                                                                     usingBlock:^(NSNotification * _Nonnull note) {
@@ -820,8 +820,13 @@ static NSString * const IsOfflineKey = @"IsOfflineKey";
 + (void)appendAVSLogMessageForConversation:(ZMConversation *)conversation withMessage:(NSString *)message;
 {
     NSDictionary *userInfo = @{@"message" :message};
-    
-    [[NSNotificationCenter defaultCenter] postNotificationName:ZMAppendAVSLogNotificationName object:conversation userInfo:userInfo];
+    if (conversation.managedObjectContext == nil) {
+        return;
+    }
+    [[[NotificationInContext alloc] initWithName:ZMAppendAVSLogNotificationName
+                                        context:conversation.managedObjectContext.zm_userInterfaceContext
+                                         object:conversation
+                                       userInfo:userInfo] post];
 }
 
 @end

--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -789,7 +789,7 @@ static NSString * const IsOfflineKey = @"IsOfflineKey";
         return;
     }
     [[[NotificationInContext alloc] initWithName:ZMRequestToOpenSyncConversationNotificationName
-                                        context:conversation.managedObjectContext
+                                        context:conversation.managedObjectContext.zm_userInterfaceContext
                                           object:conversation.objectID
                                         userInfo:nil] post];
 }

--- a/Tests/Source/Calling/ZMCallFlowRequestStrategyTests.m
+++ b/Tests/Source/Calling/ZMCallFlowRequestStrategyTests.m
@@ -66,14 +66,18 @@
 
 - (void)simulatePushChannelClose
 {
-    [[NSNotificationCenter defaultCenter] postNotificationName:ZMPushChannelStateChangeNotificationName object:nil
-                                                      userInfo:@{ZMPushChannelIsOpenKey: @(NO)}];
+    [[[NotificationInContext alloc] initWithName:ZMOperationLoop.pushChannelStateChangeNotificationName
+                                         context:self.uiMOC
+                                          object:nil
+                                       userInfo:@{ZMPushChannelIsOpenKey: @(NO)}] post];
 }
 
 - (void)simulatePushChannelOpen
 {
-    [[NSNotificationCenter defaultCenter] postNotificationName:ZMPushChannelStateChangeNotificationName object:nil
-                                                      userInfo:@{ZMPushChannelIsOpenKey: @(YES)}];
+    [[[NotificationInContext alloc] initWithName:ZMOperationLoop.pushChannelStateChangeNotificationName
+                                         context:self.uiMOC
+                                          object:nil
+                                        userInfo:@{ZMPushChannelIsOpenKey: @(YES)}] post];
 }
 
 - (void)testThatItNotifiesAVSOfNetworkChangeWhenThePushChannelIsOpened

--- a/Tests/Source/Synchronization/ZMOperationLoopTests.m
+++ b/Tests/Source/Synchronization/ZMOperationLoopTests.m
@@ -40,6 +40,7 @@
 @property (nonatomic) id pingBackStatus;
 @property (nonatomic) id mockPushChannel;
 @property (nonatomic) NSMutableArray *pushChannelNotifications;
+@property (nonatomic) id pushChannelObserverToken;
 @end
 
 
@@ -70,12 +71,19 @@
                                                     syncStrategy:self.syncStrategy
                                                            uiMOC:self.uiMOC
                                                          syncMOC:self.syncMOC];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(pushChannelDidChange:) name:ZMPushChannelStateChangeNotificationName object:nil];
+    self.pushChannelObserverToken = [NotificationInContext addObserverWithName:ZMOperationLoop.pushChannelStateChangeNotificationName
+                                       context:self.uiMOC
+                                        object:nil
+                                         queue:nil
+                                         using:^(NotificationInContext * note) {
+                                             [self pushChannelDidChange:note];
+                                         }];
 }
 
 - (void)tearDown;
 {
     WaitForAllGroupsToBeEmpty(0.5);
+    self.pushChannelObserverToken = nil;
     [self.pingBackStatus stopMocking];
     self.pingBackStatus = nil;
     [self.mockPushChannel stopMocking];
@@ -90,7 +98,7 @@
     [super tearDown];
 }
 
-- (void)pushChannelDidChange:(NSNotification *)note
+- (void)pushChannelDidChange:(NotificationInContext *)note
 {
     [self.pushChannelNotifications addObject:note];
 }

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -236,6 +236,7 @@
 		54C2F6991A6FA988003D09D9 /* ZMLocalNotificationForEventTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 54C2F6811A6FA988003D09D9 /* ZMLocalNotificationForEventTest.m */; };
 		54C2F69B1A6FA988003D09D9 /* ZMLocalNotificationForExpiredMessageTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 54C2F6821A6FA988003D09D9 /* ZMLocalNotificationForExpiredMessageTest.m */; };
 		54C2F69F1A6FA988003D09D9 /* ZMSpellOutSmallNumbersFormatterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 54C2F6841A6FA988003D09D9 /* ZMSpellOutSmallNumbersFormatterTests.m */; };
+		54C8A39C1F7536DB004961DF /* ZMOperationLoop+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54C8A39B1F7536DB004961DF /* ZMOperationLoop+Notifications.swift */; };
 		54D1751A1ADE8AA2001AA338 /* ZMUserSession+Registration.h in Headers */ = {isa = PBXBuildFile; fileRef = 54D175181ADE8AA2001AA338 /* ZMUserSession+Registration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		54D175211ADE8B18001AA338 /* ZMUserSession+Registration.m in Sources */ = {isa = PBXBuildFile; fileRef = 54D1751F1ADE8B18001AA338 /* ZMUserSession+Registration.m */; };
 		54D175241ADE9449001AA338 /* ZMUserSession+Authentication.h in Headers */ = {isa = PBXBuildFile; fileRef = 54D175221ADE9449001AA338 /* ZMUserSession+Authentication.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -744,6 +745,7 @@
 		54C2F6821A6FA988003D09D9 /* ZMLocalNotificationForExpiredMessageTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMLocalNotificationForExpiredMessageTest.m; sourceTree = "<group>"; };
 		54C2F6831A6FA988003D09D9 /* ZMPushRegistrantTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMPushRegistrantTests.m; sourceTree = "<group>"; };
 		54C2F6841A6FA988003D09D9 /* ZMSpellOutSmallNumbersFormatterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMSpellOutSmallNumbersFormatterTests.m; sourceTree = "<group>"; };
+		54C8A39B1F7536DB004961DF /* ZMOperationLoop+Notifications.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMOperationLoop+Notifications.swift"; sourceTree = "<group>"; };
 		54D175181ADE8AA2001AA338 /* ZMUserSession+Registration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ZMUserSession+Registration.h"; sourceTree = "<group>"; };
 		54D1751F1ADE8B18001AA338 /* ZMUserSession+Registration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ZMUserSession+Registration.m"; sourceTree = "<group>"; };
 		54D175221ADE9449001AA338 /* ZMUserSession+Authentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ZMUserSession+Authentication.h"; sourceTree = "<group>"; };
@@ -1770,6 +1772,7 @@
 				85D85F3EC8565FD102AC0E5B /* ZMOperationLoop.h */,
 				F962A8EF19FFD4DC00FD0F80 /* ZMOperationLoop+Private.h */,
 				85D8502FFC4412F91D0CC1A4 /* ZMOperationLoop.m */,
+				54C8A39B1F7536DB004961DF /* ZMOperationLoop+Notifications.swift */,
 				F962A8E819FFC06E00FD0F80 /* ZMOperationLoop+Background.h */,
 				F962A8E919FFC06E00FD0F80 /* ZMOperationLoop+Background.m */,
 				85D853338EC38D9B021D71BF /* ZMSyncStrategy.h */,
@@ -2555,6 +2558,7 @@
 				16D3FCE51E37A8050052A535 /* NSManagedObjectContext+ServerTimeDelta.swift in Sources */,
 				54D175211ADE8B18001AA338 /* ZMUserSession+Registration.m in Sources */,
 				549816291A432BC800A7CE2E /* ZMConnectionTranscoder.m in Sources */,
+				54C8A39C1F7536DB004961DF /* ZMOperationLoop+Notifications.swift in Sources */,
 				163495851F010AF0004E80DB /* UnauthenticatedSession+Registration.swift in Sources */,
 				BF2ADA021F41A450000980E8 /* Account+Cookie.swift in Sources */,
 				160C31271E6434500012E4BC /* OperationStatus.swift in Sources */,


### PR DESCRIPTION
Removed all relevant NSNotificationCenter-based notifications. Those that are left are OK to still use NSNotificationCenter, while `ZMLaunchedWithPhoneVerificationCodeNotificationName` is still broken and would need to be revised later in a separate PR.