### PR TITLE
Create team strategy

### DIFF
--- a/Source/Synchronization/Strategies/RegistrationStatus.swift
+++ b/Source/Synchronization/Strategies/RegistrationStatus.swift
@@ -78,6 +78,7 @@ final public class RegistrationStatus {
     /// - Parameter team: team object containing all information needed
     public func create(team: TeamToRegister) {
         phase = .createTeam(team: team)
+        RequestAvailableNotification.notifyNewRequestsAvailable(nil)
     }
 
     func handleError(_ error: Error) {

--- a/Source/Synchronization/Strategies/RegistrationStatus.swift
+++ b/Source/Synchronization/Strategies/RegistrationStatus.swift
@@ -54,7 +54,7 @@ final public class RegistrationStatus {
 
     public weak var delegate: RegistrationStatusDelegate?
 
-    /// Used to start email verificiation process by sending an email with verification
+    /// Used to start email activation process by sending an email with a
     /// code to supplied address.
     ///
     /// - Parameter email: email address to send activation code to
@@ -63,11 +63,10 @@ final public class RegistrationStatus {
         RequestAvailableNotification.notifyNewRequestsAvailable(nil)
     }
 
-    /// For checking the activation code (receive form email sent form backend) with email
+    /// For checking the activation code (received form email sent from backend) with email
     ///
-    /// - Parameters:
     /// - Parameter email: email address to check activation code of
-    ///   - code: activation code to check
+    ///  - Parameter code: activation code to check
     public func checkActivationCode(email: String, code: String) {
         phase = .checkActivationCode(email: email, code: code)
         RequestAvailableNotification.notifyNewRequestsAvailable(nil)

--- a/Source/Synchronization/Strategies/RegistrationStatus.swift
+++ b/Source/Synchronization/Strategies/RegistrationStatus.swift
@@ -20,6 +20,12 @@ import Foundation
 
 /// Used to signal changes to the registration state
 public protocol RegistrationStatusDelegate: class {
+    /// Team was successfully created
+    func teamRegistered()
+
+    /// Team creation error
+    func teamRegistrationFailed(with error: Error)
+
     /// Verify email should be sent with code
     func emailActivationCodeSent()
 
@@ -33,12 +39,22 @@ public protocol RegistrationStatusDelegate: class {
     func emailActivationCodeValidationFailed(with error: Error)
 }
 
+// Empty default implementations to let users of the protocol implement only subset of methods
+extension RegistrationStatusDelegate {
+    func teamRegistered() {}
+    func teamRegistrationFailed(with error: Error) {}
+    func emailActivationCodeSent() {}
+    func emailActivationCodeSendingFailed(with error: Error) {}
+    func emailActivationCodeValidated() {}
+    func emailActivationCodeValidationFailed(with error: Error) {}
+}
+
 final public class RegistrationStatus {
     var phase : Phase = .none
 
     public weak var delegate: RegistrationStatusDelegate?
 
-    /// Used for start email verificiation process by sending an email with verification
+    /// Used to start email verificiation process by sending an email with verification
     /// code to supplied address.
     ///
     /// - Parameter email: email address to send activation code to
@@ -46,7 +62,6 @@ final public class RegistrationStatus {
         phase = .sendActivationCode(email: email)
         RequestAvailableNotification.notifyNewRequestsAvailable(nil)
     }
-
 
     /// For checking the activation code (receive form email sent form backend) with email
     ///
@@ -58,12 +73,21 @@ final public class RegistrationStatus {
         RequestAvailableNotification.notifyNewRequestsAvailable(nil)
     }
 
+    /// Used to create a team. Also creates a new administrator account
+    ///
+    /// - Parameter team: team object containing all information needed
+    public func create(team: TeamToRegister) {
+        phase = .createTeam(team: team)
+    }
+
     func handleError(_ error: Error) {
         switch self.phase {
         case .sendActivationCode:
             self.delegate?.emailActivationCodeSendingFailed(with: error)
         case .checkActivationCode:
             self.delegate?.emailActivationCodeValidationFailed(with: error)
+        case .createTeam:
+            delegate?.teamRegistrationFailed(with: error)
         case .none:
             break
         }
@@ -76,6 +100,8 @@ final public class RegistrationStatus {
             self.delegate?.emailActivationCodeSent()
         case .checkActivationCode:
             self.delegate?.emailActivationCodeValidated()
+        case .createTeam:
+            delegate?.teamRegistered()
         case .none:
             break
         }
@@ -85,6 +111,7 @@ final public class RegistrationStatus {
     enum Phase {
         case sendActivationCode(email: String)
         case checkActivationCode(email: String, code: String)
+        case createTeam(team: TeamToRegister)
         case none
     }
 }
@@ -96,8 +123,8 @@ extension RegistrationStatus.Phase: Equatable {
             return l == r
         case let (.checkActivationCode(l, lCode), .checkActivationCode(r, rCode)):
             return l == r && lCode == rCode
-        case (.none, .none):
-            return true
+        case let (.createTeam(l), .createTeam(r)): return l == r
+        case (.none, .none): return true
         default: return false
         }
     }

--- a/Source/Synchronization/Strategies/TeamRegistrationStrategy.swift
+++ b/Source/Synchronization/Strategies/TeamRegistrationStrategy.swift
@@ -1,0 +1,69 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+final class TeamRegistrationStrategy : NSObject {
+    let registrationStatus: RegistrationStatusProtocol
+    let userInfoParser: UserInfoParser
+    var registrationSync: ZMSingleRequestSync!
+
+    init(groupQueue: ZMSGroupQueue, status : RegistrationStatusProtocol, userInfoParser: UserInfoParser) {
+        registrationStatus = status
+        self.userInfoParser = userInfoParser
+        super.init()
+        registrationSync = ZMSingleRequestSync(singleRequestTranscoder: self, groupQueue: groupQueue)
+    }
+}
+
+extension TeamRegistrationStrategy : ZMSingleRequestTranscoder {
+    func request(for sync: ZMSingleRequestSync) -> ZMTransportRequest? {
+        switch (registrationStatus.phase) {
+        case let .createTeam(team: team):
+            return ZMTransportRequest(path: "/register", method: .methodPOST, payload: team.payload)
+        default:
+            fatal("Generating request for invalid phase: \(registrationStatus.phase)")
+        }
+    }
+
+    func didReceive(_ response: ZMTransportResponse, forSingleRequest sync: ZMSingleRequestSync) {
+        if response.result == .success {
+            userInfoParser.parseUserInfo(from: response)
+            registrationStatus.success()
+        } else {
+            let error = NSError.blacklistedEmail(with: response) ??
+                NSError.invalidActivationCode(with: response) ??
+                NSError.emailAddressInUse(with: response) ??
+                NSError.unauthorizedError(with: response) ??
+                NSError.userSessionErrorWith(.unknownError, userInfo: [:])
+            registrationStatus.handleError(error)
+        }
+    }
+}
+
+extension TeamRegistrationStrategy : RequestStrategy {
+    func nextRequest() -> ZMTransportRequest? {
+        switch (registrationStatus.phase) {
+        case .createTeam:
+            registrationSync.readyForNextRequestIfNotBusy()
+            return registrationSync.nextRequest()
+        default:
+            return nil
+        }
+    }
+}

--- a/Source/Synchronization/Strategies/TeamToRegister.swift
+++ b/Source/Synchronization/Strategies/TeamToRegister.swift
@@ -1,0 +1,66 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+public struct TeamToRegister {
+    public let teamName: String
+    public let email: String
+    public let fullName: String
+    public let password: String
+    public let accentColor: ZMAccentColor
+    let locale: String
+    let label: UUID?
+
+    public init(teamName: String, email: String, fullName: String, password: String, accentColor: ZMAccentColor) {
+        self.teamName = teamName
+        self.email = email
+        self.fullName = fullName
+        self.password = password
+        self.accentColor = accentColor
+        self.locale = NSLocale.formattedLocaleIdentifier()!
+        self.label = UIDevice.current.identifierForVendor
+    }
+
+    var payload: ZMTransportData {
+        return [
+            "email" : email,
+            "team" : [
+                "name" : teamName,
+                "icon" : ""
+            ],
+            "accent_id" : accentColor.rawValue,
+            "locale" : locale,
+            "name" : fullName,
+            "password" : password,
+            "label" : label?.uuidString ?? UUID().uuidString
+            ] as ZMTransportData
+    }
+}
+
+extension TeamToRegister: Equatable {
+    public static func ==(lhs: TeamToRegister, rhs: TeamToRegister) -> Bool {
+        return lhs.teamName == rhs.teamName &&
+            lhs.email == rhs.email &&
+            lhs.fullName == rhs.fullName &&
+            lhs.password == rhs.password &&
+            lhs.accentColor == rhs.accentColor &&
+            lhs.locale == rhs.locale &&
+            lhs.label == rhs.label
+    }
+}

--- a/Source/UnauthenticatedSession/UnauthenticatedSession.swift
+++ b/Source/UnauthenticatedSession/UnauthenticatedSession.swift
@@ -64,7 +64,8 @@ public class UnauthenticatedSession: NSObject {
                 ZMLoginCodeRequestTranscoder(groupQueue: groupQueue, authenticationStatus: authenticationStatus)!,
                 ZMRegistrationTranscoder(groupQueue: groupQueue, authenticationStatus: authenticationStatus, userInfoParser: self)!,
                 ZMPhoneNumberVerificationTranscoder(groupQueue: groupQueue, authenticationStatus: authenticationStatus)!,
-                EmailVerificationStrategy(groupQueue: groupQueue, status: registrationStatus)
+                EmailVerificationStrategy(groupQueue: groupQueue, status: registrationStatus),
+                TeamRegistrationStrategy(groupQueue: groupQueue, status: registrationStatus, userInfoParser: self)
             ]
         )
     }

--- a/Tests/Source/Synchronization/Strategies/RegistrationStatusTestHelper.swift
+++ b/Tests/Source/Synchronization/Strategies/RegistrationStatusTestHelper.swift
@@ -1,0 +1,65 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+@testable import WireSyncEngine
+
+class TestRegistrationStatus: WireSyncEngine.RegistrationStatusProtocol {
+    var handleErrorCalled = 0
+    var handleErrorError: Error?
+    func handleError(_ error: Error) {
+        handleErrorCalled += 1
+        handleErrorError = error
+    }
+
+    var successCalled = 0
+    func success() {
+        successCalled += 1
+    }
+
+    var phase: WireSyncEngine.RegistrationStatus.Phase = .none
+}
+
+protocol RegistrationStatusStrategyTestHelper {
+    var registrationStatus: TestRegistrationStatus! { get }
+    func handleResponse(response: ZMTransportResponse)
+}
+
+extension RegistrationStatusStrategyTestHelper {
+    func checkResponseError(with phase: RegistrationStatus.Phase, code: ZMUserSessionErrorCode, errorLabel: String, httpStatus: NSInteger, file: StaticString = #file, line: UInt = #line) {
+        registrationStatus.phase = phase
+
+        let expectedError = NSError.userSessionErrorWith(code, userInfo: [:])
+        let payload = [
+            "label": errorLabel,
+            "message":"some"
+        ]
+
+        let response = ZMTransportResponse(payload: payload as ZMTransportData, httpStatus: httpStatus, transportSessionError: nil)
+
+        // when
+        XCTAssertEqual(registrationStatus.successCalled, 0, "Success should not be called", file: file, line: line)
+        XCTAssertEqual(registrationStatus.handleErrorCalled, 0, "HandleError should not be called", file: file, line: line)
+        handleResponse(response: response)
+
+        // then
+        XCTAssertEqual(registrationStatus.successCalled, 0, "Success should not be called", file: file, line: line)
+        XCTAssertEqual(registrationStatus.handleErrorCalled, 1, "HandleError should be called", file: file, line: line)
+        XCTAssertEqual(registrationStatus.handleErrorError as NSError?, expectedError, "HandleError should be called with error: \(expectedError), but was \(registrationStatus.handleErrorError?.localizedDescription ?? "nil")", file: file, line: line)
+    }
+}

--- a/Tests/Source/Synchronization/Strategies/TeamRegistrationStrategyTests.swift
+++ b/Tests/Source/Synchronization/Strategies/TeamRegistrationStrategyTests.swift
@@ -1,0 +1,122 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+@testable import WireSyncEngine
+
+class TeamRegistrationStrategyTests: MessagingTest {
+    var registrationStatus : TestRegistrationStatus!
+    var sut : WireSyncEngine.TeamRegistrationStrategy!
+    var userInfoParser: MockUserInfoParser!
+    var team: TeamToRegister!
+
+    override func setUp() {
+        super.setUp()
+        registrationStatus = TestRegistrationStatus()
+        userInfoParser = MockUserInfoParser()
+        sut = WireSyncEngine.TeamRegistrationStrategy(groupQueue: self.syncMOC, status: registrationStatus, userInfoParser: userInfoParser)
+        team = WireSyncEngine.TeamToRegister(teamName: "Dream Team", email: "some@email.com", fullName: "M. Jordan", password: "qwerty", accentColor: .brightOrange)
+    }
+
+    override func tearDown() {
+        sut = nil
+        registrationStatus = nil
+        userInfoParser = nil
+        team = nil
+        super.tearDown()
+    }
+
+    // MARK: - Idle state
+
+    func testThatItDoesNotGenerateRequestWhenPhaseIsNone() {
+        let request = sut.nextRequest()
+        XCTAssertNil(request);
+    }
+
+    // MARK: - Sending request
+
+    func testThatItMakesARequestWhenStateIsCreateTeam() {
+        //given
+        let path = "/register"
+        let payload = team.payload
+
+        let transportRequest = ZMTransportRequest(path: path, method: .methodPOST, payload: payload as ZMTransportData)
+        registrationStatus.phase = .createTeam(team: team)
+
+        //when
+
+        let request = sut.nextRequest()
+
+        //then
+        XCTAssertNotNil(request);
+        XCTAssertEqual(request, transportRequest)
+    }
+
+    func testThatItNotifiesStatusAfterSuccessfulResponseToTeamCreate() {
+        // given
+        registrationStatus.phase = .createTeam(team: team)
+        let response = ZMTransportResponse(payload: nil, httpStatus: 200, transportSessionError: nil)
+
+        // when
+        XCTAssertEqual(registrationStatus.successCalled, 0)
+        sut.didReceive(response, forSingleRequest: sut.registrationSync)
+
+        // then
+        XCTAssertEqual(registrationStatus.successCalled, 1)
+    }
+
+    // MARK: - Parsing user info
+
+    func testThatItCallsParseUserInfoOnSuccess() {
+        // given
+        registrationStatus.phase = .createTeam(team: team)
+        let response = ZMTransportResponse(payload: nil, httpStatus: 200, transportSessionError: nil)
+
+        // when
+        XCTAssertEqual(userInfoParser.parseCallCount, 0)
+        sut.didReceive(response, forSingleRequest: sut.registrationSync)
+
+        // then
+        XCTAssertEqual(userInfoParser.parseCallCount, 1)
+    }
+}
+
+// MARK:- error tests for team creation
+
+extension TeamRegistrationStrategyTests: RegistrationStatusStrategyTestHelper {
+
+    func handleResponse(response: ZMTransportResponse) {
+        sut.didReceive(response, forSingleRequest: sut.registrationSync)
+    }
+
+    func testThatItNotifiesStatusAfterErrorToEmailVerify_BlacklistEmail() {
+        checkResponseError(with: .createTeam(team: team), code: .blacklistedEmail, errorLabel: "blacklisted-email", httpStatus: 403)
+    }
+
+    func testThatItNotifiesStatusAfterErrorToEmailVerify_EmailExists() {
+        checkResponseError(with: .createTeam(team: team), code: .emailIsAlreadyRegistered, errorLabel: "key-exists", httpStatus: 409)
+    }
+
+    func testThatItNotifiesStatusAfterErrorToEmailVerify_InvalidActivationCode() {
+        checkResponseError(with: .createTeam(team: team), code: .invalidActivationCode, errorLabel: "invalid-code", httpStatus: 404)
+    }
+
+    func testThatItNotifiesStatusAfterErrorToEmailVerify_OtherError() {
+        checkResponseError(with: .createTeam(team: team), code: .unknownError, errorLabel: "not-clear-what-happened", httpStatus: 414)
+    }
+}

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -341,6 +341,8 @@
 		EFC8281E1FB34F9600E27E21 /* EmailVerificationStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFC8281D1FB34F9600E27E21 /* EmailVerificationStrategyTests.swift */; };
 		EFC828221FB356CE00E27E21 /* RegistrationStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFC828211FB356CE00E27E21 /* RegistrationStatusTests.swift */; };
 		F148F6671FB9AA7600BD6909 /* TeamToRegister.swift in Sources */ = {isa = PBXBuildFile; fileRef = F148F6661FB9AA7600BD6909 /* TeamToRegister.swift */; };
+		F148F6691FBAF55800BD6909 /* TeamRegistrationStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F148F6681FBAF55800BD6909 /* TeamRegistrationStrategyTests.swift */; };
+		F148F66B1FBAFAF600BD6909 /* RegistrationStatusTestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F148F66A1FBAFAF600BD6909 /* RegistrationStatusTestHelper.swift */; };
 		F159F4141F1E3134001B7D80 /* SessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F159F4131F1E3134001B7D80 /* SessionManagerTests.swift */; };
 		F159F4161F1E4C4C001B7D80 /* LocalStoreProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F159F4151F1E4C4C001B7D80 /* LocalStoreProvider.swift */; };
 		F170AF211E78013A0033DC33 /* UserImageAssetUpdateStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F170AF1F1E7800CF0033DC33 /* UserImageAssetUpdateStrategyTests.swift */; };
@@ -362,6 +364,7 @@
 		F19F4F4F1E6575F700F4D8FF /* UserProfileImageOwner.swift in Sources */ = {isa = PBXBuildFile; fileRef = F19F4F4E1E6575F700F4D8FF /* UserProfileImageOwner.swift */; };
 		F1A94BD21F010287003083D9 /* UnauthenticatedSession+Login.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A94BD11F010287003083D9 /* UnauthenticatedSession+Login.swift */; };
 		F1C51FE71FB49660009C2269 /* RegistrationStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C51FE61FB49660009C2269 /* RegistrationStatus.swift */; };
+		F1C51FE91FB4A9C7009C2269 /* TeamRegistrationStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C51FE81FB4A9C7009C2269 /* TeamRegistrationStrategy.swift */; };
 		F905C47F1E79A86A00AF34A5 /* WireCallCenterV3Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F905C47E1E79A86A00AF34A5 /* WireCallCenterV3Tests.swift */; };
 		F90EC5A31E7BF1AC00A6779E /* AVSWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90EC5A21E7BF1AC00A6779E /* AVSWrapper.swift */; };
 		F920F4D61DA3DCF8002B860B /* ConversationTests+Ephemeral.swift in Sources */ = {isa = PBXBuildFile; fileRef = F920F4D51DA3DCF8002B860B /* ConversationTests+Ephemeral.swift */; };
@@ -917,6 +920,8 @@
 		EFC8281D1FB34F9600E27E21 /* EmailVerificationStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailVerificationStrategyTests.swift; sourceTree = "<group>"; };
 		EFC828211FB356CE00E27E21 /* RegistrationStatusTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegistrationStatusTests.swift; sourceTree = "<group>"; };
 		F148F6661FB9AA7600BD6909 /* TeamToRegister.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamToRegister.swift; sourceTree = "<group>"; };
+		F148F6681FBAF55800BD6909 /* TeamRegistrationStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamRegistrationStrategyTests.swift; sourceTree = "<group>"; };
+		F148F66A1FBAFAF600BD6909 /* RegistrationStatusTestHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationStatusTestHelper.swift; sourceTree = "<group>"; };
 		F159F4131F1E3134001B7D80 /* SessionManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionManagerTests.swift; sourceTree = "<group>"; };
 		F159F4151F1E4C4C001B7D80 /* LocalStoreProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalStoreProvider.swift; sourceTree = "<group>"; };
 		F170AF1F1E7800CF0033DC33 /* UserImageAssetUpdateStrategyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserImageAssetUpdateStrategyTests.swift; sourceTree = "<group>"; };
@@ -937,6 +942,7 @@
 		F19F4F4E1E6575F700F4D8FF /* UserProfileImageOwner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserProfileImageOwner.swift; sourceTree = "<group>"; };
 		F1A94BD11F010287003083D9 /* UnauthenticatedSession+Login.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UnauthenticatedSession+Login.swift"; sourceTree = "<group>"; };
 		F1C51FE61FB49660009C2269 /* RegistrationStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationStatus.swift; sourceTree = "<group>"; };
+		F1C51FE81FB4A9C7009C2269 /* TeamRegistrationStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamRegistrationStrategy.swift; sourceTree = "<group>"; };
 		F905C47E1E79A86A00AF34A5 /* WireCallCenterV3Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WireCallCenterV3Tests.swift; sourceTree = "<group>"; };
 		F90EC5A21E7BF1AC00A6779E /* AVSWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVSWrapper.swift; sourceTree = "<group>"; };
 		F91CA6AC1BECBD3F000EE5C2 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Push.strings; sourceTree = "<group>"; };
@@ -1499,6 +1505,7 @@
 				16DABFAD1DCF98D3001973E3 /* CallingRequestStrategy.swift */,
 				547E5B591DDB67390038D936 /* UserProfileUpdateRequestStrategy.swift */,
 				F19F4F3B1E604AA700F4D8FF /* UserImageAssetUpdateStrategy.swift */,
+				F1C51FE81FB4A9C7009C2269 /* TeamRegistrationStrategy.swift */,
 				EFC8281B1FB343B600E27E21 /* EmailVerificationStrategy.swift */,
 				F1C51FE61FB49660009C2269 /* RegistrationStatus.swift */,
 				F148F6661FB9AA7600BD6909 /* TeamToRegister.swift */,
@@ -1523,8 +1530,10 @@
 				87D4625C1C3D526D00433469 /* DeleteAccountRequestStrategyTests.swift */,
 				549AEA3E1D636EF3003C0BEC /* AddressBookUploadRequestStrategyTest.swift */,
 				F170AF1F1E7800CF0033DC33 /* UserImageAssetUpdateStrategyTests.swift */,
+				F148F66A1FBAFAF600BD6909 /* RegistrationStatusTestHelper.swift */,
 				EFC8281D1FB34F9600E27E21 /* EmailVerificationStrategyTests.swift */,
 				EFC828211FB356CE00E27E21 /* RegistrationStatusTests.swift */,
+				F148F6681FBAF55800BD6909 /* TeamRegistrationStrategyTests.swift */,
 			);
 			path = Strategies;
 			sourceTree = "<group>";
@@ -2360,6 +2369,7 @@
 				3E05F252192A4FBD00F22D80 /* UserSessionErrorTests.m in Sources */,
 				545643D31C62C12E00A2129C /* ConversationTests+OTR.m in Sources */,
 				EF797FE91FB5E91C00F7FF21 /* TeamCreationTests.swift in Sources */,
+				F148F6691FBAF55800BD6909 /* TeamRegistrationStrategyTests.swift in Sources */,
 				168C0B3F1E97CE3900315044 /* ZMLastUpdateEventIDTranscoderTests.m in Sources */,
 				F190E0AA1E8D517A003E81F8 /* UserProfileImageV3Tests.swift in Sources */,
 				545434A719AB6ADA003892D9 /* ZMConnectionTranscoderTest.m in Sources */,
@@ -2464,6 +2474,7 @@
 				160195611E30C9CF00ACBFAC /* LocalNotificationDispatcherCallingTests.swift in Sources */,
 				F9B8305F1DEC86E700FF6FE7 /* UserImageStrategyTests.swift in Sources */,
 				09B730961B3045E400A5CCC9 /* ProxiedRequestStatusTests.swift in Sources */,
+				F148F66B1FBAFAF600BD6909 /* RegistrationStatusTestHelper.swift in Sources */,
 				EFC828221FB356CE00E27E21 /* RegistrationStatusTests.swift in Sources */,
 				544913B41B0247700044DE36 /* ZMCredentialsTests.m in Sources */,
 				F9B171F81C0F00E700E6EEC6 /* ClientUpdateStatusTests.swift in Sources */,
@@ -2617,6 +2628,7 @@
 				16DABFAE1DCF98D3001973E3 /* CallingRequestStrategy.swift in Sources */,
 				54DE9BEB1DE74FFB00EFFB9C /* RandomHandleGenerator.swift in Sources */,
 				549815D41A432BC700A7CE2E /* ZMSearchUser+UserSession.m in Sources */,
+				F1C51FE91FB4A9C7009C2269 /* TeamRegistrationStrategy.swift in Sources */,
 				549816301A432BC800A7CE2E /* ZMSelfStrategy.m in Sources */,
 				F19F1D381EFBF61800275E27 /* SessionManager.swift in Sources */,
 				1658C2371F503CF800889F22 /* FlowManager.swift in Sources */,

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -340,6 +340,7 @@
 		EFC8281C1FB343B600E27E21 /* EmailVerificationStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFC8281B1FB343B600E27E21 /* EmailVerificationStrategy.swift */; };
 		EFC8281E1FB34F9600E27E21 /* EmailVerificationStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFC8281D1FB34F9600E27E21 /* EmailVerificationStrategyTests.swift */; };
 		EFC828221FB356CE00E27E21 /* RegistrationStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFC828211FB356CE00E27E21 /* RegistrationStatusTests.swift */; };
+		F148F6671FB9AA7600BD6909 /* TeamToRegister.swift in Sources */ = {isa = PBXBuildFile; fileRef = F148F6661FB9AA7600BD6909 /* TeamToRegister.swift */; };
 		F159F4141F1E3134001B7D80 /* SessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F159F4131F1E3134001B7D80 /* SessionManagerTests.swift */; };
 		F159F4161F1E4C4C001B7D80 /* LocalStoreProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F159F4151F1E4C4C001B7D80 /* LocalStoreProvider.swift */; };
 		F170AF211E78013A0033DC33 /* UserImageAssetUpdateStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F170AF1F1E7800CF0033DC33 /* UserImageAssetUpdateStrategyTests.swift */; };
@@ -915,6 +916,7 @@
 		EFC8281B1FB343B600E27E21 /* EmailVerificationStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailVerificationStrategy.swift; sourceTree = "<group>"; };
 		EFC8281D1FB34F9600E27E21 /* EmailVerificationStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailVerificationStrategyTests.swift; sourceTree = "<group>"; };
 		EFC828211FB356CE00E27E21 /* RegistrationStatusTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegistrationStatusTests.swift; sourceTree = "<group>"; };
+		F148F6661FB9AA7600BD6909 /* TeamToRegister.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamToRegister.swift; sourceTree = "<group>"; };
 		F159F4131F1E3134001B7D80 /* SessionManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionManagerTests.swift; sourceTree = "<group>"; };
 		F159F4151F1E4C4C001B7D80 /* LocalStoreProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalStoreProvider.swift; sourceTree = "<group>"; };
 		F170AF1F1E7800CF0033DC33 /* UserImageAssetUpdateStrategyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserImageAssetUpdateStrategyTests.swift; sourceTree = "<group>"; };
@@ -1499,6 +1501,7 @@
 				F19F4F3B1E604AA700F4D8FF /* UserImageAssetUpdateStrategy.swift */,
 				EFC8281B1FB343B600E27E21 /* EmailVerificationStrategy.swift */,
 				F1C51FE61FB49660009C2269 /* RegistrationStatus.swift */,
+				F148F6661FB9AA7600BD6909 /* TeamToRegister.swift */,
 			);
 			path = Strategies;
 			sourceTree = "<group>";
@@ -2559,6 +2562,7 @@
 				16F5F16C1E4092C00062F0AE /* NSManagedObjectContext+CTCallCenter.swift in Sources */,
 				BF00441B1C737CE9007A6EA4 /* BackgroundAPNSPingBackStatus.swift in Sources */,
 				09531F181AE960E300B8556A /* ZMLoginCodeRequestTranscoder.m in Sources */,
+				F148F6671FB9AA7600BD6909 /* TeamToRegister.swift in Sources */,
 				F98DD6D51ABB2F7C001D58CF /* ZMUserSession+UserNotificationCategories.m in Sources */,
 				09BCDB8F1BCE7F000020DCC7 /* ZMAPSMessageDecoder.m in Sources */,
 				549816601A432BC800A7CE2E /* ZMCallFlowRequestStrategy.m in Sources */,


### PR DESCRIPTION
## What's in this PR?

We are adding a new flow for creating team (together with admin account). The current registration is handled by `ZMAuthenticationStatus` which is pretty complicated. The plan is to slowly transition to a new Swiftified `RegistrationStatus` which encodes states into an enum with associated values.

### New functionality

* Added a new `TeamRegistrationStrategy` which handles team creation. It is very similar to `ZMRegistrationTranscoder`
* Added new method for starting team registration which expects `TeamToRegister` object. This should be created by UI when all needed information is gathered.