### PR TITLE
Fix for double system message

### DIFF
--- a/Source/Synchronization/Transcoders/ZMConversationTranscoder.h
+++ b/Source/Synchronization/Transcoders/ZMConversationTranscoder.h
@@ -30,9 +30,10 @@
 
 - (instancetype)initWithManagedObjectContext:(NSManagedObjectContext *)moc applicationStatus:(id<ZMApplicationStatus>)applicationStatus NS_UNAVAILABLE;
 
-- (instancetype)initWithSyncStrategy:(ZMSyncStrategy *)syncStrategy
-                   applicationStatus:(id<ZMApplicationStatus>)applicationStatus
-                          syncStatus:(SyncStatus *)syncStatus;
+- (instancetype)initWithManagedObjectContext:(NSManagedObjectContext *)managedObjectContext
+                           applicationStatus:(id<ZMApplicationStatus>)applicationStatus
+                 localNotificationDispatcher:(id<PushMessageHandler>)localNotificationDispatcher
+                                  syncStatus:(SyncStatus *)syncStatus;
 
 @property (nonatomic) NSUInteger conversationPageSize;
 

--- a/Source/Synchronization/ZMObjectStrategyDirectory.h
+++ b/Source/Synchronization/ZMObjectStrategyDirectory.h
@@ -40,7 +40,6 @@
 @property (nonatomic, readonly) ZMUserTranscoder *userTranscoder;
 @property (nonatomic, readonly) ZMSelfStrategy *selfStrategy;
 @property (nonatomic, readonly) ZMConversationTranscoder *conversationTranscoder;
-@property (nonatomic, readonly) SystemMessageEventsConsumer *systemMessageEventConsumer;
 @property (nonatomic, readonly) ClientMessageTranscoder *clientMessageTranscoder;
 @property (nonatomic, readonly) ZMMissingUpdateEventsTranscoder *missingUpdateEventsTranscoder;
 @property (nonatomic, readonly) ZMLastUpdateEventIDTranscoder *lastUpdateEventIDTranscoder;

--- a/Source/Synchronization/ZMSyncStrategy+EventProcessing.h
+++ b/Source/Synchronization/ZMSyncStrategy+EventProcessing.h
@@ -24,7 +24,4 @@
 /// Process events that are received through the notification stream or the websocket
 - (void)processUpdateEvents:(NSArray <ZMUpdateEvent *>*)events ignoreBuffer:(BOOL)ignoreBuffer;
 
-/// Process events that were downloaded as part of the client history
-- (void)processDownloadedEvents:(NSArray <ZMUpdateEvent *>*)events;
-
 @end

--- a/Source/Synchronization/ZMSyncStrategy+EventProcessing.m
+++ b/Source/Synchronization/ZMSyncStrategy+EventProcessing.m
@@ -60,26 +60,4 @@
     }];
 }
 
-- (void)processDownloadedEvents:(NSArray <ZMUpdateEvent *>*)events;
-{
-    ZM_WEAK(self);
-    [self.eventDecoder processEvents:events block:^(NSArray<ZMUpdateEvent *> * decryptedEvents) {
-        ZM_STRONG(self);
-        if (self  == nil){
-            return;
-        }
-        
-        ZMFetchRequestBatch *fetchRequest = [self fetchRequestBatchForEvents:decryptedEvents];
-        ZMFetchRequestBatchResult *prefetchResult = [self.moc executeFetchRequestBatchOrAssert:fetchRequest];
-        
-        for(id<ZMEventConsumer> eventConsumer in self.eventConsumers) {
-            @autoreleasepool {
-                ZMSTimePoint *tp = [ZMSTimePoint timePointWithInterval:5 label:[NSString stringWithFormat:@"Processing downloaded events in %@", [eventConsumer class]]];
-                [eventConsumer processEvents:decryptedEvents liveEvents:NO prefetchResult:prefetchResult];
-                [tp warnIfLongerThanInterval];
-            }
-        }
-    }];
-}
-
 @end

--- a/Source/Synchronization/ZMSyncStrategy.m
+++ b/Source/Synchronization/ZMSyncStrategy.m
@@ -54,7 +54,6 @@
 @property (nonatomic) ZMUserTranscoder *userTranscoder;
 @property (nonatomic) ZMSelfStrategy *selfStrategy;
 @property (nonatomic) ZMConversationTranscoder *conversationTranscoder;
-@property (nonatomic) SystemMessageEventsConsumer *systemMessageEventConsumer;
 @property (nonatomic) ClientMessageTranscoder *clientMessageTranscoder;
 @property (nonatomic) ZMMissingUpdateEventsTranscoder *missingUpdateEventsTranscoder;
 @property (nonatomic) ZMLastUpdateEventIDTranscoder *lastUpdateEventIDTranscoder;
@@ -212,8 +211,7 @@ ZM_EMPTY_ASSERTING_INIT()
     self.connectionTranscoder = [[ZMConnectionTranscoder alloc] initWithManagedObjectContext:self.syncMOC applicationStatus:self.applicationStatusDirectory syncStatus:self.applicationStatusDirectory.syncStatus];
     self.userTranscoder = [[ZMUserTranscoder alloc] initWithManagedObjectContext:self.syncMOC applicationStatus:self.applicationStatusDirectory syncStatus:self.applicationStatusDirectory.syncStatus];
     self.selfStrategy = [[ZMSelfStrategy alloc] initWithManagedObjectContext:self.syncMOC applicationStatus:self.applicationStatusDirectory clientRegistrationStatus:self.applicationStatusDirectory.clientRegistrationStatus syncStatus:self.applicationStatusDirectory.syncStatus];
-    self.conversationTranscoder = [[ZMConversationTranscoder alloc] initWithSyncStrategy:self applicationStatus:self.applicationStatusDirectory syncStatus:self.applicationStatusDirectory.syncStatus];
-    self.systemMessageEventConsumer = [[SystemMessageEventsConsumer alloc] initWithMoc:self.syncMOC localNotificationDispatcher:localNotificationsDispatcher];
+    self.conversationTranscoder = [[ZMConversationTranscoder alloc] initWithManagedObjectContext:self.syncMOC applicationStatus:self.applicationStatusDirectory localNotificationDispatcher:self.localNotificationDispatcher syncStatus:self.applicationStatusDirectory.syncStatus];
     self.clientMessageTranscoder = [[ClientMessageTranscoder alloc] initIn:self.syncMOC localNotificationDispatcher:localNotificationsDispatcher applicationStatus:self.applicationStatusDirectory];
     self.missingUpdateEventsTranscoder = [[ZMMissingUpdateEventsTranscoder alloc] initWithSyncStrategy:self previouslyReceivedEventIDsCollection:self.eventDecoder application:self.application backgroundAPNSPingbackStatus:self.applicationStatusDirectory.pingBackStatus syncStatus:self.applicationStatusDirectory.syncStatus];
     self.lastUpdateEventIDTranscoder = [[ZMLastUpdateEventIDTranscoder alloc] initWithManagedObjectContext:self.syncMOC applicationStatus:self.applicationStatusDirectory syncStatus:self.applicationStatusDirectory.syncStatus objectDirectory:self];
@@ -288,7 +286,6 @@ ZM_EMPTY_ASSERTING_INIT()
     self.selfStrategy = nil;
     self.clientMessageTranscoder = nil;
     self.lastUpdateEventIDTranscoder = nil;
-    self.systemMessageEventConsumer = nil;
     self.allChangeTrackers = nil;
     self.eventDecoder = nil;
     [self.eventMOC performGroupedBlockAndWait:^{
@@ -352,7 +349,6 @@ ZM_EMPTY_ASSERTING_INIT()
             }
         }
         
-        [eventConsumers addObject:self.systemMessageEventConsumer];
         _eventConsumers = eventConsumers;
     }
     

--- a/Tests/Source/Integration/ConnectionTests.m
+++ b/Tests/Source/Integration/ConnectionTests.m
@@ -374,7 +374,6 @@
             [self addConnectionRequestInMockTransportsession:session forUser:mockUser1];
             [self addConnectionRequestInMockTransportsession:session forUser:mockUser2];
         }];
-//        WaitForEverythingToBeDone();
         WaitForAllGroupsToBeEmpty(0.5);
     }
     
@@ -412,7 +411,6 @@
             [realUser1 accept];
             [realUser2 accept];
         }];
-//        WaitForEverythingToBeDone();
         WaitForAllGroupsToBeEmpty(0.5);
         [self.mockTransportSession waitForAllRequestsToCompleteWithTimeout:0.5];
     }
@@ -453,11 +451,13 @@
         }
         XCTAssertTrue(conv1StateChanged);
         XCTAssertEqual(conv1.conversationType, ZMConversationTypeOneOnOne);
-        XCTAssertEqual(conv1.messages.count, 2u); // accepting connection request produces a new conversation system message
+        XCTAssertEqual(conv1.messages.count, 1u); // accepting connection request produces a new conversation system message
+        XCTAssertEqual(((ZMSystemMessage *)conv1.messages.firstObject).systemMessageType, ZMSystemMessageTypeNewConversation);
 
         XCTAssertTrue(conv2StateChanged);
         XCTAssertEqual(conv2.conversationType, ZMConversationTypeOneOnOne);
-        XCTAssertEqual(conv2.messages.count, 2u); // accepting connection request produces a new conversation system message
+        XCTAssertEqual(conv2.messages.count, 1u); // accepting connection request produces a new conversation system message
+        XCTAssertEqual(((ZMSystemMessage *)conv2.messages.firstObject).systemMessageType, ZMSystemMessageTypeNewConversation);
     }
     
     (void)token1;

--- a/Tests/Source/Integration/ConversationsTests.m
+++ b/Tests/Source/Integration/ConversationsTests.m
@@ -491,7 +491,7 @@
     // then
     XCTAssertNotNil(conversation.lastReadServerTimeStamp);
     XCTAssertTrue(didSendFirstArchivedMessage);
-    XCTAssertFalse(didSendLastReadMessage); // we update the last read locally but don't sync it
+    XCTAssertTrue(didSendLastReadMessage);
     XCTAssertTrue(didSendMemberLeaveRequest);
     XCTAssertTrue(didSendSecondArchivedMessage);
     XCTAssertTrue(firstIsArchived);

--- a/Tests/Source/Synchronization/SynchronizationMocks.swift
+++ b/Tests/Source/Synchronization/SynchronizationMocks.swift
@@ -24,7 +24,7 @@ import avs
 @testable import WireSyncEngine
 
 
-@objc(ZMMockApplicationStatus)
+@objc(MockApplicationStatus)
 public class MockApplicationStatus : NSObject, ApplicationStatus, DeliveryConfirmationDelegate, ClientRegistrationDelegate, ZMRequestCancellation {
 
 
@@ -260,4 +260,23 @@ public class MockSyncStatus : SyncStatus {
     public func didRegister(_ userClient: UserClient!) {
         registeredUserClient = userClient
     }
+}
+
+class MockPushMessageHandler: NSObject, PushMessageHandler {
+    
+    public func didFailToSend(_ message: ZMMessage) {
+        failedToSend.append(message)
+    }
+    
+    public func process(_ message: ZMMessage) {
+        processedMessages.append(message)
+    }
+    
+    public func process(_ genericMessage: ZMGenericMessage) {
+        processedGenericMessages.append(genericMessage)
+    }
+    
+    fileprivate(set) var failedToSend: [ZMMessage] = []
+    fileprivate(set) var processedMessages: [ZMMessage] = []
+    fileprivate(set) var processedGenericMessages: [ZMGenericMessage] = []
 }

--- a/Tests/Source/Synchronization/SynchronizationMocks.swift
+++ b/Tests/Source/Synchronization/SynchronizationMocks.swift
@@ -262,7 +262,7 @@ public class MockSyncStatus : SyncStatus {
     }
 }
 
-class MockPushMessageHandler: NSObject, PushMessageHandler {
+@objc public class MockPushMessageHandler: NSObject, PushMessageHandler {
     
     public func didFailToSend(_ message: ZMMessage) {
         failedToSend.append(message)

--- a/Tests/Source/Synchronization/Transcoders/ObjectTranscoderTests.h
+++ b/Tests/Source/Synchronization/Transcoders/ObjectTranscoderTests.h
@@ -22,12 +22,12 @@
 #import "ZMSyncStrategy+EventProcessing.h"
 
 
-@class ZMMockApplicationStatus;
+@class MockApplicationStatus;
 
 
 @interface ObjectTranscoderTests : MessagingTest
 
 @property (nonatomic) ZMSyncStrategy *syncStrategy;
-@property (nonatomic) ZMMockApplicationStatus *mockApplicationStatus;
+@property (nonatomic) MockApplicationStatus *mockApplicationStatus;
 
 @end

--- a/Tests/Source/Synchronization/Transcoders/ObjectTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ObjectTranscoderTests.m
@@ -26,7 +26,7 @@
 {
     [super setUp];
     self.syncStrategy = [OCMockObject niceMockForClass:[ZMSyncStrategy class]];
-    self.mockApplicationStatus = [[ZMMockApplicationStatus alloc] init];
+    self.mockApplicationStatus = [[MockApplicationStatus alloc] init];
 }
 
 - (void)tearDown

--- a/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderSystemMessageTests.swift
+++ b/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderSystemMessageTests.swift
@@ -53,6 +53,9 @@ class ZMConversationTranscoderSystemMessageTests: ObjectTranscoderTests {
         self.sut = nil
         self.localNotificationDispatcher = nil
         self.conversation = nil
+        self.user = nil
+        self.mockSyncStatus = nil
+        
         super.tearDown()
     }
     

--- a/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderSystemMessageTests.swift
+++ b/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderSystemMessageTests.swift
@@ -1,0 +1,275 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+import WireMessageStrategy
+import WireDataModel
+
+class ZMConversationTranscoderSystemMessageTests: ObjectTranscoderTests {
+    
+    var sut: ZMConversationTranscoder!
+    var localNotificationDispatcher: MockPushMessageHandler!
+    var conversation: ZMConversation!
+    var user: ZMUser!
+    var mockSyncStatus : MockSyncStatus!
+    
+    override func setUp() {
+        super.setUp()
+        
+        self.syncMOC.performGroupedBlockAndWait {
+            self.mockSyncStatus = MockSyncStatus(managedObjectContext: self.syncMOC, syncStateDelegate: self)
+            self.mockSyncStatus.mockPhase = .done
+            self.mockApplicationStatus.mockSynchronizationState = .eventProcessing
+            self.localNotificationDispatcher = MockPushMessageHandler()
+            self.sut = ZMConversationTranscoder(managedObjectContext: self.syncMOC, applicationStatus: self.mockApplicationStatus, localNotificationDispatcher: self.localNotificationDispatcher, syncStatus: self.mockSyncStatus)
+            self.conversation = ZMConversation.insertNewObject(in: self.syncMOC)
+            self.conversation.remoteIdentifier = UUID.create()
+            self.conversation.conversationType = .group
+            self.conversation.lastServerTimeStamp = Date(timeIntervalSince1970: 123124)
+            self.conversation.lastReadServerTimeStamp = self.conversation.lastServerTimeStamp
+            self.user = ZMUser.insertNewObject(in: self.syncMOC)
+            self.user.remoteIdentifier = UUID.create()
+            
+            self.syncMOC.saveOrRollback()
+        }
+    }
+    
+    override func tearDown() {
+        self.sut = nil
+        self.localNotificationDispatcher = nil
+        self.conversation = nil
+        super.tearDown()
+    }
+    
+    func testThatItCreatesAndNotifiesSystemMessagesFromAMemberJoin() {
+        
+        self.syncMOC.performAndWait {
+            
+            // GIVEN
+            let payload = [
+                "from": self.user.remoteIdentifier!.transportString(),
+                "conversation": self.conversation.remoteIdentifier!.transportString(),
+                "time": NSDate().transportString(),
+                "data": [
+                    "user_ids": [self.user.remoteIdentifier!.transportString()]
+                ],
+                "type": "conversation.member-join"
+                ] as [String: Any]
+            let event = ZMUpdateEvent(fromEventStreamPayload: payload as ZMTransportData, uuid: nil)!
+            
+            // WHEN
+            self.sut.processEvents([event], liveEvents: true, prefetchResult: nil)
+            
+            // THEN
+            guard let message = self.conversation.messages.lastObject as? ZMSystemMessage else {
+                XCTFail()
+                return
+            }
+            XCTAssertEqual(message.systemMessageType, .participantsAdded)
+            XCTAssertEqual(self.localNotificationDispatcher.processedMessages.last, message)
+        }
+    }
+    
+    func testThatItIgnoresMemberJoinEventsIfMemberIsAlreadyPartOfConversation() {
+        
+        self.syncMOC.performAndWait {
+            
+            // GIVEN
+            self.conversation.internalAddParticipants(Set<ZMUser>([user]), isAuthoritative: true)
+            
+            let payload = [
+                "from": self.user.remoteIdentifier!.transportString(),
+                "conversation": self.conversation.remoteIdentifier!.transportString(),
+                "time": NSDate().transportString(),
+                "data": [
+                    "user_ids": [self.user.remoteIdentifier!.transportString()]
+                ],
+                "type": "conversation.member-join"
+                ] as [String: Any]
+            let event = ZMUpdateEvent(fromEventStreamPayload: payload as ZMTransportData, uuid: nil)!
+            let messageCountBeforeProcessing = self.conversation.messages.count
+            
+            // WHEN
+            self.sut.processEvents([event], liveEvents: true, prefetchResult: nil)
+            
+            // THEN
+            XCTAssertEqual(self.conversation.messages.count, messageCountBeforeProcessing)
+        }
+    }
+    
+    func testThatItCreatesAndNotifiesSystemMessagesFromAMemberRemove() {
+        
+        self.syncMOC.performAndWait {
+            
+            // GIVEN
+            self.conversation.internalAddParticipants(Set<ZMUser>([user]), isAuthoritative: true)
+            
+            let payload = [
+                "from": self.user.remoteIdentifier!.transportString(),
+                "conversation": self.conversation.remoteIdentifier!.transportString(),
+                "time": NSDate().transportString(),
+                "data": [
+                    "user_ids": [self.user.remoteIdentifier!.transportString()]
+                ],
+                "type": "conversation.member-leave"
+                ] as [String: Any]
+            let event = ZMUpdateEvent(fromEventStreamPayload: payload as ZMTransportData, uuid: nil)!
+            
+            // WHEN
+            self.sut.processEvents([event], liveEvents: true, prefetchResult: nil)
+            
+            // THEN
+            guard let message = self.conversation.messages.lastObject as? ZMSystemMessage else {
+                XCTFail()
+                return
+            }
+            XCTAssertEqual(message.systemMessageType, .participantsRemoved)
+            XCTAssertEqual(self.localNotificationDispatcher.processedMessages.last, message)
+        }
+    }
+    
+    func testThatItIgnoresMemberRemoveEventsIfMemberIsNotPartOfConversation() {
+        
+        self.syncMOC.performAndWait {
+            
+            // GIVEN
+            let payload = [
+                "from": self.user.remoteIdentifier!.transportString(),
+                "conversation": self.conversation.remoteIdentifier!.transportString(),
+                "time": NSDate().transportString(),
+                "data": [
+                    "user_ids": [self.user.remoteIdentifier!.transportString()]
+                ],
+                "type": "conversation.member-leave"
+                ] as [String: Any]
+            let event = ZMUpdateEvent(fromEventStreamPayload: payload as ZMTransportData, uuid: nil)!
+            let messageCountBeforeProcessing = self.conversation.messages.count
+            
+            // WHEN
+            self.sut.processEvents([event], liveEvents: true, prefetchResult: nil)
+            
+            // THEN
+            XCTAssertEqual(self.conversation.messages.count, messageCountBeforeProcessing)
+        }
+    }
+    
+    func testThatItCreatesAndNotifiesSystemMessagesFromConversationRename() {
+        
+        self.syncMOC.performAndWait {
+            
+            // GIVEN
+            let payload = [
+                "from": self.user.remoteIdentifier!.transportString(),
+                "conversation": self.conversation.remoteIdentifier!.transportString(),
+                "time": NSDate().transportString(),
+                "data": [
+                    "name": "foobar"
+                ],
+                "type": "conversation.rename"
+                ] as [String: Any]
+            let event = ZMUpdateEvent(fromEventStreamPayload: payload as ZMTransportData, uuid: nil)!
+            
+            // WHEN
+            self.sut.processEvents([event], liveEvents: true, prefetchResult: nil)
+            
+            // THEN
+            guard let message = self.conversation.messages.lastObject as? ZMSystemMessage else {
+                XCTFail()
+                return
+            }
+            XCTAssertEqual(message.systemMessageType, .conversationNameChanged)
+            XCTAssertEqual(self.localNotificationDispatcher.processedMessages.last, message)
+        }
+    }
+    
+    func testThatItCreatesAndNotifiesSystemMessagesFromConversationRenameIfConversationAlreadyHasSameNameButNotYetSynced() {
+        
+        self.syncMOC.performAndWait {
+            
+            // GIVEN
+            conversation.userDefinedName = "foobar"
+            conversation.setLocallyModifiedKeys(Set<AnyHashable>([ZMConversationUserDefinedNameKey]))
+            
+            let payload = [
+                "from": self.user.remoteIdentifier!.transportString(),
+                "conversation": self.conversation.remoteIdentifier!.transportString(),
+                "time": NSDate().transportString(),
+                "data": [
+                    "name": "foobar"
+                ],
+                "type": "conversation.rename"
+                ] as [String: Any]
+            let event = ZMUpdateEvent(fromEventStreamPayload: payload as ZMTransportData, uuid: nil)!
+            
+            // WHEN
+            self.sut.processEvents([event], liveEvents: true, prefetchResult: nil)
+            
+            // THEN
+            guard let message = self.conversation.messages.lastObject as? ZMSystemMessage else {
+                XCTFail()
+                return
+            }
+            XCTAssertEqual(message.systemMessageType, .conversationNameChanged)
+            XCTAssertEqual(self.localNotificationDispatcher.processedMessages.last, message)
+        }
+    }
+    
+    func testThatItIgnoresConversationRenameEventsIfConversationAlreadyHasSameName() {
+        
+        self.syncMOC.performAndWait {
+            
+            // GIVEN
+            conversation.userDefinedName = "foobar"
+            
+            let payload = [
+                "from": self.user.remoteIdentifier!.transportString(),
+                "conversation": self.conversation.remoteIdentifier!.transportString(),
+                "time": NSDate().transportString(),
+                "data": [
+                    "name": "foobar"
+                ],
+                "type": "conversation.rename"
+                ] as [String: Any]
+            let event = ZMUpdateEvent(fromEventStreamPayload: payload as ZMTransportData, uuid: nil)!
+            let messageCountBeforeProcessing = self.conversation.messages.count
+            
+            // WHEN
+            self.sut.processEvents([event], liveEvents: true, prefetchResult: nil)
+            
+            // THEN
+            XCTAssertEqual(self.conversation.messages.count, messageCountBeforeProcessing)
+        }
+    }
+    
+}
+
+extension ZMConversationTranscoderSystemMessageTests : ZMSyncStateDelegate {
+    
+    func didStartSync() {
+        // nop
+    }
+    
+    func didFinishSync() {
+        // nop
+    }
+    
+    func didRegister(_ userClient: UserClient!) {
+        // nop
+    }
+    
+}

--- a/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.m
@@ -40,11 +40,11 @@ static NSString *const CONVERSATION_ID_REQUEST_PREFIX = @"/conversations?ids=";
 - (ZMConversation *)setupConversation;
 - (ZMTransportRequest *)requestToSyncConversation:(ZMConversation *)conversation andCompleteWithResponse:(ZMTransportResponse*)response;
 
-@property (nonatomic) NSMutableArray *downloadedEvents;
 @property (nonatomic) ZMConversationTranscoder<ZMUpstreamTranscoder, ZMDownstreamTranscoder> *sut;
 @property (nonatomic) NSUUID *selfUserID;
 @property (nonatomic) MockSyncStatus *mockSyncStatus;
 @property (nonatomic) ZMMockClientRegistrationStatus *mockClientRegistrationDelegate;
+@property (nonatomic) id mockLocalNotificationDispatcher;
 @property (nonatomic) id syncStateDelegate;
 
 @end
@@ -59,23 +59,13 @@ static NSString *const CONVERSATION_ID_REQUEST_PREFIX = @"/conversations?ids=";
     self.selfUserID = NSUUID.createUUID;
     [self setupSelfConversation]; // when updating lastRead we are posting to the selfConversation
 
-    [[[(id)self.syncStrategy stub] andReturn:self.syncMOC] moc];
-    [self verifyMockLater:self.syncStrategy];
-    
-    NSMutableArray *downloadedEvents = [NSMutableArray array];
-    ZMSyncStrategy* syncStrategyMock = [(id)self.syncStrategy stub];
-    [syncStrategyMock processDownloadedEvents:[OCMArg checkWithBlock:^BOOL(NSArray* events) {
-        [downloadedEvents addObjectsFromArray:events];
-        return YES;
-    }]];
-    
-    self.downloadedEvents = downloadedEvents;
     self.syncStateDelegate = [OCMockObject niceMockForProtocol:@protocol(ZMSyncStateDelegate)];
     self.mockSyncStatus = [[MockSyncStatus alloc] initWithManagedObjectContext:self.syncMOC syncStateDelegate:self.syncStateDelegate];
     self.mockSyncStatus.mockPhase = SyncPhaseDone;
     self.mockApplicationStatus.mockSynchronizationState = ZMSynchronizationStateEventProcessing;
+    self.mockLocalNotificationDispatcher = [OCMockObject niceMockForProtocol:@protocol(PushMessageHandler)];
 
-    self.sut = (id) [[ZMConversationTranscoder alloc] initWithSyncStrategy:self.syncStrategy applicationStatus:self.mockApplicationStatus syncStatus:self.mockSyncStatus];
+    self.sut = (id) [[ZMConversationTranscoder alloc] initWithManagedObjectContext:self.syncMOC applicationStatus:self.mockApplicationStatus localNotificationDispatcher:self.mockLocalNotificationDispatcher syncStatus:self.mockSyncStatus];
     WaitForAllGroupsToBeEmpty(0.5);
 }
 
@@ -645,10 +635,6 @@ static NSString *const CONVERSATION_ID_REQUEST_PREFIX = @"/conversations?ids=";
     [self.syncMOC performGroupedBlockAndWait:^{
         // then
         XCTAssertFalse([conversation.keysThatHaveLocalModifications containsObject:ZMConversationUserDefinedNameKey]);
-        
-        XCTAssertEqual(self.downloadedEvents.count, 1u);
-        ZMUpdateEvent *downloadedEvent = self.downloadedEvents.firstObject;
-        XCTAssertEqualObjects(downloadedEvent.payload, responsePayload);
     }];
 }
 
@@ -1944,7 +1930,7 @@ static NSString *const CONVERSATION_ID_REQUEST_PREFIX = @"/conversations?ids=";
         XCTAssertTrue([self.syncMOC saveOrRollback]);
     }];
     
-    self.sut = (id) [[ZMConversationTranscoder alloc] initWithSyncStrategy:self.syncStrategy applicationStatus:self.mockApplicationStatus syncStatus:self.mockSyncStatus];
+    self.sut = (id) [[ZMConversationTranscoder alloc] initWithManagedObjectContext:self.syncMOC applicationStatus:self.mockApplicationStatus localNotificationDispatcher:self.mockLocalNotificationDispatcher syncStatus:self.mockSyncStatus];
     WaitForAllGroupsToBeEmpty(0.5);
     
     [ZMChangeTrackerBootstrap bootStrapChangeTrackers:self.sut.contextChangeTrackers onContext:self.syncMOC];
@@ -2135,7 +2121,7 @@ static NSString *const CONVERSATION_ID_REQUEST_PREFIX = @"/conversations?ids=";
 - (void)testThatItDoesAppendsNewConversationSystemMessage
 {
     // given
-    self.sut = (id) [[ZMConversationTranscoder alloc] initWithSyncStrategy:self.syncStrategy applicationStatus:self.mockApplicationStatus syncStatus:self.mockSyncStatus];
+    self.sut = (id) [[ZMConversationTranscoder alloc] initWithManagedObjectContext:self.syncMOC applicationStatus:self.mockApplicationStatus localNotificationDispatcher:self.mockLocalNotificationDispatcher syncStatus:self.mockSyncStatus];
     
     __block NSDictionary *rawConversation;
     [self.syncMOC performGroupedBlockAndWait:^{
@@ -2312,14 +2298,7 @@ static NSString *const CONVERSATION_ID_REQUEST_PREFIX = @"/conversations?ids=";
     XCTAssertEqual(request.method, ZMMethodDELETE);
     NSString *expectedPath = [NSString pathWithComponents:@[ @"/", @"conversations", conversationID.transportString, @"members", user3ID.transportString ]];
     XCTAssertEqualObjects(request.path, expectedPath);
-    
     XCTAssertFalse([conversation.keysThatHaveLocalModifications containsObject:modifiedKey]);
-    
-    XCTAssertEqual(self.downloadedEvents.count, 1u);
-    ZMUpdateEvent *downloadedEvent = self.downloadedEvents.firstObject;
-    XCTAssertEqualObjects(downloadedEvent.payload, responsePayload);
-    
-    
 }
 
 - (void)testThatItCreatesSeveralRequestsForRemovingSeveralParticipants
@@ -2654,10 +2633,6 @@ static NSString *const CONVERSATION_ID_REQUEST_PREFIX = @"/conversations?ids=";
         XCTAssertEqualObjects(request.payload, @{ @"users": @[ user3ID.transportString ] });
         
         XCTAssertFalse([conversation.keysThatHaveLocalModifications containsObject:modifiedKey]);
-        
-        XCTAssertEqual(self.downloadedEvents.count, 1u);
-        ZMUpdateEvent *downloadedEvent = self.downloadedEvents.firstObject;
-        XCTAssertEqualObjects(downloadedEvent.payload, responsePayload);
     }];
 }
 
@@ -3552,7 +3527,7 @@ static NSString *const CONVERSATION_ID_REQUEST_PREFIX = @"/conversations?ids=";
     [[[accountStatus stub]
       andReturnValue: OCMOCK_VALUE((AccountState){AccountStateOldDeviceActiveAccount})] currentAccountState];
     
-    self.sut = (id) [[ZMConversationTranscoder alloc]  initWithSyncStrategy:self.syncStrategy applicationStatus:self.mockApplicationStatus syncStatus:self.mockSyncStatus];
+    self.sut = (id) [[ZMConversationTranscoder alloc] initWithManagedObjectContext:self.syncMOC applicationStatus:self.mockApplicationStatus localNotificationDispatcher:self.mockLocalNotificationDispatcher syncStatus:self.mockSyncStatus];
 
     
     NSUUID *otherUserID = [NSUUID createUUID];

--- a/Tests/Source/Synchronization/ZMSyncStrategyTests.m
+++ b/Tests/Source/Synchronization/ZMSyncStrategyTests.m
@@ -136,7 +136,7 @@
     
     self.conversationTranscoder = [OCMockObject mockForClass:ZMConversationTranscoder.class];
     [[[[self.conversationTranscoder expect] andReturn:self.conversationTranscoder] classMethod] alloc];
-    (void) [[[self.conversationTranscoder stub] andReturn:self.conversationTranscoder] initWithSyncStrategy:OCMOCK_ANY applicationStatus:OCMOCK_ANY syncStatus:OCMOCK_ANY];
+    (void) [[[self.conversationTranscoder stub] andReturn:self.conversationTranscoder] initWithManagedObjectContext:OCMOCK_ANY applicationStatus:OCMOCK_ANY localNotificationDispatcher:OCMOCK_ANY syncStatus:OCMOCK_ANY];
 
     id clientMessageTranscoder = [OCMockObject mockForClass:ClientMessageTranscoder.class];
     [[[[clientMessageTranscoder expect] andReturn:clientMessageTranscoder] classMethod] alloc];
@@ -262,29 +262,6 @@
     self.sut = nil;
     self.syncObjects = nil;
     [super tearDown];
-}
-
-- (void)testThatDownloadedEventsAreForwardedToAllIndividualObjects
-{
-    // given
-    ZMConversation *conv = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
-    conv.remoteIdentifier = [NSUUID createUUID];
-    NSDictionary *payload = [self payloadForMessageInConversation:conv type:EventConversationAdd data:@{@"foo" : @"bar"}];
-    ZMUpdateEvent *event = [ZMUpdateEvent eventFromEventStreamPayload:payload uuid:[NSUUID createUUID]];
-    NSArray *eventsArray = @[event];
-    
-    
-    // expect
-    [self expectSyncObjectsToProcessEvents:YES
-                                liveEvents:NO
-                             decryptEvents:YES
-                   returnIDsForPrefetching:YES
-                                withEvents:eventsArray];
-    
-    // when
-    [self.sut processDownloadedEvents:eventsArray];
-    WaitForAllGroupsToBeEmpty(0.5);
-    
 }
 
 - (void)testThatPushEventsAreProcessedForConversationEventSyncBeforeConversationSync

--- a/Tests/Source/Test-Bridging-Header.h
+++ b/Tests/Source/Test-Bridging-Header.h
@@ -19,6 +19,7 @@
 
 #import <WireSyncEngine/WireSyncEngine.h>
 #import "MessagingTest.h"
+#import "ObjectTranscoderTests.h"
 #import "ZMUserSessionTestsBase.h"
 #import "MessagingTest+EventFactory.h"
 #import "ConversationTestsBase.h"

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		1634958B1F0254CB004E80DB /* SessionManager+ServerConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1634958A1F0254CB004E80DB /* SessionManager+ServerConnection.swift */; };
 		163BB8131EE1A6EE00DF9384 /* IntegrationTest+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163BB8111EE1A65A00DF9384 /* IntegrationTest+Search.swift */; };
 		163BB8161EE1B1AC00DF9384 /* SearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163BB8151EE1B1AC00DF9384 /* SearchTests.swift */; };
+		16466C0E1F9F7EDF00E3F970 /* ZMConversationTranscoderSystemMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16466C0D1F9F7EDF00E3F970 /* ZMConversationTranscoderSystemMessageTests.swift */; };
 		164B8C211E254AD00060AB26 /* WireCallCenterV3Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165D3A1A1E1D43870052E654 /* WireCallCenterV3Mock.swift */; };
 		164C29A31ECF437E0026562A /* SearchRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 164C29A21ECF437E0026562A /* SearchRequestTests.swift */; };
 		164C29A51ECF47D80026562A /* SearchDirectoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 164C29A41ECF47D80026562A /* SearchDirectoryTests.swift */; };
@@ -548,6 +549,7 @@
 		1634958A1F0254CB004E80DB /* SessionManager+ServerConnection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SessionManager+ServerConnection.swift"; sourceTree = "<group>"; };
 		163BB8111EE1A65A00DF9384 /* IntegrationTest+Search.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "IntegrationTest+Search.swift"; sourceTree = "<group>"; };
 		163BB8151EE1B1AC00DF9384 /* SearchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchTests.swift; sourceTree = "<group>"; };
+		16466C0D1F9F7EDF00E3F970 /* ZMConversationTranscoderSystemMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMConversationTranscoderSystemMessageTests.swift; sourceTree = "<group>"; };
 		164C29A21ECF437E0026562A /* SearchRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchRequestTests.swift; sourceTree = "<group>"; };
 		164C29A41ECF47D80026562A /* SearchDirectoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchDirectoryTests.swift; sourceTree = "<group>"; };
 		164C29A61ED2D7B00026562A /* SearchResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchResult.swift; sourceTree = "<group>"; };
@@ -1662,6 +1664,7 @@
 				54F8D74919AB67B300146664 /* ObjectTranscoderTests.m */,
 				54F8D72B19AB677300146664 /* ZMConnectionTranscoderTest.m */,
 				54F8D72D19AB677300146664 /* ZMConversationTranscoderTests.m */,
+				16466C0D1F9F7EDF00E3F970 /* ZMConversationTranscoderSystemMessageTests.swift */,
 				F9DAC54D1C2034E70001F11E /* ConversationStatusStrategyTests.swift */,
 				54F8D72F19AB677300146664 /* ZMMissingUpdateEventsTranscoderTests.m */,
 				54188DCA19D19DE200DA40E4 /* ZMLastUpdateEventIDTranscoderTests.m */,
@@ -2434,6 +2437,7 @@
 				F190E0DD1E8E7C9D003E81F8 /* SlowSyncTests+Swift.swift in Sources */,
 				BFAB67B01E535B4B00D67C1A /* TextSearchTests.swift in Sources */,
 				F9ABE8561EFD56BF00D83214 /* TeamDownloadRequestStrategyTests.swift in Sources */,
+				16466C0E1F9F7EDF00E3F970 /* ZMConversationTranscoderSystemMessageTests.swift in Sources */,
 				5430FF151CE4A359004ECFFE /* FileTransferTests.m in Sources */,
 				545434AE19AB6ADA003892D9 /* ZMUserTranscoderTests.m in Sources */,
 				BF2A9D581D6B5BDB00FA7DBC /* StoreUpdateEventTests.swift in Sources */,


### PR DESCRIPTION
ZMConversationTranscoder has taken over the task of inserting system messages.

*NOTE:* also noticed that processDownloadedEvents was never called anywhere and
that therefore all events are considered "live".

---

## Problem
When a user changes a conversation name or add/remove a participant we currently will insert
two system message for this event. This happens because the change event arrives twice, first
in the response of POST response and second in the notification stream.

## Solution:
Add a check before inserting these system messages for if the change has already been applied.