### PR TITLE
Fix/group missed call ZIOS 8951

### DIFF
--- a/Source/UserSession/CallStateObserver.swift
+++ b/Source/UserSession/CallStateObserver.swift
@@ -79,13 +79,15 @@ extension CallStateObserver : WireCallCenterCallStateObserver, WireCallCenterMis
             
             self.updateConversationListIndicator(convObjectID: conversation.objectID, callState: callState)
             
-            let systemMessage = self.systemMessageGenerator.appendSystemMessageIfNeeded(callState: callState, conversation: conversation, user: user, timeStamp: timeStamp)
-            if systemMessage?.systemMessageType == .missedCall
-                && (callState == .terminating(reason: .canceled) || callState == .terminating(reason: .normal) && conversation.conversationType == .group)
-            {
-                // group calls we didn't join, end with reason .normal. We should still insert a missed call in this case.
-                // since the systemMessageGenerator keeps track whether we joined or not, we can use it to decide whether we should show a missed call APNS
-                self.localNotificationDispatcher.processMissedCall(in: conversation, sender: user)
+            if let systemMessage = self.systemMessageGenerator.appendSystemMessageIfNeeded(callState: callState, conversation: conversation, user: user, timeStamp: timeStamp) {
+                switch (systemMessage.systemMessageType, callState, conversation.conversationType) {
+                case (.missedCall, .terminating(reason: .normal), .group):
+                    // group calls we didn't join, end with reason .normal. We should still insert a missed call in this case.
+                    // since the systemMessageGenerator keeps track whether we joined or not, we can use it to decide whether we should show a missed call APNS
+                    self.localNotificationDispatcher.processMissedCall(in: conversation, sender: user)
+                default:
+                    break
+                }
             }
             
             if let timeStamp = timeStamp {


### PR DESCRIPTION
## Issue
If one account is logged into different two iOS devices, and one device is used to answer a group call, then the other device receives a notification that they missed a call from themselves.

## Reason
We process a missed call notification if we do not join a group call, and this call ends normally. However, the condition `callState == .terminating(reason: .normal)` will be true for any terminating call state, because definition of call state equality does not consider the reason (see `WireCallCenterV3.swift` line 106). As a result, we we're processing missed call notifications with the reason `answeredElsewhere` where the user object refers to the self user.

## Solution
Using a `switch` to correctly check the `callState` value.

## Extra
The condition `callState == .terminating(reason: .canceled)` was removed as it is unnecessary and handled by the `WireCallCenterMissedCallObserver`