### PR TITLE
Fix/analyzer

### DIFF
--- a/Source/UserSession/ZMStoredLocalNotification.h
+++ b/Source/UserSession/ZMStoredLocalNotification.h
@@ -24,8 +24,8 @@
 
 @interface ZMStoredLocalNotification : NSObject
 
-@property (nonatomic, readonly, nonnull) ZMConversation *conversation;
-@property (nonatomic, readonly, nonnull) ZMMessage *message;
+@property (nonatomic, readonly, nullable) ZMConversation *conversation;
+@property (nonatomic, readonly, nullable) ZMMessage *message;
 @property (nonatomic, readonly, nonnull) NSUUID *senderUUID;
 
 @property (nonatomic, readonly, nullable) NSString *category;

--- a/Source/UserSession/ZMUserSession+Actions.swift
+++ b/Source/UserSession/ZMUserSession+Actions.swift
@@ -37,14 +37,14 @@ extension ZMUserSession {
     
     public func handleCallCategoryNotification(_ note : ZMStoredLocalNotification) {
         guard let actionIdentifier = note.actionIdentifier, actionIdentifier == ZMCallAcceptAction,
-              let callState = note.conversation.voiceChannel?.state
+            let callState = note.conversation?.voiceChannel?.state
         else {
             open(note.conversation, at: nil)
             return
         }
         
         if case let .incoming(video: video, shouldRing: _, degraded: _) = callState, callCenter?.activeCallConversations(in: self).count == 0 {
-            _ = note.conversation.voiceChannel?.join(video: video, userSession: self)
+            _ = note.conversation?.voiceChannel?.join(video: video, userSession: self)
         }
         
         open(note.conversation, at: nil)

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   xcode:
     version: "9.0"
   environment:
-    DEPENDENCIES_BASE_URL: "https://raw.githubusercontent.com/wireapp/wire-ios-shared-resources/master"
+    DEPENDENCIES_BASE_URL: "https://raw.githubusercontent.com/wireapp/wire-ios-shared-resources/danger"
 
 checkout:
   post:

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   xcode:
     version: "9.0"
   environment:
-    DEPENDENCIES_BASE_URL: "https://raw.githubusercontent.com/wireapp/wire-ios-shared-resources/danger"
+    DEPENDENCIES_BASE_URL: "https://raw.githubusercontent.com/wireapp/wire-ios-shared-resources/master"
 
 checkout:
   post:


### PR DESCRIPTION
## What's new in this PR?

### Issues

Fixed several issues pointed out by the analyzer

### Causes

Some variables can be nil but they are marked as `nonnull` in the header. This would crash when going to Swiftland and possibly could cause problems in ObjC.

### Solutions

Updated nullability annotations to reflect reality.

## Dependencies

Analyzer will be run on each PR. The changes are in shared scrips:

- [x] https://github.com/wireapp/wire-ios-shared-resources/pull/14
