### PR TITLE
-fetchRequest is not availble: Fixed crash on iOS9

### DIFF
--- a/Source/Synchronization/Transcoders/ZMConversationTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMConversationTranscoder.m
@@ -177,7 +177,7 @@ static NSString *const ConversationTeamManagedKey = @"managed";
 - (void)updateSelfUserActiveConversations:(NSOrderedSet<ZMConversation *> *)activeConversations
 {
     ZMUser *selfUser = [ZMUser selfUserInContext:self.managedObjectContext];
-    NSMutableOrderedSet *inactiveConversations = [NSMutableOrderedSet orderedSetWithArray:[self.managedObjectContext executeFetchRequestOrAssert:[ZMConversation fetchRequest]]];
+    NSMutableOrderedSet *inactiveConversations = [NSMutableOrderedSet orderedSetWithArray:[self.managedObjectContext executeFetchRequestOrAssert:[ZMConversation sortedFetchRequest]]];
     [inactiveConversations minusOrderedSet:activeConversations];
     
     for (ZMConversation *inactiveConversation in inactiveConversations) {


### PR DESCRIPTION
# Issue

Method `-[NSManagedObject fetchRequest]` is only available on iOS 10.

# Investigation

Objective-C compiler is not checking the usage of new selectors. Shame!