### PR TITLE
Possible fix for messages getting stuck

### DIFF
--- a/Source/Synchronization/ApplicationStatusDirectory.swift
+++ b/Source/Synchronization/ApplicationStatusDirectory.swift
@@ -45,7 +45,7 @@ public final class ApplicationStatusDirectory : NSObject, ApplicationStatus {
         self.requestCancellation = requestCancellation
         self.apnsConfirmationStatus = BackgroundAPNSConfirmationStatus(application: application, managedObjectContext: managedObjectContext, backgroundActivityFactory: BackgroundActivityFactory.sharedInstance())
         self.operationStatus = OperationStatus()
-        self.operationStatus.isInBackground = application.applicationState == .background;
+        self.operationStatus.isInBackground = application.applicationState == .background
         self.syncStatus = SyncStatus(managedObjectContext: managedObjectContext, syncStateDelegate: syncStateDelegate)
         self.userProfileUpdateStatus = UserProfileUpdateStatus(managedObjectContext: managedObjectContext)
         self.clientUpdateStatus = ClientUpdateStatus(syncManagedObjectContext: managedObjectContext)

--- a/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
@@ -96,8 +96,7 @@ previouslyReceivedEventIDsCollection:(id<PreviouslyReceivedEventIDsCollection>)e
 
 - (BOOL)isFetchingStreamForAPNS
 {
-    return self.application.applicationState == UIApplicationStateBackground
-        && self.pingbackStatus.status == BackgroundNotificationFetchStatusInProgress;
+    return self.pingbackStatus.status == BackgroundNotificationFetchStatusInProgress;
 }
 
 - (BOOL)isFetchingStreamInBackground

--- a/Source/Synchronization/ZMSyncStrategy.m
+++ b/Source/Synchronization/ZMSyncStrategy.m
@@ -370,7 +370,7 @@ ZM_EMPTY_ASSERTING_INIT()
         return nil;
     }
     
-    return [self.requestStrategies firstNonNilReturnedFromSelector:@selector(nextRequest)];;
+    return [self.requestStrategies firstNonNilReturnedFromSelector:@selector(nextRequest)];
 }
 
 - (ZMFetchRequestBatch *)fetchRequestBatchForEvents:(NSArray<ZMUpdateEvent *> *)events

--- a/Tests/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoderTests.m
@@ -1073,7 +1073,6 @@ static NSString * const LastUpdateEventIDStoreKey = @"LastUpdateEventID";
 - (void)testThatItReportsWhenItIsFetchingFromAPushNotification
 {
     // given
-    self.application.applicationState = UIApplicationStateBackground;
     [(BackgroundAPNSPingBackStatus *)[[self.mockPingbackStatus expect] andReturnValue:@(BackgroundNotificationFetchStatusInProgress)] status];
 
     // then


### PR DESCRIPTION
# Issue

For some users frequently it is not possible to send the message because of the timeout.

# Investigation

It comes out that at least one of the issue cases can be reproduced with the following steps:
1. Configure the client to have 2 accounts logged in (A is active, B inactive)
2. Kill the client
2. Enable Wi-Fi
2. Start the client
3. Disable Wi-Fi
4. Send the message from another device to the B (inactive) account
5. Activate B
-> Any message sent on B would not be delivered.


During the investigation it came clear that no request was generated, since the `ApplicationStatus` in `AbstractRequestStrategy` was signaling that `notificationFetchStatus` is still `.inProgress`, which means that the sync engine was thinking that we are still fetching the notification stream due to the push received. This is caused by the fact that before the SE never fetched the notification stream due to the push when the app was in the foreground, whereas with the multi-account support this is the normal behavior for the user session that is started on the background.

After the check it comes out that the Wi-Fi switching in STR is irrelevant.

Possible fix is in `ZMMissingUpdateEventsTranscoder.m`, so `isFetchingStreamForAPNS` is only relying on the `pingbackStatus`'s status, which seems enough at this point.