### PR TITLE
Fixed swift porting issue with localization

### DIFF
--- a/Source/Calling/CallKitDelegate.swift
+++ b/Source/Calling/CallKitDelegate.swift
@@ -410,7 +410,7 @@ extension ZMConversation {
         
         switch conversationType {
         case .group:
-            return ("callkit.call.started" as NSString).localizedString(with: self, count: 0)
+            return ("callkit.call.started" as NSString).localizedString(with: user, conversation: self, count: 0)
         case .oneOnOne:
             return connectedUser?.displayName
         default:


### PR DESCRIPTION
Obj-C code was calling another method: 
https://github.com/wireapp/wire-ios-sync-engine/blob/118.0.0/Source/Calling/ZMCallKitDelegate.m#L110

Most likely missed while porting to Swift.

![bug](https://user-images.githubusercontent.com/715129/31270640-7662c926-aa85-11e7-8b06-f2ccde673438.jpg)
