### PR TITLE
Fix/notification title

### DIFF
--- a/Resources/Base.lproj/Push.strings
+++ b/Resources/Base.lproj/Push.strings
@@ -31,6 +31,11 @@
 "push.notification.default" = "New message";
 "push.notification.ephemeral" = "Someone sent you a message";
 
+// Push Title: [Conversation Name] in [Team Name]
+"push.notification.title" = "%1$@ in %2$@";
+"push.notification.title.noconversationname" = "in %1$@";
+"push.notification.title.noteamname" = "%1$@";
+
 // 2 Components: Sender, Message
 "push.notification.add.message.group" = "%1$@: %2$@";
 "push.notification.add.message.group.nousername" = "New message: %1$@";

--- a/Source/Notifications/Push notifications/Helpers/UILocalNotification+UserInfo.h
+++ b/Source/Notifications/Push notifications/Helpers/UILocalNotification+UserInfo.h
@@ -29,6 +29,8 @@ extern NSString * const MessageNonceIDStringKey;
 extern NSString * const SenderIDStringKey;
 extern NSString * const EventTimeKey;
 extern NSString * const SelfUserIDStringKey;
+extern NSString * const ConversationNameStringKey;
+extern NSString * const TeamNameStringKey;
 NS_ASSUME_NONNULL_END
 
 @interface UILocalNotification (UserInfo)

--- a/Source/Notifications/Push notifications/Helpers/UILocalNotification+UserInfo.m
+++ b/Source/Notifications/Push notifications/Helpers/UILocalNotification+UserInfo.m
@@ -22,11 +22,13 @@
 @import WireDataModel;
 @import WireSystem;
 
-NSString * const ConversationIDStringKey = @"conversationIDString";
-NSString * const MessageNonceIDStringKey = @"messageNonceString";
-NSString * const SenderIDStringKey       = @"senderIDString";
-NSString * const EventTimeKey            = @"eventTime";
-NSString * const SelfUserIDStringKey     = @"selfUserIDString";
+NSString * const ConversationIDStringKey    = @"conversationIDString";
+NSString * const MessageNonceIDStringKey    = @"messageNonceString";
+NSString * const SenderIDStringKey          = @"senderIDString";
+NSString * const EventTimeKey               = @"eventTime";
+NSString * const SelfUserIDStringKey        = @"selfUserIDString";
+NSString * const ConversationNameStringKey  = @"conversationNameString";
+NSString * const TeamNameStringKey          = @"teamNameString";
 
 @implementation UILocalNotification (UserInfo)
 

--- a/Source/Notifications/Push notifications/Helpers/ZMLocalNotificationLocalization.h
+++ b/Source/Notifications/Push notifications/Helpers/ZMLocalNotificationLocalization.h
@@ -45,4 +45,6 @@
 
 - (NSString *)localizedStringForPushNotification;
 
+- (NSString *)localizedStringWithConversationName:(NSString *)conversationName teamName:(NSString *)teamName;
+
 @end

--- a/Source/Notifications/Push notifications/Helpers/ZMLocalNotificationLocalization.m
+++ b/Source/Notifications/Push notifications/Helpers/ZMLocalNotificationLocalization.m
@@ -24,8 +24,6 @@
 static NSString *localizedStringWithKeyAndArguments(NSString *key, NSArray *arguments);
 static NSString * ZMPushLocalizedString(NSString *key);
 
-
-
 static NSString *const OneOnOneKey = @"oneonone";
 static NSString *const GroupKey = @"group";
 
@@ -33,6 +31,7 @@ static NSString *const SelfKey = @"self";
 static NSString *const NoConversationNameKey = @"noconversationname";
 static NSString *const NoUserNameKey = @"nousername";
 static NSString *const NoOtherUserNameKey = @"nootherusername";
+static NSString *const NoTeamNameKey = @"noteamname";
 
 
 
@@ -225,6 +224,32 @@ static NSString *const NoOtherUserNameKey = @"nootherusername";
 - (NSString *)localizedStringForPushNotification;
 {
     return localizedStringWithKeyAndArguments(ZMPushLocalizedString(self), nil);
+}
+
+- (NSString *)localizedStringWithConversationName:(NSString *)conversationName teamName:(NSString *)teamName
+{
+    NSMutableArray *arguments = [NSMutableArray array];
+    NSString *key = self;
+    
+    if (conversationName == nil) {
+        key = [key stringByAppendingPathExtension:NoConversationNameKey];
+    }
+    else {
+        [arguments addObject:conversationName];
+    }
+    
+    if (teamName == nil) {
+        key = [key stringByAppendingPathExtension:NoTeamNameKey];
+    }
+    else {
+        [arguments addObject:teamName];
+    }
+    
+    if (arguments.count == 0) {
+        return nil;
+    }
+    
+    return localizedStringWithKeyAndArguments(ZMPushLocalizedString(key), arguments);
 }
 
 

--- a/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification+Calling.swift
+++ b/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification+Calling.swift
@@ -23,8 +23,8 @@ extension ZMLocalNotification {
     
     convenience init?(callState: CallState, conversation: ZMConversation, sender: ZMUser) {
         guard conversation.remoteIdentifier != nil else { return nil }
-        let constructor = CallNotificationBuilder(callState: callState, sender: sender, conversation: conversation)
-        self.init(conversation: conversation, type: .calling(callState), constructor: constructor)
+        let builder = CallNotificationBuilder(callState: callState, sender: sender, conversation: conversation)
+        self.init(conversation: conversation, type: .calling(callState), builder: builder)
     }
     
     private class CallNotificationBuilder: NotificationBuilder {

--- a/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification+Calling.swift
+++ b/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification+Calling.swift
@@ -32,6 +32,7 @@ extension ZMLocalNotification {
         let callState: CallState
         let sender: ZMUser
         var conversation: ZMConversation?
+        private var teamName: String?
         
         let ignoredCallStates : [CallState] = [
             .established, .answered(degraded: false), .outgoing(degraded: false), .none, .unknown
@@ -57,16 +58,11 @@ extension ZMLocalNotification {
         }
         
         func titleText() -> String? {
-            guard let conversation = conversation else { return nil }
-            var title = conversation.meaningfulDisplayName ?? ""
-            
-            if let moc = conversation.managedObjectContext,
-                let teamName = ZMUser.selfUser(in: moc).team?.name {
-                title += " in \(teamName)"
+            if let moc = conversation?.managedObjectContext {
+                teamName = ZMUser.selfUser(in: moc).team?.name
             }
             
-            let trimmed = title.trimmingCharacters(in: .whitespaces)
-            return trimmed.isEmpty ? nil : trimmed
+            return ZMPushStringTitle.localizedString(withConversationName: conversation?.meaningfulDisplayName, teamName: teamName)
         }
         
         func bodyText() -> String {
@@ -122,6 +118,8 @@ extension ZMLocalNotification {
             userInfo[SelfUserIDStringKey] = selfUserID.transportString()
             userInfo[SenderIDStringKey] = senderID.transportString()
             userInfo[ConversationIDStringKey] = conversationID.transportString()
+            userInfo[ConversationNameStringKey] = conversation?.meaningfulDisplayName
+            userInfo[TeamNameStringKey] = teamName
             return userInfo
         }
     }

--- a/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification+Events.swift
+++ b/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification+Events.swift
@@ -19,38 +19,38 @@
 
 extension ZMLocalNotification {
     
-    // for each supported event type, use the corresponding notification constructor.
+    // for each supported event type, use the corresponding notification builder.
     //
     convenience init?(event: ZMUpdateEvent, conversation: ZMConversation?, managedObjectContext moc: NSManagedObjectContext) {
-        var constructor: NotificationBuilder?
+        var builder: NotificationBuilder?
         
         switch event.type {
         case .conversationOtrMessageAdd:
-            constructor = ReactionEventNotificationBuilder(
+            builder = ReactionEventNotificationBuilder(
                 event: event, conversation: conversation, managedObjectContext: moc)
             
         case .conversationCreate:
-            constructor = ConversationCreateEventNotificationBuilder(
+            builder = ConversationCreateEventNotificationBuilder(
                 event: event, conversation: conversation, managedObjectContext: moc)
             
         case .userConnection:
-            constructor = UserConnectionEventNotificationBuilder(
+            builder = UserConnectionEventNotificationBuilder(
                 event: event, conversation: conversation, managedObjectContext: moc)
             
         case .userContactJoin:
-            constructor = NewUserEventNotificationBuilder(
+            builder = NewUserEventNotificationBuilder(
                 event: event, conversation: conversation, managedObjectContext: moc)
             
         default:
             return nil
         }
         
-        self.init(conversation: conversation, type: .event(event.type), constructor: constructor!)
+        self.init(conversation: conversation, type: .event(event.type), builder: builder!)
     }
     
 }
 
-// Base class for event notification constructors. Subclass this for each
+// Base class for event notification builders. Subclass this for each
 // event type, and override the components specific for that type.
 ///
 fileprivate class EventNotificationBuilder: NotificationBuilder {

--- a/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification+Messages.swift
+++ b/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification+Messages.swift
@@ -24,8 +24,8 @@ extension ZMLocalNotification {
     convenience init?(message: ZMMessage) {
         guard message.conversation?.remoteIdentifier  != nil else { return nil }
         let contentType = ZMLocalNotificationContentType.typeForMessage(message)
-        let constructor = MessageNotificationBuilder(message: message, contentType: contentType)
-        self.init(conversation: message.conversation, type: .message(contentType), constructor: constructor)
+        let builder = MessageNotificationBuilder(message: message, contentType: contentType)
+        self.init(conversation: message.conversation, type: .message(contentType), builder: builder)
         self.isEphemeral = message.isEphemeral
     }
     
@@ -152,8 +152,8 @@ extension ZMLocalNotification {
     convenience init?(systemMessage: ZMSystemMessage) {
         guard systemMessage.conversation?.remoteIdentifier != nil else { return nil }
         let contentType = ZMLocalNotificationContentType.typeForMessage(systemMessage)
-        let constructor = SystemMessageNotificationBuilder(message: systemMessage)
-        self.init(conversation: systemMessage.conversation, type: .message(contentType), constructor: constructor)
+        let builder = SystemMessageNotificationBuilder(message: systemMessage)
+        self.init(conversation: systemMessage.conversation, type: .message(contentType), builder: builder)
     }
     
     private class SystemMessageNotificationBuilder : MessageNotificationBuilder {
@@ -215,8 +215,8 @@ extension ZMLocalNotification {
     }
     
     convenience init?(expiredMessageIn conversation: ZMConversation) {
-        let constructor = FailedMessageNotificationBuilder(conversation: conversation)
-        self.init(conversation: conversation, type: .failedMessage, constructor: constructor)
+        let builder = FailedMessageNotificationBuilder(conversation: conversation)
+        self.init(conversation: conversation, type: .failedMessage, builder: builder)
     }
     
     private func configureforExpiredMessage(in conversation: ZMConversation!) {

--- a/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification.swift
+++ b/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification.swift
@@ -35,7 +35,7 @@ public enum LocalNotificationType {
     case failedMessage
 }
 
-/// A notification constructor provides the main components used to configure
+/// A notification builder provides the main components used to configure
 /// a local notification. 
 ///
 protocol NotificationBuilder {
@@ -70,14 +70,14 @@ open class ZMLocalNotification: NSObject {
     
     public var isEphemeral: Bool = false
     
-    init?(conversation: ZMConversation?, type: LocalNotificationType, constructor: NotificationBuilder) {
-        guard constructor.shouldCreateNotification() else { return nil }
+    init?(conversation: ZMConversation?, type: LocalNotificationType, builder: NotificationBuilder) {
+        guard builder.shouldCreateNotification() else { return nil }
         self.type = type
-        self.title = constructor.titleText()
-        self.body = constructor.bodyText().escapingPercentageSymbols()
-        self.category = constructor.category()
-        self.soundName = constructor.soundName()
-        self.userInfo = constructor.userInfo()
+        self.title = builder.titleText()
+        self.body = builder.bodyText().escapingPercentageSymbols()
+        self.category = builder.category()
+        self.soundName = builder.soundName()
+        self.userInfo = builder.userInfo()
     }
     
     /// Returns a configured concrete UILocalNotification object.

--- a/Source/Notifications/Push notifications/Notification Types/ZMLocalNotificationKeys.swift
+++ b/Source/Notifications/Push notifications/Notification Types/ZMLocalNotificationKeys.swift
@@ -32,6 +32,9 @@ public let FailedMessageInOneOnOneConversationText: NSString = "failed.message.o
 public let ZMPushStringDefault             = "default"
 public let ZMPushStringEphemeral           = "ephemeral"
 
+// Title with team name
+public let ZMPushStringTitle               = "title"          // "[conversationName] in [teamName]
+
 // 1 user, 1 conversation, 1 string
 // %1$@    %2$@            %3$@
 //

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationLocalizationTests.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationLocalizationTests.swift
@@ -1,0 +1,37 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+
+class ZMLocalNotificationLocalizationTests: XCTestCase {
+    
+    func testThatItLocalizesTitle() {
+        
+        let conversationName = "iOS Team"
+        let teamName = "Wire"
+        
+        let result: (String?, String?) -> String? = {
+            ZMPushStringTitle.localizedString(withConversationName: $0, teamName: $1)
+        }
+        
+        XCTAssertEqual(result(conversationName, teamName), "iOS Team in Wire")
+        XCTAssertEqual(result(conversationName, nil), "iOS Team")
+        XCTAssertEqual(result(nil, teamName), "in Wire")
+        XCTAssertNil(result(nil, nil))
+    }
+}

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -330,6 +330,7 @@
 		EE01E04A1F93D9EB001AA33C /* ZMStoredLocalNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE01E0491F93D9EB001AA33C /* ZMStoredLocalNotificationTests.swift */; };
 		EE5BF6351F8F907C00B49D06 /* ZMLocalNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5BF6341F8F907C00B49D06 /* ZMLocalNotificationTests.swift */; };
 		EE5BF6371F8F9D6100B49D06 /* ZMLocalNotificationTests_Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5BF6361F8F9D6100B49D06 /* ZMLocalNotificationTests_Event.swift */; };
+		EEB568191FA22FBE003ADA3A /* ZMLocalNotificationLocalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB568181FA22FBE003ADA3A /* ZMLocalNotificationLocalizationTests.swift */; };
 		EEEA75FA1F8A6142006D1070 /* ZMLocalNotification+Messages.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEEA75F51F8A613F006D1070 /* ZMLocalNotification+Messages.swift */; };
 		EEEA75FB1F8A6142006D1070 /* ZMLocalNotification+Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEEA75F61F8A6140006D1070 /* ZMLocalNotification+Events.swift */; };
 		EEEA75FC1F8A6142006D1070 /* ZMLocalNotification+Calling.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEEA75F71F8A6141006D1070 /* ZMLocalNotification+Calling.swift */; };
@@ -390,7 +391,6 @@
 		F98DD6D31ABB2F7C001D58CF /* ZMUserSession+UserNotificationCategories.h in Headers */ = {isa = PBXBuildFile; fileRef = F98DD6D01ABB2F7C001D58CF /* ZMUserSession+UserNotificationCategories.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F98DD6D51ABB2F7C001D58CF /* ZMUserSession+UserNotificationCategories.m in Sources */ = {isa = PBXBuildFile; fileRef = F98DD6D11ABB2F7C001D58CF /* ZMUserSession+UserNotificationCategories.m */; };
 		F98EDCD71D82B913001E65CB /* ZMLocalNotificationContentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F98EDCCD1D82B913001E65CB /* ZMLocalNotificationContentType.swift */; };
-		F98EDCEA1D82B924001E65CB /* SessionTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F98EDCDE1D82B924001E65CB /* SessionTracker.swift */; };
 		F98EDCEB1D82B924001E65CB /* NotificationSounds.swift in Sources */ = {isa = PBXBuildFile; fileRef = F98EDCDF1D82B924001E65CB /* NotificationSounds.swift */; };
 		F98EDCEC1D82B924001E65CB /* UILocalNotification+StringProcessing.h in Headers */ = {isa = PBXBuildFile; fileRef = F98EDCE01D82B924001E65CB /* UILocalNotification+StringProcessing.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F98EDCED1D82B924001E65CB /* UILocalNotification+StringProcessing.m in Sources */ = {isa = PBXBuildFile; fileRef = F98EDCE11D82B924001E65CB /* UILocalNotification+StringProcessing.m */; };
@@ -900,6 +900,7 @@
 		EE01E0491F93D9EB001AA33C /* ZMStoredLocalNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMStoredLocalNotificationTests.swift; sourceTree = "<group>"; };
 		EE5BF6341F8F907C00B49D06 /* ZMLocalNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ZMLocalNotificationTests.swift; path = Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests.swift; sourceTree = SOURCE_ROOT; };
 		EE5BF6361F8F9D6100B49D06 /* ZMLocalNotificationTests_Event.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ZMLocalNotificationTests_Event.swift; path = Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_Event.swift; sourceTree = SOURCE_ROOT; };
+		EEB568181FA22FBE003ADA3A /* ZMLocalNotificationLocalizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ZMLocalNotificationLocalizationTests.swift; path = Tests/Source/Notifications/PushNotifications/ZMLocalNotificationLocalizationTests.swift; sourceTree = SOURCE_ROOT; };
 		EEEA75F51F8A613F006D1070 /* ZMLocalNotification+Messages.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMLocalNotification+Messages.swift"; sourceTree = "<group>"; };
 		EEEA75F61F8A6140006D1070 /* ZMLocalNotification+Events.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMLocalNotification+Events.swift"; sourceTree = "<group>"; };
 		EEEA75F71F8A6141006D1070 /* ZMLocalNotification+Calling.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMLocalNotification+Calling.swift"; sourceTree = "<group>"; };
@@ -966,7 +967,6 @@
 		F98DD6D01ABB2F7C001D58CF /* ZMUserSession+UserNotificationCategories.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ZMUserSession+UserNotificationCategories.h"; sourceTree = "<group>"; };
 		F98DD6D11ABB2F7C001D58CF /* ZMUserSession+UserNotificationCategories.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ZMUserSession+UserNotificationCategories.m"; sourceTree = "<group>"; };
 		F98EDCCD1D82B913001E65CB /* ZMLocalNotificationContentType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMLocalNotificationContentType.swift; sourceTree = "<group>"; };
-		F98EDCDE1D82B924001E65CB /* SessionTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionTracker.swift; sourceTree = "<group>"; };
 		F98EDCDF1D82B924001E65CB /* NotificationSounds.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationSounds.swift; sourceTree = "<group>"; };
 		F98EDCE01D82B924001E65CB /* UILocalNotification+StringProcessing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UILocalNotification+StringProcessing.h"; sourceTree = "<group>"; };
 		F98EDCE11D82B924001E65CB /* UILocalNotification+StringProcessing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UILocalNotification+StringProcessing.m"; sourceTree = "<group>"; };
@@ -1592,21 +1592,15 @@
 			children = (
 				EE5BF6341F8F907C00B49D06 /* ZMLocalNotificationTests.swift */,
 				EE5BF6361F8F9D6100B49D06 /* ZMLocalNotificationTests_Event.swift */,
-				1671F9FE1E2FAF50009F3150 /* ZMLocalNotificationForTests_CallState.swift */,
-				F96C8E811D7ECECF004B6D87 /* ZMLocalNotificationTests_Message.swift */,
-				F96C8E891D7F6F8C004B6D87 /* ZMLocalNotificationTests_SystemMessage.swift */,
 				EE01E0381F90FEC1001AA33C /* ZMLocalNotificationTests_ExpiredMessage.swift */,
 				EE01E0491F93D9EB001AA33C /* ZMStoredLocalNotificationTests.swift */,
 				546F815A1E685F1A00775059 /* LocalNotificationDispatcherTests.swift */,
 				160195601E30C9CF00ACBFAC /* LocalNotificationDispatcherCallingTests.swift */,
 				F9E4779D1D21640E003A99AC /* ZMLocalNotificationSetTests.swift */,
-				F95373F01C7C6FF500BE6427 /* ZMLocalNotificationForEventTest.h */,
-				54C2F6811A6FA988003D09D9 /* ZMLocalNotificationForEventTest.m */,
-				F96C8E811D7ECECF004B6D87 /* ZMLocalNotificationForMessageTests.swift */,
-				1671F9FE1E2FAF50009F3150 /* ZMLocalNotificationForCallStateTests.swift */,
-				F96C8E891D7F6F8C004B6D87 /* ZMLocalNotificationForSystemMessageTests.swift */,
-				F93667041D79723100E15420 /* ZMLocalNotificationForEventTests+Reactions.swift */,
-				54C2F6821A6FA988003D09D9 /* ZMLocalNotificationForExpiredMessageTest.m */,
+				F96C8E811D7ECECF004B6D87 /* ZMLocalNotificationTests_Message.swift */,
+				1671F9FE1E2FAF50009F3150 /* ZMLocalNotificationForTests_CallState.swift */,
+				F96C8E891D7F6F8C004B6D87 /* ZMLocalNotificationTests_SystemMessage.swift */,
+				EEB568181FA22FBE003ADA3A /* ZMLocalNotificationLocalizationTests.swift */,
 				54C2F6831A6FA988003D09D9 /* ZMPushRegistrantTests.m */,
 				54C2F6841A6FA988003D09D9 /* ZMSpellOutSmallNumbersFormatterTests.m */,
 			);
@@ -2396,7 +2390,6 @@
 				545434A919AB6ADA003892D9 /* ZMConversationTranscoderTests.m in Sources */,
 				F9ABE8551EFD56BF00D83214 /* MemberDownloadRequestStrategyTests.swift in Sources */,
 				54D785011A37256C00F47798 /* ZMEncodedNSUUIDWithTimestampTests.m in Sources */,
-				54C2F6991A6FA988003D09D9 /* ZMLocalNotificationForEventTest.m in Sources */,
 				F9ABDF441CECC6C0008461B2 /* AccountStatusTests.swift in Sources */,
 				5447E4681AECDE6500411FCD /* ZMUserSessionTestsBase.m in Sources */,
 				16D3FD021E3A5C0D0052A535 /* ZMConversationVoiceChannelRouterTests.swift in Sources */,
@@ -2463,6 +2456,7 @@
 				164B8C211E254AD00060AB26 /* WireCallCenterV3Mock.swift in Sources */,
 				F170AF211E78013A0033DC33 /* UserImageAssetUpdateStrategyTests.swift in Sources */,
 				F95ECF511B94BD05009F91BA /* ZMHotFixTests.m in Sources */,
+				EEB568191FA22FBE003ADA3A /* ZMLocalNotificationLocalizationTests.swift in Sources */,
 				F9410F681DE4BE42007451FF /* PushTokenStrategyTests.swift in Sources */,
 				16D448F51F1D00C40037285C /* SlowSyncTests+Teams.swift in Sources */,
 				F9ABE8571EFD56BF00D83214 /* TeamDownloadRequestStrategy+EventsTests.swift in Sources */,
@@ -2644,7 +2638,6 @@
 				F9ABE84F1EFD568B00D83214 /* TeamDownloadRequestStrategy.swift in Sources */,
 				871667FA1BB2AE9C009C6EEA /* APSSignalingKeysStore.swift in Sources */,
 				54A343471D6B589A004B65EA /* AddressBookSearch.swift in Sources */,
-				F98EDCD91D82B913001E65CB /* ZMLocalNotificationForSystemMessage.swift in Sources */,
 				5497100A1F6FFE9900026EDD /* ClientUpdateNotification.swift in Sources */,
 				549815DA1A432BC700A7CE2E /* ZMUserSession+Background.m in Sources */,
 				3E887BA51ABC51880022797E /* ZMPushKitLogging.m in Sources */,


### PR DESCRIPTION
## What's in this PR?
- Added push string localization for notification titles
- Store conversation name and team name in the notification `userInfo` (this is useful for `ChatHeadView`
- Renamed `constructor` to `builder` for consistency