### PR TITLE
Fix calls not connecting after disabling Callkit

### DIFF
--- a/Source/Calling/CallKitDelegate.swift
+++ b/Source/Calling/CallKitDelegate.swift
@@ -53,11 +53,7 @@ public class CallKitDelegate : NSObject {
         super.init()
         
         provider.setDelegate(self, queue: nil)
-        
-        // Should be set when CallKit is used. Then AVS will not start
-        // the audio before the audio session is active
-        mediaManager?.setUiStartsAudio(true)
-        
+                
         callStateObserverToken = WireCallCenterV3.addCallStateObserver(observer: self, context: userSession.managedObjectContext)
         missedCallObserverToken = WireCallCenterV3.addMissedCallObserver(observer: self, context: userSession.managedObjectContext)
     }

--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -519,11 +519,16 @@ ZM_EMPTY_ASSERTING_INIT()
     switch (callNotificationStyle) {
         case ZMCallNotificationStylePushNotifications:
             self.callKitDelegate = nil;
+            [self.mediaManager setUiStartsAudio:NO];
             break;
         case ZMCallNotificationStyleCallKit:
         {
             CXProvider *provider = [[CXProvider alloc] initWithConfiguration:[CallKitDelegate providerConfiguration]];
             CXCallController *callController = [[CXCallController alloc] initWithQueue:dispatch_get_main_queue()];
+            
+            // Should be set when CallKit is used. Then AVS will not start
+            // the audio before the audio session is active
+            [self.mediaManager setUiStartsAudio:YES];
             
             self.callKitDelegate = [[CallKitDelegate alloc] initWithProvider:provider
                                                               callController:callController


### PR DESCRIPTION
## Problem
Disabling Callkit would make all calls not connect until the next restart.

## Solution
Update `setUiStartsAudio` flag on media manager when disabling Callkit, otherwise AVS will never start the audio recording.