### PR TITLE
Team creation tweaks

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -647,7 +647,7 @@ extension SessionManager: UnauthenticatedSessionDelegate {
                 self.updateProfileImage(imageData: profileImageData)
             }
             
-            let registered = session.authenticationStatus.completedRegistration
+            let registered = session.authenticationStatus.completedRegistration || session.registrationStatus.completedRegistration
             let emailCredentials = session.authenticationStatus.emailCredentials()
             
             userSession.syncManagedObjectContext.performGroupedBlock {

--- a/Source/Synchronization/Strategies/RegistrationStatus.swift
+++ b/Source/Synchronization/Strategies/RegistrationStatus.swift
@@ -52,6 +52,8 @@ extension RegistrationStatusDelegate {
 final public class RegistrationStatus {
     var phase : Phase = .none
 
+    public internal(set) var completedRegistration: Bool = false
+
     public weak var delegate: RegistrationStatusDelegate?
 
     /// Used to start email activation process by sending an email with a
@@ -101,6 +103,7 @@ final public class RegistrationStatus {
         case .checkActivationCode:
             self.delegate?.emailActivationCodeValidated()
         case .createTeam:
+            self.completedRegistration = true
             delegate?.teamRegistered()
         case .none:
             break

--- a/Source/Synchronization/Strategies/TeamToRegister.swift
+++ b/Source/Synchronization/Strategies/TeamToRegister.swift
@@ -42,7 +42,7 @@ public struct TeamToRegister {
             "email" : email,
             "team" : [
                 "name" : teamName,
-                "icon" : ""
+                "icon" : "abc"
             ],
             "accent_id" : accentColor.rawValue,
             "locale" : locale,

--- a/Source/Synchronization/Strategies/TeamToRegister.swift
+++ b/Source/Synchronization/Strategies/TeamToRegister.swift
@@ -21,15 +21,17 @@ import Foundation
 public struct TeamToRegister {
     public let teamName: String
     public let email: String
+    public let emailCode: String
     public let fullName: String
     public let password: String
     public let accentColor: ZMAccentColor
     let locale: String
     let label: UUID?
 
-    public init(teamName: String, email: String, fullName: String, password: String, accentColor: ZMAccentColor) {
+    public init(teamName: String, email: String, emailCode: String, fullName: String, password: String, accentColor: ZMAccentColor) {
         self.teamName = teamName
         self.email = email
+        self.emailCode = emailCode
         self.fullName = fullName
         self.password = password
         self.accentColor = accentColor
@@ -40,6 +42,7 @@ public struct TeamToRegister {
     var payload: ZMTransportData {
         return [
             "email" : email,
+            "email_code" : emailCode,
             "team" : [
                 "name" : teamName,
                 "icon" : "abc"
@@ -57,6 +60,7 @@ extension TeamToRegister: Equatable {
     public static func ==(lhs: TeamToRegister, rhs: TeamToRegister) -> Bool {
         return lhs.teamName == rhs.teamName &&
             lhs.email == rhs.email &&
+            lhs.emailCode == rhs.emailCode &&
             lhs.fullName == rhs.fullName &&
             lhs.password == rhs.password &&
             lhs.accentColor == rhs.accentColor &&

--- a/Tests/Source/Integration/TeamCreationTests.swift
+++ b/Tests/Source/Integration/TeamCreationTests.swift
@@ -32,7 +32,7 @@ class TeamCreationTests : IntegrationTest {
         super.setUp()
         delegate = TestRegistrationStatusDelegate()
         sessionManager?.unauthenticatedSession?.registrationStatus.delegate = delegate
-        team = TeamToRegister(teamName: "A-Team", email: "ba@a-team.de", fullName: "Bosco B. A. Baracus", password: "BadAttitude", accentColor: .vividRed)
+        team = TeamToRegister(teamName: "A-Team", email: "ba@a-team.de", emailCode: "911", fullName: "Bosco B. A. Baracus", password: "BadAttitude", accentColor: .vividRed)
     }
 
     override func tearDown() {

--- a/Tests/Source/Synchronization/Strategies/RegistrationStatusTests.swift
+++ b/Tests/Source/Synchronization/Strategies/RegistrationStatusTests.swift
@@ -74,7 +74,7 @@ class RegistrationStatusTests : MessagingTest{
         sut.delegate = delegate
         email = "some@foo.bar"
         code = "123456"
-        team = WireSyncEngine.TeamToRegister(teamName: "Dream Team", email: email, fullName: "M. Jordan", password: "qwerty", accentColor: .brightOrange)
+        team = WireSyncEngine.TeamToRegister(teamName: "Dream Team", email: email, emailCode: "23", fullName: "M. Jordan", password: "qwerty", accentColor: .brightOrange)
     }
 
     override func tearDown() {

--- a/Tests/Source/Synchronization/Strategies/RegistrationStatusTests.swift
+++ b/Tests/Source/Synchronization/Strategies/RegistrationStatusTests.swift
@@ -210,6 +210,7 @@ class RegistrationStatusTests : MessagingTest{
         sut.success()
 
         //then
+        XCTAssertTrue(sut.completedRegistration)
         XCTAssertEqual(delegate.teamRegisteredCalled, 1)
         XCTAssertEqual(delegate.teamRegistrationFailedCalled, 0)
     }

--- a/Tests/Source/Synchronization/Strategies/TeamRegistrationStrategyTests.swift
+++ b/Tests/Source/Synchronization/Strategies/TeamRegistrationStrategyTests.swift
@@ -30,7 +30,7 @@ class TeamRegistrationStrategyTests: MessagingTest {
         registrationStatus = TestRegistrationStatus()
         userInfoParser = MockUserInfoParser()
         sut = WireSyncEngine.TeamRegistrationStrategy(groupQueue: self.syncMOC, status: registrationStatus, userInfoParser: userInfoParser)
-        team = WireSyncEngine.TeamToRegister(teamName: "Dream Team", email: "some@email.com", fullName: "M. Jordan", password: "qwerty", accentColor: .brightOrange)
+        team = WireSyncEngine.TeamToRegister(teamName: "Dream Team", email: "some@email.com", emailCode: "23", fullName: "M. Jordan", password: "qwerty", accentColor: .brightOrange)
     }
 
     override func tearDown() {


### PR DESCRIPTION
## What's new in this PR?

### Issues

There were several issues that were noticed after integrating the API call with real data:
* We were not posting the email activation code together with payload
* `icon` in team payload is required. To align implementation with Android we simply send `abc`, because we don't yet support team images.
* Flag that shows if we have just completed registration is needed in the UI.
