### PR TITLE
Assign sender to the call initiator when a call terminates

### DIFF
--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -612,8 +612,8 @@ public struct CallEvent {
         case .terminating(reason: let reason):
             if reason == .stillOngoing {
                 callState = .incoming(video: false, shouldRing: false, degraded: isDegraded(conversationId: conversationId))
-                userId = initiatorForCall(conversationId: conversationId) ?? selfUserId
             }
+            userId = initiatorForCall(conversationId: conversationId) ?? selfUserId
         default:
             break
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When a group ends the push notification says the self user called

### Causes

the user id associated with the terminating event is the self user.

### Solutions

The user id associated with the event is not relevant. We should instead use the userId associated with the incoming call event. This PR changes so that userId associated with the terminating event is always the call initiator.