### PR TITLE
Wait for UI to be torn down on logout

### DIFF
--- a/Tests/Source/Integration/IntegrationTest.swift
+++ b/Tests/Source/Integration/IntegrationTest.swift
@@ -506,6 +506,10 @@ extension IntegrationTest {
 
 extension IntegrationTest : SessionManagerDelegate {
     
+    public func sessionManagerDidFailToLogin(error: Error) {
+        // no-op
+    }
+    
     public func sessionManagerCreated(userSession: ZMUserSession) {
         self.userSession = userSession
         
@@ -522,22 +526,10 @@ extension IntegrationTest : SessionManagerDelegate {
     public func sessionManagerWillStartMigratingLocalStore() {
         // no-op
     }
-
-    public func sessionManagerDidLogout(error: Error?) {
-        guard let error = error as NSError? else { return }
-        
-        guard let userSessionErrorCode = ZMUserSessionErrorCode(rawValue: UInt(error.code)) else {
-            return
-        }
-        
-        switch userSessionErrorCode {
-        case .clientDeletedRemotely,
-             .accessTokenExpired,
-             .accountDeleted:
-            self.userSession = nil
-        default:
-            break
-        }
+    
+    public func sessionManagerWillLogout(error: Error?, userSessionCanBeTornDown: @escaping () -> Void) {
+        self.userSession = nil
+        userSessionCanBeTornDown()
     }
 
     public func sessionManagerDidBlacklistCurrentVersion() {

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -765,12 +765,16 @@ class SessionManagerTests_Push: IntegrationTest {
 // MARK: - Mocks
 class SessionManagerTestDelegate: SessionManagerDelegate {
     
-    func sessionManagerWillOpenAccount(_ account: Account) {
-        // no-op
+    func sessionManagerWillLogout(error: Error?, userSessionCanBeTornDown: @escaping () -> Void) {
+        userSessionCanBeTornDown()
     }
     
-    func sessionManagerDidLogout(error: Error?) {
+    func sessionManagerDidFailToLogin(error: Error) {
         // no op
+    }
+    
+    func sessionManagerWillOpenAccount(_ account: Account) {
+        // no-op
     }
     
     func sessionManagerDidBlacklistCurrentVersion() {


### PR DESCRIPTION
### Problem
We sometimes crash when we transition fast between logged in / logged out state. For example when you open the app and discover that your client has been deleted. The crashes happen because we load the UI asynchronously and  therefore might reference the user session after it has been destroyed.

### Solution
When the `SessionManager` want to tear down a user session it will now ask the UI to logout and tell us when it's done doing that. Only after being told the UI is done transitioning to the logged out state will we begin tearing down the user session. 

NOTE: We could also do a similar thing when switching between accounts.