### PR TITLE
always generate system message for self member join event

### DIFF
--- a/Source/Synchronization/Transcoders/ZMConversationTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMConversationTranscoder.m
@@ -522,7 +522,12 @@ static NSString *const ConversationTeamManagedKey = @"managed";
 {
     NSSet *users = [event usersFromUserIDsInManagedObjectContext:self.managedObjectContext createIfNeeded:YES];
     
-    if (![users isSubsetOfSet:conversation.activeParticipants.set] || [conversation.modifiedKeys intersectsSet:[NSSet setWithObjects:ZMConversationIsSelfAnActiveMemberKey, ZMConversationUnsyncedActiveParticipantsKey, nil]]) {
+    ZMUser *selfUser = [ZMUser selfUserInContext:self.managedObjectContext];
+    
+    if (![users isSubsetOfSet:conversation.activeParticipants.set]
+        || (selfUser && [users intersectsSet:[NSSet setWithObject:selfUser]])
+        || [conversation.modifiedKeys intersectsSet:[NSSet setWithObjects:ZMConversationIsSelfAnActiveMemberKey, ZMConversationUnsyncedActiveParticipantsKey, nil]])
+    {
         [self appendSystemMessageForUpdateEvent:event inConversation:conversation];
     }
     


### PR DESCRIPTION
## Problem
The self user was not generating system messages and notifications when they were added to a group conversation.

## Reason
A conversation’s `isSelfAnActiveMember` flag defaults to true, thus if the self user is added to a group, the `users` set will always be a subset of `conversation.activeParticipants` and consequently the check would fail.

## Solution
If the `users` set contains the self user, pass the check.

### NOTE
If the self user added a person to a group, the `memberJoin` event would be fired twice, first in response to the POST, second when decoding from the notification stream. This would then create double system messages (the reason why the original check is there in the first place). However, since the self user can never add him/herself to a group conversation, it is safe to assume that the user was added externally, meaning we would only get the event once.

- [ ] depends on: https://github.com/wireapp/wire-ios-data-model/pull/390