### PR TITLE
don't force unwrap file path

### DIFF
--- a/Source/Utility/ZMSound.swift
+++ b/Source/Utility/ZMSound.swift
@@ -105,9 +105,15 @@ public enum ZMSound: String, CustomStringConvertible {
         case .None:
             return nil
         case .WireText, .WirePing, .WireCall:
-            return URL(fileURLWithPath: Bundle.main.path(forResource: self.rawValue, ofType: type(of: self).fileExtension, inDirectory: "audio-notifications")!)
+            guard let path = Bundle.main.path(forResource: self.rawValue, ofType: type(of: self).fileExtension, inDirectory: "audio-notifications") else {
+                return nil
+            }
+            return URL(fileURLWithPath: path)
         default:
-            return URL(fileURLWithPath: Bundle.main.path(forResource: self.rawValue, ofType: type(of: self).fileExtension)!)
+            guard let path = Bundle.main.path(forResource: self.rawValue, ofType: type(of: self).fileExtension) else {
+                return nil
+            }
+            return URL(fileURLWithPath: path)
         }
     }
     


### PR DESCRIPTION
## Issue
We were force unwrapping nil in the case that the sound file wasn't in our bundle, leading to a crash on start up when trying to set the custom sound.

## Solution
Safely unwrap the path.