### PR TITLE
fix ephemeral string being overwritten by default push string

### DIFF
--- a/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification+Messages.swift
+++ b/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification+Messages.swift
@@ -27,8 +27,7 @@ extension ZMLocalNotification {
         let builder = MessageNotificationBuilder(message: message, contentType: contentType)
         self.init(conversation: message.conversation, type: .message(contentType), builder: builder)
         self.isEphemeral = message.isEphemeral
-        let shouldHideSetting = LocalNotificationDispatcher.shouldHideNotificationContent(moc: message.managedObjectContext)
-        self.shouldHideContent = shouldHideSetting || message.isEphemeral
+        self.shouldHideContent = LocalNotificationDispatcher.shouldHideNotificationContent(moc: message.managedObjectContext)
     }
     
     fileprivate class MessageNotificationBuilder: NotificationBuilder {
@@ -101,7 +100,11 @@ extension ZMLocalNotification {
         }
         
         func soundName() -> String {
-            return contentType == .knock ? ZMCustomSound.notificationPingSoundName() : ZMCustomSound.notificationNewMessageSoundName()
+            if message.isEphemeral {
+                return ZMCustomSound.notificationNewMessageSoundName()
+            } else {
+                return contentType == .knock ? ZMCustomSound.notificationPingSoundName() : ZMCustomSound.notificationNewMessageSoundName()
+            }
         }
         
         func userInfo() -> [AnyHashable: Any]? {

--- a/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification.swift
+++ b/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification.swift
@@ -86,7 +86,7 @@ open class ZMLocalNotification: NSObject {
     public lazy var uiLocalNotification: UILocalNotification = {
         let note = UILocalNotification()
         note.alertTitle = (self.isEphemeral || self.shouldHideContent) ? nil : self.title
-        note.alertBody = self.shouldHideContent ? ZMPushStringDefault.localizedStringForPushNotification() : self.body
+        note.alertBody = (!self.isEphemeral && self.shouldHideContent) ? ZMPushStringDefault.localizedStringForPushNotification() : self.body
         note.category = self.category
         note.soundName = self.shouldHideContent ? ZMCustomSound.notificationNewMessageSoundName() : self.soundName
         note.userInfo = self.userInfo


### PR DESCRIPTION
Quick fix for a minor mistake in the last build. The problem was that for messages, the ephemeral flag was being considered in the `shouldHideContent` flag, thus the default push string *New message* was always appearing in the APNS. 

Now, `shouldHideContent` refers only to the user settings. When setting the `alertBody` for the `uiNotification`, we only use the default push string if the content should be hidden **AND** the notification is not ephemeral (since if the notification is ephemeral, the body text will already be set appropriately with *Someone sent you a message*.

Finally, the `soundName` should be the standard **new message sound** if the content is to be hidden or the message is ephemeral.