### PR TITLE
Add account parameter to failed-to-login delegate method

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -28,7 +28,7 @@ public typealias LaunchOptions = [UIApplicationLaunchOptionsKey : Any]
 
 @objc public protocol SessionManagerDelegate : class {
     func sessionManagerCreated(userSession : ZMUserSession)
-    func sessionManagerDidFailToLogin(error : Error)
+    func sessionManagerDidFailToLogin(account: Account?, error : Error)
     func sessionManagerWillLogout(error : Error?, userSessionCanBeTornDown: @escaping () -> Void)
     func sessionManagerWillOpenAccount(_ account: Account, userSessionCanBeTornDown: @escaping () -> Void)
     func sessionManagerWillStartMigratingLocalStore()
@@ -389,10 +389,10 @@ public protocol LocalNotificationResponder : class {
     }
 
     /// Loads a session for a given account.
-    internal func loadSession(for account: Account?, completion: @escaping (ZMUserSession) -> Void) {
-        guard let account = account, account.isAuthenticated else {
+    internal func loadSession(for selectedAccount: Account?, completion: @escaping (ZMUserSession) -> Void) {
+        guard let account = selectedAccount, account.isAuthenticated else {
             createUnauthenticatedSession()
-            delegate?.sessionManagerDidFailToLogin(error: NSError.userSessionErrorWith(.accessTokenExpired, userInfo: nil))
+            delegate?.sessionManagerDidFailToLogin(account: selectedAccount, error: NSError.userSessionErrorWith(.accessTokenExpired, userInfo: nil))
             return
         }
 
@@ -681,7 +681,7 @@ extension SessionManager: PostLoginAuthenticationObserver {
             createUnauthenticatedSession()
         }
         
-        delegate?.sessionManagerDidFailToLogin(error: error)
+        delegate?.sessionManagerDidFailToLogin(account: accountManager.account(with: accountId), error: error)
     }
     
     public func authenticationInvalidated(_ error: NSError, accountId: UUID) {
@@ -709,7 +709,7 @@ extension SessionManager: PostLoginAuthenticationObserver {
                 createUnauthenticatedSession()
             }
             
-            delegate?.sessionManagerDidFailToLogin(error: error)
+            delegate?.sessionManagerDidFailToLogin(account: accountManager.account(with: accountId), error: error)
         }
     }
 
@@ -774,7 +774,7 @@ extension SessionManager : PreLoginAuthenticationObserver {
             createUnauthenticatedSession()
         }
         
-        delegate?.sessionManagerDidFailToLogin(error: error)
+        delegate?.sessionManagerDidFailToLogin(account: nil, error: error)
     }
 }
 

--- a/Tests/Source/Integration/IntegrationTest.swift
+++ b/Tests/Source/Integration/IntegrationTest.swift
@@ -507,7 +507,7 @@ extension IntegrationTest {
 
 extension IntegrationTest : SessionManagerDelegate {
     
-    public func sessionManagerDidFailToLogin(error: Error) {
+    public func sessionManagerDidFailToLogin(account: Account?, error: Error) {
         // no-op
     }
     

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -854,7 +854,7 @@ class SessionManagerTestDelegate: SessionManagerDelegate {
         userSessionCanBeTornDown()
     }
     
-    func sessionManagerDidFailToLogin(error: Error) {
+    func sessionManagerDidFailToLogin(account: Account?, error: Error) {
         // no op
     }
     


### PR DESCRIPTION
## Problem
We don't show the cancel-login button when switching to an account which is unauthenticated. This is because we don't show cancel button if there's a login error for the currently selected account, but in this case the login error is actually not from the selected account.

## Solution
In order to correctly decide when to show the cancel button we need to know which account failed to log in. Therefore I'm adding an `account` parameter to the `sessionManagerDidFailToLogin()` delegate method.