### PR TITLE
don’t require non active app state to handle call action

### DIFF
--- a/Source/UserSession/ZMUserSession+Push.swift
+++ b/Source/UserSession/ZMUserSession+Push.swift
@@ -131,12 +131,12 @@ extension ZMUserSession: ForegroundNotificationsDelegate {
     }
 
     public func didReceiveLocal(notification: UILocalNotification, application: ZMApplication) {
-        if application.applicationState == .inactive || application.applicationState == .background {
-            self.pendingLocalNotification = ZMStoredLocalNotification(notification: notification,
-                                                                      managedObjectContext: self.managedObjectContext,
-                                                                      actionIdentifier: nil,
-                                                                      textInput: nil)
-        }
+        
+        self.pendingLocalNotification = ZMStoredLocalNotification(notification: notification,
+                                                                  managedObjectContext: self.managedObjectContext,
+                                                                  actionIdentifier: nil,
+                                                                  textInput: nil)
+
         if self.didStartInitialSync && !self.isPerformingSync && self.pushChannelIsOpen {
             self.processPendingNotificationActions()
         }

--- a/Tests/Source/UserSession/ZMUserSessionTests.m
+++ b/Tests/Source/UserSession/ZMUserSessionTests.m
@@ -1017,21 +1017,6 @@
     }];
 }
 
-- (void)testThat_OnLaunch_ItDoesNotCall_DelegateShowConversationList_WhenNotLoggedIn
-{
-    // given
-    UILocalNotification *note = [[UILocalNotification alloc] init];
-    note.category = ZMConversationCategory;
-    
-    // expect
-    [self checkThatItCallsOnLaunchTheDelegateForNotification:note withBlock:^(id mockDelegate) {
-        [[mockDelegate reject] showConversationListForUserSession:self.sut];
-        [[mockDelegate reject] userSession:self.sut showMessage:OCMOCK_ANY inConversation:OCMOCK_ANY];
-        [[mockDelegate reject] userSession:self.sut showConversation:OCMOCK_ANY];
-    }];
-}
-
-
 - (void)testThatItCalls_DelegateShowConversation_ForZMConversationCategory
 {
     //given


### PR DESCRIPTION
## Problem
Since iOS11, tapping on incoming call notification for the inactive account would not switch to that account to display the call overlay.

## Reason & Solution
On iOS 11, tapping a call notification would invoke this method with an active app state, meaning we would not create and process the pending notification and thus not handle the action. By not requiring the app to be `inactive` or in `background`, the notification action is always handled. Allowing an active state is acceptable because this method is only called when tapping a system notification, which can only be done when the app is not in the foreground. If a call comes for the inactive account while the app is in the foreground, the `LocalNotificationDispatcher` will funnel the notification to the `ChatHeadsViewController`, which will handle the tap action separately.