### PR TITLE
combine title & body for APNS if iOS9

### DIFF
--- a/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification.swift
+++ b/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification.swift
@@ -85,8 +85,24 @@ open class ZMLocalNotification: NSObject {
     ///
     public lazy var uiLocalNotification: UILocalNotification = {
         let note = UILocalNotification()
-        note.alertTitle = (self.isEphemeral || self.shouldHideContent) ? nil : self.title
-        note.alertBody = (!self.isEphemeral && self.shouldHideContent) ? ZMPushStringDefault.localizedStringForPushNotification() : self.body
+        
+        let candidateTitle = (self.isEphemeral || self.shouldHideContent) ? nil : self.title
+        let candidateBody = (!self.isEphemeral && self.shouldHideContent) ? ZMPushStringDefault.localizedStringForPushNotification() : self.body
+        
+        if #available(iOS 10, *) {
+            note.alertTitle = candidateTitle
+            note.alertBody = candidateBody
+        }
+        else {
+            // on iOS 9, the alert title is only visible in the notification center, so we
+            // display all info in the body
+            if let title = candidateTitle, let body = candidateBody {
+                note.alertBody = "\(title)\n\(body)"
+            } else {
+                note.alertBody = candidateBody
+            }
+        }
+        
         note.category = self.category
         note.soundName = self.shouldHideContent ? ZMCustomSound.notificationNewMessageSoundName() : self.soundName
         note.userInfo = self.userInfo


### PR DESCRIPTION
## What's new in this PR?

### Issues

iOS9 devices don't show the APNS `alertTitle` in the lock screen or banners, only in the notification center.

### Solutions
Combine the title and body text (separated by a newline) and use it as the notification's `alertBody`.
