### PR TITLE
Make call center API more clear

### DIFF
--- a/Source/Calling/CallKitDelegate.swift
+++ b/Source/Calling/CallKitDelegate.swift
@@ -390,28 +390,26 @@ extension CallKitDelegate : CXProviderDelegate {
 @available(iOS 10.0, *)
 extension CallKitDelegate : WireCallCenterCallStateObserver, WireCallCenterMissedCallObserver {
     
-    public func callCenterDidChange(callState: CallState, conversation: ZMConversation, user: ZMUser?, timeStamp: Date?) {
+    public func callCenterDidChange(callState: CallState, conversation: ZMConversation, caller: ZMUser, timestamp: Date?) {
         
         switch callState {
         case .incoming(video: let video, shouldRing: let shouldRing, degraded: _):
-            guard let user = user else { break }
-            
             if shouldRing {
                 if !conversation.isSilenced {
-                    reportIncomingCall(from: user, in: conversation, video: video)
+                    reportIncomingCall(from: caller, in: conversation, video: video)
                 }
             } else {
-                reportCall(in: conversation, endedAt: timeStamp, reason: .unanswered)
+                reportCall(in: conversation, endedAt: timestamp, reason: .unanswered)
             }
         case let .terminating(reason: reason):
-            reportCall(in: conversation, endedAt: timeStamp, reason: reason.CXCallEndedReason)
+            reportCall(in: conversation, endedAt: timestamp, reason: reason.CXCallEndedReason)
             
         default:
             break
         }
     }
     
-    public func callCenterMissedCall(conversation: ZMConversation, user: ZMUser, timestamp: Date, video: Bool) {
+    public func callCenterMissedCall(conversation: ZMConversation, caller: ZMUser, timestamp: Date, video: Bool) {
         // Since we missed the call we will not have an assigned callUUID and can just create a random one
         provider.reportCall(with: UUID(), endedAt: timestamp, reason: .unanswered)
     }
@@ -498,7 +496,7 @@ class CallObserver : WireCallCenterCallStateObserver {
         token = WireCallCenterV3.addCallStateObserver(observer: self, for: conversation, context: conversation.managedObjectContext!)
     }
     
-    public func callCenterDidChange(callState: CallState, conversation: ZMConversation, user userId: ZMUser?, timeStamp: Date?) {
+    public func callCenterDidChange(callState: CallState, conversation: ZMConversation, caller: ZMUser, timestamp: Date?) {
         switch callState {
         case .answered(degraded: false):
             onAnswered?()

--- a/Source/Calling/SystemMessageCallObserver.swift
+++ b/Source/Calling/SystemMessageCallObserver.swift
@@ -25,54 +25,45 @@ private let log = ZMSLog(tag: "Calling System Message")
 /// Inserts a calling system message for V3 calls
 final class CallSystemMessageGenerator: NSObject {
     
-    var callerByConversation = [ZMConversation: ZMUser]()
     var startDateByConversation = [ZMConversation: Date]()
     var connectDateByConversation = [ZMConversation: Date]()
 
-    public func appendSystemMessageIfNeeded(callState: CallState, conversation: ZMConversation, user: ZMUser?, timeStamp: Date?) -> ZMSystemMessage?{
+    public func appendSystemMessageIfNeeded(callState: CallState, conversation: ZMConversation, caller: ZMUser, timestamp: Date?) -> ZMSystemMessage?{
         var systemMessage : ZMSystemMessage? = nil
 
         switch callState {
         case .outgoing:
             log.info("Setting call start date for \(conversation.displayName)")
             startDateByConversation[conversation] = Date()
-            fallthrough
-        case .incoming:
-            log.info("Adding \(user?.displayName ?? "") as caller in \"\(conversation.displayName)\"")
-            callerByConversation[conversation] = user
         case .established:
-            if nil == callerByConversation[conversation] { log.info("No caller present when setting call start date") }
             log.info("Setting call connect date for \(conversation.displayName)")
             connectDateByConversation[conversation] = Date()
         case .terminating(reason: let reason):
-            systemMessage = appendCallEndedSystemMessage(reason: reason, conversation: conversation, timeStamp: timeStamp)
-        case .none, .unknown, .answered, .establishedDataChannel:
+            systemMessage = appendCallEndedSystemMessage(reason: reason, conversation: conversation, caller: caller, timestamp: timestamp)
+        case .none, .unknown, .answered, .establishedDataChannel, .incoming:
             break
         }
         return systemMessage
     }
 
-    private func appendCallEndedSystemMessage(reason: CallClosedReason, conversation: ZMConversation, timeStamp: Date?) -> ZMSystemMessage? {
+    private func appendCallEndedSystemMessage(reason: CallClosedReason, conversation: ZMConversation, caller: ZMUser, timestamp: Date?) -> ZMSystemMessage? {
         
         var systemMessage : ZMSystemMessage? = nil
-        if let caller = callerByConversation[conversation], let connectDate = connectDateByConversation[conversation] {
+        if let connectDate = connectDateByConversation[conversation] {
             let duration = -connectDate.timeIntervalSinceNow
             log.info("Appending performed call message: \(duration), \(caller.displayName), \"\(conversation.displayName)\"")
             systemMessage =  conversation.appendPerformedCallMessage(with: duration, caller: caller)
         }
-        else if let caller = callerByConversation[conversation] {
+        else {
             if let startDate = startDateByConversation[conversation] {
                 log.info("Appending performed call message: \(startDate), \(caller.displayName), \"\(conversation.displayName)\"")
                 systemMessage =  conversation.appendPerformedCallMessage(with: 0, caller: caller)
             } else {
                 log.info("Appending missed call message: \(caller.displayName), \"\(conversation.displayName)\"")
-                systemMessage = conversation.appendMissedCallMessage(fromUser: caller, at: timeStamp ?? Date())
+                systemMessage = conversation.appendMissedCallMessage(fromUser: caller, at: timestamp ?? Date())
             }
-        } else {
-            log.info("Call ended but no call info present in order to insert system message")
         }
         
-        callerByConversation[conversation] = nil
         startDateByConversation[conversation] = nil
         connectDateByConversation[conversation] = nil
         return systemMessage

--- a/Source/Calling/SystemMessageCallObserver.swift
+++ b/Source/Calling/SystemMessageCallObserver.swift
@@ -58,7 +58,7 @@ final class CallSystemMessageGenerator: NSObject {
             if let startDate = startDateByConversation[conversation] {
                 log.info("Appending performed call message: \(startDate), \(caller.displayName), \"\(conversation.displayName)\"")
                 systemMessage =  conversation.appendPerformedCallMessage(with: 0, caller: caller)
-            } else {
+            } else if reason == .canceled || reason == .timeout || reason == .normal {
                 log.info("Appending missed call message: \(caller.displayName), \"\(conversation.displayName)\"")
                 systemMessage = conversation.appendMissedCallMessage(fromUser: caller, at: timestamp ?? Date())
             }

--- a/Source/Notifications/Push notifications/LocalNotificationDispatcher+Calling.swift
+++ b/Source/Notifications/Push notifications/LocalNotificationDispatcher+Calling.swift
@@ -20,7 +20,7 @@ import Foundation
 
 public extension LocalNotificationDispatcher {
     
-    public func process(callState: CallState, in conversation: ZMConversation, sender: ZMUser) {
+    public func process(callState: CallState, in conversation: ZMConversation, caller: ZMUser) {
         // missed call notification are handled separately
         // but if call was answered elsewhere then proceed
         switch callState {
@@ -32,14 +32,14 @@ public extension LocalNotificationDispatcher {
         default: break
         }
         
-        let note = ZMLocalNotification(callState: callState, conversation: conversation, sender: sender)
+        let note = ZMLocalNotification(callState: callState, conversation: conversation, caller: caller)
         callingNotifications.cancelNotifications(conversation)
         note.apply(scheduleLocalNotification)
         note.apply(callingNotifications.addObject)
     }
     
-    public func processMissedCall(in conversation: ZMConversation, sender: ZMUser) {
-        let note = ZMLocalNotification(callState: .terminating(reason: .canceled), conversation: conversation, sender: sender)
+    public func processMissedCall(in conversation: ZMConversation, caller: ZMUser) {
+        let note = ZMLocalNotification(callState: .terminating(reason: .canceled), conversation: conversation, caller: caller)
         callingNotifications.cancelNotifications(conversation)
         note.apply(scheduleLocalNotification)
         note.apply(callingNotifications.addObject)

--- a/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification+Calling.swift
+++ b/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification+Calling.swift
@@ -21,16 +21,16 @@
 
 extension ZMLocalNotification {
     
-    convenience init?(callState: CallState, conversation: ZMConversation, sender: ZMUser) {
+    convenience init?(callState: CallState, conversation: ZMConversation, caller: ZMUser) {
         guard conversation.remoteIdentifier != nil else { return nil }
-        let builder = CallNotificationBuilder(callState: callState, sender: sender, conversation: conversation)
+        let builder = CallNotificationBuilder(callState: callState, caller: caller, conversation: conversation)
         self.init(conversation: conversation, type: .calling(callState), builder: builder)
     }
     
     private class CallNotificationBuilder: NotificationBuilder {
         
         let callState: CallState
-        let sender: ZMUser
+        let caller: ZMUser
         var conversation: ZMConversation?
         private var teamName: String?
         
@@ -38,9 +38,9 @@ extension ZMLocalNotification {
             .established, .answered(degraded: false), .outgoing(degraded: false), .none, .unknown
         ]
         
-        init(callState: CallState, sender: ZMUser, conversation: ZMConversation) {
+        init(callState: CallState, caller: ZMUser, conversation: ZMConversation) {
             self.callState = callState
-            self.sender = sender
+            self.caller = caller
             self.conversation = conversation
         }
         
@@ -80,7 +80,7 @@ extension ZMLocalNotification {
             }
             
             if nil != key {
-                text = key!.localizedString(with: sender, conversation: conversation) ?? ""
+                text = key!.localizedString(with: caller, conversation: conversation) ?? ""
             }
             
             return text.escapingPercentageSymbols()
@@ -110,7 +110,7 @@ extension ZMLocalNotification {
             guard
                 let moc = conversation?.managedObjectContext,
                 let selfUserID = ZMUser.selfUser(in: moc).remoteIdentifier,
-                let senderID = sender.remoteIdentifier,
+                let senderID = caller.remoteIdentifier,
                 let conversationID = conversation?.remoteIdentifier
                 else { return nil }
             

--- a/Tests/Source/Calling/CallKitDelegateTests.swift
+++ b/Tests/Source/Calling/CallKitDelegateTests.swift
@@ -365,7 +365,7 @@ class CallKitDelegateTest: MessagingTest {
         self.uiMOC.saveOrRollback()
         
         mockWireCallCenterV3.mockCallState = .incoming(video: true, shouldRing: true, degraded: false)
-        self.sut.callCenterDidChange(callState: .incoming(video: true, shouldRing: true, degraded: false), conversation: conversation, user: otherUser, timeStamp: Date())
+        self.sut.callCenterDidChange(callState: .incoming(video: true, shouldRing: true, degraded: false), conversation: conversation, caller: otherUser, timestamp: Date())
         
         let call = CallKitDelegateTestsMocking.mockCall(with: sut.callUUID(for: conversation)!, outgoing: false)
         self.callKitController.mockCallObserver.mockCalls = [call]
@@ -456,7 +456,7 @@ class CallKitDelegateTest: MessagingTest {
         
         // when
         self.sut.provider(provider, perform: action)
-        mockWireCallCenterV3.update(callState: .answered(degraded: false), conversationId: conversation.remoteIdentifier!)
+        mockWireCallCenterV3.update(callState: .answered(degraded: false), conversationId: conversation.remoteIdentifier!, callerId: ZMUser.selfUser(in: uiMOC).remoteIdentifier!)
         
         // then
         XCTAssertTrue(provider.connectingCalls.contains(callUUID))
@@ -473,7 +473,7 @@ class CallKitDelegateTest: MessagingTest {
         
         // when
         self.sut.provider(provider, perform: action)
-        mockWireCallCenterV3.update(callState: .establishedDataChannel, conversationId: conversation.remoteIdentifier!)
+        mockWireCallCenterV3.update(callState: .establishedDataChannel, conversationId: conversation.remoteIdentifier!, callerId: ZMUser.selfUser(in: uiMOC).remoteIdentifier!)
         
         // then
         XCTAssertTrue(provider.connectedCalls.contains(callUUID))
@@ -487,7 +487,7 @@ class CallKitDelegateTest: MessagingTest {
         let otherUser = self.otherUser(moc: self.uiMOC)
         
         mockWireCallCenterV3.mockCallState = .incoming(video: true, shouldRing: true, degraded: false)
-        self.sut.callCenterDidChange(callState: .incoming(video: true, shouldRing: true, degraded: false), conversation: conversation, user: otherUser, timeStamp: Date())
+        self.sut.callCenterDidChange(callState: .incoming(video: true, shouldRing: true, degraded: false), conversation: conversation, caller: otherUser, timestamp: Date())
         let callUUID = sut.callUUID(for: conversation)!
         
         // when
@@ -507,7 +507,7 @@ class CallKitDelegateTest: MessagingTest {
         let otherUser = self.otherUser(moc: self.uiMOC)
         
         mockWireCallCenterV3.mockCallState = .incoming(video: true, shouldRing: true, degraded: false)
-        self.sut.callCenterDidChange(callState: .incoming(video: true, shouldRing: true, degraded: false), conversation: conversation, user: otherUser, timeStamp: Date())
+        self.sut.callCenterDidChange(callState: .incoming(video: true, shouldRing: true, degraded: false), conversation: conversation, caller: otherUser, timestamp: Date())
         let callUUID = sut.callUUID(for: conversation)
         
         // when
@@ -629,7 +629,7 @@ class CallKitDelegateTest: MessagingTest {
         let otherUser = self.otherUser(moc: self.uiMOC)
         
         // when
-        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: true, degraded: false), conversation: conversation, user: otherUser, timeStamp: nil)
+        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: true, degraded: false), conversation: conversation, caller: otherUser, timestamp: nil)
         
         // then
         XCTAssertEqual(self.callKitProvider.timesReportNewIncomingCallCalled, 1)
@@ -645,7 +645,7 @@ class CallKitDelegateTest: MessagingTest {
         let otherUser = self.otherUser(moc: self.uiMOC)
         
         // when
-        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: true, degraded: false), conversation: conversation, user: otherUser, timeStamp: nil)
+        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: true, degraded: false), conversation: conversation, caller: otherUser, timestamp: nil)
         
         // then
         XCTAssertEqual(self.callKitProvider.timesReportNewIncomingCallCalled, 0)
@@ -661,7 +661,7 @@ class CallKitDelegateTest: MessagingTest {
         sut.requestStartCall(in: conversation, video: false)
         
         // when
-        sut.callCenterDidChange(callState: .terminating(reason: .normal), conversation: conversation, user: otherUser, timeStamp: nil)
+        sut.callCenterDidChange(callState: .terminating(reason: .normal), conversation: conversation, caller: otherUser, timestamp: nil)
         
         // then
         XCTAssertEqual(self.callKitProvider.timesReportNewIncomingCallCalled, 0)
@@ -677,10 +677,10 @@ class CallKitDelegateTest: MessagingTest {
         let otherUser = self.otherUser(moc: self.uiMOC)
         
         mockWireCallCenterV3.mockCallState = .incoming(video: true, shouldRing: true, degraded: false)
-        self.sut.callCenterDidChange(callState: .incoming(video: true, shouldRing: true, degraded: false), conversation: conversation, user: otherUser, timeStamp: Date())
+        self.sut.callCenterDidChange(callState: .incoming(video: true, shouldRing: true, degraded: false), conversation: conversation, caller: otherUser, timestamp: Date())
         
         // when
-        sut.callCenterDidChange(callState: .terminating(reason: .lostMedia), conversation: conversation, user: otherUser, timeStamp: nil)
+        sut.callCenterDidChange(callState: .terminating(reason: .lostMedia), conversation: conversation, caller: otherUser, timestamp: nil)
         
         // then
         XCTAssertEqual(self.callKitProvider.lastEndedReason, .failed)
@@ -692,10 +692,10 @@ class CallKitDelegateTest: MessagingTest {
         let otherUser = self.otherUser(moc: self.uiMOC)
         
         mockWireCallCenterV3.mockCallState = .incoming(video: true, shouldRing: true, degraded: false)
-        self.sut.callCenterDidChange(callState: .incoming(video: true, shouldRing: true, degraded: false), conversation: conversation, user: otherUser, timeStamp: Date())
+        self.sut.callCenterDidChange(callState: .incoming(video: true, shouldRing: true, degraded: false), conversation: conversation, caller: otherUser, timestamp: Date())
         
         // when
-        sut.callCenterDidChange(callState: .terminating(reason: .timeout), conversation: conversation, user: otherUser, timeStamp: nil)
+        sut.callCenterDidChange(callState: .terminating(reason: .timeout), conversation: conversation, caller: otherUser, timestamp: nil)
         
         // then
         XCTAssertEqual(self.callKitProvider.lastEndedReason, .unanswered)
@@ -707,10 +707,10 @@ class CallKitDelegateTest: MessagingTest {
         let otherUser = self.otherUser(moc: self.uiMOC)
         
         mockWireCallCenterV3.mockCallState = .incoming(video: true, shouldRing: true, degraded: false)
-        self.sut.callCenterDidChange(callState: .incoming(video: true, shouldRing: true, degraded: false), conversation: conversation, user: otherUser, timeStamp: Date())
+        self.sut.callCenterDidChange(callState: .incoming(video: true, shouldRing: true, degraded: false), conversation: conversation, caller: otherUser, timestamp: Date())
         
         // when
-        sut.callCenterDidChange(callState: .terminating(reason: .anweredElsewhere), conversation: conversation, user: otherUser, timeStamp: nil)
+        sut.callCenterDidChange(callState: .terminating(reason: .anweredElsewhere), conversation: conversation, caller: otherUser, timestamp: nil)
         
         // then
         XCTAssertEqual(self.callKitProvider.lastEndedReason, .answeredElsewhere)

--- a/Tests/Source/Calling/CallStateObserverTests.swift
+++ b/Tests/Source/Calling/CallStateObserverTests.swift
@@ -90,7 +90,7 @@ class CallStateObserverTests : MessagingTest {
 
         // when
         sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: false, degraded: false), conversation: conversation, caller: sender, timestamp: nil)
-        sut.callCenterDidChange(callState: .terminating(reason: .canceled), conversation: conversation, caller: receiver, timestamp: nil)
+        sut.callCenterDidChange(callState: .terminating(reason: .canceled), conversation: conversation, caller: sender, timestamp: nil)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then
@@ -124,7 +124,6 @@ class CallStateObserverTests : MessagingTest {
         
         // given
         let ignoredCallStates : [CallState] = [.terminating(reason: .anweredElsewhere),
-                                               .terminating(reason: .normal),
                                                .terminating(reason: .lostMedia),
                                                .terminating(reason: .internalError),
                                                .terminating(reason: .unknown),

--- a/Tests/Source/Calling/CallStateObserverTests.swift
+++ b/Tests/Source/Calling/CallStateObserverTests.swift
@@ -89,8 +89,8 @@ class CallStateObserverTests : MessagingTest {
     func testThatMissedCallMessageIsAppendedForCanceledCallByReceiver() {
 
         // when
-        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: false, degraded: false), conversation: conversation, user:sender, timeStamp: nil)
-        sut.callCenterDidChange(callState: .terminating(reason: .canceled), conversation: conversation, user: receiver, timeStamp: nil)
+        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: false, degraded: false), conversation: conversation, caller: sender, timestamp: nil)
+        sut.callCenterDidChange(callState: .terminating(reason: .canceled), conversation: conversation, caller: receiver, timestamp: nil)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then
@@ -105,8 +105,8 @@ class CallStateObserverTests : MessagingTest {
     func testThatMissedCallMessageIsAppendedForCanceledCallBySender() {
         
         // given when
-        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: false, degraded: false), conversation: conversation, user: sender, timeStamp: nil)
-        sut.callCenterDidChange(callState: .terminating(reason: .canceled), conversation: conversation, user: sender, timeStamp: nil)
+        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: false, degraded: false), conversation: conversation, caller: sender, timestamp: nil)
+        sut.callCenterDidChange(callState: .terminating(reason: .canceled), conversation: conversation, caller: sender, timestamp: nil)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         self.syncMOC.performGroupedBlockAndWait {
@@ -138,7 +138,7 @@ class CallStateObserverTests : MessagingTest {
         
         // when
         for callState in ignoredCallStates {
-            sut.callCenterDidChange(callState: callState, conversation: conversation, user: sender, timeStamp: nil)
+            sut.callCenterDidChange(callState: callState, conversation: conversation, caller: sender, timestamp: nil)
         }
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
@@ -149,7 +149,7 @@ class CallStateObserverTests : MessagingTest {
     func testThatMissedCallMessageIsAppendedForMissedCalls() {
         
         // given when
-        sut.callCenterMissedCall(conversation: conversation, user: sender, timestamp: Date(), video: false)
+        sut.callCenterMissedCall(conversation: conversation, caller: sender, timestamp: Date(), video: false)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then
@@ -163,7 +163,7 @@ class CallStateObserverTests : MessagingTest {
     
     func testThatMissedCallsAreForwardedToTheNotificationDispatcher() {
         // given when
-        sut.callCenterMissedCall(conversation: conversation, user: sender, timestamp: Date(), video: false)
+        sut.callCenterMissedCall(conversation: conversation, caller: sender, timestamp: Date(), video: false)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then
@@ -172,7 +172,7 @@ class CallStateObserverTests : MessagingTest {
     
     func testThatCallStatesAreForwardedToTheNotificationDispatcher() {
         // given when
-        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: true, degraded: false), conversation: conversation, user: sender, timeStamp: nil)
+        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: true, degraded: false), conversation: conversation, caller: sender, timestamp: nil)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then
@@ -182,7 +182,7 @@ class CallStateObserverTests : MessagingTest {
     func testThatWeSendNotificationWhenCallStarts() {
         
         // given when
-        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: false, degraded: false), conversation: conversation, user: sender, timeStamp: nil)
+        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: false, degraded: false), conversation: conversation, caller: sender, timestamp: nil)
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
     }
     
@@ -201,7 +201,7 @@ class CallStateObserverTests : MessagingTest {
         }
         
         // given when
-        sut.callCenterDidChange(callState: .outgoing(degraded: false), conversation: conversation, user: sender, timeStamp: Date())
+        sut.callCenterDidChange(callState: .outgoing(degraded: false), conversation: conversation, caller: sender, timestamp: Date())
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
         
         // tear down
@@ -213,7 +213,7 @@ class CallStateObserverTests : MessagingTest {
         mockCallCenter = WireCallCenterV3Mock(userId: UUID.create(), clientId: "1234567", uiMOC: uiMOC, flowManager: FlowManagerMock(), transport: WireCallCenterTransportMock())
         mockCallCenter?.mockNonIdleCalls = [conversation.remoteIdentifier! : .incoming(video: false, shouldRing: true, degraded: false)]
         mockUserSession.managedObjectContext.zm_callCenter = mockCallCenter
-        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: false, degraded: false), conversation: conversation, user: sender, timeStamp: Date())
+        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: false, degraded: false), conversation: conversation, caller: sender, timestamp: Date())
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // expect
@@ -227,7 +227,7 @@ class CallStateObserverTests : MessagingTest {
         
         // when
         mockCallCenter?.mockNonIdleCalls = [:]
-        sut.callCenterDidChange(callState: .none, conversation: conversation, user: sender, timeStamp: Date())
+        sut.callCenterDidChange(callState: .none, conversation: conversation, caller: sender, timestamp: Date())
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
         
         // tear down
@@ -239,8 +239,8 @@ class CallStateObserverTests : MessagingTest {
         self.syncMOC.performGroupedBlockAndWait {
             // given when
             self.conversation.conversationType = .group
-            self.sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: false, degraded: false), conversation: self.conversation, user: self.sender, timeStamp: nil)
-            self.sut.callCenterDidChange(callState: .terminating(reason: .normal), conversation: self.conversation, user: self.sender, timeStamp: nil)
+            self.sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: false, degraded: false), conversation: self.conversation, caller: self.sender, timestamp: nil)
+            self.sut.callCenterDidChange(callState: .terminating(reason: .normal), conversation: self.conversation, caller: self.sender, timestamp: nil)
         }
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
@@ -254,8 +254,8 @@ class CallStateObserverTests : MessagingTest {
         self.syncMOC.performGroupedBlockAndWait {
             // given when
             self.conversation.conversationType = .group
-            self.sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: false, degraded: false), conversation: self.conversation, user: self.sender, timeStamp: nil)
-            self.sut.callCenterDidChange(callState: .terminating(reason: .anweredElsewhere), conversation: self.conversation, user: self.sender, timeStamp: nil)
+            self.sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: false, degraded: false), conversation: self.conversation, caller: self.sender, timestamp: nil)
+            self.sut.callCenterDidChange(callState: .terminating(reason: .anweredElsewhere), conversation: self.conversation, caller: self.sender, timestamp: nil)
         }
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         

--- a/Tests/Source/Calling/CallSystemMessageGeneratorTests.swift
+++ b/Tests/Source/Calling/CallSystemMessageGeneratorTests.swift
@@ -65,9 +65,9 @@ class CallSystemMessageGeneratorTests : MessagingTest {
         let messageCount = conversation.messages.count
         
         // when
-        let msg1 = sut.appendSystemMessageIfNeeded(callState: .outgoing(degraded: false), conversation: conversation, user: selfUser, timeStamp: nil)
-        let msg2 = sut.appendSystemMessageIfNeeded(callState: .established, conversation: conversation, user: selfUser, timeStamp: nil)
-        let msg3 = sut.appendSystemMessageIfNeeded(callState: .terminating(reason: .canceled), conversation: conversation, user: user, timeStamp: nil)
+        let msg1 = sut.appendSystemMessageIfNeeded(callState: .outgoing(degraded: false), conversation: conversation, caller: selfUser, timestamp: nil)
+        let msg2 = sut.appendSystemMessageIfNeeded(callState: .established, conversation: conversation, caller: selfUser, timestamp: nil)
+        let msg3 = sut.appendSystemMessageIfNeeded(callState: .terminating(reason: .canceled), conversation: conversation, caller: user, timestamp: nil)
         
         // then
         XCTAssertEqual(conversation.messages.count, messageCount+1)
@@ -87,9 +87,9 @@ class CallSystemMessageGeneratorTests : MessagingTest {
         let messageCount = conversation.messages.count
         
         // when
-        let msg1 = sut.appendSystemMessageIfNeeded(callState: .incoming(video: false, shouldRing: true, degraded: false), conversation: conversation, user: user, timeStamp: nil)
-        let msg2 = sut.appendSystemMessageIfNeeded(callState: .established , conversation: conversation, user: user, timeStamp: nil)
-        let msg3 = sut.appendSystemMessageIfNeeded(callState: .terminating(reason: .canceled), conversation: conversation, user: user, timeStamp: nil)
+        let msg1 = sut.appendSystemMessageIfNeeded(callState: .incoming(video: false, shouldRing: true, degraded: false), conversation: conversation, caller: user, timestamp: nil)
+        let msg2 = sut.appendSystemMessageIfNeeded(callState: .established , conversation: conversation, caller: user, timestamp: nil)
+        let msg3 = sut.appendSystemMessageIfNeeded(callState: .terminating(reason: .canceled), conversation: conversation, caller: user, timestamp: nil)
         
         // then
         XCTAssertEqual(conversation.messages.count, messageCount+1)
@@ -109,10 +109,10 @@ class CallSystemMessageGeneratorTests : MessagingTest {
         let messageCount = conversation.messages.count
         
         // when
-        let msg1 =  sut.appendSystemMessageIfNeeded(callState: .incoming(video:false, shouldRing: true, degraded: false), conversation: conversation, user: user, timeStamp: nil)
+        let msg1 =  sut.appendSystemMessageIfNeeded(callState: .incoming(video:false, shouldRing: true, degraded: false), conversation: conversation, caller: user, timestamp: nil)
         var msg2 : ZMSystemMessage?
         self.performIgnoringZMLogError { 
-            msg2 = self.sut.appendSystemMessageIfNeeded(callState: .terminating(reason: .canceled), conversation: self.conversation, user: self.user, timeStamp: nil)
+            msg2 = self.sut.appendSystemMessageIfNeeded(callState: .terminating(reason: .canceled), conversation: self.conversation, caller: self.user, timestamp: nil)
         }
 
         // then

--- a/Tests/Source/Calling/CallSystemMessageGeneratorTests.swift
+++ b/Tests/Source/Calling/CallSystemMessageGeneratorTests.swift
@@ -67,7 +67,7 @@ class CallSystemMessageGeneratorTests : MessagingTest {
         // when
         let msg1 = sut.appendSystemMessageIfNeeded(callState: .outgoing(degraded: false), conversation: conversation, caller: selfUser, timestamp: nil)
         let msg2 = sut.appendSystemMessageIfNeeded(callState: .established, conversation: conversation, caller: selfUser, timestamp: nil)
-        let msg3 = sut.appendSystemMessageIfNeeded(callState: .terminating(reason: .canceled), conversation: conversation, caller: user, timestamp: nil)
+        let msg3 = sut.appendSystemMessageIfNeeded(callState: .terminating(reason: .canceled), conversation: conversation, caller: selfUser, timestamp: nil)
         
         // then
         XCTAssertEqual(conversation.messages.count, messageCount+1)

--- a/Tests/Source/Calling/WireCallCenterV3Mock.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Mock.swift
@@ -149,9 +149,9 @@ public class WireCallCenterV3Mock : WireCallCenterV3 {
         super.init(userId: userId, clientId: clientId, avsWrapper: mockAVSWrapper, uiMOC: uiMOC, flowManager: flowManager, transport: transport)
     }
 
-    public func update(callState : CallState, conversationId: UUID, userId: UUID? = nil) {
+    public func update(callState : CallState, conversationId: UUID, callerId: UUID) {
         mockCallState = callState
-        WireCallCenterCallStateNotification(callState: callState, conversationId: conversationId, userId: userId, messageTime: nil).post(in: uiMOC!.notificationContext)
+        WireCallCenterCallStateNotification(callState: callState, conversationId: conversationId, callerId: callerId, messageTime: nil).post(in: uiMOC!.notificationContext)
     }
     
     public override func isVideoCall(conversationId: UUID) -> Bool {

--- a/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -41,11 +41,16 @@ class WireCallCenterV3Tests: MessagingTest {
     var flowManager : FlowManagerMock!
     var mockAVSWrapper : MockAVSWrapper!
     var sut : WireCallCenterV3!
+    let otherUserID : UUID = UUID()
     var selfUserID : UUID!
     var conversationID : UUID!
     var otherConversationID : UUID!
     var clientID: String!
     var mockTransport : WireCallCenterTransportMock!
+    var conversationIDRef : [CChar]!
+    var otherConversationIDRef : [CChar]!
+    var otherUserIDRef : [CChar]!
+    var context : UnsafeMutableRawPointer!
     
     override func setUp() {
         super.setUp()
@@ -67,6 +72,10 @@ class WireCallCenterV3Tests: MessagingTest {
         mockAVSWrapper = MockAVSWrapper(userId: selfUserID, clientId: clientID, observer: nil)
         mockTransport = WireCallCenterTransportMock()
         sut = WireCallCenterV3(userId: selfUserID, clientId: clientID, avsWrapper: mockAVSWrapper, uiMOC: uiMOC, flowManager: flowManager, transport: mockTransport)
+        conversationIDRef = conversationID.transportString().cString(using: .utf8)
+        otherConversationIDRef = otherConversationID.transportString().cString(using: .utf8)
+        otherUserIDRef = otherUserID.transportString().cString(using: .utf8)
+        context = Unmanaged.passUnretained(self.sut).toOpaque()
     }
     
     override func tearDown() {
@@ -77,80 +86,70 @@ class WireCallCenterV3Tests: MessagingTest {
         conversationID = nil
         mockTransport = nil
         mockAVSWrapper = nil
+        conversationIDRef = nil
+        otherUserIDRef = nil
+        context = nil
         
         super.tearDown()
     }
     
-    func checkThatItPostsNotification(expectedCallState: CallState, userIsNil: Bool = false, expectedUserId: UUID? = nil, line: UInt = #line, file : StaticString = #file, actionBlock: ((UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void)){
-        // given
-        let userId = UUID()
-        let conversationIdRef = conversationID.transportString().cString(using: .utf8)
-        let userIdRef = userId.transportString().cString(using: .utf8)
-        let context = Unmanaged.passUnretained(self.sut).toOpaque()
-
+    func checkThatItPostsNotification(expectedCallState: CallState, expectedCallerId: UUID, line: UInt = #line, file : StaticString = #file, actionBlock: () -> Void) {
         // expect
         expectation(forNotification: WireCallCenterCallStateNotification.notificationName.rawValue, object: nil) { wrappedNote in
             guard let note = wrappedNote.userInfo?[WireCallCenterCallStateNotification.userInfoKey] as? WireCallCenterCallStateNotification else { return false }
             XCTAssertEqual(note.conversationId, self.conversationID, "conversationIds are not the same", file: file, line: line)
-            if userIsNil {
-                XCTAssertNil(note.callerId)
-            } else if let otherId = expectedUserId {
-                XCTAssertEqual(note.callerId, otherId, "userIds are not the same", file: file, line: line)
-            }
-            else {
-                XCTAssertEqual(note.callerId, userId, "userIds are not the same", file: file, line: line)
-            }
+            XCTAssertEqual(note.callerId, expectedCallerId, "callerIds are not the same", file: file, line: line)
             XCTAssertEqual(note.callState, expectedCallState, "callStates are not the same", file: file, line: line)
 
             return true
         }
         
         // when
-        actionBlock(conversationIdRef, userIdRef, context)
+        actionBlock()
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then
         XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
     }
     
-    func testThatTheIncomingCallHandlerPostsTheRightNotification_IsVideo(){
-        checkThatItPostsNotification(expectedCallState: .incoming(video: true, shouldRing: false, degraded: false)) { (conversationIdRef, userIdRef, context) in
-            WireSyncEngine.incomingCallHandler(conversationId: conversationIdRef,
+    func testThatTheIncomingCallHandlerPostsTheRightNotification_IsVideo() {
+        checkThatItPostsNotification(expectedCallState: .incoming(video: true, shouldRing: false, degraded: false), expectedCallerId: otherUserID) {
+            WireSyncEngine.incomingCallHandler(conversationId: conversationIDRef,
                                                messageTime: 0,
-                                               userId: userIdRef,
+                                               userId: otherUserIDRef,
                                                isVideoCall: 1,
                                                shouldRing: 0,
                                                contextRef: context)
         }
     }
     
-    func testThatTheIncomingCallHandlerPostsTheRightNotification(){
-        checkThatItPostsNotification(expectedCallState: .incoming(video: false, shouldRing: false, degraded: false)) { (conversationIdRef, userIdRef, context) in
-            WireSyncEngine.incomingCallHandler(conversationId: conversationIdRef,
+    func testThatTheIncomingCallHandlerPostsTheRightNotification() {
+        checkThatItPostsNotification(expectedCallState: .incoming(video: false, shouldRing: false, degraded: false), expectedCallerId: otherUserID) {
+            WireSyncEngine.incomingCallHandler(conversationId: conversationIDRef,
                                                messageTime: 0,
-                                               userId: userIdRef,
+                                               userId: otherUserIDRef,
                                                isVideoCall: 0,
                                                shouldRing: 0,
                                                contextRef: context)
         }
     }
     
-    func testThatTheIncomingCallHandlerPostsTheRightNotification_IsVideo_ShouldRing(){
-        checkThatItPostsNotification(expectedCallState: .incoming(video: true, shouldRing: true, degraded: false)) { (conversationIdRef, userIdRef, context) in
-            WireSyncEngine.incomingCallHandler(conversationId: conversationIdRef,
+    func testThatTheIncomingCallHandlerPostsTheRightNotification_IsVideo_ShouldRing() {
+        checkThatItPostsNotification(expectedCallState: .incoming(video: true, shouldRing: true, degraded: false), expectedCallerId: otherUserID) {
+            WireSyncEngine.incomingCallHandler(conversationId: conversationIDRef,
                                                messageTime: 0,
-                                               userId: userIdRef,
+                                               userId: otherUserIDRef,
                                                isVideoCall: 1,
                                                shouldRing: 1,
                                                contextRef: context)
         }
     }
     
-    func testThatTheIncomingCallHandlerPostsTheRightNotification_ShouldRing(){
-        checkThatItPostsNotification(expectedCallState: .incoming(video: false, shouldRing: true, degraded: false)) { (conversationIdRef, userIdRef, context) in
-            WireSyncEngine.incomingCallHandler(conversationId: conversationIdRef,
+    func testThatTheIncomingCallHandlerPostsTheRightNotification_ShouldRing() {
+        checkThatItPostsNotification(expectedCallState: .incoming(video: false, shouldRing: true, degraded: false), expectedCallerId: otherUserID) {
+            WireSyncEngine.incomingCallHandler(conversationId: conversationIDRef,
                                                messageTime: 0,
-                                               userId: userIdRef,
+                                               userId: otherUserIDRef,
                                                isVideoCall: 0,
                                                shouldRing: 1,
                                                contextRef: context)
@@ -158,7 +157,7 @@ class WireCallCenterV3Tests: MessagingTest {
     }
     
     
-    func testThatTheMissedCallHandlerPostANotification(){
+    func testThatTheMissedCallHandlerPostANotification() {
         // given
         let conversationId = UUID()
         let userId = UUID()
@@ -186,47 +185,55 @@ class WireCallCenterV3Tests: MessagingTest {
         XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
     }
     
-    func testThatTheAnsweredCallHandlerPostsTheRightNotification(){
-        checkThatItPostsNotification(expectedCallState: .answered(degraded: false), userIsNil: true) { (conversationIdRef, userIdRef, context) in
-            WireSyncEngine.answeredCallHandler(conversationId: conversationIdRef, contextRef: context)
-        }
-    }
-    
-    func testThatTheEstablishedHandlerPostsTheRightNotification(){
-        checkThatItPostsNotification(expectedCallState: .established) { (conversationIdRef, userIdRef, context) in
-            WireSyncEngine.establishedCallHandler(conversationId: conversationIdRef, userId: userIdRef, contextRef: context)
-        }
-    }
-    
-    func testThatTheEstablishedHandlerSetsTheStartTime(){
+    func testThatTheAnsweredCallHandlerPostsTheRightNotification() {
         // given
+        WireSyncEngine.incomingCallHandler(conversationId: conversationIDRef, messageTime: 0, userId: otherUserIDRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        checkThatItPostsNotification(expectedCallState: .answered(degraded: false), expectedCallerId: otherUserID) {
+            WireSyncEngine.answeredCallHandler(conversationId: conversationIDRef, contextRef: context)
+        }
+    }
+    
+    func testThatTheEstablishedHandlerPostsTheRightNotification() {
+        // given
+        WireSyncEngine.incomingCallHandler(conversationId: conversationIDRef, messageTime: 0, userId: otherUserIDRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        checkThatItPostsNotification(expectedCallState: .established, expectedCallerId: otherUserID) {
+            WireSyncEngine.establishedCallHandler(conversationId: conversationIDRef, userId: otherUserIDRef, contextRef: context)
+        }
+    }
+    
+    func testThatTheEstablishedHandlerSetsTheStartTime() {
+        // given
+        WireSyncEngine.incomingCallHandler(conversationId: conversationIDRef, messageTime: 0, userId: otherUserIDRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         XCTAssertNil(sut.establishedDate)
-
+        
         // when
-        checkThatItPostsNotification(expectedCallState: .established) { (conversationIdRef, userIdRef, context) in
-            WireSyncEngine.establishedCallHandler(conversationId: conversationIdRef, userId: userIdRef, contextRef: context)
+        checkThatItPostsNotification(expectedCallState: .established, expectedCallerId: otherUserID) {
+            WireSyncEngine.establishedCallHandler(conversationId: conversationIDRef, userId: otherUserIDRef, contextRef: context)
         }
         
         // then
         XCTAssertNotNil(sut.establishedDate)
     }
     
-    func testThatTheClosedCallHandlerPostsTheRightNotification(){
-        checkThatItPostsNotification(expectedCallState: .terminating(reason: .canceled)) { (conversationIdRef, userIdRef, context) in
-            WireSyncEngine.closedCallHandler(reason: WCALL_REASON_CANCELED, conversationId: conversationIdRef, messageTime: 0, userId: userIdRef, contextRef: context)
+    func testThatTheClosedCallHandlerPostsTheRightNotification() {
+        // given
+        WireSyncEngine.incomingCallHandler(conversationId: conversationIDRef, messageTime: 0, userId: otherUserIDRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        checkThatItPostsNotification(expectedCallState: .terminating(reason: .canceled), expectedCallerId: otherUserID) {
+            WireSyncEngine.closedCallHandler(reason: WCALL_REASON_CANCELED, conversationId: conversationIDRef, messageTime: 0, userId: otherUserIDRef, contextRef: context)
         }
     }
     
     func testThatOtherIncomingCallsAreRejectedWhenWeAnswerCall() {
         // given
-        let userId = UUID()
-        let conversationIdRef = conversationID.transportString().cString(using: .utf8)
-        let otherConversationIdRef = otherConversationID.transportString().cString(using: .utf8)
-        let userIdRef = userId.transportString().cString(using: .utf8)
-        let context = Unmanaged.passUnretained(self.sut).toOpaque()
-        
-        WireSyncEngine.incomingCallHandler(conversationId: conversationIdRef, messageTime: 0, userId: userIdRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
-        WireSyncEngine.incomingCallHandler(conversationId: otherConversationIdRef, messageTime: 0, userId: userIdRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
+        WireSyncEngine.incomingCallHandler(conversationId: conversationIDRef, messageTime: 0, userId: otherUserIDRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
+        WireSyncEngine.incomingCallHandler(conversationId: otherConversationIDRef, messageTime: 0, userId: otherUserIDRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // when
@@ -238,13 +245,8 @@ class WireCallCenterV3Tests: MessagingTest {
     
     func testThatOtherOutgoingCallsAreCanceledWhenWeAnswerCall() {
         // given
-        let userId = UUID()
-        let conversationIdRef = conversationID.transportString().cString(using: .utf8)
-        let userIdRef = userId.transportString().cString(using: .utf8)
-        let context = Unmanaged.passUnretained(self.sut).toOpaque()
-        
         XCTAssertTrue(sut.startCall(conversationId: otherConversationID, video: false, isGroup: false))
-        WireSyncEngine.incomingCallHandler(conversationId: conversationIdRef, messageTime: 0, userId: userIdRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
+        WireSyncEngine.incomingCallHandler(conversationId: conversationIDRef, messageTime: 0, userId: otherUserIDRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // when
@@ -256,12 +258,7 @@ class WireCallCenterV3Tests: MessagingTest {
     
     func testThatOtherIncomingCallsAreRejectedWhenWeStartCall() {
         // given
-        let userId = UUID()
-        let conversationIdRef = conversationID.transportString().cString(using: .utf8)
-        let userIdRef = userId.transportString().cString(using: .utf8)
-        let context = Unmanaged.passUnretained(self.sut).toOpaque()
-        
-        WireSyncEngine.incomingCallHandler(conversationId: conversationIdRef, messageTime: 0, userId: userIdRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
+        WireSyncEngine.incomingCallHandler(conversationId: conversationIDRef, messageTime: 0, userId: otherUserIDRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // when
@@ -271,68 +268,60 @@ class WireCallCenterV3Tests: MessagingTest {
         XCTAssertTrue(mockAVSWrapper.didCallRejectCall)
     }
     
-    func testThatItRejectsACall_Group(){
+    func testThatItRejectsACall_Group() {
         // given
-        let userId = UUID()
-        let conversationIdRef = conversationID.transportString().cString(using: .utf8)
-        let userIdRef = userId.transportString().cString(using: .utf8)
-        let context = Unmanaged.passUnretained(self.sut).toOpaque()
-        
-        WireSyncEngine.incomingCallHandler(conversationId: conversationIdRef, messageTime: 0, userId: userIdRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
+        WireSyncEngine.incomingCallHandler(conversationId: conversationIDRef, messageTime: 0, userId: otherUserIDRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // expect
         expectation(forNotification: WireCallCenterCallStateNotification.notificationName.rawValue, object: nil) { wrappedNote in
             guard let note = wrappedNote.userInfo?[WireCallCenterCallStateNotification.userInfoKey] as? WireCallCenterCallStateNotification else { return false }
             XCTAssertEqual(note.conversationId, self.conversationID)
-            XCTAssertEqual(note.callerId, userId)
+            XCTAssertEqual(note.callerId, self.otherUserID)
             XCTAssertEqual(note.callState, .incoming(video: false, shouldRing: false, degraded: false))
             return true
         }
         
         // when
         sut.rejectCall(conversationId: conversationID)
-        WireSyncEngine.closedCallHandler(reason: WCALL_REASON_STILL_ONGOING, conversationId: conversationIdRef, messageTime: 0, userId: userIdRef, contextRef: context)
+        WireSyncEngine.closedCallHandler(reason: WCALL_REASON_STILL_ONGOING, conversationId: conversationIDRef, messageTime: 0, userId: otherUserIDRef, contextRef: context)
 
         // then
         XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
         XCTAssertTrue(mockAVSWrapper.didCallRejectCall)
     }
     
-    func testThatItRejectsACall_1on1(){
+    func testThatItRejectsACall_1on1() {
         // given
-        let userId = UUID()
-        let conversationIdRef = conversationID.transportString().cString(using: .utf8)
-        let userIdRef = userId.transportString().cString(using: .utf8)
-        let context = Unmanaged.passUnretained(self.sut).toOpaque()
-        
-        WireSyncEngine.incomingCallHandler(conversationId: conversationIdRef, messageTime: 0, userId: userIdRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
+        WireSyncEngine.incomingCallHandler(conversationId: conversationIDRef, messageTime: 0, userId: otherUserIDRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // expect
         expectation(forNotification: WireCallCenterCallStateNotification.notificationName.rawValue, object: nil) { wrappedNote in
             guard let note = wrappedNote.userInfo?[WireCallCenterCallStateNotification.userInfoKey] as? WireCallCenterCallStateNotification else { return false }
             XCTAssertEqual(note.conversationId, self.conversationID)
-            XCTAssertEqual(note.callerId, userId)
+            XCTAssertEqual(note.callerId, self.otherUserID)
             XCTAssertEqual(note.callState, .incoming(video: false, shouldRing: false, degraded: false))
             return true
         }
         
         // when
         sut.rejectCall(conversationId: conversationID)
-        WireSyncEngine.closedCallHandler(reason: WCALL_REASON_STILL_ONGOING, conversationId: conversationIdRef, messageTime: 0, userId: userIdRef, contextRef: context)
+        WireSyncEngine.closedCallHandler(reason: WCALL_REASON_STILL_ONGOING, conversationId: conversationIDRef, messageTime: 0, userId: otherUserIDRef, contextRef: context)
 
         // then
         XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
         XCTAssertTrue(mockAVSWrapper.didCallRejectCall)
     }
     
-    func testThatItAnswersACall(){
-        checkThatItPostsNotification(expectedCallState: .answered(degraded: false), expectedUserId: selfUserID) { (conversationIdRef, _, _) in
-            let conversationId = UUID(cString: conversationIdRef)!
-            
+    func testThatItAnswersACall() {
+        // given
+        WireSyncEngine.incomingCallHandler(conversationId: conversationIDRef, messageTime: 0, userId: otherUserIDRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        checkThatItPostsNotification(expectedCallState: .answered(degraded: false), expectedCallerId: otherUserID) {
             // when
-            _ = sut.answerCall(conversationId: conversationId)
+            _ = sut.answerCall(conversationId: conversationID)
             
             // then
             XCTAssertTrue(mockAVSWrapper.didCallAnswerCall)
@@ -340,23 +329,19 @@ class WireCallCenterV3Tests: MessagingTest {
     }
     
     func testThatItStartsACall(){
-        checkThatItPostsNotification(expectedCallState: .outgoing(degraded: false), expectedUserId: selfUserID) { (conversationIdRef, _, _) in
-            let conversationId = UUID(cString: conversationIdRef)!
-            
+        checkThatItPostsNotification(expectedCallState: .outgoing(degraded: false), expectedCallerId: selfUserID) {
             // when
-            _ = sut.startCall(conversationId: conversationId, video: false, isGroup: true)
+            _ = sut.startCall(conversationId: conversationID, video: false, isGroup: true)
             
             // then
             XCTAssertTrue(mockAVSWrapper.didCallStartCall)
         }
     }
     
-    func testThatItSetsTheCallStartTimeBeforePostingTheNotification(){
+    func testThatItSetsTheCallStartTimeBeforePostingTheNotification() {
         // given
-        let userId = UUID()
-        let conversationIdRef = conversationID.transportString().cString(using: .utf8)
-        let userIdRef = userId.transportString().cString(using: .utf8)
-        let context = Unmanaged.passUnretained(self.sut).toOpaque()
+        WireSyncEngine.incomingCallHandler(conversationId: conversationIDRef, messageTime: 0, userId: otherUserIDRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         XCTAssertNil(sut.establishedDate)
         
         // expect
@@ -366,14 +351,13 @@ class WireCallCenterV3Tests: MessagingTest {
         }
         
         // when
-        WireSyncEngine.establishedCallHandler(conversationId: conversationIdRef, userId: userIdRef, contextRef: context)
+        WireSyncEngine.establishedCallHandler(conversationId: conversationIDRef, userId: otherUserIDRef, contextRef: context)
         
         // then
         XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
-    
     }
     
-    func testThatItBuffersEventsUntilAVSIsReady(){
+    func testThatItBuffersEventsUntilAVSIsReady() {
         // given
         let userId = UUID()
         let clientId = "foo"
@@ -431,64 +415,48 @@ class WireCallCenterV3Tests: MessagingTest {
 
 extension WireCallCenterV3Tests {
     
-    func testThatItWhenIgnoringACallItWillSetsTheCallStateToIncomingInactive(){
+    func testThatItWhenIgnoringACallItWillSetsTheCallStateToIncomingInactive() {
         // given
-        let userId = UUID()
-        let conversationIdRef = conversationID.transportString().cString(using: .utf8)
-        let userIdRef = userId.transportString().cString(using: .utf8)
-        let context = Unmanaged.passUnretained(self.sut).toOpaque()
+        WireSyncEngine.incomingCallHandler(conversationId: conversationIDRef, messageTime: 0, userId: otherUserIDRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // when
-        WireSyncEngine.incomingCallHandler(conversationId: conversationIdRef, messageTime: 0, userId: userIdRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
-        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         sut.rejectCall(conversationId: conversationID)
         
         // then
         XCTAssertEqual(sut.callState(conversationId: conversationID), .incoming(video: false, shouldRing: false, degraded: false))
     }
     
-    func testThatItWhenRejectingAOneOnOneCallItWilltSetTheCallStateToIncomingInactive(){
+    func testThatItWhenRejectingAOneOnOneCallItWilltSetTheCallStateToIncomingInactive() {
         // given
-        let userId = UUID()
-        let conversationIdRef = conversationID.transportString().cString(using: .utf8)
-        let userIdRef = userId.transportString().cString(using: .utf8)
-        let context = Unmanaged.passUnretained(self.sut).toOpaque()
+        WireSyncEngine.incomingCallHandler(conversationId: conversationIDRef, messageTime: 0, userId: otherUserIDRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // when
-        WireSyncEngine.incomingCallHandler(conversationId: conversationIdRef, messageTime: 0, userId: userIdRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
-        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         sut.rejectCall(conversationId: conversationID)
         
         // then
         XCTAssertEqual(sut.callState(conversationId: conversationID), .incoming(video: false, shouldRing: false, degraded: false))
     }
     
-    func testThatItWhenClosingAGroupCallItWillSetsTheCallStateToIncomingInactive(){
+    func testThatItWhenClosingAGroupCallItWillSetsTheCallStateToIncomingInactive() {
         // given
-        let userId = UUID()
-        let conversationIdRef = conversationID.transportString().cString(using: .utf8)
-        let userIdRef = userId.transportString().cString(using: .utf8)
-        let context = Unmanaged.passUnretained(self.sut).toOpaque()
+        WireSyncEngine.incomingCallHandler(conversationId: conversationIDRef, messageTime: 0, userId: otherUserIDRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // when
-        WireSyncEngine.incomingCallHandler(conversationId: conversationIdRef, messageTime: 0, userId: userIdRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
-        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         sut.closeCall(conversationId: conversationID, isGroup: true)
         
         // then
         XCTAssertEqual(sut.callState(conversationId: conversationID), .incoming(video: false, shouldRing: false, degraded: false))
     }
     
-    func testThatItWhenClosingAOneOnOneCallItDoesNotSetTheCallStateToIncomingInactive(){
+    func testThatItWhenClosingAOneOnOneCallItDoesNotSetTheCallStateToIncomingInactive() {
         // given
-        let userId = UUID()
-        let conversationIdRef = conversationID.transportString().cString(using: .utf8)
-        let userIdRef = userId.transportString().cString(using: .utf8)
-        let context = Unmanaged.passUnretained(self.sut).toOpaque()
+        WireSyncEngine.incomingCallHandler(conversationId: conversationIDRef, messageTime: 0, userId: otherUserIDRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // when
-        WireSyncEngine.incomingCallHandler(conversationId: conversationIdRef, messageTime: 0, userId: userIdRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
-        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         sut.closeCall(conversationId: conversationID, isGroup: false)
         
         // then
@@ -501,19 +469,13 @@ extension WireCallCenterV3Tests {
 // MARK: - Participants
 extension WireCallCenterV3Tests {
 
-    func testThatItCreatesAParticipantSnapshotForAnIncomingCall(){
-        // given
-        let userId = UUID()
-        let conversationIdRef = conversationID.transportString().cString(using: .utf8)
-        let userIdRef = userId.transportString().cString(using: .utf8)
-        let context = Unmanaged.passUnretained(self.sut).toOpaque()
-
+    func testThatItCreatesAParticipantSnapshotForAnIncomingCall() {
         // when
-        WireSyncEngine.incomingCallHandler(conversationId: conversationIdRef, messageTime: 0, userId: userIdRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
+        WireSyncEngine.incomingCallHandler(conversationId: conversationIDRef, messageTime: 0, userId: otherUserIDRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then
-        XCTAssertEqual(sut.callParticipants(conversationId: conversationID), [userId])
+        XCTAssertEqual(sut.callParticipants(conversationId: conversationID), [otherUserID])
     }
     
     func callBackMemberHandler(conversationIdRef: UnsafePointer<Int8>?, userId: UUID, audioEstablished: Bool, context: UnsafeMutableRawPointer?) {
@@ -521,41 +483,30 @@ extension WireCallCenterV3Tests {
         WireSyncEngine.groupMemberHandler(conversationIdRef: conversationIdRef, contextRef: context)
     }
     
-    func testThatItUpdatesTheParticipantsWhenGroupHandlerIsCalled(){
-        // given
-        let userId = UUID()
-        let conversationIdRef = conversationID.transportString().cString(using: .utf8)
-        let context = Unmanaged.passUnretained(self.sut).toOpaque()
-
+    func testThatItUpdatesTheParticipantsWhenGroupHandlerIsCalled() {
         // when
-        callBackMemberHandler(conversationIdRef: conversationIdRef, userId: userId, audioEstablished: false, context: context)
+        callBackMemberHandler(conversationIdRef: conversationIDRef, userId: otherUserID, audioEstablished: false, context: context)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then
-        XCTAssertEqual(sut.callParticipants(conversationId: conversationID), [userId])
+        XCTAssertEqual(sut.callParticipants(conversationId: conversationID), [otherUserID])
     }
     
-    func testThatItUpdatesTheStateForParticipant(){
-        // given
-        let userId = UUID()
-        let conversationIdRef = conversationID.transportString().cString(using: .utf8)
-        let userIdRef = userId.transportString().cString(using: .utf8)
-        let context = Unmanaged.passUnretained(self.sut).toOpaque()
-
+    func testThatItUpdatesTheStateForParticipant() {
         // when
-        WireSyncEngine.incomingCallHandler(conversationId: conversationIdRef, messageTime: 0, userId: userIdRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
+        WireSyncEngine.incomingCallHandler(conversationId: conversationIDRef, messageTime: 0, userId: otherUserIDRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then
-        let connectingState = sut.state(forUser: userId, in: conversationID)
+        let connectingState = sut.state(forUser: otherUserID, in: conversationID)
         XCTAssertEqual(connectingState, CallParticipantState.connecting)
         
         // when
-        callBackMemberHandler(conversationIdRef: conversationIdRef, userId: userId, audioEstablished: true, context: context)
+        callBackMemberHandler(conversationIdRef: conversationIDRef, userId: otherUserID, audioEstablished: true, context: context)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then
-        let connectedState = sut.state(forUser: userId, in: conversationID)
+        let connectedState = sut.state(forUser: otherUserID, in: conversationID)
         XCTAssertEqual(connectedState, CallParticipantState.connected(muted: false, sendingVideo: false))
     }
 }

--- a/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -93,12 +93,12 @@ class WireCallCenterV3Tests: MessagingTest {
             guard let note = wrappedNote.userInfo?[WireCallCenterCallStateNotification.userInfoKey] as? WireCallCenterCallStateNotification else { return false }
             XCTAssertEqual(note.conversationId, self.conversationID, "conversationIds are not the same", file: file, line: line)
             if userIsNil {
-                XCTAssertNil(note.userId)
+                XCTAssertNil(note.callerId)
             } else if let otherId = expectedUserId {
-                XCTAssertEqual(note.userId, otherId, "userIds are not the same", file: file, line: line)
+                XCTAssertEqual(note.callerId, otherId, "userIds are not the same", file: file, line: line)
             }
             else {
-                XCTAssertEqual(note.userId, userId, "userIds are not the same", file: file, line: line)
+                XCTAssertEqual(note.callerId, userId, "userIds are not the same", file: file, line: line)
             }
             XCTAssertEqual(note.callState, expectedCallState, "callStates are not the same", file: file, line: line)
 
@@ -172,7 +172,7 @@ class WireCallCenterV3Tests: MessagingTest {
         expectation(forNotification: WireCallCenterMissedCallNotification.notificationName.rawValue, object: nil) { wrappedNote in
             guard let note = wrappedNote.userInfo?[WireCallCenterMissedCallNotification.userInfoKey] as? WireCallCenterMissedCallNotification else { return false }
             XCTAssertEqual(note.conversationId, conversationId)
-            XCTAssertEqual(note.userId, userId)
+            XCTAssertEqual(note.callerId, userId)
             XCTAssertEqual(note.timestamp.timeIntervalSince1970, timestamp.timeIntervalSince1970, accuracy: 1)
             XCTAssertEqual(note.video, isVideo)
             return true
@@ -285,7 +285,7 @@ class WireCallCenterV3Tests: MessagingTest {
         expectation(forNotification: WireCallCenterCallStateNotification.notificationName.rawValue, object: nil) { wrappedNote in
             guard let note = wrappedNote.userInfo?[WireCallCenterCallStateNotification.userInfoKey] as? WireCallCenterCallStateNotification else { return false }
             XCTAssertEqual(note.conversationId, self.conversationID)
-            XCTAssertEqual(note.userId, userId)
+            XCTAssertEqual(note.callerId, userId)
             XCTAssertEqual(note.callState, .incoming(video: false, shouldRing: false, degraded: false))
             return true
         }
@@ -313,7 +313,7 @@ class WireCallCenterV3Tests: MessagingTest {
         expectation(forNotification: WireCallCenterCallStateNotification.notificationName.rawValue, object: nil) { wrappedNote in
             guard let note = wrappedNote.userInfo?[WireCallCenterCallStateNotification.userInfoKey] as? WireCallCenterCallStateNotification else { return false }
             XCTAssertEqual(note.conversationId, self.conversationID)
-            XCTAssertEqual(note.userId, userId)
+            XCTAssertEqual(note.callerId, userId)
             XCTAssertEqual(note.callState, .incoming(video: false, shouldRing: false, degraded: false))
             return true
         }

--- a/Tests/Source/Integration/CallingV3Tests.swift
+++ b/Tests/Source/Integration/CallingV3Tests.swift
@@ -30,7 +30,7 @@ class CallStateTestObserver : WireCallCenterCallStateObserver {
         token = WireCallCenterV3.addCallStateObserver(observer: self, for: conversation, context: context)
     }
     
-    func callCenterDidChange(callState: CallState, conversation: ZMConversation, user: ZMUser?, timeStamp: Date?) {
+    func callCenterDidChange(callState: CallState, conversation: ZMConversation, caller: ZMUser, timestamp: Date?) {
         changes.append(callState)
     }
     

--- a/Tests/Source/Notifications/PushNotifications/LocalNotificationDispatcherCallingTests.swift
+++ b/Tests/Source/Notifications/PushNotifications/LocalNotificationDispatcherCallingTests.swift
@@ -60,7 +60,7 @@ class LocalNotificationDispatcherCallingTests : MessagingTest {
     
     func testThatMissedCallCreatesCallingNotification() {
         // when
-        sut.processMissedCall(in: conversation, sender: sender)
+        sut.processMissedCall(in: conversation, caller: sender)
         
         // then
         XCTAssertEqual(sut.callingNotifications.notifications.count, 1)
@@ -69,7 +69,7 @@ class LocalNotificationDispatcherCallingTests : MessagingTest {
     
     func testThatIncomingCallCreatesCallingNotification() {
         // when
-        sut.process(callState: .incoming(video: false, shouldRing: true, degraded: false), in: conversation, sender: sender)
+        sut.process(callState: .incoming(video: false, shouldRing: true, degraded: false), in: conversation, caller: sender)
         
         // then
         XCTAssertEqual(sut.callingNotifications.notifications.count, 1)
@@ -82,7 +82,7 @@ class LocalNotificationDispatcherCallingTests : MessagingTest {
         
         for ignoredCallState in ignoredCallStates {
             // when
-            sut.process(callState: ignoredCallState, in: conversation, sender: sender)
+            sut.process(callState: ignoredCallState, in: conversation, caller: sender)
             
             // then
             XCTAssertEqual(sut.callingNotifications.notifications.count, 0)
@@ -92,13 +92,13 @@ class LocalNotificationDispatcherCallingTests : MessagingTest {
     
     func testThatIncomingCallIsReplacedByCanceledCallNotification() {
         // given 
-        sut.process(callState: .incoming(video: false, shouldRing: true, degraded: false), in: conversation, sender: sender)
+        sut.process(callState: .incoming(video: false, shouldRing: true, degraded: false), in: conversation, caller: sender)
         XCTAssertEqual(sut.callingNotifications.notifications.count, 1)
         XCTAssertEqual(application.scheduledLocalNotifications.count, 1)
         let incomingCallNotification = application.scheduledLocalNotifications.first!
         
         // when
-        sut.processMissedCall(in: conversation, sender: sender)
+        sut.processMissedCall(in: conversation, caller: sender)
         
         // then
         XCTAssertEqual(sut.callingNotifications.notifications.count, 1)
@@ -108,13 +108,13 @@ class LocalNotificationDispatcherCallingTests : MessagingTest {
     
     func testThatIncomingCallIsClearedWhenCallIsAnsweredElsewhere() {
         // given
-        sut.process(callState: .incoming(video: false, shouldRing: true, degraded: false), in: conversation, sender: sender)
+        sut.process(callState: .incoming(video: false, shouldRing: true, degraded: false), in: conversation, caller: sender)
         XCTAssertEqual(sut.callingNotifications.notifications.count, 1)
         XCTAssertEqual(application.scheduledLocalNotifications.count, 1)
         let incomingCallNotification = application.scheduledLocalNotifications.first!
         
         // when
-        sut.process(callState: .terminating(reason: .anweredElsewhere), in: conversation, sender: sender)
+        sut.process(callState: .terminating(reason: .anweredElsewhere), in: conversation, caller: sender)
         
         // then
         XCTAssertEqual(sut.callingNotifications.notifications.count, 0)

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationForTests_CallState.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationForTests_CallState.swift
@@ -46,7 +46,7 @@ class ZMLocalNotificationTests_CallState : MessagingTest {
     }
     
     func note(for callState: CallState) -> ZMLocalNotification? {
-        return ZMLocalNotification(callState: callState, conversation: conversation, sender: sender)
+        return ZMLocalNotification(callState: callState, conversation: conversation, caller: sender)
     }
     
     func testIncomingAudioCall() {


### PR DESCRIPTION
### Issues

When a group ends the push notification says the self user called

### Causes

the user id associated with the terminating event is the self user.

### Solutions

The user id associated with the event is not relevant. We should instead use the userId associated with the incoming call event.

The sender parameter on the calling update methods has always been a bit unclear to which user it actually refers. This PR replaces it with a `caller` parameter which is always the user which initiated the call.