### PR TITLE
Correctly tear down the background session

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -662,7 +662,7 @@ extension SessionManager: PostLoginAuthenticationObserver {
                     logoutCurrentSession(deleteCookie: true, error: error)
                 }
                 else {
-                    session.closeAndDeleteCookie(true)
+                    self.tearDownBackgroundSession(for: accountId)
                 }
             }
             


### PR DESCRIPTION
`closeAndDeleteCookie` is dangerous, since then the session would be torn down but not deallocated and persist in `backgroundUserSessions` as the reference. 