### PR TITLE
Add account limit check to SessionManager

### DIFF
--- a/Source/Public/NSError+ZMUserSession.h
+++ b/Source/Public/NSError+ZMUserSession.h
@@ -69,7 +69,9 @@ typedef NS_ENUM(NSUInteger, ZMUserSessionErrorCode) {
     /// The user account is suspended and may not be logged in
     ZMUserSessionAccountSuspended,
     /// The user account was deleted
-    ZMUserSessionAccountDeleted
+    ZMUserSessionAccountDeleted,
+    /// The account can't be created because the account limit has been reached
+    ZMUserSessionAccountLimitReached
 };
 
 FOUNDATION_EXPORT NSString * const ZMUserSessionErrorDomain;

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -104,6 +104,9 @@ public protocol LocalMessageNotificationResponder : class {
 
 @objc public class SessionManager : NSObject {
 
+    /// Maximum number of accounts which can be logged in simultanously
+    public static let maxNumberAccounts = 3
+    
     public let appVersion: String
     var isAppVersionBlacklisted = false
     public weak var delegate: SessionManagerDelegate? = nil
@@ -638,6 +641,11 @@ extension SessionManager: UnauthenticatedSessionDelegate {
     }
     
     public func session(session: UnauthenticatedSession, createdAccount account: Account) {
+        guard !(accountManager.accounts.count == SessionManager.maxNumberAccounts && accountManager.account(with: account.userIdentifier) == nil) else {
+            session.authenticationStatus.notifyAuthenticationDidFail(NSError.userSessionErrorWith(.accountLimitReached, userInfo: nil))
+            return
+        }
+        
         accountManager.addAndSelect(account)
 
         let group = self.dispatchGroup

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -319,6 +319,25 @@ class SessionManagerTests_Teams: IntegrationTest {
         // then
         XCTAssertFalse(FileManager.default.fileExists(atPath: accountFolder.path))
     }
+    
+    func testThatItSendsAuthenticationErrorWhenAccountLimitIsReached() throws {
+        // given
+        let account1 = Account(userName: "Account 1", userIdentifier: UUID.create())
+        let account2 = Account(userName: "Account 2", userIdentifier: UUID.create())
+        let account3 = Account(userName: "Account 3", userIdentifier: UUID.create())
+        
+        sessionManager?.accountManager.addOrUpdate(account1)
+        sessionManager?.accountManager.addOrUpdate(account2)
+        sessionManager?.accountManager.addOrUpdate(account3)
+        
+        let recorder = PreLoginAuthenticationNotificationRecorder(authenticationStatus: sessionManager!.unauthenticatedSession!.authenticationStatus)
+        
+        // when
+        XCTAssert(login(ignoreAuthenticationFailures: true))
+
+        // then
+        XCTAssertEqual(NSError.userSessionErrorWith(.accountLimitReached, userInfo: nil), recorder.notifications.last!.error)
+    }
 }
 
 class SessionManagerPayloadCheckerTests: MessagingTest {


### PR DESCRIPTION
### Problem
It was possible to add more than three accounts by triggering a logout and then logging into a new account.

### Solution
We do an additional account limit check before adding the account.