### PR TITLE
Do not set the BackgroundActivityFactory from the ZMUserSession

### DIFF
--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -112,9 +112,6 @@ ZM_EMPTY_ASSERTING_INIT()
         storeProvider.contextDirectory.syncContext.analytics = analytics;
     }];
 
-    [[BackgroundActivityFactory sharedInstance] setApplication:[UIApplication sharedApplication]]; // TODO make BackgroundActivityFactory work with ZMApplication
-    [[BackgroundActivityFactory sharedInstance] setMainGroupQueue:storeProvider.contextDirectory.uiContext];
-    
     RequestLoopAnalyticsTracker *tracker = [[RequestLoopAnalyticsTracker alloc] initWithAnalytics:analytics];
     
     if ([transportSession respondsToSelector:@selector(setRequestLoopDetectionCallback:)]) {


### PR DESCRIPTION
# Issue

The fields on the shared instance of `BackgroundActivityFactory` are:

- Shared application
- Main group queue

Those are reset every time the `ZMUserSession` is created and in `SessionManager`.

# Solution

It is enough to initialize the fields in the `SessionManager` once.