### PR TITLE
Fixed possible multi session creation via push

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -126,6 +126,9 @@ public protocol LocalMessageNotificationResponder : class {
     
     internal var authenticatedSessionFactory: AuthenticatedSessionFactory
     internal let unauthenticatedSessionFactory: UnauthenticatedSessionFactory
+    
+    fileprivate let sessionLoadingQueue : DispatchQueue = DispatchQueue(label: "sessionLoadingQueue")
+    
     fileprivate let sharedContainerURL: URL
     fileprivate let dispatchGroup: ZMSDispatchGroup?
     fileprivate var accountTokens : [UUID : [Any]] = [:]
@@ -477,25 +480,31 @@ public protocol LocalMessageNotificationResponder : class {
     }
     
     // Loads user session for @c account given and executes the @c action block.
-    public func withSession(for account: Account, perform action: @escaping (ZMUserSession)->()) {
-        if let session = backgroundUserSessions[account.userIdentifier] {
-            action(session)
-        }
-        else {
-            LocalStoreProvider.createStack(
-                applicationContainer: sharedContainerURL,
-                userIdentifier: account.userIdentifier,
-                dispatchGroup: dispatchGroup,
-                migration: { [weak self] in self?.delegate?.sessionManagerWillStartMigratingLocalStore() },
-                completion: { provider in
-                    self.activateBackgroundSession(for: account, with: provider, completion: action)
-                }
-            )
-        }
+    public func withSession(for account: Account, perform completion: @escaping (ZMUserSession)->()) {
+        self.sessionLoadingQueue.serialAsync(do: { finally in
+
+            if let session = self.backgroundUserSessions[account.userIdentifier] {
+                completion(session)
+                finally()
+            }
+            else {
+                LocalStoreProvider.createStack(
+                    applicationContainer: self.sharedContainerURL,
+                    userIdentifier: account.userIdentifier,
+                    dispatchGroup: self.dispatchGroup,
+                    migration: { [weak self] in self?.delegate?.sessionManagerWillStartMigratingLocalStore() },
+                    completion: { provider in
+                        let userSession = self.activateBackgroundSession(for: account, with: provider)
+                        finally()
+                        completion(userSession)
+                    }
+                )
+            }
+        })
     }
 
     // Creates the user session for @c account given, calls @c completion when done.
-    fileprivate func activateBackgroundSession(for account: Account, with provider: LocalStoreProviderProtocol, completion: @escaping (ZMUserSession)->()) {
+    private func activateBackgroundSession(for account: Account, with provider: LocalStoreProviderProtocol) -> ZMUserSession {
         guard let newSession = authenticatedSessionFactory.session(for: account, storeProvider: provider) else {
             preconditionFailure("Unable to create session for \(account)")
         }
@@ -504,7 +513,8 @@ public protocol LocalMessageNotificationResponder : class {
         self.configure(session: newSession, for: account)
 
         log.debug("Created ZMUserSession for account \(String(describing: account.userName)) — \(account.userIdentifier)")
-        completion(newSession)
+        
+        return newSession
     }
     
     internal func tearDownBackgroundSession(for accountId: UUID) {

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -481,11 +481,11 @@ public protocol LocalMessageNotificationResponder : class {
     
     // Loads user session for @c account given and executes the @c action block.
     public func withSession(for account: Account, perform completion: @escaping (ZMUserSession)->()) {
-        self.sessionLoadingQueue.serialAsync(do: { finally in
+        self.sessionLoadingQueue.serialAsync(do: { onWorkDone in
 
             if let session = self.backgroundUserSessions[account.userIdentifier] {
                 completion(session)
-                finally()
+                onWorkDone()
             }
             else {
                 LocalStoreProvider.createStack(
@@ -495,8 +495,8 @@ public protocol LocalMessageNotificationResponder : class {
                     migration: { [weak self] in self?.delegate?.sessionManagerWillStartMigratingLocalStore() },
                     completion: { provider in
                         let userSession = self.activateBackgroundSession(for: account, with: provider)
-                        finally()
                         completion(userSession)
+                        onWorkDone()
                     }
                 )
             }

--- a/Source/Utility/DispatchQueue+SerialAsync.swift
+++ b/Source/Utility/DispatchQueue+SerialAsync.swift
@@ -18,8 +18,11 @@
 
 import Foundation
 
+public typealias AsyncAction = (_ whenDone: @escaping ()->()) -> ()
+
 extension DispatchQueue {
-    public func serialAsync(do action: @escaping (@escaping ()->()) -> ()) {
+    // Dispatches the @c action on the queue in the serial way, waiting for the completion call (whenDone).
+    public func serialAsync(do action: @escaping AsyncAction) {
         self.async {
             let loadingGroup = DispatchGroup()
             loadingGroup.enter()

--- a/Source/Utility/DispatchQueue+SerialAsync.swift
+++ b/Source/Utility/DispatchQueue+SerialAsync.swift
@@ -1,0 +1,37 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension DispatchQueue {
+    public func serialAsync(do action: @escaping (@escaping ()->()) -> ()) {
+        self.async {
+            let loadingGroup = DispatchGroup()
+            loadingGroup.enter()
+            
+            DispatchQueue.main.async {
+                action {
+                    loadingGroup.leave()
+                }
+            }
+            
+            loadingGroup.wait()
+        }
+        
+    }
+}

--- a/Tests/Source/Utility/DispatchQueueSerialAsyncTests.swift
+++ b/Tests/Source/Utility/DispatchQueueSerialAsyncTests.swift
@@ -1,0 +1,57 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import XCTest
+
+class DispatchQueueSerialAsyncTests: XCTestCase {
+    let sut = DispatchQueue(label: "test")
+    
+    func testThatItWaitsForOneTaskBeforeAnother() {
+        let doneExpectation = self.expectation(description: "Done with jobs")
+        
+        var done1: Bool = false
+        var done2: Bool = false
+        
+        sut.serialAsync { finally in
+            let time = DispatchTime.now() + DispatchTimeInterval.milliseconds(200)
+            
+            DispatchQueue.global(qos: .background).asyncAfter(deadline: time) {
+                XCTAssertFalse(done1)
+                XCTAssertFalse(done2)
+                done1 = true
+                finally()
+            }
+        }
+        
+        sut.serialAsync { finally in
+            XCTAssertTrue(done1)
+            XCTAssertFalse(done2)
+            done2 = true
+            finally()
+            doneExpectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 0.5) { error in
+            XCTAssertNil(error)
+        }
+        
+        XCTAssertTrue(done1)
+        XCTAssertTrue(done2)
+    }
+}

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -285,6 +285,8 @@
 		8754B84C1F73C38900EC02AD /* MessageChangeInfo+UserSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8754B84B1F73C38900EC02AD /* MessageChangeInfo+UserSession.swift */; };
 		8766853C1F2A1AA00031081B /* UnauthenticatedSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8766853A1F2A1A860031081B /* UnauthenticatedSessionTests.swift */; };
 		878F63E51EF91E7C006E819B /* HotFixDuplicatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878F63E41EF91E7C006E819B /* HotFixDuplicatesTests.swift */; };
+		879634401F7BEA4700FC79BA /* DispatchQueue+SerialAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8796343F1F7BEA4700FC79BA /* DispatchQueue+SerialAsync.swift */; };
+		879634421F7BEC5100FC79BA /* DispatchQueueSerialAsyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 879634411F7BEC5100FC79BA /* DispatchQueueSerialAsyncTests.swift */; };
 		8798607B1C3D48A400218A3E /* DeleteAccountRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8798607A1C3D48A400218A3E /* DeleteAccountRequestStrategy.swift */; };
 		87ADCE3B1DA6539F00CC06DC /* ZMCallKitDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 87ADCE391DA6539F00CC06DC /* ZMCallKitDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		87ADCE3C1DA6539F00CC06DC /* ZMCallKitDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 87ADCE3A1DA6539F00CC06DC /* ZMCallKitDelegate.m */; };
@@ -832,6 +834,8 @@
 		8754B84B1F73C38900EC02AD /* MessageChangeInfo+UserSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MessageChangeInfo+UserSession.swift"; sourceTree = "<group>"; };
 		8766853A1F2A1A860031081B /* UnauthenticatedSessionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnauthenticatedSessionTests.swift; sourceTree = "<group>"; };
 		878F63E41EF91E7C006E819B /* HotFixDuplicatesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HotFixDuplicatesTests.swift; sourceTree = "<group>"; };
+		8796343F1F7BEA4700FC79BA /* DispatchQueue+SerialAsync.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DispatchQueue+SerialAsync.swift"; sourceTree = "<group>"; };
+		879634411F7BEC5100FC79BA /* DispatchQueueSerialAsyncTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DispatchQueueSerialAsyncTests.swift; sourceTree = "<group>"; };
 		8798607A1C3D48A400218A3E /* DeleteAccountRequestStrategy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeleteAccountRequestStrategy.swift; sourceTree = "<group>"; };
 		87ADCE391DA6539F00CC06DC /* ZMCallKitDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZMCallKitDelegate.h; sourceTree = "<group>"; };
 		87ADCE3A1DA6539F00CC06DC /* ZMCallKitDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMCallKitDelegate.m; sourceTree = "<group>"; };
@@ -1865,6 +1869,7 @@
 				874F142C1C16FD9700C15118 /* Device.swift */,
 				87508E9F1D08264000162483 /* ZMSound.swift */,
 				546392711D79D5210094EC66 /* Application.swift */,
+				8796343F1F7BEA4700FC79BA /* DispatchQueue+SerialAsync.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -1876,6 +1881,7 @@
 				BF40AC711D096A0E00287E29 /* AnalyticsTests.swift */,
 				BF325E9C1EC067D600772145 /* RequestLoopAnalyticsTrackerTests.swift */,
 				543ED0001D79E0EE00A9CDF3 /* ApplicationMock.swift */,
+				879634411F7BEC5100FC79BA /* DispatchQueueSerialAsyncTests.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -2400,6 +2406,7 @@
 				F190E0AA1E8D517A003E81F8 /* UserProfileImageV3Tests.swift in Sources */,
 				545434A719AB6ADA003892D9 /* ZMConnectionTranscoderTest.m in Sources */,
 				3E26BEE91A408F590071B4C9 /* ZMTypingUsersTests.m in Sources */,
+				879634421F7BEC5100FC79BA /* DispatchQueueSerialAsyncTests.swift in Sources */,
 				54AB428E1DF5C5B400381F2C /* TopConversationsDirectoryTests.swift in Sources */,
 				CE99C4A01D378C5D0001D297 /* MockLinkPreviewDetector.m in Sources */,
 				F96C8E821D7ECECF004B6D87 /* ZMLocalNotificationForMessageTests.swift in Sources */,
@@ -2577,6 +2584,7 @@
 				5498162B1A432BC800A7CE2E /* ZMConversationTranscoder.m in Sources */,
 				54E2C1E01E682DC400536569 /* LocalNotificationDispatcher.swift in Sources */,
 				F98EDCED1D82B924001E65CB /* UILocalNotification+StringProcessing.m in Sources */,
+				879634401F7BEA4700FC79BA /* DispatchQueue+SerialAsync.swift in Sources */,
 				F93A75F21C1F219800252586 /* ConversationStatusStrategy.swift in Sources */,
 				1679D1C71EF81E42007B0DF5 /* VoiceChannelV2.m in Sources */,
 				544F8FF31DDCD34600D1AB04 /* UserProfileUpdateNotifications.swift in Sources */,


### PR DESCRIPTION
Session loading is async, this makes it possible to accidentally load the session twice when the session loading event (push) is happening quickly one after another.