### PR TITLE
Fix/make voice channel mockable

### DIFF
--- a/Source/Calling/VoiceChannel.swift
+++ b/Source/Calling/VoiceChannel.swift
@@ -35,9 +35,9 @@ public enum CaptureDevice : Int {
 
 public protocol VoiceChannel : class, CallProperties, CallActions, CallActionsInternal, CallObservers {
     
+    init(conversation: ZMConversation)
+    
 }
-
-public protocol VoiceChannelInternal : CallProperties, CallActionsInternal { }
 
 public protocol CallProperties : NSObjectProtocol {
     

--- a/Source/Calling/VoiceChannel.swift
+++ b/Source/Calling/VoiceChannel.swift
@@ -33,7 +33,7 @@ public enum CaptureDevice : Int {
     }
 }
 
-public protocol VoiceChannel : CallProperties, CallActions, CallActionsInternal, CallObservers {
+public protocol VoiceChannel : class, CallProperties, CallActions, CallActionsInternal, CallObservers {
     
 }
 

--- a/Source/Calling/VoiceChannelV3.swift
+++ b/Source/Calling/VoiceChannelV3.swift
@@ -43,7 +43,7 @@ public class VoiceChannelV3 : NSObject, VoiceChannel {
         return NSOrderedSet(array: users)
     }
     
-    init(conversation: ZMConversation) {
+    public required init(conversation: ZMConversation) {
         self.conversation = conversation
         super.init()
     }

--- a/Source/Calling/VoiceChannelV3.swift
+++ b/Source/Calling/VoiceChannelV3.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-public class VoiceChannelV3 : NSObject, CallProperties, VoiceChannel {
+public class VoiceChannelV3 : NSObject, VoiceChannel {
 
     public var callCenter: WireCallCenterV3? {
         return self.conversation?.managedObjectContext?.zm_callCenter

--- a/Source/Calling/WireCallCenterV3Factory.swift
+++ b/Source/Calling/WireCallCenterV3Factory.swift
@@ -23,6 +23,7 @@ import WireDataModel
 public class WireCallCenterV3Factory : NSObject {
     
     public static var wireCallCenterClass : WireCallCenterV3.Type = WireCallCenterV3.self
+    public static var voiceChannelClass : VoiceChannel.Type = VoiceChannelV3.self
     
     public class func callCenter(withUserId userId: UUID, clientId: String, uiMOC: NSManagedObjectContext, flowManager: FlowManagerType, analytics: AnalyticsType? = nil, transport: WireCallCenterTransport) -> WireCallCenterV3 {
         if let wireCallCenter = uiMOC.zm_callCenter {

--- a/Source/Calling/ZMConversation+VoiceChannel.swift
+++ b/Source/Calling/ZMConversation+VoiceChannel.swift
@@ -27,10 +27,10 @@ public extension ZMConversation {
         get {
             guard conversationType == .oneOnOne || conversationType == .group else { return nil }
             
-            if let voiceChannel = objc_getAssociatedObject(self, &voiceChannelAssociatedKey) as? VoiceChannelV3 {
+            if let voiceChannel = objc_getAssociatedObject(self, &voiceChannelAssociatedKey) as? VoiceChannel {
                 return voiceChannel
             } else {
-                let voiceChannel = VoiceChannelV3(conversation: self)
+                let voiceChannel = WireCallCenterV3Factory.voiceChannelClass.init(conversation: self)
                 objc_setAssociatedObject(self, &voiceChannelAssociatedKey, voiceChannel, .OBJC_ASSOCIATION_RETAIN)
                 return voiceChannel
             }

--- a/Source/Calling/ZMConversation+VoiceChannel.swift
+++ b/Source/Calling/ZMConversation+VoiceChannel.swift
@@ -24,12 +24,6 @@ public extension ZMConversation {
     
     /// NOTE: this object is transient, and will be re-created periodically. Do not hold on to this object, hold on to the owning conversation instead.
     var voiceChannel : VoiceChannel? {
-        return voiceChannelInternal
-    }
-    
-    /// NOTE: this object is transient, and will be re-created periodically. Do not hold on to this object, hold on to the owning conversation instead.
-    var voiceChannelInternal : VoiceChannelV3? {
-        
         get {
             guard conversationType == .oneOnOne || conversationType == .group else { return nil }
             
@@ -41,7 +35,6 @@ public extension ZMConversation {
                 return voiceChannel
             }
         }
-        
     }
     
 }

--- a/Tests/Source/Data Model/ZMConversationVoiceChannelRouterTests.swift
+++ b/Tests/Source/Data Model/ZMConversationVoiceChannelRouterTests.swift
@@ -60,10 +60,10 @@ class ZMConversationVoiceChannelTests : MessagingTest {
     
     func testThatItAlwaysReturnsTheSameVoiceChannelForAOneOnOneConversations() {
         // when
-        let voiceChannel = oneToOneconversation.voiceChannelInternal
+        let voiceChannel = oneToOneconversation.voiceChannel
         
         // then
-        XCTAssertEqual(oneToOneconversation.voiceChannelInternal, voiceChannel)
+        XCTAssertTrue(oneToOneconversation.voiceChannel === voiceChannel)
     }
     
 }

--- a/Tests/Source/Integration/CallingV3Tests.swift
+++ b/Tests/Source/Integration/CallingV3Tests.swift
@@ -81,7 +81,7 @@ class CallingV3Tests : IntegrationTest {
     
     func selfJoinCall(isStart: Bool) {
         userSession?.enqueueChanges {
-            _ = self.conversationUnderTest.voiceChannelInternal?.join(video: false)
+            _ = self.conversationUnderTest.voiceChannel?.join(video: false)
         }
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
     }
@@ -90,7 +90,7 @@ class CallingV3Tests : IntegrationTest {
         let convIdRef = self.conversationIdRef
         let userIdRef = self.selfUser.identifier.cString(using: .utf8)
         userSession?.enqueueChanges {
-            self.conversationUnderTest.voiceChannelInternal?.leave()
+            self.conversationUnderTest.voiceChannel?.leave()
             WireSyncEngine.closedCallHandler(reason: WCALL_REASON_STILL_ONGOING,
                                              conversationId: convIdRef,
                                              messageTime: 0,
@@ -104,7 +104,7 @@ class CallingV3Tests : IntegrationTest {
         let convIdRef = self.conversationIdRef
         let userIdRef = self.selfUser.identifier.cString(using: .utf8)
         userSession?.performChanges{
-            self.conversationUnderTest.voiceChannelInternal?.ignore()
+            self.conversationUnderTest.voiceChannel?.ignore()
             WireSyncEngine.closedCallHandler(reason: WCALL_REASON_STILL_ONGOING,
                                              conversationId: convIdRef,
                                              messageTime: 0,


### PR DESCRIPTION
After making the VoiceChannel swift only it wasn't possible anymore to mock the VoiceChannel for the snapshots tests. This PR exposes a way to replace the `VoiceChannel` implementation with a mock.