### PR TITLE
filter system messages for push/chathead notifications

### DIFF
--- a/Source/Notifications/Push notifications/LocalNotificationDispatcher+Messages.swift
+++ b/Source/Notifications/Push notifications/LocalNotificationDispatcher+Messages.swift
@@ -131,16 +131,26 @@ extension LocalNotificationDispatcher {
     
     fileprivate func localNotificationForSystemMessage(_ message : ZMSystemMessage) -> ZMLocalNotificationForSystemMessage? {
         
-        // We might want to "bundle" notifications, e.g. member join / leave events
-        if let newNote: ZMLocalNotificationForSystemMessage = messageNotifications.copyExistingMessageNotification(message) {
-            return newNote;
-        }
-        
+        // we only want participation messages concerning self user
+        guard message.isGroupParticipationMessageForSelf else { return nil }
+                
         if let newNote = ZMLocalNotificationForSystemMessage(message: message, application:self.application) {
             messageNotifications.addObject(newNote)
             return newNote;
         }
         return nil
+    }
+}
+
+private extension ZMSystemMessage {
+    
+    /// Returns true if the system message notifies the self user was added or removed
+    /// from a conversation.
+    ///
+    var isGroupParticipationMessageForSelf: Bool {
+        let addOrRemove = systemMessageType == .participantsAdded || systemMessageType == .participantsRemoved
+        let forSelf = users.count == 1 && users.first!.isSelfUser
+        return addOrRemove && forSelf
     }
 }
 

--- a/Source/Notifications/Push notifications/LocalNotificationDispatcher+Messages.swift
+++ b/Source/Notifications/Push notifications/LocalNotificationDispatcher+Messages.swift
@@ -131,9 +131,11 @@ extension LocalNotificationDispatcher {
     
     fileprivate func localNotificationForSystemMessage(_ message : ZMSystemMessage) -> ZMLocalNotificationForSystemMessage? {
         
-        // we only want participation messages concerning self user
-        guard message.isGroupParticipationMessageForSelf else { return nil }
-                
+        // we only want participation messages concerning only the self user
+        if message.isGroupParticipationMessageNotForSelf {
+            return nil
+        }
+        
         if let newNote = ZMLocalNotificationForSystemMessage(message: message, application:self.application) {
             messageNotifications.addObject(newNote)
             return newNote;
@@ -144,13 +146,13 @@ extension LocalNotificationDispatcher {
 
 private extension ZMSystemMessage {
     
-    /// Returns true if the system message notifies the self user was added or removed
-    /// from a conversation.
+    /// Returns true if the system message notifies that a user(s) that is not the self user
+    /// was added or removed from a conversation.
     ///
-    var isGroupParticipationMessageForSelf: Bool {
+    var isGroupParticipationMessageNotForSelf: Bool {
         let addOrRemove = systemMessageType == .participantsAdded || systemMessageType == .participantsRemoved
         let forSelf = users.count == 1 && users.first!.isSelfUser
-        return addOrRemove && forSelf
+        return addOrRemove && !forSelf
     }
 }
 


### PR DESCRIPTION
The only system message notifications that were being dispatched were concerning members joining/leaving group conversations. But we only want to be notified if someone adds/deletes us from a conversation.

Additionally, we no longer need to bundle these notifications since we are not collecting participation notifications from other members (bundled notifications lead to "People were added to the group")