### PR TITLE
Don't start loading loading the new user session until the UI has been torn down

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -325,12 +325,11 @@ public protocol LocalMessageNotificationResponder : class {
         delegate?.sessionManagerWillOpenAccount(account, userSessionCanBeTornDown: { [weak self] in
             self?.activeUserSession = nil
             tearDownCompletion?()
+            self?.loadSession(for: account) { [weak self] session in
+                self?.accountManager.select(account)
+                completion?(session)
+            }
         })
-        
-        loadSession(for: account) { [weak self] session in
-            self?.accountManager.select(account)
-            completion?(session)
-        }
     }
     
     public func addAccount() {


### PR DESCRIPTION
### Problem
we were crashing on switching between accounts
https://rink.hockeyapp.net/manage/apps/65633/app_versions/1150/crash_reasons/188662498

### Cause
when running `select()` to switch active account the following happens:

1. start tearing down UI and display the skeleton
2. load the new session and set `activeUserSession`
3. tearing down the UI finishes and we nil out the `activeUserSession`
4. we start loading the UI but it will crash because `activeUserSession` is nil 

### Solution
Delay loading the new session until we've finished tearing down the UI