### PR TITLE
Conversation list off fix

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -417,6 +417,7 @@ public protocol LocalMessageNotificationResponder : class {
 
         if let backgroundSession = self.backgroundUserSessions[account.userIdentifier] {
             session = backgroundSession
+            ZMConversationList.refetchAllLists(inUserSession: session)
         }
         else {
             guard let newSession = authenticatedSessionFactory.session(for: account, storeProvider: provider) else {

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -389,7 +389,7 @@ public protocol LocalMessageNotificationResponder : class {
             dispatchGroup: dispatchGroup,
             migration: { [weak self] in self?.delegate?.sessionManagerWillStartMigratingLocalStore() },
             completion: { [weak self] provider in
-                self?.createSession(for: account, with: provider) { session in
+                self?.activateSession(for: account, with: provider) { session in
                     self?.registerSessionForRemoteNotificationsIfNeeded(session)
                     completion(session)
                 }}
@@ -412,7 +412,7 @@ public protocol LocalMessageNotificationResponder : class {
         }
     }
     
-    fileprivate func createSession(for account: Account, with provider: LocalStoreProviderProtocol, completion: @escaping (ZMUserSession) -> Void) {
+    fileprivate func activateSession(for account: Account, with provider: LocalStoreProviderProtocol, completion: @escaping (ZMUserSession) -> Void) {
         let session: ZMUserSession
 
         if let backgroundSession = self.backgroundUserSessions[account.userIdentifier] {
@@ -642,7 +642,7 @@ extension SessionManager: UnauthenticatedSessionDelegate {
         let group = self.dispatchGroup
         group?.enter()
         LocalStoreProvider.createStack(applicationContainer: sharedContainerURL, userIdentifier: account.userIdentifier, dispatchGroup: dispatchGroup) { [weak self] provider in
-            self?.createSession(for: account, with: provider) { userSession in
+            self?.activateSession(for: account, with: provider) { userSession in
                 self?.registerSessionForRemoteNotificationsIfNeeded(userSession)
                 self?.updateCurrentAccount(in: userSession.managedObjectContext)
                 

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -417,7 +417,6 @@ public protocol LocalMessageNotificationResponder : class {
 
         if let backgroundSession = self.backgroundUserSessions[account.userIdentifier] {
             session = backgroundSession
-            ZMConversationList.refetchAllLists(inUserSession: session)
         }
         else {
             guard let newSession = authenticatedSessionFactory.session(for: account, storeProvider: provider) else {

--- a/Source/UserSession/ZMUserSession+Background.m
+++ b/Source/UserSession/ZMUserSession+Background.m
@@ -139,6 +139,8 @@ performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult result))comp
     self.didNotifyThirdPartyServices = NO;
 
     [self mergeChangesFromStoredSaveNotificationsIfNeeded];
+    
+    [ZMConversationList refetchAllListsInUserSession:self];
 }
 
 - (void)mergeChangesFromStoredSaveNotificationsIfNeeded

--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -204,8 +204,8 @@ ZM_EMPTY_ASSERTING_INIT()
             self.syncManagedObjectContext.zm_fileAssetCache = fileAssetCache;
             
             self.localNotificationDispatcher = [[LocalNotificationDispatcher alloc] initWithManagedObjectContext:self.syncManagedObjectContext
-                                               foregroundNotificationDelegate:self
-                                                                  application:application];
+                                                                                  foregroundNotificationDelegate:self
+                                                                                                     application:application];
 
             
             


### PR DESCRIPTION
# Issue

Problem appears when 2 user sessions are active (A, B) -- for example user started the app and switched from A to B and back: A is active, B on background.

1. User sends the app to the background -> Observation system is paused
2. Someone creates the conversation with user from B and writes the message while the app is in the 
3. User activates the app
4. The observation of the list has to catch up, and now it's done in UI and only for the active session with `    [ZMConversationList refetchAllListsInUserSession:ZMUserSession.sharedSession]`
5. The list on the session A is up to date, but on B it's missing the new conversation


Consequences: conversation is missing from the list if user activates B, the dot is absent for B.

# Solution

Make `ZMUserSession` refresh it's lists when the app is going to the foreground.