### PR TITLE
Fix/notification adjustments

### DIFF
--- a/Resources/Base.lproj/Push.strings
+++ b/Resources/Base.lproj/Push.strings
@@ -32,6 +32,7 @@
 
 "push.notification.ephemeral.oneonone" = "sent you a message";
 "push.notification.ephemeral.group" = "Someone sent a message";
+"push.notification.ephemeral.group.noconversationname" = "Someone sent a message";
 
 // Push Title: [Conversation Name] in [Team Name]
 "push.notification.title" = "%1$@ in %2$@";

--- a/Resources/Base.lproj/Push.strings
+++ b/Resources/Base.lproj/Push.strings
@@ -29,7 +29,9 @@
 // content in the alert body.
 
 "push.notification.default" = "New message";
-"push.notification.ephemeral" = "Someone sent you a message";
+
+"push.notification.ephemeral.oneonone" = "sent a message";
+"push.notification.ephemeral.group" = "Someone sent a message";
 
 // Push Title: [Conversation Name] in [Team Name]
 "push.notification.title" = "%1$@ in %2$@";
@@ -145,8 +147,8 @@
 "push.notification.callkit.call.started.group.noconversationname" = "%@ calling in a conversation";
 
 // CONVERSATION CREATE
-"push.notification.conversation.create" = "%1$@ created a group conversation with you";
-"push.notification.conversation.create.nousername" = "Someone created a group conversation with you";
+"push.notification.conversation.create" = "%1$@ created a group";
+"push.notification.conversation.create.nousername" = "Someone created a group";
 
 // CONNECTIONS (there should be no alert titles for these)
 "push.notification.connection.request" = "%@ wants to connect";

--- a/Resources/Base.lproj/Push.strings
+++ b/Resources/Base.lproj/Push.strings
@@ -30,7 +30,7 @@
 
 "push.notification.default" = "New message";
 
-"push.notification.ephemeral.oneonone" = "sent a message";
+"push.notification.ephemeral.oneonone" = "sent you a message";
 "push.notification.ephemeral.group" = "Someone sent a message";
 
 // Push Title: [Conversation Name] in [Team Name]

--- a/Source/Notifications/Push notifications/Helpers/ZMLocalNotificationLocalization+Components.swift
+++ b/Source/Notifications/Push notifications/Helpers/ZMLocalNotificationLocalization+Components.swift
@@ -42,7 +42,7 @@ public extension NSString {
     public func localizationInfo(forUser user: ZMUser, conversation: ZMConversation) -> LocalizationInfo {
         
         let userName = user.name
-        let convName = conversation.userDefinedName
+        let convName = conversation.meaningfulDisplayName
         var arguments = [String]()
         var keyComponents = [String]()
         

--- a/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification+Messages.swift
+++ b/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification+Messages.swift
@@ -85,7 +85,12 @@ extension ZMLocalNotification {
         
         func bodyText() -> String {
             if shouldHideContent {
-                return (message.isEphemeral ? ZMPushStringEphemeral : ZMPushStringDefault).localizedStringForPushNotification()
+                if message.isEphemeral {
+                    return ZMPushStringEphemeral.localizedString(with: sender, conversation: conversation)
+                }
+                else {
+                    return ZMPushStringDefault.localizedStringForPushNotification()
+                }
             } else {
                 
                 var text: String?

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests.swift
@@ -28,6 +28,7 @@ class ZMLocalNotificationTests: MessagingTest {
     var userWithNoName: ZMUser!
     var oneOnOneConversation: ZMConversation!
     var groupConversation: ZMConversation!
+    var groupConversationWithoutUserDefinedName: ZMConversation!
     var groupConversationWithoutName: ZMConversation!
     
     override func setUp() {
@@ -38,8 +39,11 @@ class ZMLocalNotificationTests: MessagingTest {
         userWithNoName = insertUser(with: UUID.create(), name: nil)
         oneOnOneConversation = insertConversation(with: UUID.create(), name: "Super Conversation", type: .oneOnOne, isSilenced: false)
         groupConversation = insertConversation(with: UUID.create(), name: "Super Conversation", type: .group, isSilenced: false)
-        groupConversationWithoutName = insertConversation(with: UUID.create(), name: nil, type: .group, isSilenced: false)
         
+        // an empty conversation will have no meaninful display name
+        groupConversationWithoutName = insertConversation(with: UUID.create(), name: nil, type: .group, isSilenced: false, isEmpty: true)
+        groupConversationWithoutUserDefinedName = insertConversation(with: UUID.create(), name: nil, type: .group, isSilenced: false)
+
         syncMOC.performGroupedBlockAndWait {
             self.selfUser = ZMUser.selfUser(in: self.syncMOC)
             self.selfUser.remoteIdentifier = UUID.create()
@@ -55,6 +59,7 @@ class ZMLocalNotificationTests: MessagingTest {
         oneOnOneConversation = nil
         groupConversation = nil
         groupConversationWithoutName = nil
+        groupConversationWithoutUserDefinedName = nil
         selfUser.remoteIdentifier = nil
         super.tearDown()
     }
@@ -72,7 +77,7 @@ class ZMLocalNotificationTests: MessagingTest {
         return user
     }
     
-    func insertConversation(with remoteID: UUID, name: String?, type: ZMConversationType, isSilenced: Bool) -> ZMConversation {
+    func insertConversation(with remoteID: UUID, name: String?, type: ZMConversationType, isSilenced: Bool, isEmpty: Bool = false) -> ZMConversation {
         var conversation: ZMConversation!
         syncMOC.performGroupedBlockAndWait {
             conversation = ZMConversation.insertNewObject(in: self.syncMOC)
@@ -82,7 +87,7 @@ class ZMLocalNotificationTests: MessagingTest {
             conversation.isSilenced = isSilenced
             conversation.lastServerTimeStamp = Date()
             conversation.lastReadServerTimeStamp = conversation.lastServerTimeStamp
-            conversation.mutableOtherActiveParticipants.addObjects(from: [self.sender, self.otherUser1])
+            if !isEmpty { conversation.mutableOtherActiveParticipants.addObjects(from: [self.sender, self.otherUser1]) }
             self.syncMOC.saveOrRollback()
         }
         return conversation

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_Event.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_Event.swift
@@ -276,7 +276,7 @@ class ZMLocalNotificationTests_Event: ZMLocalNotificationTests {
     
     func testThatItCreatesTheCorrectAlertBody_ConvWithoutName(){
         guard let alertBody = alertBody(groupConversationWithoutName, aSender: otherUser1) else { return XCTFail()}
-        XCTAssertEqual(alertBody, "Other User1 ❤️ your message")
+        XCTAssertEqual(alertBody, "Other User1 ❤️ your message in a conversation")
     }
     
     func testThatItCreatesTheCorrectAlertBody(){
@@ -293,7 +293,7 @@ class ZMLocalNotificationTests_Event: ZMLocalNotificationTests {
     func testThatItCreatesTheCorrectAlertBody_UnknownUser_UnknownConversationName(){
         otherUser1.name = ""
         guard let alertBody = alertBody(groupConversationWithoutName, aSender: otherUser1) else { return XCTFail()}
-        XCTAssertEqual(alertBody, "Someone ❤️ your message")
+        XCTAssertEqual(alertBody, "Someone ❤️ your message in a conversation")
     }
     
     func testThatItCreatesTheCorrectAlertBody_UnknownUser_OneOnOneConv(){

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_Event.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_Event.swift
@@ -32,7 +32,7 @@ class ZMLocalNotificationTests_Event: ZMLocalNotificationTests {
         
         // then
         XCTAssertNotNil(note)
-        XCTAssertEqual(note!.body, "Super User created a group conversation with you")
+        XCTAssertEqual(note!.body, "Super User created a group")
     }
     
     func testThatItCreatesConversationCreateNotification_NoUsername() {
@@ -44,7 +44,7 @@ class ZMLocalNotificationTests_Event: ZMLocalNotificationTests {
         
          // then
         XCTAssertNotNil(note)
-        XCTAssertEqual(note!.body, "Someone created a group conversation with you")
+        XCTAssertEqual(note!.body, "Someone created a group")
     }
     
     // MARK: - Connection
@@ -276,7 +276,7 @@ class ZMLocalNotificationTests_Event: ZMLocalNotificationTests {
     
     func testThatItCreatesTheCorrectAlertBody_ConvWithoutName(){
         guard let alertBody = alertBody(groupConversationWithoutName, aSender: otherUser1) else { return XCTFail()}
-        XCTAssertEqual(alertBody, "Other User1 ❤️ your message in a conversation")
+        XCTAssertEqual(alertBody, "Other User1 ❤️ your message")
     }
     
     func testThatItCreatesTheCorrectAlertBody(){
@@ -293,7 +293,7 @@ class ZMLocalNotificationTests_Event: ZMLocalNotificationTests {
     func testThatItCreatesTheCorrectAlertBody_UnknownUser_UnknownConversationName(){
         otherUser1.name = ""
         guard let alertBody = alertBody(groupConversationWithoutName, aSender: otherUser1) else { return XCTFail()}
-        XCTAssertEqual(alertBody, "Someone ❤️ your message in a conversation")
+        XCTAssertEqual(alertBody, "Someone ❤️ your message")
     }
     
     func testThatItCreatesTheCorrectAlertBody_UnknownUser_OneOnOneConv(){

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_Message.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_Message.swift
@@ -62,16 +62,18 @@ class ZMLocalNotificationTests_Message : ZMLocalNotificationTests {
         
         //    "push.notification.add.message.oneonone" = "%1$@";
         //    "push.notification.add.message.group" = "%1$@: %2$@";
-        //    "push.notification.add.message.group.noconversationname" = "%1$@: %2$@";
+        //    "push.notification.add.message.group.noconversationname" = "%1$@ in a conversation: %2$@";
         
         XCTAssertEqual(bodyForNote(oneOnOneConversation, sender: sender), "Hello Hello!")
         XCTAssertEqual(bodyForNote(groupConversation, sender: sender), "Super User: Hello Hello!")
-        XCTAssertEqual(bodyForNote(groupConversationWithoutName, sender: sender), "Super User: Hello Hello!")
+        XCTAssertEqual(bodyForNote(groupConversationWithoutUserDefinedName, sender: sender), "Super User: Hello Hello!")
+        XCTAssertEqual(bodyForNote(groupConversationWithoutName, sender: sender), "Super User in a conversation: Hello Hello!")
     }
     
     func testThatObfuscatesNotificationsForEphemeralMessages(){
         XCTAssertEqual(bodyForNote(oneOnOneConversation, sender: sender, isEphemeral: true), "sent you a message")
         XCTAssertEqual(bodyForNote(groupConversation, sender: sender, isEphemeral: true), "Someone sent a message")
+        XCTAssertEqual(bodyForNote(groupConversationWithoutUserDefinedName, sender: sender, isEphemeral: true), "Someone sent a message")
         XCTAssertEqual(bodyForNote(groupConversationWithoutName, sender: sender, isEphemeral: true), "Someone sent a message")
     }
     
@@ -126,7 +128,8 @@ class ZMLocalNotificationTests_Message : ZMLocalNotificationTests {
     func testThatItCreatesPushNotificationForMessageOfUnknownType() {
         XCTAssertEqual(bodyForUnknownNote(oneOnOneConversation, sender: sender), "New message")
         XCTAssertEqual(bodyForUnknownNote(groupConversation, sender: sender), "Super User: new message")
-        XCTAssertEqual(bodyForUnknownNote(groupConversationWithoutName, sender: sender), "Super User: new message")
+        XCTAssertEqual(bodyForUnknownNote(groupConversationWithoutUserDefinedName, sender: sender), "Super User: new message")
+        XCTAssertEqual(bodyForUnknownNote(groupConversationWithoutName, sender: sender), "Super User sent a message")
     }
 
     func testThatItAddsATitleIfTheUserIsPartOfATeam() {
@@ -185,16 +188,18 @@ extension ZMLocalNotificationTests_Message {
     func testItCreatesImageNotificationsCorrectly(){
         //    "push.notification.add.image.oneonone" = "%1$@ shared a picture";
         //    "push.notification.add.image.group" = "%1$@ shared a picture";
-        //    "push.notification.add.image.group.noconversationname" = "%1$@ shared a picture";
+        //    "push.notification.add.image.group.noconversationname" = "%1$@ shared a picture in a conversation";
 
         XCTAssertEqual(bodyForImageNote(oneOnOneConversation, sender: sender), "shared a picture")
         XCTAssertEqual(bodyForImageNote(groupConversation, sender: sender), "Super User shared a picture")
-        XCTAssertEqual(bodyForImageNote(groupConversationWithoutName, sender: sender), "Super User shared a picture")
+        XCTAssertEqual(bodyForImageNote(groupConversationWithoutUserDefinedName, sender: sender), "Super User shared a picture")
+        XCTAssertEqual(bodyForImageNote(groupConversationWithoutName, sender: sender), "Super User shared a picture in a conversation")
     }
 
     func testThatObfuscatesNotificationsForEphemeralImageMessages(){
         XCTAssertEqual(bodyForImageNote(oneOnOneConversation, sender: sender, isEphemeral: true), "sent you a message")
         XCTAssertEqual(bodyForImageNote(groupConversation, sender: sender, isEphemeral: true), "Someone sent a message")
+        XCTAssertEqual(bodyForImageNote(groupConversationWithoutUserDefinedName, sender: sender, isEphemeral: true), "Someone sent a message")
         XCTAssertEqual(bodyForImageNote(groupConversationWithoutName, sender: sender, isEphemeral: true), "Someone sent a message")
     }
 }
@@ -271,45 +276,50 @@ extension ZMLocalNotificationTests_Message {
     func testThatItCreatesFileAddNotificationsCorrectly() {
         //    "push.notification.add.file.group" = "%1$@ shared a file"
         //    "push.notification.add.file.group.noconversationname" = "%1$@ shared a file"
-        //    "push.notification.add.file.oneonone" = "%1$@ shared a file"
+        //    "push.notification.add.file.oneonone" = "%1$@ shared a file in a conversation"
         //
 
         XCTAssertEqual(bodyForAssetNote(.txt, conversation: oneOnOneConversation, sender: sender), "shared a file")
         XCTAssertEqual(bodyForAssetNote(.txt, conversation: groupConversation, sender: sender), "Super User shared a file")
-        XCTAssertEqual(bodyForAssetNote(.txt, conversation: groupConversationWithoutName, sender: sender), "Super User shared a file")
+        XCTAssertEqual(bodyForAssetNote(.txt, conversation: groupConversationWithoutUserDefinedName, sender: sender), "Super User shared a file")
+        XCTAssertEqual(bodyForAssetNote(.txt, conversation: groupConversationWithoutName, sender: sender), "Super User shared a file in a conversation")
     }
 
     func testThatItCreatesVideoAddNotificationsCorrectly() {
         //    "push.notification.add.video.group" = "%1$@ shared a video
         //    "push.notification.add.video.group.noconversationname" = "%1$@ shared a video"
-        //    "push.notification.add.video.oneonone" = "%1$@ shared a video"
+        //    "push.notification.add.video.oneonone" = "%1$@ shared a video in a conversation"
         //
 
         XCTAssertEqual(bodyForAssetNote(.video, conversation: oneOnOneConversation, sender: sender), "shared a video")
         XCTAssertEqual(bodyForAssetNote(.video, conversation: groupConversation, sender: sender), "Super User shared a video")
-        XCTAssertEqual(bodyForAssetNote(.video, conversation: groupConversationWithoutName, sender: sender), "Super User shared a video")
+        XCTAssertEqual(bodyForAssetNote(.video, conversation: groupConversationWithoutUserDefinedName, sender: sender), "Super User shared a video")
+        XCTAssertEqual(bodyForAssetNote(.video, conversation: groupConversationWithoutName, sender: sender), "Super User shared a video in a conversation")
     }
 
     func testThatItCreatesEphemeralFileAddNotificationsCorrectly() {
         XCTAssertEqual(bodyForAssetNote(.txt, conversation: oneOnOneConversation, sender: sender, isEphemeral: true), "sent you a message")
         XCTAssertEqual(bodyForAssetNote(.txt, conversation: groupConversation, sender: sender, isEphemeral: true), "Someone sent a message")
+        XCTAssertEqual(bodyForAssetNote(.txt, conversation: groupConversationWithoutUserDefinedName, sender: sender, isEphemeral: true), "Someone sent a message")
         XCTAssertEqual(bodyForAssetNote(.txt, conversation: groupConversationWithoutName, sender: sender, isEphemeral: true), "Someone sent a message")
     }
 
     func testThatItCreatesEphemeralVideoAddNotificationsCorrectly() {
         XCTAssertEqual(bodyForAssetNote(.video, conversation: oneOnOneConversation, sender: sender, isEphemeral: true), "sent you a message")
         XCTAssertEqual(bodyForAssetNote(.video, conversation: groupConversation, sender: sender, isEphemeral: true), "Someone sent a message")
+        XCTAssertEqual(bodyForAssetNote(.video, conversation: groupConversationWithoutUserDefinedName, sender: sender, isEphemeral: true), "Someone sent a message")
         XCTAssertEqual(bodyForAssetNote(.video, conversation: groupConversationWithoutName, sender: sender, isEphemeral: true), "Someone sent a message")
     }
 
     func testThatItCreatesAudioNotificationsCorrectly() {
         //    "push.notification.add.audio.group" = "%1$@ shared an audio message";
         //    "push.notification.add.audio.group.noconversationname" = "%1$@ shared an audio message";
-        //    "push.notification.add.audio.oneonone" = "%1$@ shared an audio message";
+        //    "push.notification.add.audio.oneonone" = "%1$@ shared an audio message in a conversation";
 
         XCTAssertEqual(bodyForAssetNote(.audio, conversation: oneOnOneConversation, sender: sender), "shared an audio message")
         XCTAssertEqual(bodyForAssetNote(.audio, conversation: groupConversation, sender: sender), "Super User shared an audio message")
-        XCTAssertEqual(bodyForAssetNote(.audio, conversation: groupConversationWithoutName, sender: sender), "Super User shared an audio message")
+        XCTAssertEqual(bodyForAssetNote(.audio, conversation: groupConversationWithoutUserDefinedName, sender: sender), "Super User shared an audio message")
+        XCTAssertEqual(bodyForAssetNote(.audio, conversation: groupConversationWithoutName, sender: sender), "Super User shared an audio message in a conversation")
     }
 }
 
@@ -337,12 +347,13 @@ extension ZMLocalNotificationTests_Message {
     func testThatItCreatesKnockNotificationsCorrectly() {
         XCTAssertEqual(bodyForKnockNote(oneOnOneConversation, sender: sender), "pinged")
         XCTAssertEqual(bodyForKnockNote(groupConversation, sender: sender), "Super User pinged")
-        XCTAssertEqual(bodyForKnockNote(groupConversationWithoutName, sender: sender), "Super User pinged")
+        XCTAssertEqual(bodyForKnockNote(groupConversationWithoutUserDefinedName, sender: sender), "Super User pinged")
     }
 
     func testThatItCreatesEphemeralKnockNotificationsCorrectly() {
         XCTAssertEqual(bodyForKnockNote(oneOnOneConversation, sender: sender, isEphemeral: true), "sent you a message")
         XCTAssertEqual(bodyForKnockNote(groupConversation, sender: sender, isEphemeral: true), "Someone sent a message")
+        XCTAssertEqual(bodyForKnockNote(groupConversationWithoutUserDefinedName, sender: sender, isEphemeral: true), "Someone sent a message")
         XCTAssertEqual(bodyForKnockNote(groupConversationWithoutName, sender: sender, isEphemeral: true), "Someone sent a message")
     }
 }
@@ -368,10 +379,11 @@ extension ZMLocalNotificationTests_Message {
     func testThatItCreatesANotificationForAnEditMessage(){
         //    "push.notification.add.message.oneonone" = "%1$@";
         //    "push.notification.add.message.group" = "%1$@: %2$@";
-        //    "push.notification.add.message.group.noconversationname" = "%1$@: %2$@";
+        //    "push.notification.add.message.group.noconversationname" = "%1$@ in a conversation: %2$@";
 
         XCTAssertEqual(bodyForEditNote(oneOnOneConversation, sender: sender, text: "Edited Text"), "Edited Text")
         XCTAssertEqual(bodyForEditNote(groupConversation, sender: sender, text: "Edited Text"), "Super User: Edited Text")
-        XCTAssertEqual(bodyForEditNote(groupConversationWithoutName, sender: sender, text: "Edited Text"), "Super User: Edited Text")
+        XCTAssertEqual(bodyForEditNote(groupConversationWithoutUserDefinedName, sender: sender, text: "Edited Text"), "Super User: Edited Text")
+        XCTAssertEqual(bodyForEditNote(groupConversationWithoutName, sender: sender, text: "Edited Text"), "Super User in a conversation: Edited Text")
     }
 }

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_Message.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_Message.swift
@@ -62,17 +62,17 @@ class ZMLocalNotificationTests_Message : ZMLocalNotificationTests {
         
         //    "push.notification.add.message.oneonone" = "%1$@";
         //    "push.notification.add.message.group" = "%1$@: %2$@";
-        //    "push.notification.add.message.group.noconversationname" = "%1$@ in a conversation: %2$@";
+        //    "push.notification.add.message.group.noconversationname" = "%1$@: %2$@";
         
         XCTAssertEqual(bodyForNote(oneOnOneConversation, sender: sender), "Hello Hello!")
         XCTAssertEqual(bodyForNote(groupConversation, sender: sender), "Super User: Hello Hello!")
-        XCTAssertEqual(bodyForNote(groupConversationWithoutName, sender: sender), "Super User in a conversation: Hello Hello!")
+        XCTAssertEqual(bodyForNote(groupConversationWithoutName, sender: sender), "Super User: Hello Hello!")
     }
     
     func testThatObfuscatesNotificationsForEphemeralMessages(){
-        XCTAssertEqual(bodyForNote(oneOnOneConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
-        XCTAssertEqual(bodyForNote(groupConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
-        XCTAssertEqual(bodyForNote(groupConversationWithoutName, sender: sender, isEphemeral: true), "Someone sent you a message")
+        XCTAssertEqual(bodyForNote(oneOnOneConversation, sender: sender, isEphemeral: true), "sent you a message")
+        XCTAssertEqual(bodyForNote(groupConversation, sender: sender, isEphemeral: true), "Someone sent a message")
+        XCTAssertEqual(bodyForNote(groupConversationWithoutName, sender: sender, isEphemeral: true), "Someone sent a message")
     }
     
     func testThatItDuplicatesPercentageSignsInTextAndConversationName() {
@@ -126,7 +126,7 @@ class ZMLocalNotificationTests_Message : ZMLocalNotificationTests {
     func testThatItCreatesPushNotificationForMessageOfUnknownType() {
         XCTAssertEqual(bodyForUnknownNote(oneOnOneConversation, sender: sender), "New message")
         XCTAssertEqual(bodyForUnknownNote(groupConversation, sender: sender), "Super User: new message")
-        XCTAssertEqual(bodyForUnknownNote(groupConversationWithoutName, sender: sender), "Super User sent a message")
+        XCTAssertEqual(bodyForUnknownNote(groupConversationWithoutName, sender: sender), "Super User: new message")
     }
 
     func testThatItAddsATitleIfTheUserIsPartOfATeam() {
@@ -184,18 +184,18 @@ extension ZMLocalNotificationTests_Message {
     
     func testItCreatesImageNotificationsCorrectly(){
         //    "push.notification.add.image.oneonone" = "%1$@ shared a picture";
-        //    "push.notification.add.image.group" = "%1$@ shared a picture in %2$@";
+        //    "push.notification.add.image.group" = "%1$@ shared a picture";
         //    "push.notification.add.image.group.noconversationname" = "%1$@ shared a picture";
 
         XCTAssertEqual(bodyForImageNote(oneOnOneConversation, sender: sender), "shared a picture")
         XCTAssertEqual(bodyForImageNote(groupConversation, sender: sender), "Super User shared a picture")
-        XCTAssertEqual(bodyForImageNote(groupConversationWithoutName, sender: sender), "Super User shared a picture in a conversation")
+        XCTAssertEqual(bodyForImageNote(groupConversationWithoutName, sender: sender), "Super User shared a picture")
     }
 
     func testThatObfuscatesNotificationsForEphemeralImageMessages(){
-        XCTAssertEqual(bodyForImageNote(oneOnOneConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
-        XCTAssertEqual(bodyForImageNote(groupConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
-        XCTAssertEqual(bodyForImageNote(groupConversationWithoutName, sender: sender, isEphemeral: true), "Someone sent you a message")
+        XCTAssertEqual(bodyForImageNote(oneOnOneConversation, sender: sender, isEphemeral: true), "sent you a message")
+        XCTAssertEqual(bodyForImageNote(groupConversation, sender: sender, isEphemeral: true), "Someone sent a message")
+        XCTAssertEqual(bodyForImageNote(groupConversationWithoutName, sender: sender, isEphemeral: true), "Someone sent a message")
     }
 }
 
@@ -270,46 +270,46 @@ extension ZMLocalNotificationTests_Message {
     
     func testThatItCreatesFileAddNotificationsCorrectly() {
         //    "push.notification.add.file.group" = "%1$@ shared a file"
-        //    "push.notification.add.file.group.noconversationname" = "%1$@ shared a file in a conversation"
+        //    "push.notification.add.file.group.noconversationname" = "%1$@ shared a file"
         //    "push.notification.add.file.oneonone" = "%1$@ shared a file"
         //
 
         XCTAssertEqual(bodyForAssetNote(.txt, conversation: oneOnOneConversation, sender: sender), "shared a file")
         XCTAssertEqual(bodyForAssetNote(.txt, conversation: groupConversation, sender: sender), "Super User shared a file")
-        XCTAssertEqual(bodyForAssetNote(.txt, conversation: groupConversationWithoutName, sender: sender), "Super User shared a file in a conversation")
+        XCTAssertEqual(bodyForAssetNote(.txt, conversation: groupConversationWithoutName, sender: sender), "Super User shared a file")
     }
 
     func testThatItCreatesVideoAddNotificationsCorrectly() {
-        //    "push.notification.add.file.group" = "%1$@ shared a file
-        //    "push.notification.add.file.group.noconversationname" = "%1$@ shared a file in a conversation"
-        //    "push.notification.add.file.oneonone" = "%1$@ shared a file"
+        //    "push.notification.add.video.group" = "%1$@ shared a video
+        //    "push.notification.add.video.group.noconversationname" = "%1$@ shared a video"
+        //    "push.notification.add.video.oneonone" = "%1$@ shared a video"
         //
 
         XCTAssertEqual(bodyForAssetNote(.video, conversation: oneOnOneConversation, sender: sender), "shared a video")
         XCTAssertEqual(bodyForAssetNote(.video, conversation: groupConversation, sender: sender), "Super User shared a video")
-        XCTAssertEqual(bodyForAssetNote(.video, conversation: groupConversationWithoutName, sender: sender), "Super User shared a video in a conversation")
+        XCTAssertEqual(bodyForAssetNote(.video, conversation: groupConversationWithoutName, sender: sender), "Super User shared a video")
     }
 
     func testThatItCreatesEphemeralFileAddNotificationsCorrectly() {
-        XCTAssertEqual(bodyForAssetNote(.txt, conversation: oneOnOneConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
-        XCTAssertEqual(bodyForAssetNote(.txt, conversation: groupConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
-        XCTAssertEqual(bodyForAssetNote(.txt, conversation: groupConversationWithoutName, sender: sender, isEphemeral: true), "Someone sent you a message")
+        XCTAssertEqual(bodyForAssetNote(.txt, conversation: oneOnOneConversation, sender: sender, isEphemeral: true), "sent you a message")
+        XCTAssertEqual(bodyForAssetNote(.txt, conversation: groupConversation, sender: sender, isEphemeral: true), "Someone sent a message")
+        XCTAssertEqual(bodyForAssetNote(.txt, conversation: groupConversationWithoutName, sender: sender, isEphemeral: true), "Someone sent a message")
     }
 
     func testThatItCreatesEphemeralVideoAddNotificationsCorrectly() {
-        XCTAssertEqual(bodyForAssetNote(.video, conversation: oneOnOneConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
-        XCTAssertEqual(bodyForAssetNote(.video, conversation: groupConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
-        XCTAssertEqual(bodyForAssetNote(.video, conversation: groupConversationWithoutName, sender: sender, isEphemeral: true), "Someone sent you a message")
+        XCTAssertEqual(bodyForAssetNote(.video, conversation: oneOnOneConversation, sender: sender, isEphemeral: true), "sent you a message")
+        XCTAssertEqual(bodyForAssetNote(.video, conversation: groupConversation, sender: sender, isEphemeral: true), "Someone sent a message")
+        XCTAssertEqual(bodyForAssetNote(.video, conversation: groupConversationWithoutName, sender: sender, isEphemeral: true), "Someone sent a message")
     }
 
     func testThatItCreatesAudioNotificationsCorrectly() {
         //    "push.notification.add.audio.group" = "%1$@ shared an audio message";
-        //    "push.notification.add.audio.group.noconversationname" = "%1$@ shared an audio message in a conversation";
+        //    "push.notification.add.audio.group.noconversationname" = "%1$@ shared an audio message";
         //    "push.notification.add.audio.oneonone" = "%1$@ shared an audio message";
 
         XCTAssertEqual(bodyForAssetNote(.audio, conversation: oneOnOneConversation, sender: sender), "shared an audio message")
         XCTAssertEqual(bodyForAssetNote(.audio, conversation: groupConversation, sender: sender), "Super User shared an audio message")
-        XCTAssertEqual(bodyForAssetNote(.audio, conversation: groupConversationWithoutName, sender: sender), "Super User shared an audio message in a conversation")
+        XCTAssertEqual(bodyForAssetNote(.audio, conversation: groupConversationWithoutName, sender: sender), "Super User shared an audio message")
     }
 }
 
@@ -335,19 +335,15 @@ extension ZMLocalNotificationTests_Message {
     // MARK: Tests
     
     func testThatItCreatesKnockNotificationsCorrectly() {
-        //"push.notification.knock.group" = "%1$@ pinged %3$@ times in %2$@";
-        //"push.notification.knock.group.noconversationname" = "%1$@ pinged %2$@ times in a conversation";
-        //"push.notification.knock.oneonone" = "%1$@ pinged you %2$@ times";
-
         XCTAssertEqual(bodyForKnockNote(oneOnOneConversation, sender: sender), "pinged")
         XCTAssertEqual(bodyForKnockNote(groupConversation, sender: sender), "Super User pinged")
-        XCTAssertEqual(bodyForKnockNote(groupConversationWithoutName, sender: sender), "Super User pinged in a conversation")
+        XCTAssertEqual(bodyForKnockNote(groupConversationWithoutName, sender: sender), "Super User pinged")
     }
 
     func testThatItCreatesEphemeralKnockNotificationsCorrectly() {
-        XCTAssertEqual(bodyForKnockNote(oneOnOneConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
-        XCTAssertEqual(bodyForKnockNote(groupConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
-        XCTAssertEqual(bodyForKnockNote(groupConversationWithoutName, sender: sender, isEphemeral: true), "Someone sent you a message")
+        XCTAssertEqual(bodyForKnockNote(oneOnOneConversation, sender: sender, isEphemeral: true), "sent you a message")
+        XCTAssertEqual(bodyForKnockNote(groupConversation, sender: sender, isEphemeral: true), "Someone sent a message")
+        XCTAssertEqual(bodyForKnockNote(groupConversationWithoutName, sender: sender, isEphemeral: true), "Someone sent a message")
     }
 }
 
@@ -372,10 +368,10 @@ extension ZMLocalNotificationTests_Message {
     func testThatItCreatesANotificationForAnEditMessage(){
         //    "push.notification.add.message.oneonone" = "%1$@";
         //    "push.notification.add.message.group" = "%1$@: %2$@";
-        //    "push.notification.add.message.group.noconversationname" = "%1$@ in a conversation: %2$@";
+        //    "push.notification.add.message.group.noconversationname" = "%1$@: %2$@";
 
         XCTAssertEqual(bodyForEditNote(oneOnOneConversation, sender: sender, text: "Edited Text"), "Edited Text")
         XCTAssertEqual(bodyForEditNote(groupConversation, sender: sender, text: "Edited Text"), "Super User: Edited Text")
-        XCTAssertEqual(bodyForEditNote(groupConversationWithoutName, sender: sender, text: "Edited Text"), "Super User in a conversation: Edited Text")
+        XCTAssertEqual(bodyForEditNote(groupConversationWithoutName, sender: sender, text: "Edited Text"), "Super User: Edited Text")
     }
 }


### PR DESCRIPTION
## Adjustments
- different ephemeral push strings for one on one and group conversations
- push strings for created group conversations are now shorter (so they don't truncate)
- use `meaningfulDisplayName` instead of `displayName` when determining the conversation name, since the latter will return a placeholder name if it can't generate a "meaningful" name