### PR TITLE
Remove unnecessary dispatch_once

### DIFF
--- a/Source/Synchronization/Transcoders/ZMSelfStrategy.m
+++ b/Source/Synchronization/Transcoders/ZMSelfStrategy.m
@@ -37,16 +37,13 @@ static NSString * const CompleteProfileAssetIdentifierKey = @"completeProfileAss
 NSTimeInterval ZMSelfStrategyPendingValidationRequestInterval = 5;
 
 @interface ZMSelfStrategy ()
-{
-    dispatch_once_t didCheckNeedsToBeUdpatedFromBackend;
-}
 
 @property (nonatomic) ZMUpstreamModifiedObjectSync *upstreamObjectSync;
 @property (nonatomic) ZMSingleRequestSync *downstreamSelfUserSync;
 @property (nonatomic) NSPredicate *needsToBeUdpatedFromBackend;
 @property (nonatomic, weak) ZMClientRegistrationStatus *clientStatus;
 @property (nonatomic, weak) SyncStatus *syncStatus;
-
+@property (nonatomic) BOOL didCheckNeedsToBeUdpatedFromBackend;
 @end
 
 @interface ZMSelfStrategy (SingleRequestTranscoder) <ZMSingleRequestTranscoder>
@@ -158,12 +155,13 @@ NSTimeInterval ZMSelfStrategyPendingValidationRequestInterval = 5;
 
 - (void)checkIfNeedsToBeUdpatedFromBackend;
 {
-    dispatch_once(&didCheckNeedsToBeUdpatedFromBackend, ^{
+    if (!self.didCheckNeedsToBeUdpatedFromBackend) {
+        self.didCheckNeedsToBeUdpatedFromBackend = YES;
         ZMUser *selfUser = [ZMUser selfUserInContext:self.managedObjectContext];
         if ([self.needsToBeUdpatedFromBackend evaluateWithObject:selfUser]) {
             [self.downstreamSelfUserSync readyForNextRequest];
         }
-    });
+    }
 }
 
 - (BOOL)isSelfUserComplete

--- a/Source/Synchronization/ZMSyncStrategy.m
+++ b/Source/Synchronization/ZMSyncStrategy.m
@@ -43,10 +43,8 @@
 #import <WireSyncEngine/WireSyncEngine-Swift.h>
 
 @interface ZMSyncStrategy ()
-{
-    dispatch_once_t _didFetchObjects;
-}
 
+@property (nonatomic) BOOL didFetchObjects;
 @property (nonatomic) NSManagedObjectContext *syncMOC;
 @property (nonatomic, weak) NSManagedObjectContext *uiMOC;
 
@@ -364,9 +362,10 @@ ZM_EMPTY_ASSERTING_INIT()
 
 - (ZMTransportRequest *)nextRequest
 {
-    dispatch_once(&_didFetchObjects, ^{
+    if (!self.didFetchObjects) {
+        self.didFetchObjects = YES;
         [self.changeTrackerBootStrap fetchObjectsForChangeTrackers];
-    });
+    }
     
     if(self.tornDown) {
         return nil;


### PR DESCRIPTION
The same behaviour can be achieved with a normal instance variable. Having dispatch once causes analysis warnings.