### PR TITLE
always open conversation when calling APNS is opened

### DIFF
--- a/Source/UserSession/ZMUserSession+Actions.swift
+++ b/Source/UserSession/ZMUserSession+Actions.swift
@@ -38,7 +38,10 @@ extension ZMUserSession {
     public func handleCallCategoryNotification(_ note : ZMStoredLocalNotification) {
         guard let actionIdentifier = note.actionIdentifier, actionIdentifier == ZMCallAcceptAction,
               let callState = note.conversation.voiceChannel?.state
-        else { return }
+        else {
+            open(note.conversation, at: nil)
+            return
+        }
         
         if case let .incoming(video: video, shouldRing: _, degraded: _) = callState, callCenter.activeCallConversations(in: self).count == 0 {
             _ = note.conversation.voiceChannel?.join(video: video, userSession: self)


### PR DESCRIPTION
## Problem
Swiping on an APNS notification for incoming calls only opens the app, it does not switch to the appropriate account to display the conversation and calling overlay

## Reason
Previously, when handling the incoming call notification, we were requiring that `actionIdentifier == ZMCallAcceptAction`. However, when swiping right on notification, the `actionIdentifier` is nil (since the notification is just being opened, not triggering an action), and consequently we return early.

## Solution
Just before returning, we open the conversation attached to the notification. This will switch accounts if necessary, and show the call screen overlay.