### PR TITLE
Don't skip notifying network state if app is in the background

### DIFF
--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -632,7 +632,8 @@ ZM_EMPTY_ASSERTING_INIT()
     
     ZMNetworkState const previous = self.networkState;
     self.networkState = state;
-    if(previous != self.networkState && self.application.applicationState != UIApplicationStateBackground) {
+    
+    if (previous != self.networkState) {
         [ZMNetworkAvailabilityChangeNotification notifyWithNetworkState:self.networkState userSession:self];
     }
 }


### PR DESCRIPTION
Skipping notifying the UI would leave the UI in a inconsistent state because we wouldn't be notified again if the app entered the foreground.