### PR TITLE
Register session manager to user session

### DIFF
--- a/Source/Public/ZMUserSession.h
+++ b/Source/Public/ZMUserSession.h
@@ -87,7 +87,7 @@ extern NSString * const ZMTransportRequestLoopNotificationName;
                      apnsEnvironment:(ZMAPNSEnvironment *)apnsEnvironment
                          application:(id<ZMApplication>)application
                           appVersion:(NSString *)appVersion
-                       storeProvider:(id<LocalStoreProviderProtocol>)storeProvider;;
+                       storeProvider:(id<LocalStoreProviderProtocol>)storeProvider;
 
 @property (nonatomic, weak) SessionManager *sessionManager;
 @property (nonatomic, weak) id<ZMRequestsToOpenViewsDelegate> requestToOpenViewDelegate;


### PR DESCRIPTION
Issue happened because the `ZMUserSession` created from the push never got `SessionManager` assigned.

Implemented the single method `configure(session userSession: ZMUserSession, for account: Account)` to configure the new user session.