### PR TITLE
Respect "hide notification preview" setting

### DIFF
--- a/Source/Notifications/Push notifications/LocalNotificationDispatcher.swift
+++ b/Source/Notifications/Push notifications/LocalNotificationDispatcher.swift
@@ -85,6 +85,14 @@ public class LocalNotificationDispatcher: NSObject {
             application.scheduleLocalNotification(note.uiLocalNotification)
         }
     }
+    
+    /// Determines if the notification content should be hidden as reflected in the store
+    /// metatdata for the given managed object context.
+    ///
+    static func shouldHideNotificationContent(moc: NSManagedObjectContext?) -> Bool {
+        let value = moc?.persistentStoreMetadata(forKey: ZMShouldHideNotificationContentKey) as? NSNumber
+        return value?.boolValue ?? false
+    }
 }
 
 extension LocalNotificationDispatcher: ZMEventConsumer {

--- a/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification+Calling.swift
+++ b/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification+Calling.swift
@@ -44,6 +44,8 @@ extension ZMLocalNotification {
             self.conversation = conversation
         }
         
+        var shouldHideContent: Bool { return false }
+        
         func shouldCreateNotification() -> Bool {
             switch callState {
             case .terminating(reason: .anweredElsewhere), .terminating(reason: .normal):

--- a/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification+Calling.swift
+++ b/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification+Calling.swift
@@ -44,8 +44,6 @@ extension ZMLocalNotification {
             self.conversation = conversation
         }
         
-        var shouldHideContent: Bool { return false }
-        
         func shouldCreateNotification() -> Bool {
             switch callState {
             case .terminating(reason: .anweredElsewhere), .terminating(reason: .normal):

--- a/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification.swift
+++ b/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification.swift
@@ -69,6 +69,7 @@ open class ZMLocalNotification: NSObject {
     public var conversationID: UUID? { return uuid(for: ConversationIDStringKey) }
     
     public var isEphemeral: Bool = false
+    var shouldHideContent: Bool = false
     
     init?(conversation: ZMConversation?, type: LocalNotificationType, builder: NotificationBuilder) {
         guard builder.shouldCreateNotification() else { return nil }
@@ -84,10 +85,10 @@ open class ZMLocalNotification: NSObject {
     ///
     public lazy var uiLocalNotification: UILocalNotification = {
         let note = UILocalNotification()
-        if !self.isEphemeral { note.alertTitle = self.title }
-        note.alertBody = self.body
+        note.alertTitle = (self.isEphemeral || self.shouldHideContent) ? nil : self.title
+        note.alertBody = self.shouldHideContent ? ZMPushStringDefault.localizedStringForPushNotification() : self.body
         note.category = self.category
-        note.soundName = self.soundName
+        note.soundName = self.shouldHideContent ? ZMCustomSound.notificationNewMessageSoundName() : self.soundName
         note.userInfo = self.userInfo
         return note
     }()

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_Message.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_Message.swift
@@ -58,6 +58,25 @@ class ZMLocalNotificationTests_Message : ZMLocalNotificationTests {
     
     // MARK: Tests
     
+    func testThatItShowsDefaultAlertBodyWhenHidePreviewSettingIsTrue() {
+        // given
+        let note1 = textNotification(oneOnOneConversation, sender: sender)
+        XCTAssertEqual(note1?.uiLocalNotification.alertTitle, "Super User")
+        XCTAssertEqual(note1?.uiLocalNotification.alertBody, "Hello Hello!")
+        
+        // when
+        let moc = oneOnOneConversation.managedObjectContext!
+        let key = LocalNotificationDispatcher.ZMShouldHideNotificationContentKey
+        moc.setPersistentStoreMetadata(true as NSNumber, key: key)
+        let setting = moc.persistentStoreMetadata(forKey: key) as? NSNumber
+        XCTAssertEqual(setting?.boolValue, true)
+        let note2 = textNotification(oneOnOneConversation, sender: sender)
+        
+        // then
+        XCTAssertNil(note2?.uiLocalNotification.alertTitle)
+        XCTAssertEqual(note2?.uiLocalNotification.alertBody, "New message")
+    }
+    
     func testItCreatesMessageNotificationsCorrectly(){
         
         //    "push.notification.add.message.oneonone" = "%1$@";


### PR DESCRIPTION
When this setting is enabled, then the APNS notification should have no title and the body should say *New message*.

Note: since this setting affects only APNS notifications, the logic only affects the `ZMLocalNotification`s `uiNotification` properties.