### PR TITLE
Fix using wrong UUID when reporting call connection state of call

### DIFF
--- a/Source/Calling/CallKitDelegate.swift
+++ b/Source/Calling/CallKitDelegate.swift
@@ -282,11 +282,11 @@ extension CallKitDelegate : CXProviderDelegate {
         calls[action.callUUID] = callObserver
         
         callObserver.onAnswered = {
-            provider.reportOutgoingCall(with: action.uuid, startedConnectingAt: Date())
+            provider.reportOutgoingCall(with: action.callUUID, startedConnectingAt: Date())
         }
         
         callObserver.onEstablished = {
-            provider.reportOutgoingCall(with: action.uuid, connectedAt: Date())
+            provider.reportOutgoingCall(with: action.callUUID, connectedAt: Date())
         }
         
         mediaManager?.setupAudioDevice()

--- a/Tests/Source/Calling/CallKitDelegateTests.swift
+++ b/Tests/Source/Calling/CallKitDelegateTests.swift
@@ -137,20 +137,19 @@ class MockStartCallAction : CXStartCallAction {
 @available(iOS 10.0, *)
 class MockProvider : CXProvider {
     
-    var isConnected : Bool = false
-    var hasStartedConnecting = false
-    
+    var connectingCalls : Set<UUID> = Set()
+    var connectedCalls : Set<UUID> = Set()
     
     convenience init(foo: Bool) {
         self.init(configuration: CXProviderConfiguration(localizedName: "test"))
     }
     
     override func reportOutgoingCall(with UUID: UUID, startedConnectingAt dateStartedConnecting: Date?) {
-        hasStartedConnecting = true
+        connectingCalls.insert(UUID)
     }
     
     override func reportOutgoingCall(with UUID: UUID, connectedAt dateConnected: Date?) {
-        isConnected = true
+        connectedCalls.insert(UUID)
     }
     
 }
@@ -453,7 +452,7 @@ class CallKitDelegateTest: MessagingTest {
         mockWireCallCenterV3.update(callState: .answered(degraded: false), conversationId: conversation.remoteIdentifier!)
         
         // then
-        XCTAssertTrue(provider.hasStartedConnecting)
+        XCTAssertTrue(provider.connectingCalls.contains(conversation.remoteIdentifier!))
     }
     
     func testThatStartCallActionUpdatesWhenTheCallHasConnected() {
@@ -467,7 +466,7 @@ class CallKitDelegateTest: MessagingTest {
         mockWireCallCenterV3.update(callState: .establishedDataChannel, conversationId: conversation.remoteIdentifier!)
         
         // then
-        XCTAssertTrue(provider.isConnected)
+        XCTAssertTrue(provider.connectedCalls.contains(conversation.remoteIdentifier!))
     }
     
     // Public API - report end on outgoing call


### PR DESCRIPTION
Not correctly informing Callkit that the call had connected would trigger and error when the remote party ended the call.

https://wearezeta.atlassian.net/browse/ZIOS-9093