### PR TITLE
Fix crash because of wrong change participant change update

### DIFF
--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -817,10 +817,12 @@ public struct CallEvent {
         if let snapshot = participantSnapshots[conversationId] {
             snapshot.callParticipantsChanged(newParticipants: participants)
         } else if participants.count > 0 {
-            participantSnapshots[conversationId] = VoiceChannelParticipantV3Snapshot(conversationId: conversationId,
-                                                                                     selfUserID: selfUserId,
-                                                                                     members: participants,
-                                                                                     callCenter: self)
+            let snaphot = VoiceChannelParticipantV3Snapshot(conversationId: conversationId,
+                                                            selfUserID: selfUserId,
+                                                            members: [],
+                                                            callCenter: self)
+            participantSnapshots[conversationId] = snaphot
+            snaphot.callParticipantsChanged(newParticipants: participants)
         }
     }
     


### PR DESCRIPTION
## Problem
When starting a call, the participants snapshot will be created when the first
person joins the call. This however did not create a change notification. When
the second person joins the first change set will not include first person.
This wasn't a problem before since we created the participants collection view
after the first person had joined the call.

## Solution
Also create a change notification for the first person joining the call.