### PR TITLE
Fix: Stuck during login

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -320,7 +320,8 @@ public protocol LocalMessageNotificationResponder : class {
     /// - completion: runs when the user session was loaded
     /// - tearDownCompletion: runs when the UI no longer holds any references to the previous user session.
     public func select(_ account: Account, completion: ((ZMUserSession)->())? = nil, tearDownCompletion: (() -> Void)? = nil) {
-        delegate?.sessionManagerWillOpenAccount(account, userSessionCanBeTornDown: { 
+        delegate?.sessionManagerWillOpenAccount(account, userSessionCanBeTornDown: { [weak self] in
+            self?.activeUserSession = nil
             tearDownCompletion?()
         })
         


### PR DESCRIPTION
A second part of fixing the same problem as https://github.com/wireapp/wire-ios/pull/1316

It manifests when logging in to an account that doesn’t have the cookie anymore. The reason behing the problem is that there is already an active user session available when trying to login to another account. This puts session manager in weird state and prevents login from proceeding.

N.B. There are no tests for this and I had trouble writing it because MockTransport doesn't support multiple accounts. Some more thinking is needed to come up with a solution to this.