### PR TITLE
Fix/first push

### DIFF
--- a/Source/SessionManager/SessionManager+Push.swift
+++ b/Source/SessionManager/SessionManager+Push.swift
@@ -155,17 +155,7 @@ extension SessionManager: PushDispatcherClient {
             return
         }
         
-        guard let userInfoData = payload[PushChannelDataKey] as? [String: Any] else {
-            log.debug("No data dictionary in notification userInfo payload");
-            return
-        }
-        
-        guard let userIdString = userInfoData[PushChannelUserIDKey] as? String else {
-            return
-        }
-        
-        
-        if let userId = UUID(uuidString: userIdString),
+        if let userId = payload.accountId(),
             let account = self.accountManager.account(with: userId) {
             
             self.withSession(for: account, perform: { userSession in

--- a/Source/UserSession/ZMUserSession+Push.swift
+++ b/Source/UserSession/ZMUserSession+Push.swift
@@ -50,6 +50,19 @@ extension Dictionary {
         
         return false
     }
+    
+    internal func accountId() -> UUID? {
+        guard let userInfoData = self[PushChannelDataKey as! Key] as? [String: Any] else {
+            log.debug("No data dictionary in notification userInfo payload");
+            return nil
+        }
+    
+        guard let userIdString = userInfoData[PushChannelUserIDKey] as? String else {
+            return nil
+        }
+    
+        return UUID(uuidString: userIdString)
+    }
 }
 
 extension NSDictionary {

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -835,6 +835,16 @@ class SessionManagerTests_Push: IntegrationTest {
         // CLEANUP
         self.sessionManager!.tearDownAllBackgroundSessions()
     }
+    
+    // the purpose of this test is to ensure push payloads can be processed in
+    // the background as soon as the SessionManager is created
+    func testThatABackgroundTaskCanBeCreatedAfterCreatingSessionManager() {
+        // WHEN
+        let activity = BackgroundActivityFactory.sharedInstance().backgroundActivity(withName: "PushActivity")
+        
+        // THEN
+        XCTAssertNotNil(activity)
+    }
 }
 
 // MARK: - Mocks


### PR DESCRIPTION
## Problem
If the app receives a push (message, calling etc) while in a terminated state, the app is woken but does not display a notification. Only after receiving a second push do both the first and second notifications get fired.

## Reason
When the `PKPushRegistryDelegate` invokes the `pushRegistry:didReceiveIncomingPush:forType:` method after receiving the initial push, it asks `BackgroundActivityFactory` for a background activity session in order to process the payload. However the factory class was not beginning the background activity  because it required it's `application` and `mainGroupQueue` properties to be non nil (which are being set each time we load a `ZMUserSession` and is a separate issue to address).

## Solution
Set these properties before we initialise the `PushDispatcher`.