### PR TITLE
Wait for a new UserSession to be ready before removing the old one

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -299,8 +299,6 @@ public protocol LocalMessageNotificationResponder : class {
         delegate?.sessionManagerWillOpenAccount(account)
         tearDownObservers(account: account.userIdentifier)
         
-        activeUserSession = nil
-        
         loadSession(for: account) { [weak self] session in
             self?.accountManager.select(account)
             completion?(session)


### PR DESCRIPTION
This change avoids having a time when there is no active session while we switch to another session. Not having an active session causes the UI to crash in many places during a switch.