### PR TITLE
Notify when a new user session is created

### DIFF
--- a/Source/SessionManager/SessionManager+ServerConnection.swift
+++ b/Source/SessionManager/SessionManager+ServerConnection.swift
@@ -32,8 +32,7 @@ public protocol ServerConnection {
     var isMobileConnection : Bool { get }
     var isOffline : Bool { get }
     
-    func addObserver(_ observer: ServerConnectionObserver) -> Any
-    func removeObserver(_ token: Any)
+    func addServerConnectionObserver(_ observer: ServerConnectionObserver) -> Any
 }
 
 extension SessionManager {
@@ -55,19 +54,14 @@ extension SessionManager : ServerConnection {
     }
 
     /// Add observer of server connection. Returns a token for de-registering the observer.
-    public func addObserver(_ observer: ServerConnectionObserver) -> Any {
+    public func addServerConnectionObserver(_ observer: ServerConnectionObserver) -> Any {
         
-        return NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: ZMTransportSessionReachabilityChangedNotificationName),
+        let token = NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: ZMTransportSessionReachabilityChangedNotificationName),
                                                       object: nil,
                                                       queue: OperationQueue.main) { [weak self, weak observer] (note) in
                                                         guard let `self` = self else { return }
                                                         observer?.serverConnection(didChange: self)
         }
+        return SelfUnregisteringNotificationCenterToken(token)
     }
-    
-    // Remove an observer by supplying a token.
-    public func removeObserver(_ token: Any) {
-        NotificationCenter.default.removeObserver(token)
-    }
-    
 }

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -22,50 +22,6 @@ import WireTesting
 import PushKit
 @testable import WireSyncEngine
 
-
-class SessionManagerTestDelegate: SessionManagerDelegate {
-
-    func sessionManagerWillOpenAccount(_ account: Account) {
-        // no-op
-    }
-    
-    func sessionManagerDidLogout(error: Error?) {
-        // no op
-    }
-    
-    func sessionManagerDidBlacklistCurrentVersion() {
-        // no op
-    }
-
-    var unauthenticatedSession : UnauthenticatedSession?
-    func sessionManagerCreated(unauthenticatedSession : UnauthenticatedSession) {
-        self.unauthenticatedSession = unauthenticatedSession
-    }
-    
-    var userSession : ZMUserSession?
-    func sessionManagerCreated(userSession : ZMUserSession) {
-        self.userSession = userSession
-    }
-    
-    var startedMigrationCalled = false
-    func sessionManagerWillStartMigratingLocalStore() {
-        startedMigrationCalled = true
-    }
-
-}
-
-class TestReachability: ReachabilityProvider, ReachabilityTearDown {
-    var mayBeReachable = true
-    var isMobileConnection = true
-    var oldMayBeReachable = true
-    var oldIsMobileConnection = true
-    
-    var tearDownCalled = false
-    func tearDown() {
-        tearDownCalled = true
-    }
-}
-
 class SessionManagerTests: IntegrationTest {
 
     var delegate: SessionManagerTestDelegate!
@@ -110,12 +66,20 @@ class SessionManagerTests: IntegrationTest {
     }
     
     func testThatItCreatesUnauthenticatedSessionAndNotifiesDelegateIfStoreIsNotAvailable() {
+        
+        // given
+        let observer = SessionManagerObserverMock()
+        let token = sut?.addSessionManagerObserver(observer)
+        
         // when
         sut = createManager()
         
         // then
         XCTAssertNil(delegate.userSession)
         XCTAssertNotNil(delegate.unauthenticatedSession)
+        withExtendedLifetime(token) {
+            XCTAssertEqual([], observer.createdUserSession)
+        }
     }
     
     func testThatItCreatesUserSessionAndNotifiesDelegateIfStoreIsAvailable() {
@@ -138,11 +102,70 @@ class SessionManagerTests: IntegrationTest {
 
         // when
         sut = createManager()
+        let observer = SessionManagerObserverMock()
+        let token = sut?.addSessionManagerObserver(observer)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.1))
         
         // then
         XCTAssertNotNil(delegate.userSession)
         XCTAssertNil(delegate.unauthenticatedSession)
+        withExtendedLifetime(token) {
+            XCTAssertEqual([delegate.userSession].flatMap { $0 }, observer.createdUserSession)
+        }
+    }
+    
+    func testThatItNotifiesDelegateAndObserverWhenCreatingSession() {
+        
+        // GIVEN
+        let account = self.createAccount()
+        account.cookieStorage().authenticationCookieData = NSData.secureRandomData(ofLength: 16)
+        
+        guard let mediaManager = mediaManager, let application = application else { return XCTFail() }
+        
+        let sessionManagerExpectation = self.expectation(description: "Session manager and session is loaded")
+
+        var realSessionManager: SessionManager! = nil
+        //let observer = SessionManagerObserverMock()
+        //var observerToken: Any? = nil
+        SessionManager.create(appVersion: "0.0.0",
+                              mediaManager: mediaManager,
+                              analytics: nil,
+                              delegate: nil,
+                              application: application,
+                              launchOptions: [:],
+                              blacklistDownloadInterval : 60) { sessionManager in
+                                
+                                let environment = ZMBackendEnvironment(type: .staging)
+                                let reachability = TestReachability()
+                                let authenticatedSessionFactory = MockAuthenticatedSessionFactory(
+                                    apnsEnvironment: self.apnsEnvironment!,
+                                    application: application,
+                                    mediaManager: mediaManager,
+                                    flowManager: FlowManagerMock(),
+                                    transportSession: self.transportSession!,
+                                    environment: environment,
+                                    reachability: reachability
+                                )
+                                
+                                sessionManager.authenticatedSessionFactory = authenticatedSessionFactory
+                                
+                                // WHEN
+                                //observerToken = sessionManager.addSessionManagerObserver(observer)
+                                sessionManager.loadSession(for: account) { userSession in
+                                    realSessionManager = sessionManager
+                                    XCTAssertNotNil(userSession)
+                                    sessionManagerExpectation.fulfill()
+                                }
+        }
+        
+        // THEN
+        XCTAssertTrue(self.waitForCustomExpectations(withTimeout: 0.5))
+        //XCTAssertEqual([realSessionManager.activeUserSession!], observer.createdUserSession)
+        
+        // AFTER
+//        withExtendedLifetime(observerToken) {
+//            realSessionManager.tearDownAllBackgroundSessions()
+//        }
     }
     
 }
@@ -717,3 +740,56 @@ class SessionManagerTests_Push: IntegrationTest {
     }
 }
 
+// MARK: - Mocks
+class SessionManagerTestDelegate: SessionManagerDelegate {
+    
+    func sessionManagerWillOpenAccount(_ account: Account) {
+        // no-op
+    }
+    
+    func sessionManagerDidLogout(error: Error?) {
+        // no op
+    }
+    
+    func sessionManagerDidBlacklistCurrentVersion() {
+        // no op
+    }
+    
+    var unauthenticatedSession : UnauthenticatedSession?
+    func sessionManagerCreated(unauthenticatedSession : UnauthenticatedSession) {
+        self.unauthenticatedSession = unauthenticatedSession
+    }
+    
+    var userSession : ZMUserSession?
+    func sessionManagerCreated(userSession : ZMUserSession) {
+        self.userSession = userSession
+    }
+    
+    var startedMigrationCalled = false
+    func sessionManagerWillStartMigratingLocalStore() {
+        startedMigrationCalled = true
+    }
+    
+}
+
+class SessionManagerObserverMock: SessionManagerObserver {
+    
+    var createdUserSession: [ZMUserSession] = []
+    
+    func sessionManagerCreated(userSession: ZMUserSession) {
+        createdUserSession.append(userSession)
+    }
+    
+}
+
+class TestReachability: ReachabilityProvider, ReachabilityTearDown {
+    var mayBeReachable = true
+    var isMobileConnection = true
+    var oldMayBeReachable = true
+    var oldIsMobileConnection = true
+    
+    var tearDownCalled = false
+    func tearDown() {
+        tearDownCalled = true
+    }
+}

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -125,8 +125,8 @@ class SessionManagerTests: IntegrationTest {
         let sessionManagerExpectation = self.expectation(description: "Session manager and session is loaded")
 
         var realSessionManager: SessionManager! = nil
-        //let observer = SessionManagerObserverMock()
-        //var observerToken: Any? = nil
+        let observer = SessionManagerObserverMock()
+        var observerToken: Any? = nil
         SessionManager.create(appVersion: "0.0.0",
                               mediaManager: mediaManager,
                               analytics: nil,
@@ -150,7 +150,7 @@ class SessionManagerTests: IntegrationTest {
                                 sessionManager.authenticatedSessionFactory = authenticatedSessionFactory
                                 
                                 // WHEN
-                                //observerToken = sessionManager.addSessionManagerObserver(observer)
+                                observerToken = sessionManager.addSessionManagerObserver(observer)
                                 sessionManager.loadSession(for: account) { userSession in
                                     realSessionManager = sessionManager
                                     XCTAssertNotNil(userSession)
@@ -160,12 +160,12 @@ class SessionManagerTests: IntegrationTest {
         
         // THEN
         XCTAssertTrue(self.waitForCustomExpectations(withTimeout: 0.5))
-        //XCTAssertEqual([realSessionManager.activeUserSession!], observer.createdUserSession)
+        XCTAssertEqual([realSessionManager.activeUserSession!], observer.createdUserSession)
         
         // AFTER
-//        withExtendedLifetime(observerToken) {
-//            realSessionManager.tearDownAllBackgroundSessions()
-//        }
+        withExtendedLifetime(observerToken) {
+            realSessionManager.tearDownAllBackgroundSessions()
+        }
     }
     
 }


### PR DESCRIPTION
I added observers for when a new user session is created in the `SessionManager`. I could not reuse the already existing  delegate as the observer needs to be added later and multiple observers might be needed.

In doing this, I had to rename the method to register `ServerConnection` observer as the name was clashing.