### PR TITLE
Fixes for account deletion & logout

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -27,11 +27,10 @@ public typealias LaunchOptions = [UIApplicationLaunchOptionsKey : Any]
 
 
 @objc public protocol SessionManagerDelegate : class {
-    func sessionManagerCreated(unauthenticatedSession : UnauthenticatedSession)
     func sessionManagerCreated(userSession : ZMUserSession)
     func sessionManagerDidFailToLogin(error : Error)
     func sessionManagerWillLogout(error : Error?, userSessionCanBeTornDown: @escaping () -> Void)
-    func sessionManagerWillOpenAccount(_ account: Account)
+    func sessionManagerWillOpenAccount(_ account: Account, userSessionCanBeTornDown: @escaping () -> Void)
     func sessionManagerWillStartMigratingLocalStore()
     func sessionManagerDidBlacklistCurrentVersion()
 }
@@ -314,9 +313,13 @@ public protocol LocalMessageNotificationResponder : class {
         }
     }
     
-    public func select(_ account: Account, completion: ((ZMUserSession)->())? = nil) {
-        delegate?.sessionManagerWillOpenAccount(account)
-        tearDownObservers(account: account.userIdentifier)
+    /// Select the account to be the active account.
+    /// - completion: runs when the user session was loaded
+    /// - tearDownCompletion: runs when the UI no longer holds any references to the previous user session.
+    public func select(_ account: Account, completion: ((ZMUserSession)->())? = nil, tearDownCompletion: (() -> Void)? = nil) {
+        delegate?.sessionManagerWillOpenAccount(account, userSessionCanBeTornDown: { 
+            tearDownCompletion?()
+        })
         
         loadSession(for: account) { [weak self] session in
             self?.accountManager.select(account)
@@ -330,58 +333,64 @@ public protocol LocalMessageNotificationResponder : class {
     
     public func delete(account: Account) {
         log.debug("Deleting account \(account.userIdentifier)...")
-        if let secondAccount = accountManager.accounts.first(where: { $0.userIdentifier != account.userIdentifier }) {
-            select(secondAccount)
+        if accountManager.selectedAccount != account {
+            // Deleted an account associated with a background session
+            self.tearDownBackgroundSession(for: account.userIdentifier)
+            self.deleteAccountData(for: account)
+        } else if let secondAccount = accountManager.accounts.first(where: { $0.userIdentifier != account.userIdentifier }) {
+            // Deleted the active account but we can switch to another account
+            select(secondAccount, tearDownCompletion: { [weak self] in
+                self?.tearDownBackgroundSession(for: account.userIdentifier)
+                self?.deleteAccountData(for: account)
+            })
         } else {
-            logoutCurrentSession(deleteCookie: true, error: NSError.userSessionErrorWith(.addAccountRequested, userInfo: nil))
+            // Deleted the active account and there's not other account we can switch to
+            logoutCurrentSession(deleteCookie: true, deleteAccount:true, error: NSError.userSessionErrorWith(.addAccountRequested, userInfo: nil))
         }
-        deleteAccountData(for: account)
     }
     
     public func logoutCurrentSession(deleteCookie: Bool = true) {
         logoutCurrentSession(deleteCookie: deleteCookie, error: nil)
     }
     
-    fileprivate func logoutCurrentSession(deleteCookie: Bool = true, error : Error?) {
-        guard let currentSession = activeUserSession else {
+    fileprivate func logoutCurrentSession(deleteCookie: Bool = true, deleteAccount: Bool = false, error : Error?) {
+        guard let currentSession = activeUserSession, let account = accountManager.selectedAccount else {
             return
         }
-        
-        let matchingAccountSession = backgroundUserSessions.first { (_, session) in
-            session == currentSession
-        }
-        
-        if let matchingAccount = matchingAccountSession?.key {
-            backgroundUserSessions[matchingAccount] = nil
-            tearDownObservers(account: matchingAccount)
-        }
-        
+    
+        backgroundUserSessions[account.userIdentifier] = nil
+        tearDownObservers(account: account.userIdentifier)
         self.createUnauthenticatedSession()
         
         delegate?.sessionManagerWillLogout(error: error, userSessionCanBeTornDown: { [weak self] in
             currentSession.closeAndDeleteCookie(deleteCookie)
             self?.activeUserSession = nil
+            
+            if deleteAccount {
+                self?.deleteAccountData(for: account)
+            }
         })
     }
 
+    /// Loads a session for a given account.
     internal func loadSession(for account: Account?, completion: @escaping (ZMUserSession) -> Void) {
-        guard let account = account else { return createUnauthenticatedSession() }
-
-        if account.isAuthenticated {
-            LocalStoreProvider.createStack(
-                applicationContainer: sharedContainerURL,
-                userIdentifier: account.userIdentifier,
-                dispatchGroup: dispatchGroup,
-                migration: { [weak self] in self?.delegate?.sessionManagerWillStartMigratingLocalStore() },
-                completion: { [weak self] provider in
-                    self?.createSession(for: account, with: provider) { session in
-                        self?.registerSessionForRemoteNotificationsIfNeeded(session)
-                        completion(session)
-                    }}
-            )
-        } else {
+        guard let account = account, account.isAuthenticated else {
             createUnauthenticatedSession()
+            delegate?.sessionManagerDidFailToLogin(error: NSError.userSessionErrorWith(.accessTokenExpired, userInfo: nil))
+            return
         }
+
+        LocalStoreProvider.createStack(
+            applicationContainer: sharedContainerURL,
+            userIdentifier: account.userIdentifier,
+            dispatchGroup: dispatchGroup,
+            migration: { [weak self] in self?.delegate?.sessionManagerWillStartMigratingLocalStore() },
+            completion: { [weak self] provider in
+                self?.createSession(for: account, with: provider) { session in
+                    self?.registerSessionForRemoteNotificationsIfNeeded(session)
+                    completion(session)
+                }}
+        )
     }
 
     public func deleteAccountData(for account: Account) {
@@ -465,7 +474,6 @@ public protocol LocalMessageNotificationResponder : class {
         let unauthenticatedSession = unauthenticatedSessionFactory.session(withDelegate: self)
         self.unauthenticatedSession = unauthenticatedSession
         self.preLoginAuthenticationToken = unauthenticatedSession.addAuthenticationObserver(self)
-        delegate?.sessionManagerCreated(unauthenticatedSession: unauthenticatedSession)
     }
     
     fileprivate func configure(session userSession: ZMUserSession, for account: Account) {
@@ -643,7 +651,7 @@ extension SessionManager: UnauthenticatedSessionDelegate {
 extension SessionManager: PostLoginAuthenticationObserver {
 
     @objc public func clientRegistrationDidSucceed(accountId: UUID) {
-        log.debug("Tearing down unauthenticated session as reaction to successfull client registration")
+        log.debug("Tearing down unauthenticated session as reaction to successful client registration")
         unauthenticatedSession?.tearDown()
         unauthenticatedSession = nil
     }
@@ -656,7 +664,6 @@ extension SessionManager: PostLoginAuthenticationObserver {
         
     public func accountDeleted(accountId: UUID) {
         log.debug("\(accountId): Account was deleted")
-        logoutCurrentSession(deleteCookie: true, error: NSError(domain: ZMUserSessionErrorDomain, code: Int(ZMUserSessionErrorCode.accountDeleted.rawValue), userInfo: nil))
         
         if let account = accountManager.account(with: accountId) {
             delete(account: account)
@@ -664,11 +671,11 @@ extension SessionManager: PostLoginAuthenticationObserver {
     }
     
     public func clientRegistrationDidFail(_ error: NSError, accountId: UUID) {
-        delegate?.sessionManagerDidFailToLogin(error: error)
-        
         if unauthenticatedSession == nil {
             createUnauthenticatedSession()
         }
+        
+        delegate?.sessionManagerDidFailToLogin(error: error)
     }
     
     public func authenticationInvalidated(_ error: NSError, accountId: UUID) {
@@ -676,7 +683,7 @@ extension SessionManager: PostLoginAuthenticationObserver {
             return
         }
         
-        log.debug("Authenticatio invalidated for \(accountId): \(error.code)")
+        log.debug("Authentication invalidated for \(accountId): \(error.code)")
         
         switch userSessionErrorCode {
         case .clientDeletedRemotely,
@@ -692,11 +699,11 @@ extension SessionManager: PostLoginAuthenticationObserver {
             }
             
         default:
-            delegate?.sessionManagerDidFailToLogin(error: error)
-            
             if unauthenticatedSession == nil {
                 createUnauthenticatedSession()
             }
+            
+            delegate?.sessionManagerDidFailToLogin(error: error)
         }
     }
 
@@ -723,11 +730,11 @@ extension SessionManager: ZMConversationListObserver {
 extension SessionManager : PreLoginAuthenticationObserver {
     
     public func authenticationDidFail(_ error: NSError) {
-        delegate?.sessionManagerDidFailToLogin(error: error)
-        
         if unauthenticatedSession == nil {
             createUnauthenticatedSession()
         }
+        
+        delegate?.sessionManagerDidFailToLogin(error: error)
     }
 }
 

--- a/Tests/Source/Integration/IntegrationTest.h
+++ b/Tests/Source/Integration/IntegrationTest.h
@@ -43,7 +43,6 @@
 @property (nonatomic, nullable) ZMAPNSEnvironment *apnsEnvironment;
 @property (nonatomic, nullable) ApplicationMock *application;
 @property (nonatomic, nullable) ZMUserSession *userSession;
-@property (nonatomic, nullable) UnauthenticatedSession *unauthenticatedSession;
 @property (nonatomic, null_unspecified) NSURL *sharedContainerDirectory;
 @property (nonatomic, readonly) BOOL useInMemoryStore;
 @property (nonatomic, readonly) BOOL useRealKeychain;

--- a/Tests/Source/Integration/IntegrationTest.swift
+++ b/Tests/Source/Integration/IntegrationTest.swift
@@ -536,8 +536,9 @@ extension IntegrationTest : SessionManagerDelegate {
         // no-op
     }
     
-    public func sessionManagerWillOpenAccount(_ account: Account) {
-        // no-op
+    public func sessionManagerWillOpenAccount(_ account: Account, userSessionCanBeTornDown: @escaping () -> Void) {
+        self.userSession = nil
+        userSessionCanBeTornDown()
     }
     
 }

--- a/Tests/Source/Integration/IntegrationTest.swift
+++ b/Tests/Source/Integration/IntegrationTest.swift
@@ -131,8 +131,6 @@ extension IntegrationTest {
         sharedSearchDirectory = nil
         userSession = nil
         userSession?.tearDown()
-        unauthenticatedSession?.tearDown()
-        unauthenticatedSession = nil
         mockTransportSession?.cleanUp()
         mockTransportSession = nil
         sessionManager = nil
@@ -164,8 +162,6 @@ extension IntegrationTest {
     func destroySessionManager() {
         userSession?.tearDown()
         userSession = nil
-        unauthenticatedSession?.tearDown()
-        unauthenticatedSession = nil
         sessionManager = nil
         
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
@@ -247,6 +243,11 @@ extension IntegrationTest {
     @objc
     func destroyPersistentStore() {
         StorageStack.reset()
+    }
+    
+    @objc
+    var unauthenticatedSession : UnauthenticatedSession? {
+        return sessionManager?.unauthenticatedSession
     }
     
     @objc
@@ -358,7 +359,7 @@ extension IntegrationTest {
     func login(withCredentials credentials: ZMCredentials, ignoreAuthenticationFailures: Bool = false) -> Bool {
         let queue = DispatchGroupQueue(queue: .main)
         queue.add(self.dispatchGroup)
-        var authenticationObserver : AuthenticationObserver? = AuthenticationObserver(unauthenticatedSession: unauthenticatedSession!, groupQueue: queue)
+        var authenticationObserver : AuthenticationObserver? = AuthenticationObserver(unauthenticatedSession: sessionManager!.unauthenticatedSession!, groupQueue: queue)
         var didSucceed = false
         
         authenticationObserver?.onSuccess = {
@@ -371,7 +372,7 @@ extension IntegrationTest {
             }
         }
         
-        unauthenticatedSession?.login(with: credentials)
+        sessionManager?.unauthenticatedSession?.login(with: credentials)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         authenticationObserver = nil
         
@@ -516,11 +517,6 @@ extension IntegrationTest : SessionManagerDelegate {
         userSession.syncManagedObjectContext.performGroupedBlock {
             userSession.syncManagedObjectContext.setPersistentStoreMetadata(NSNumber(value: true), key: ZMSkipHotfix)
         }
-    }
-    
-    public func sessionManagerCreated(unauthenticatedSession: UnauthenticatedSession) {
-        self.unauthenticatedSession = unauthenticatedSession
-        unauthenticatedSession.groupQueue.add(self.dispatchGroup)
     }
     
     public func sessionManagerWillStartMigratingLocalStore() {

--- a/Tests/Source/Integration/PhoneRegistrationTests.m
+++ b/Tests/Source/Integration/PhoneRegistrationTests.m
@@ -47,7 +47,6 @@
     [super tearDown];
 }
 
-
 - (ZMIncompleteRegistrationUser *)createUserWithPhone:(NSString *)phone code:(NSString *)code
 {
     ZMIncompleteRegistrationUser *user = [[ZMIncompleteRegistrationUser alloc] init];

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -76,7 +76,7 @@ class SessionManagerTests: IntegrationTest {
         
         // then
         XCTAssertNil(delegate.userSession)
-        XCTAssertNotNil(delegate.unauthenticatedSession)
+        XCTAssertNotNil(sut?.unauthenticatedSession)
         withExtendedLifetime(token) {
             XCTAssertEqual([], observer.createdUserSession)
         }
@@ -108,7 +108,7 @@ class SessionManagerTests: IntegrationTest {
         
         // then
         XCTAssertNotNil(delegate.userSession)
-        XCTAssertNil(delegate.unauthenticatedSession)
+        XCTAssertNil(sut?.unauthenticatedSession)
         withExtendedLifetime(token) {
             XCTAssertEqual([delegate.userSession].flatMap { $0 }, observer.createdUserSession)
         }
@@ -312,7 +312,9 @@ class SessionManagerTests_Teams: IntegrationTest {
         try FileManager.default.createDirectory(at: accountFolder, withIntermediateDirectories: true, attributes: nil)
         
         // when
-        self.sessionManager!.delete(account: account)
+        performIgnoringZMLogError {
+            self.sessionManager!.delete(account: account)
+        }
         
         // then
         XCTAssertFalse(FileManager.default.fileExists(atPath: accountFolder.path))
@@ -779,11 +781,6 @@ class SessionManagerTestDelegate: SessionManagerDelegate {
     
     func sessionManagerDidBlacklistCurrentVersion() {
         // no op
-    }
-    
-    var unauthenticatedSession : UnauthenticatedSession?
-    func sessionManagerCreated(unauthenticatedSession : UnauthenticatedSession) {
-        self.unauthenticatedSession = unauthenticatedSession
     }
     
     var userSession : ZMUserSession?

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -773,8 +773,8 @@ class SessionManagerTestDelegate: SessionManagerDelegate {
         // no op
     }
     
-    func sessionManagerWillOpenAccount(_ account: Account) {
-        // no-op
+    func sessionManagerWillOpenAccount(_ account: Account, userSessionCanBeTornDown: @escaping () -> Void) {
+        userSessionCanBeTornDown()
     }
     
     func sessionManagerDidBlacklistCurrentVersion() {


### PR DESCRIPTION
### problem
Since logout is now asynchronous the account deleted needed to be refactored.

### also 
I also deleted `sessionManagerCreated(unauthenticatedSession:)` since didn't have much
of purpose anymore and was interfering with the logout. This could happen if it was
executed before the `sessionManagerDidFailToLogin()` or `sessionManagerWillLogout()`,
we would then lose the error message.

This should fix the pre-filling of the email on logout.