### PR TITLE
only store conversation name if notification requires it

### DIFF
--- a/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification+Events.swift
+++ b/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification+Events.swift
@@ -144,7 +144,10 @@ fileprivate class EventNotificationBuilder: NotificationBuilder {
             userInfo[EventTimeKey] = eventTime
         }
         
-        userInfo[ConversationNameStringKey] = conversation?.meaningfulDisplayName
+        if requiresConversation {
+            userInfo[ConversationNameStringKey] = conversation?.meaningfulDisplayName
+        }
+        
         userInfo[TeamNameStringKey] = teamName
         
         return userInfo


### PR DESCRIPTION
## Problem
`ZMLocalNotification`s for `conversationCreate` events were displaying the conversation name (initially a list of user's first names) in the chatheads, because if the chatted is for the active account, the conversation name stored in the `userInfo` is used as the title.

## Solution
For event notifications that do not require a conversation (even if they may have one), do not store the conversation name in the `userInfo`.