### PR TITLE
Fix/callkit string

### DIFF
--- a/Source/Calling/CallKitDelegate.swift
+++ b/Source/Calling/CallKitDelegate.swift
@@ -410,7 +410,7 @@ extension ZMConversation {
         
         switch conversationType {
         case .group:
-            return ("callkit.call.started" as NSString).localizedString(with: user, conversation: self, count: 0)
+            return ("callkit.call.started.group" as NSString).localizedCallKitString(with: user, conversation: self)
         case .oneOnOne:
             return connectedUser?.displayName
         default:

--- a/Source/Notifications/Push notifications/Helpers/ZMLocalNotificationLocalization.h
+++ b/Source/Notifications/Push notifications/Helpers/ZMLocalNotificationLocalization.h
@@ -46,5 +46,6 @@
 - (NSString *)localizedStringForPushNotification;
 
 - (NSString *)localizedStringWithConversationName:(NSString *)conversationName teamName:(NSString *)teamName;
+- (NSString *)localizedCallKitStringWithUser:(ZMUser *)user conversation:(ZMConversation *)conversation;
 
 @end

--- a/Source/Notifications/Push notifications/Helpers/ZMLocalNotificationLocalization.m
+++ b/Source/Notifications/Push notifications/Helpers/ZMLocalNotificationLocalization.m
@@ -252,6 +252,26 @@ static NSString *const NoTeamNameKey = @"noteamname";
     return localizedStringWithKeyAndArguments(ZMPushLocalizedString(key), arguments);
 }
 
+- (NSString *)localizedCallKitStringWithUser:(ZMUser *)user conversation:(ZMConversation *)conversation;
+{
+    NSString *key = self;
+    NSMutableArray *arguments = [NSMutableArray array];
+    
+    if (user.name == nil) {
+        key = [key stringByAppendingPathExtension:NoUserNameKey];
+    } else {
+        [arguments addObject:user.name];
+    }
+    
+    if (conversation.meaningfulDisplayName == nil) {
+        key = [key stringByAppendingPathExtension:NoConversationNameKey];
+    } else {
+        [arguments addObject:conversation.meaningfulDisplayName];
+    }
+    
+    return localizedStringWithKeyAndArguments(ZMPushLocalizedString(key), arguments);
+}
+
 
 @end
 

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationLocalizationTests.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationLocalizationTests.swift
@@ -17,11 +17,12 @@
 //
 
 import XCTest
+@testable import WireSyncEngine
 
-class ZMLocalNotificationLocalizationTests: XCTestCase {
+class ZMLocalNotificationLocalizationTests: ZMLocalNotificationTests {
     
     func testThatItLocalizesTitle() {
-        
+        // given
         let conversationName = "iOS Team"
         let teamName = "Wire"
         
@@ -29,9 +30,27 @@ class ZMLocalNotificationLocalizationTests: XCTestCase {
             ZMPushStringTitle.localizedString(withConversationName: $0, teamName: $1)
         }
         
+        // then
         XCTAssertEqual(result(conversationName, teamName), "iOS Team in Wire")
         XCTAssertEqual(result(conversationName, nil), "iOS Team")
         XCTAssertEqual(result(nil, teamName), "in Wire")
         XCTAssertNil(result(nil, nil))
+    }
+    
+    func testThatItLocalizesCallkitPushString() {
+        // "push.notification.callkit.call.started.group" = "%1$@ in %2$@";
+        // "push.notification.callkit.call.started.group.nousername.noconversationname" = "Someone calling in a conversation";
+        // "push.notification.callkit.call.started.group.nousername" = "Someone calling in %1$@";
+        // "push.notification.callkit.call.started.group.noconversationname" = "%@ calling in a conversation";
+        
+        let result: (ZMUser, ZMConversation) -> String = {
+            ("callkit.call.started.group" as NSString).localizedCallKitString(with: $0, conversation: $1)
+        }
+        
+        // then
+        XCTAssertEqual(result(sender, groupConversation), "Super User in Super Conversation")
+        XCTAssertEqual(result(userWithNoName, groupConversationWithoutName), "Someone calling in a conversation")
+        XCTAssertEqual(result(userWithNoName, groupConversation), "Someone calling in Super Conversation")
+        XCTAssertEqual(result(sender, groupConversationWithoutName), "Super User calling in a conversation")
     }
 }


### PR DESCRIPTION
## Problem
The CallKit overlay was displaying the title **[Username] in 0**.

## Reason
When constructing the push strings, we are not adding the conversation name in the arguments array for the format string. However, for some reason we are including a count (???), and so this count is inserted in the push string where the conversation name should be.

## Solution
We have been excluding the conversation name from all (other) push string because the conversation name appears in the APNS/Chathead title. The only case where we want to include the conversation name is for this CallKit overlay. Instead of constructing the push string as we normally do, we construct it separately.