### PR TITLE
Fix/localization info

### DIFF
--- a/Source/Notifications/Push notifications/Helpers/ZMLocalNotificationLocalization+Components.swift
+++ b/Source/Notifications/Push notifications/Helpers/ZMLocalNotificationLocalization+Components.swift
@@ -50,19 +50,18 @@ public extension NSString {
         keyComponents.append(convTypeKey)
         
         if let userName = userName, !userName.isEmpty {
-            if conversation.conversationType == .group {
-                // we only want the user name if we're in a group conversation, since
-                // otherwise the sender name will be displayed in the notification title
+            // if the conversation is oneOnOne, then the sender name will be
+            // in the notification title
+            if conversation.conversationType != .oneOnOne {
                 arguments.append(userName)
             }
         } else {
             keyComponents.append(NoUserNameKey)
         }
         
-        if conversation.conversationType == .group {
-            if convName?.isEmpty ?? true {
-                keyComponents.append(NoConversationNameKey)
-            }
+        // we don't use the conversation name for oneOnOne conversations
+        if conversation.conversationType != .oneOnOne && convName?.isEmpty ?? true {
+            keyComponents.append(NoConversationNameKey)
         }
         
         let localizationString = (self as String) + "." + keyComponents.joined(separator: ".")

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationLocalizationTests.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationLocalizationTests.swift
@@ -52,5 +52,6 @@ class ZMLocalNotificationLocalizationTests: ZMLocalNotificationTests {
         XCTAssertEqual(result(userWithNoName, groupConversationWithoutName), "Someone calling in a conversation")
         XCTAssertEqual(result(userWithNoName, groupConversation), "Someone calling in Super Conversation")
         XCTAssertEqual(result(sender, groupConversationWithoutName), "Super User calling in a conversation")
+        XCTAssertEqual(result(sender, invalidConversation), "Super User calling in a conversation")
     }
 }

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests.swift
@@ -30,6 +30,7 @@ class ZMLocalNotificationTests: MessagingTest {
     var groupConversation: ZMConversation!
     var groupConversationWithoutUserDefinedName: ZMConversation!
     var groupConversationWithoutName: ZMConversation!
+    var invalidConversation: ZMConversation!
     
     override func setUp() {
         super.setUp()
@@ -43,6 +44,7 @@ class ZMLocalNotificationTests: MessagingTest {
         // an empty conversation will have no meaninful display name
         groupConversationWithoutName = insertConversation(with: UUID.create(), name: nil, type: .group, isSilenced: false, isEmpty: true)
         groupConversationWithoutUserDefinedName = insertConversation(with: UUID.create(), name: nil, type: .group, isSilenced: false)
+        invalidConversation = insertConversation(with: UUID.create(), name: nil, type: .invalid, isSilenced: false)
 
         syncMOC.performGroupedBlockAndWait {
             self.selfUser = ZMUser.selfUser(in: self.syncMOC)
@@ -60,6 +62,7 @@ class ZMLocalNotificationTests: MessagingTest {
         groupConversation = nil
         groupConversationWithoutName = nil
         groupConversationWithoutUserDefinedName = nil
+        invalidConversation = nil
         selfUser.remoteIdentifier = nil
         super.tearDown()
     }

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_Message.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_Message.swift
@@ -106,6 +106,7 @@ class ZMLocalNotificationTests_Message : ZMLocalNotificationTests {
         XCTAssertEqual(bodyForNote(groupConversation, sender: sender), "Super User: Hello Hello!")
         XCTAssertEqual(bodyForNote(groupConversationWithoutUserDefinedName, sender: sender), "Super User: Hello Hello!")
         XCTAssertEqual(bodyForNote(groupConversationWithoutName, sender: sender), "Super User in a conversation: Hello Hello!")
+        XCTAssertEqual(bodyForNote(invalidConversation, sender: sender), "Super User in a conversation: Hello Hello!")
     }
     
     func testThatObfuscatesNotificationsForEphemeralMessages(){
@@ -113,6 +114,7 @@ class ZMLocalNotificationTests_Message : ZMLocalNotificationTests {
         XCTAssertEqual(bodyForNote(groupConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
         XCTAssertEqual(bodyForNote(groupConversationWithoutUserDefinedName, sender: sender, isEphemeral: true), "Someone sent you a message")
         XCTAssertEqual(bodyForNote(groupConversationWithoutName, sender: sender, isEphemeral: true), "Someone sent you a message")
+        XCTAssertEqual(bodyForNote(invalidConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
     }
     
     func testThatItDuplicatesPercentageSignsInTextAndConversationName() {
@@ -168,6 +170,7 @@ class ZMLocalNotificationTests_Message : ZMLocalNotificationTests {
         XCTAssertEqual(bodyForUnknownNote(groupConversation, sender: sender), "Super User: new message")
         XCTAssertEqual(bodyForUnknownNote(groupConversationWithoutUserDefinedName, sender: sender), "Super User: new message")
         XCTAssertEqual(bodyForUnknownNote(groupConversationWithoutName, sender: sender), "Super User sent a message")
+        XCTAssertEqual(bodyForUnknownNote(invalidConversation, sender: sender), "Super User sent a message")
     }
 
     func testThatItAddsATitleIfTheUserIsPartOfATeam() {
@@ -232,6 +235,7 @@ extension ZMLocalNotificationTests_Message {
         XCTAssertEqual(bodyForImageNote(groupConversation, sender: sender), "Super User shared a picture")
         XCTAssertEqual(bodyForImageNote(groupConversationWithoutUserDefinedName, sender: sender), "Super User shared a picture")
         XCTAssertEqual(bodyForImageNote(groupConversationWithoutName, sender: sender), "Super User shared a picture in a conversation")
+        XCTAssertEqual(bodyForImageNote(invalidConversation, sender: sender), "Super User shared a picture in a conversation")
     }
 
     func testThatObfuscatesNotificationsForEphemeralImageMessages(){
@@ -239,6 +243,7 @@ extension ZMLocalNotificationTests_Message {
         XCTAssertEqual(bodyForImageNote(groupConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
         XCTAssertEqual(bodyForImageNote(groupConversationWithoutUserDefinedName, sender: sender, isEphemeral: true), "Someone sent you a message")
         XCTAssertEqual(bodyForImageNote(groupConversationWithoutName, sender: sender, isEphemeral: true), "Someone sent you a message")
+        XCTAssertEqual(bodyForImageNote(invalidConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
     }
 }
 
@@ -321,6 +326,7 @@ extension ZMLocalNotificationTests_Message {
         XCTAssertEqual(bodyForAssetNote(.txt, conversation: groupConversation, sender: sender), "Super User shared a file")
         XCTAssertEqual(bodyForAssetNote(.txt, conversation: groupConversationWithoutUserDefinedName, sender: sender), "Super User shared a file")
         XCTAssertEqual(bodyForAssetNote(.txt, conversation: groupConversationWithoutName, sender: sender), "Super User shared a file in a conversation")
+        XCTAssertEqual(bodyForAssetNote(.txt, conversation: invalidConversation, sender: sender), "Super User shared a file in a conversation")
     }
 
     func testThatItCreatesVideoAddNotificationsCorrectly() {
@@ -333,6 +339,7 @@ extension ZMLocalNotificationTests_Message {
         XCTAssertEqual(bodyForAssetNote(.video, conversation: groupConversation, sender: sender), "Super User shared a video")
         XCTAssertEqual(bodyForAssetNote(.video, conversation: groupConversationWithoutUserDefinedName, sender: sender), "Super User shared a video")
         XCTAssertEqual(bodyForAssetNote(.video, conversation: groupConversationWithoutName, sender: sender), "Super User shared a video in a conversation")
+        XCTAssertEqual(bodyForAssetNote(.video, conversation: invalidConversation, sender: sender), "Super User shared a video in a conversation")
     }
 
     func testThatItCreatesEphemeralFileAddNotificationsCorrectly() {
@@ -340,6 +347,7 @@ extension ZMLocalNotificationTests_Message {
         XCTAssertEqual(bodyForAssetNote(.txt, conversation: groupConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
         XCTAssertEqual(bodyForAssetNote(.txt, conversation: groupConversationWithoutUserDefinedName, sender: sender, isEphemeral: true), "Someone sent you a message")
         XCTAssertEqual(bodyForAssetNote(.txt, conversation: groupConversationWithoutName, sender: sender, isEphemeral: true), "Someone sent you a message")
+        XCTAssertEqual(bodyForAssetNote(.txt, conversation: invalidConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
     }
 
     func testThatItCreatesEphemeralVideoAddNotificationsCorrectly() {
@@ -347,6 +355,7 @@ extension ZMLocalNotificationTests_Message {
         XCTAssertEqual(bodyForAssetNote(.video, conversation: groupConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
         XCTAssertEqual(bodyForAssetNote(.video, conversation: groupConversationWithoutUserDefinedName, sender: sender, isEphemeral: true), "Someone sent you a message")
         XCTAssertEqual(bodyForAssetNote(.video, conversation: groupConversationWithoutName, sender: sender, isEphemeral: true), "Someone sent you a message")
+        XCTAssertEqual(bodyForAssetNote(.video, conversation: invalidConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
     }
 
     func testThatItCreatesAudioNotificationsCorrectly() {
@@ -358,6 +367,7 @@ extension ZMLocalNotificationTests_Message {
         XCTAssertEqual(bodyForAssetNote(.audio, conversation: groupConversation, sender: sender), "Super User shared an audio message")
         XCTAssertEqual(bodyForAssetNote(.audio, conversation: groupConversationWithoutUserDefinedName, sender: sender), "Super User shared an audio message")
         XCTAssertEqual(bodyForAssetNote(.audio, conversation: groupConversationWithoutName, sender: sender), "Super User shared an audio message in a conversation")
+        XCTAssertEqual(bodyForAssetNote(.audio, conversation: invalidConversation, sender: sender), "Super User shared an audio message in a conversation")
     }
 }
 
@@ -393,6 +403,7 @@ extension ZMLocalNotificationTests_Message {
         XCTAssertEqual(bodyForKnockNote(groupConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
         XCTAssertEqual(bodyForKnockNote(groupConversationWithoutUserDefinedName, sender: sender, isEphemeral: true), "Someone sent you a message")
         XCTAssertEqual(bodyForKnockNote(groupConversationWithoutName, sender: sender, isEphemeral: true), "Someone sent you a message")
+        XCTAssertEqual(bodyForKnockNote(invalidConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
     }
 }
 
@@ -423,5 +434,6 @@ extension ZMLocalNotificationTests_Message {
         XCTAssertEqual(bodyForEditNote(groupConversation, sender: sender, text: "Edited Text"), "Super User: Edited Text")
         XCTAssertEqual(bodyForEditNote(groupConversationWithoutUserDefinedName, sender: sender, text: "Edited Text"), "Super User: Edited Text")
         XCTAssertEqual(bodyForEditNote(groupConversationWithoutName, sender: sender, text: "Edited Text"), "Super User in a conversation: Edited Text")
+        XCTAssertEqual(bodyForEditNote(invalidConversation, sender: sender, text: "Edited Text"), "Super User in a conversation: Edited Text")
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues
If the user was added to a group conversation while their client was in the background, any future message APNS notifications would be incorrectly formatted.

### Causes
When building the push string key, we only really care about missing conversation names of group conversations. However, we were explicitly checking if the `conversationType` is equal to `group`, then adding the conversation name to the push string arguments array, or appending the `noconversationname` component to the push key. The problem is that if you are added to a new group conversation and the app is backgrounded, the client hasn't fetched the conversation from BE and so the `conversationType` will be `invalid`. And so the `noconversationname` isn't appended to the push key, thus generating the wrong push string with an incorrect number of arguments.

### Solutions
Improve the `if` conditions so that we consider missing the `invalid` conversation type.