### PR TITLE
Annotate ZMPushToken with nullability to avoid force unwrap in Swift

### DIFF
--- a/Source/Data Model/Push Token/ZMPushToken.h
+++ b/Source/Data Model/Push Token/ZMPushToken.h
@@ -23,24 +23,24 @@
 /// A push token used to register the app with the backend + APNS.
 @interface ZMPushToken : NSObject <NSSecureCoding>
 
-- (instancetype)initWithDeviceToken:(NSData *)deviceToken
-                         identifier:(NSString *)appIdentifier
-                      transportType:(NSString *)transportType
-                           fallback:(NSString *)fallback
+- (instancetype _Nonnull)initWithDeviceToken:(NSData * _Nonnull)deviceToken
+                         identifier:(NSString * _Nonnull)appIdentifier
+                      transportType:(NSString * _Nonnull)transportType
+                           fallback:(NSString * _Nullable)fallback
                        isRegistered:(BOOL)isRegistered;
 
-@property (nonatomic, copy, readonly) NSData *deviceToken;
-@property (nonatomic, copy, readonly) NSString *appIdentifier;
-@property (nonatomic, copy, readonly) NSString *transportType;
-@property (nonatomic, copy, readonly) NSString *fallback;
+@property (nonatomic, copy, readonly, nonnull) NSData *deviceToken;
+@property (nonatomic, copy, readonly, nonnull) NSString *appIdentifier;
+@property (nonatomic, copy, readonly, nonnull) NSString *transportType;
+@property (nonatomic, copy, readonly, nullable) NSString *fallback;
 @property (nonatomic, readonly) BOOL isRegistered;
 @property (nonatomic, readonly) BOOL isMarkedForDeletion;
 
 /// Returns a copy of the receiver with @c isRegistered set to @c NO
-- (instancetype)unregisteredCopy;
+- (instancetype _Nonnull)unregisteredCopy;
 
 /// Returns a copy of the receiver is @c isMarkedForDeletion set to @c YES or nil if the token is not registered
-- (instancetype)forDeletionMarkedCopy;
+- (instancetype _Nullable)forDeletionMarkedCopy;
 
 @end
 
@@ -49,9 +49,9 @@
 @interface NSManagedObjectContext (PushToken)
 
 /// The token used for @c UIApplication based remote push notifications.
-@property (nonatomic, copy) ZMPushToken *pushToken;
+@property (nonatomic, copy, nullable) ZMPushToken *pushToken;
 /// The token used for PushKit based remote push notifications. PushKit also refers to the token as ‘credentials’.
-@property (nonatomic, copy) ZMPushToken *pushKitToken;
+@property (nonatomic, copy, nullable) ZMPushToken *pushKitToken;
 
 @end
 
@@ -59,6 +59,6 @@
 
 @interface NSString (ZMPushToken)
 
-- (NSData *)zmDeviceTokenData;
+- (nullable NSData *)zmDeviceTokenData;
 
 @end

--- a/Source/SessionManager/SessionManager+Push.swift
+++ b/Source/SessionManager/SessionManager+Push.swift
@@ -27,12 +27,12 @@ extension SessionManager {
             self.pushDispatcher.lastKnownPushTokens.forEach { type, actualToken in
                 switch type {
                 case .voip:
-                    if actualToken != session.managedObjectContext.pushKitToken.deviceToken {
+                    if actualToken != session.managedObjectContext.pushKitToken?.deviceToken {
                         session.managedObjectContext.pushKitToken = nil
                         session.setPushKitToken(actualToken)
                     }
                 case .regular:
-                    if actualToken != session.managedObjectContext.pushToken.deviceToken {
+                    if actualToken != session.managedObjectContext.pushToken?.deviceToken {
                         session.managedObjectContext.pushToken = nil
                         session.setPushToken(actualToken)
                     }

--- a/Source/Synchronization/Strategies/PushTokenStrategy.swift
+++ b/Source/Synchronization/Strategies/PushTokenStrategy.swift
@@ -81,11 +81,6 @@ public class PushTokenStrategy : AbstractRequestStrategy, ZMSingleRequestTransco
             sync.resetCompletionState()
             return nil
         }
-        if ((token.deviceToken == nil) || (token.appIdentifier == nil) || (token.transportType == nil)) {
-            storePushToken(token: nil, forSingleRequestSync:sync)
-            sync.resetCompletionState()
-            return nil;
-        }
         
         // hex encode the token:
         let encodedToken = token.deviceToken.reduce(""){$0 + String(format: "%02hhx", $1)}
@@ -152,6 +147,7 @@ public class PushTokenStrategy : AbstractRequestStrategy, ZMSingleRequestTransco
               let identifier = payloadDictionary["app"] as? String,
               let transportType = payloadDictionary["transport"] as? String
         else { return nil }
+        
         let fallback = payloadDictionary["fallback"] as? String
 
         return ZMPushToken(deviceToken:deviceToken, identifier:identifier, transportType:transportType, fallback:fallback, isRegistered:true)
@@ -219,8 +215,8 @@ extension PushTokenStrategy : ZMEventConsumer {
         //    }
         // }
         // we ignore the payload and reregister both tokens whenever we receive a user.push-remove event
-        managedObjectContext.pushToken = managedObjectContext.pushToken.unregisteredCopy()
-        managedObjectContext.pushKitToken = managedObjectContext.pushKitToken.unregisteredCopy()
+        managedObjectContext.pushToken = managedObjectContext.pushToken?.unregisteredCopy()
+        managedObjectContext.pushKitToken = managedObjectContext.pushKitToken?.unregisteredCopy()
     }
 }
 

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -775,14 +775,14 @@ class SessionManagerTests_Push: IntegrationTest {
         
         // THEN
         XCTAssertNotNil(session.managedObjectContext.pushKitToken)
-        XCTAssertFalse(session.managedObjectContext.pushKitToken.isMarkedForDeletion)
+        XCTAssertFalse(session.managedObjectContext.pushKitToken!.isMarkedForDeletion)
         
         // AND WHEN
         self.sessionManager?.pushDispatcher.pushRegistrant.pushRegistry(PKPushRegistry.init(queue: nil), didInvalidatePushTokenForType:.voIP)
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // THEN
-        XCTAssertTrue(session.managedObjectContext.pushKitToken.isMarkedForDeletion)
+        XCTAssertTrue(session.managedObjectContext.pushKitToken!.isMarkedForDeletion)
         
         // CLEANUP
         self.sessionManager!.tearDownAllBackgroundSessions()
@@ -810,8 +810,8 @@ class SessionManagerTests_Push: IntegrationTest {
         
         // THEN
         XCTAssertNotNil(session.managedObjectContext.pushKitToken)
-        XCTAssertEqual(session.managedObjectContext.pushKitToken.deviceToken, credentials.token)
-        XCTAssertFalse(session.managedObjectContext.pushKitToken.isMarkedForDeletion)
+        XCTAssertEqual(session.managedObjectContext.pushKitToken!.deviceToken, credentials.token)
+        XCTAssertFalse(session.managedObjectContext.pushKitToken!.isMarkedForDeletion)
         
         // CLEANUP
         self.sessionManager!.tearDownAllBackgroundSessions()

--- a/Tests/Source/Synchronization/Strategies/PushTokenStrategyTests.swift
+++ b/Tests/Source/Synchronization/Strategies/PushTokenStrategyTests.swift
@@ -27,12 +27,12 @@ class PushTokenStrategyTests: MessagingTest {
     var mockApplicationStatus : MockApplicationStatus!
     let deviceTokenString = "c5e24e41e4d4329037928449349487547ef14f162c77aee3aa8e12a39c8db1d5"
     var deviceToken : Data {
-        return deviceTokenString.zmDeviceTokenData()
+        return deviceTokenString.zmDeviceTokenData()!
     }
 
     let deviceTokenBString = "0c11633011485c4558615009045b022d565e0c380a5330444d3a0f4b185a014a"
     var deviceTokenB : Data {
-        return deviceTokenBString.zmDeviceTokenData()
+        return deviceTokenBString.zmDeviceTokenData()!
     }
 
     let identifier = "com.wire.zclient"
@@ -133,12 +133,12 @@ extension PushTokenStrategyTests {
         
         // then
         XCTAssertNotNil(uiMOC.pushToken);
-        XCTAssertEqual(uiMOC.pushToken.deviceToken, deviceToken);
-        XCTAssertFalse(uiMOC.pushToken.isRegistered);
+        XCTAssertEqual(uiMOC.pushToken!.deviceToken, deviceToken);
+        XCTAssertFalse(uiMOC.pushToken!.isRegistered);
         
         XCTAssertNotNil(uiMOC.pushKitToken);
-        XCTAssertEqual(uiMOC.pushKitToken.deviceToken, deviceTokenB);
-        XCTAssertFalse(uiMOC.pushKitToken.isRegistered);
+        XCTAssertEqual(uiMOC.pushKitToken!.deviceToken, deviceTokenB);
+        XCTAssertFalse(uiMOC.pushKitToken!.isRegistered);
     }
     
     func testThatItMarksATokenAsNotRegisteredWhenReceivingAPushRemoveEvent_ApplicationToken() {
@@ -210,10 +210,10 @@ extension PushTokenStrategyTests {
         
         // then
         XCTAssertNotNil(uiMOC.pushToken)
-        XCTAssertTrue(uiMOC.pushToken.isRegistered)
-        XCTAssertEqual(uiMOC.pushToken.appIdentifier, "foo.bar")
+        XCTAssertTrue(uiMOC.pushToken!.isRegistered)
+        XCTAssertEqual(uiMOC.pushToken!.appIdentifier, "foo.bar")
         let newDeviceToken = Data(bytes: [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff])
-        XCTAssertEqual(uiMOC.pushToken.deviceToken, newDeviceToken)
+        XCTAssertEqual(uiMOC.pushToken!.deviceToken, newDeviceToken)
     }
     
     func testThatItDoesNotRegisterThePushTokenAgainAfterTheRequestCompletes() {
@@ -321,10 +321,10 @@ extension PushTokenStrategyTests {
         
         // then
         XCTAssertNotNil(uiMOC.pushKitToken)
-        XCTAssertTrue(uiMOC.pushKitToken.isRegistered)
-        XCTAssertEqual(uiMOC.pushKitToken.appIdentifier, "foo.bar")
+        XCTAssertTrue(uiMOC.pushKitToken!.isRegistered)
+        XCTAssertEqual(uiMOC.pushKitToken!.appIdentifier, "foo.bar")
         let newDeviceToken = Data(bytes: [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff])
-        XCTAssertEqual(uiMOC.pushKitToken.deviceToken, newDeviceToken)
+        XCTAssertEqual(uiMOC.pushKitToken!.deviceToken, newDeviceToken)
     }
     
     func testThatItDoesNotRegisterThePushKitTokenAgainAfterTheRequestCompletes() {
@@ -356,10 +356,10 @@ extension PushTokenStrategyTests {
     func insertTokenMarkedForDeletion(transport: String) {
         if transport == transportTypeVOIP {
             uiMOC.pushKitToken = ZMPushToken(deviceToken:deviceToken, identifier:identifier, transportType:transport, fallback:nil, isRegistered:true)
-            uiMOC.pushKitToken = uiMOC.pushKitToken.forDeletionMarkedCopy()
+            uiMOC.pushKitToken = uiMOC.pushKitToken?.forDeletionMarkedCopy()
         } else {
             uiMOC.pushToken = ZMPushToken(deviceToken:deviceToken, identifier:identifier, transportType:transport, fallback:nil, isRegistered:true)
-            uiMOC.pushToken = uiMOC.pushToken.forDeletionMarkedCopy()
+            uiMOC.pushToken = uiMOC.pushToken?.forDeletionMarkedCopy()
         }
         try! uiMOC.save()
     }


### PR DESCRIPTION
### Problem
The iOS client crashes when you login on the release candidate build.
https://wearezeta.atlassian.net/browse/ZIOS-9032

### Background
The Release candidate build is a special build were we have taken the app store build but re-signed it with a different provisioning profile so that it can run on our test devices. This however makes the push token entitlements invalid and we wont' get a device token. This wasn't a problem until we moved the push token handling to Swift, we now end up force unwrapping a nil value.

### Solution
Annotate the `ZMPushToken` with nullability so that we don't force unwrap a nil value.