### PR TITLE
Added error localization

### DIFF
--- a/Source/Public/NSError+ZMUserSession.h
+++ b/Source/Public/NSError+ZMUserSession.h
@@ -75,10 +75,10 @@ typedef NS_ENUM(NSUInteger, ZMUserSessionErrorCode) {
     /// The account can't be created because the account limit has been reached
     ZMUserSessionAccountLimitReached,
     /// The email used in the registration is blacklisted
-    ZMUserSessionBlacklistedEmail
+    ZMUserSessionBlacklistedEmail,
+    /// Unauthorized e-mail address
+    ZMUserSessionUnauthorizedEmail
 };
-
-FOUNDATION_EXPORT NSString * const ZMUserSessionErrorDomain;
 
 FOUNDATION_EXPORT NSString * const ZMClientsKey;
 

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -344,7 +344,7 @@ public protocol LocalNotificationResponder : class {
     }
     
     public func addAccount() {
-        logoutCurrentSession(deleteCookie: false, error: NSError.userSessionErrorWith(.addAccountRequested, userInfo: nil))
+        logoutCurrentSession(deleteCookie: false, error: NSError(code: .addAccountRequested, userInfo: nil))
     }
     
     public func delete(account: Account) {
@@ -361,7 +361,7 @@ public protocol LocalNotificationResponder : class {
             })
         } else {
             // Deleted the active account and there's not other account we can switch to
-            logoutCurrentSession(deleteCookie: true, deleteAccount:true, error: NSError.userSessionErrorWith(.addAccountRequested, userInfo: nil))
+            logoutCurrentSession(deleteCookie: true, deleteAccount:true, error: NSError(code: .addAccountRequested, userInfo: nil))
         }
     }
     
@@ -394,7 +394,7 @@ public protocol LocalNotificationResponder : class {
     internal func loadSession(for selectedAccount: Account?, completion: @escaping (ZMUserSession) -> Void) {
         guard let account = selectedAccount, account.isAuthenticated else {
             createUnauthenticatedSession()
-            delegate?.sessionManagerDidFailToLogin(account: selectedAccount, error: NSError.userSessionErrorWith(.accessTokenExpired, userInfo: nil))
+            delegate?.sessionManagerDidFailToLogin(account: selectedAccount, error: NSError(code: .accessTokenExpired, userInfo: nil))
             return
         }
 
@@ -633,7 +633,7 @@ extension SessionManager: UnauthenticatedSessionDelegate {
     
     public func session(session: UnauthenticatedSession, createdAccount account: Account) {
         guard !(accountManager.accounts.count == SessionManager.maxNumberAccounts && accountManager.account(with: account.userIdentifier) == nil) else {
-            session.authenticationStatus.notifyAuthenticationDidFail(NSError.userSessionErrorWith(.accountLimitReached, userInfo: nil))
+            session.authenticationStatus.notifyAuthenticationDidFail(NSError(code: .accountLimitReached, userInfo: nil))
             return
         }
         

--- a/Source/Synchronization/Strategies/EmailVerificationStrategy.swift
+++ b/Source/Synchronization/Strategies/EmailVerificationStrategy.swift
@@ -65,10 +65,10 @@ extension EmailVerificationStrategy : ZMSingleRequestTranscoder {
                 error = NSError.blacklistedEmail(with: response) ??
                     NSError.emailAddressInUse(with: response) ??
                     NSError.invalidEmail(with: response) ??
-                    NSError.userSessionErrorWith(.unknownError, userInfo: [:])
+                    NSError(code: .unknownError, userInfo: [:])
             case .checkActivationCode:
                 error = NSError.invalidActivationCode(with: response) ??
-                    NSError.userSessionErrorWith(.unknownError, userInfo: [:])
+                    NSError(code: .unknownError, userInfo: [:])
             default:
                 fatal("Error occurs for invalid phase: \(registrationStatus.phase)")
             }

--- a/Source/Synchronization/Strategies/TeamRegistrationStrategy.swift
+++ b/Source/Synchronization/Strategies/TeamRegistrationStrategy.swift
@@ -49,8 +49,8 @@ extension TeamRegistrationStrategy : ZMSingleRequestTranscoder {
             let error = NSError.blacklistedEmail(with: response) ??
                 NSError.invalidActivationCode(with: response) ??
                 NSError.emailAddressInUse(with: response) ??
-                NSError.unauthorizedError(with: response) ??
-                NSError.userSessionErrorWith(.unknownError, userInfo: [:])
+                NSError.unauthorizedEmailError(with: response) ??
+                NSError(code: .unknownError, userInfo: [:])
             registrationStatus.handleError(error)
         }
     }

--- a/Source/Synchronization/Strategies/UserClientRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/UserClientRequestStrategy.swift
@@ -286,7 +286,7 @@ public final class UserClientRequestStrategy: ZMObjectSyncStrategy, ZMObjectStra
                 }
             }
         }
-        return NSError(domain: ZMUserSessionErrorDomain, code: Int(errorCode.rawValue), userInfo: nil)
+        return NSError(domain: NSError.ZMUserSessionErrorDomain, code: Int(errorCode.rawValue), userInfo: nil)
     }
     
     public func didReceive(_ response: ZMTransportResponse, forSingleRequest sync: ZMSingleRequestSync) {

--- a/Source/Synchronization/Strategies/UserProfileUpdateRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/UserProfileUpdateRequestStrategy.swift
@@ -179,7 +179,7 @@ extension UserProfileRequestStrategy : ZMSingleRequestTranscoder {
             } else {
                 let error : Error = NSError.phoneNumberIsAlreadyRegisteredError(with: response) ??
                     NSError.invalidPhoneNumber(withReponse: response) ??
-                    NSError.userSessionErrorWith(ZMUserSessionErrorCode.unknownError, userInfo: nil)
+                    NSError(code: .unknownError, userInfo: nil)
                 self.userProfileUpdateStatus.didFailPhoneVerificationCodeRequest(error: error)
             }
             
@@ -188,7 +188,7 @@ extension UserProfileRequestStrategy : ZMSingleRequestTranscoder {
                 self.userProfileUpdateStatus.didChangePhoneSuccesfully()
             } else {
                 let error : Error = NSError.invalidPhoneVerificationCodeError(with: response) ??
-                    NSError.userSessionErrorWith(ZMUserSessionErrorCode.unknownError, userInfo: nil)
+                    NSError(code: .unknownError, userInfo: nil)
                 self.userProfileUpdateStatus.didFailChangingPhone(error: error)
             }
             
@@ -211,7 +211,7 @@ extension UserProfileRequestStrategy : ZMSingleRequestTranscoder {
             } else {
                 let error : Error = NSError.invalidEmail(with: response) ??
                     NSError.keyExistsError(with: response) ??
-                    NSError.userSessionErrorWith(ZMUserSessionErrorCode.unknownError, userInfo: nil)
+                    NSError(code: .unknownError, userInfo: nil)
                 self.userProfileUpdateStatus.didFailEmailUpdate(error: error)
             }
             
@@ -221,7 +221,7 @@ extension UserProfileRequestStrategy : ZMSingleRequestTranscoder {
                 self.userProfileUpdateStatus.didRemovePhoneNumberSuccessfully()
             } else {
                 let error : Error = NSError.lastUserIdentityCantBeRemoved(with: response) ??
-                    NSError.userSessionErrorWith(ZMUserSessionErrorCode.unknownError, userInfo: nil)
+                    NSError(code: .unknownError, userInfo: nil)
                 self.userProfileUpdateStatus.didFailPhoneNumberRemoval(error: error)
             }
             

--- a/Source/UnauthenticatedSession/UnauthenticatedSession+Login.swift
+++ b/Source/UnauthenticatedSession/UnauthenticatedSession+Login.swift
@@ -38,9 +38,9 @@ extension UnauthenticatedSession {
         guard !updatedCredentialsInUserSession else { return }
         
         if credentials.isInvalid {
-            authenticationStatus.notifyAuthenticationDidFail(NSError.userSessionErrorWith(.needsCredentials, userInfo: nil))
+            authenticationStatus.notifyAuthenticationDidFail(NSError(code: .needsCredentials, userInfo: nil))
         } else if !self.reachability.mayBeReachable {
-            authenticationStatus.notifyAuthenticationDidFail(NSError.userSessionErrorWith(.networkError, userInfo:nil))
+            authenticationStatus.notifyAuthenticationDidFail(NSError(code: .networkError, userInfo:nil))
         } else {
             self.authenticationStatus.prepareForLogin(with: credentials)
         }

--- a/Source/UnauthenticatedSession/UnauthenticatedSession+Registration.swift
+++ b/Source/UnauthenticatedSession/UnauthenticatedSession+Registration.swift
@@ -66,7 +66,7 @@ extension UnauthenticatedSession {
                 try ZMUser.validatePhoneNumber(&phoneNumber)
             }
         } catch {
-            ZMUserSessionRegistrationNotification.notifyRegistrationDidFail(NSError.userSessionErrorWith(.needsCredentials, userInfo: nil), context: authenticationStatus)
+            ZMUserSessionRegistrationNotification.notifyRegistrationDidFail(NSError(code: .needsCredentials, userInfo: nil), context: authenticationStatus)
             return
         }
         

--- a/Source/UserSession/NSError+Localized.swift
+++ b/Source/UserSession/NSError+Localized.swift
@@ -1,29 +1,32 @@
-// 
+//
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
-// 
+// Copyright (C) 2017 Wire Swiss GmbH
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
+//
 
+import Foundation
 
+extension NSError {
+    public static var ZMUserSessionErrorDomain = "ZMUserSession"
 
-"conversation.username.groupingSeparator" = ", ";
-
-"user_session.error.balcklisted-email" = "E-mail address has been blacklisted";
-"user_session.error.email-exists" = "E-mail address is already in use";
-"user_session.error.invalid-email" = "Invalid e-mail";
-"user_session.error.invalid-code" = "Invalid activation code";
-"user_session.error.unauthorized-email" = "Unauthorized e-mail";
-"user_session.error.unknown" = "Unknown error";
-
+    @objc(initWitUserSessionErrorWithErrorCode:userInfo:)
+    public convenience init(code: ZMUserSessionErrorCode, userInfo: [String : Any]?) {
+        var info = userInfo ?? [:]
+        if let description = code.errorDescription {
+            info[NSLocalizedDescriptionKey] = description
+        }
+        self.init(domain: NSError.ZMUserSessionErrorDomain, code: Int(code.rawValue), userInfo: info)
+    }
+}

--- a/Source/UserSession/NSError+ZMUserSession.m
+++ b/Source/UserSession/NSError+ZMUserSession.m
@@ -20,43 +20,17 @@
 @import WireTransport;
 
 #import "NSError+ZMUserSession.h"
+#import <WireSyncEngine/WireSyncEngine-Swift.h>
 
-
-NSString * const ZMUserSessionErrorDomain = @"ZMUserSession";
 NSString * const ZMClientsKey = @"clients";
 NSString * const ZMPhoneCredentialKey = @"phone";
 NSString * const ZMEmailCredentialKey = @"email";
-
-static NSString *LocalizedDescriptionStringFromZMUserSessionErrorCode(ZMUserSessionErrorCode code)
-{
-    struct TypeMap {
-        NSUInteger code;
-        CFStringRef name;
-    } const TypeMapping[] = {
-        { ZMUserSessionNoError, CFSTR("User session no error") },
-        { ZMUserSessionUnknownError, CFSTR("User session unknown error") },
-        { ZMUserSessionNeedsCredentials, CFSTR("User session needs credentials") },
-        { ZMUserSessionInvalidCredentials, CFSTR("User session invalid credentials") },
-        { ZMUserSessionAccountIsPendingActivation, CFSTR("User session account is pending activation") },
-        { ZMUserSessionNetworkError, CFSTR("User session network error") },
-        { ZMUserSessionEmailIsAlreadyRegistered, CFSTR("User session email is already registered") },
-        { ZMUserSessionRegistrationDidFailWithUnknownError, CFSTR("User session registration did fail with unknown error") },
-    };
-    
-    for (size_t i = 0; i < (sizeof(TypeMapping)/sizeof(*TypeMapping)); ++i) {
-        if (TypeMapping[i].code == code) {
-            return (__bridge NSString *) TypeMapping[i].name;
-        }
-    }
-    return nil;
-}
-
 
 @implementation NSError (ZMUserSession)
 
 - (ZMUserSessionErrorCode)userSessionErrorCode
 {
-    if (! [self.domain isEqualToString:ZMUserSessionErrorDomain]) {
+    if (! [self.domain isEqualToString:NSError.ZMUserSessionErrorDomain]) {
         return ZMUserSessionNoError;
     } else {
         return (ZMUserSessionErrorCode) self.code;
@@ -71,12 +45,7 @@ static NSString *LocalizedDescriptionStringFromZMUserSessionErrorCode(ZMUserSess
 
 + (instancetype)userSessionErrorWithErrorCode:(ZMUserSessionErrorCode)code userInfo:(NSDictionary *)userInfo
 {
-    NSMutableDictionary *newUserInfo = [NSMutableDictionary dictionaryWithDictionary:userInfo];
-    NSString *description = LocalizedDescriptionStringFromZMUserSessionErrorCode(code);
-    if (description != nil) {
-        newUserInfo[NSLocalizedDescriptionKey] = description;
-    }
-    return [NSError errorWithDomain:ZMUserSessionErrorDomain code:code userInfo:newUserInfo];
+    return [[NSError alloc] initWitUserSessionErrorWithErrorCode:code userInfo:userInfo];
 }
 
 + (instancetype)pendingLoginErrorWithResponse:(ZMTransportResponse *)response
@@ -91,6 +60,14 @@ static NSString *LocalizedDescriptionStringFromZMUserSessionErrorCode(ZMUserSess
 {
     if (response.HTTPStatus == 403 && [[response payloadLabel] isEqualToString:@"unauthorized"]) {
         return [NSError userSessionErrorWithErrorCode:ZMUserSessionInvalidPhoneNumber userInfo:nil];
+    }
+    return nil;
+}
+
++ (instancetype)unauthorizedEmailErrorWithResponse:(ZMTransportResponse *)response
+{
+    if (response.HTTPStatus == 403 && [[response payloadLabel] isEqualToString:@"unauthorized"]) {
+        return [NSError userSessionErrorWithErrorCode:ZMUserSessionUnauthorizedEmail userInfo:nil];
     }
     return nil;
 }

--- a/Source/UserSession/NSError+ZMUserSessionInternal.h
+++ b/Source/UserSession/NSError+ZMUserSessionInternal.h
@@ -29,6 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (__nullable instancetype)pendingLoginErrorWithResponse:(ZMTransportResponse *)response;
 + (__nullable instancetype)unauthorizedErrorWithResponse:(ZMTransportResponse *)response;
++ (__nullable instancetype)unauthorizedEmailErrorWithResponse:(ZMTransportResponse *)response;
 
 + (__nullable instancetype)invalidPhoneNumberErrorWithReponse:(ZMTransportResponse *)response;
 + (__nullable instancetype)phoneNumberIsAlreadyRegisteredErrorWithResponse:(ZMTransportResponse *)response;

--- a/Source/UserSession/ZMClientRegistrationStatus.m
+++ b/Source/UserSession/ZMClientRegistrationStatus.m
@@ -337,7 +337,7 @@ static NSString *ZMLogTag ZM_UNUSED = @"Authentication";
 
 - (void)notifyEmailIsNecessary
 {
-    NSError *emailMissingError = [[NSError alloc] initWithDomain:ZMUserSessionErrorDomain
+    NSError *emailMissingError = [[NSError alloc] initWithDomain:NSError.ZMUserSessionErrorDomain
                                                             code:ZMUserSessionNeedsToRegisterEmailToRegisterClient
                                                         userInfo:nil];
     [PostLoginAuthenticationNotification notifyClientRegistrationDidFailWithError:emailMissingError context:self.managedObjectContext];

--- a/Source/UserSession/ZMUserSessionErrorCode+Localized.swift
+++ b/Source/UserSession/ZMUserSessionErrorCode+Localized.swift
@@ -1,0 +1,40 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension ZMUserSessionErrorCode: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .blacklistedEmail:
+            return NSLocalizedString("user_session.error.balcklisted-email", comment: "")
+        case .emailIsAlreadyRegistered:
+            return NSLocalizedString("user_session.error.email-exists", comment: "")
+        case .invalidEmail:
+            return NSLocalizedString("user_session.error.invalid-email", comment: "")
+        case .invalidActivationCode:
+            return NSLocalizedString("user_session.error.invalid-code", comment: "")
+        case .unknownError:
+            return NSLocalizedString("user_session.error.unknown", comment: "")
+        case .unauthorizedEmail:
+            return NSLocalizedString("user_session.error.unknown", comment: "")
+        default:
+            return nil
+        }
+    }
+}

--- a/Source/UserSession/ZMUserSessionErrorCode+Localized.swift
+++ b/Source/UserSession/ZMUserSessionErrorCode+Localized.swift
@@ -20,19 +20,20 @@ import Foundation
 
 extension ZMUserSessionErrorCode: LocalizedError {
     public var errorDescription: String? {
+        let bundle = Bundle(for: ZMUserSession.self)
         switch self {
         case .blacklistedEmail:
-            return NSLocalizedString("user_session.error.balcklisted-email", comment: "")
+            return bundle.localizedString(forKey: "user_session.error.balcklisted-email", value: nil, table: "ZMLocalizable")
         case .emailIsAlreadyRegistered:
-            return NSLocalizedString("user_session.error.email-exists", comment: "")
+            return bundle.localizedString(forKey: "user_session.error.email-exists", value: nil, table: "ZMLocalizable")
         case .invalidEmail:
-            return NSLocalizedString("user_session.error.invalid-email", comment: "")
+            return bundle.localizedString(forKey: "user_session.error.invalid-email", value: nil, table: "ZMLocalizable")
         case .invalidActivationCode:
-            return NSLocalizedString("user_session.error.invalid-code", comment: "")
+            return bundle.localizedString(forKey: "user_session.error.invalid-code", value: nil, table: "ZMLocalizable")
         case .unknownError:
-            return NSLocalizedString("user_session.error.unknown", comment: "")
+            return bundle.localizedString(forKey: "user_session.error.unknown", value: nil, table: "ZMLocalizable")
         case .unauthorizedEmail:
-            return NSLocalizedString("user_session.error.unknown", comment: "")
+            return bundle.localizedString(forKey: "user_session.error.unknown", value: nil, table: "ZMLocalizable")
         default:
             return nil
         }

--- a/Tests/Source/E2EE/UserClientRequestStrategyTests.swift
+++ b/Tests/Source/E2EE/UserClientRequestStrategyTests.swift
@@ -358,7 +358,7 @@ extension UserClientRequestStrategyTests {
         guard let request = self.sut.nextRequest() else { return XCTFail() }
         let responsePayload = ["code": 403, "message": "Re-authentication via password required", "label": "missing-auth"] as [String : Any]
         let response = ZMTransportResponse(payload: responsePayload as ZMTransportData, httpStatus: 403, transportSessionError: nil)
-        let expectedError = NSError(domain: ZMUserSessionErrorDomain, code: Int(ZMUserSessionErrorCode.invalidCredentials.rawValue), userInfo: nil)
+        let expectedError = NSError(domain: NSError.ZMUserSessionErrorDomain, code: Int(ZMUserSessionErrorCode.invalidCredentials.rawValue), userInfo: nil)
         
         // when
         request.complete(with: response)
@@ -391,7 +391,7 @@ extension UserClientRequestStrategyTests {
         let responsePayload = ["code": 403, "message": "Re-authentication via password required", "label": "missing-auth"] as [String : Any]
         let response = ZMTransportResponse(payload: responsePayload as ZMTransportData, httpStatus: 403, transportSessionError: nil)
 
-        let expectedError = NSError(domain: ZMUserSessionErrorDomain, code: Int(ZMUserSessionErrorCode.needsPasswordToRegisterClient.rawValue), userInfo: [ ZMEmailCredentialKey : selfUser.emailAddress ])
+        let expectedError = NSError(domain: NSError.ZMUserSessionErrorDomain, code: Int(ZMUserSessionErrorCode.needsPasswordToRegisterClient.rawValue), userInfo: [ ZMEmailCredentialKey : selfUser.emailAddress ])
         
         // when
         request.complete(with: response)
@@ -429,7 +429,7 @@ extension UserClientRequestStrategyTests {
         let response = ZMTransportResponse(payload: responsePayload as ZMTransportData?, httpStatus: 403, transportSessionError: nil)
         
 
-        _ = NSError(domain: ZMUserSessionErrorDomain, code: Int(ZMUserSessionErrorCode.canNotRegisterMoreClients.rawValue), userInfo: nil)
+        _ = NSError(domain: NSError.ZMUserSessionErrorDomain, code: Int(ZMUserSessionErrorCode.canNotRegisterMoreClients.rawValue), userInfo: nil)
         
         // when
         clientRegistrationStatus.mockPhase = nil

--- a/Tests/Source/Integration/PhoneRegistrationTests.m
+++ b/Tests/Source/Integration/PhoneRegistrationTests.m
@@ -268,7 +268,7 @@
     // expect
     [[self.registrationObserver expect] registrationDidFail:[OCMArg checkWithBlock:^BOOL(NSError *error) {
         XCTAssertEqual(error.code, (int) ZMUserSessionPhoneNumberIsAlreadyRegistered);
-        XCTAssertEqualObjects(error.domain, ZMUserSessionErrorDomain);
+        XCTAssertEqualObjects(error.domain, NSError.ZMUserSessionErrorDomain);
         return YES;
     }]];
     

--- a/Tests/Source/Integration/UserProfileTests.m
+++ b/Tests/Source/Integration/UserProfileTests.m
@@ -261,7 +261,7 @@
     
     // expect
     [[userObserver expect] phoneNumberVerificationCodeRequestDidFail:[OCMArg checkWithBlock:^BOOL(NSError *error) {
-        return error.code == ZMUserSessionPhoneNumberIsAlreadyRegistered && [error.domain isEqualToString:ZMUserSessionErrorDomain];
+        return error.code == ZMUserSessionPhoneNumberIsAlreadyRegistered && [error.domain isEqualToString:NSError.ZMUserSessionErrorDomain];
     }]];
     
     self.mockTransportSession.responseGeneratorBlock = ^ZMTransportResponse*(ZMTransportRequest *request) {

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -472,7 +472,7 @@ class SessionManagerTests_Teams: IntegrationTest {
         XCTAssert(login(ignoreAuthenticationFailures: true))
 
         // then
-        XCTAssertEqual(NSError.userSessionErrorWith(.accountLimitReached, userInfo: nil), recorder.notifications.last!.error)
+        XCTAssertEqual(NSError(code: .accountLimitReached, userInfo: nil), recorder.notifications.last!.error)
     }
 }
 

--- a/Tests/Source/Synchronization/Strategies/RegistrationStatusTestHelper.swift
+++ b/Tests/Source/Synchronization/Strategies/RegistrationStatusTestHelper.swift
@@ -44,7 +44,7 @@ extension RegistrationStatusStrategyTestHelper {
     func checkResponseError(with phase: RegistrationStatus.Phase, code: ZMUserSessionErrorCode, errorLabel: String, httpStatus: NSInteger, file: StaticString = #file, line: UInt = #line) {
         registrationStatus.phase = phase
 
-        let expectedError = NSError.userSessionErrorWith(code, userInfo: [:])
+        let expectedError = NSError(code: code, userInfo: [:])
         let payload = [
             "label": errorLabel,
             "message":"some"

--- a/Tests/Source/Synchronization/Transcoders/ZMLoginCodeRequestTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMLoginCodeRequestTranscoderTests.m
@@ -97,7 +97,7 @@
     id token = [[PreLoginAuthenticationObserverToken alloc] initWithAuthenticationStatus:self.authenticationStatus handler:^(enum PreLoginAuthenticationEventObjc event, NSError *error) {
         XCTAssertEqual(event, PreLoginAuthenticationEventObjcLoginCodeRequestDidFail);
         XCTAssertEqual(error.code, (long) ZMUserSessionUnknownError);
-        XCTAssertEqualObjects(error.domain, ZMUserSessionErrorDomain);
+        XCTAssertEqualObjects(error.domain, NSError.ZMUserSessionErrorDomain);
         [expectation fulfill];
     }];
     
@@ -126,7 +126,7 @@
     id token = [[PreLoginAuthenticationObserverToken alloc] initWithAuthenticationStatus:self.authenticationStatus handler:^(enum PreLoginAuthenticationEventObjc event, NSError *error) {
         XCTAssertEqual(event, PreLoginAuthenticationEventObjcLoginCodeRequestDidFail);
         XCTAssertEqual(error.code, (long) ZMUserSessionInvalidPhoneNumber);
-        XCTAssertEqualObjects(error.domain, ZMUserSessionErrorDomain);
+        XCTAssertEqualObjects(error.domain, NSError.ZMUserSessionErrorDomain);
         [expectation fulfill];
     }];
     
@@ -154,7 +154,7 @@
     id token = [[PreLoginAuthenticationObserverToken alloc] initWithAuthenticationStatus:self.authenticationStatus handler:^(enum PreLoginAuthenticationEventObjc event, NSError *error) {
         XCTAssertEqual(event, PreLoginAuthenticationEventObjcLoginCodeRequestDidFail);
         XCTAssertEqual(error.code, (long) ZMUserSessionCodeRequestIsAlreadyPending);
-        XCTAssertEqualObjects(error.domain, ZMUserSessionErrorDomain);
+        XCTAssertEqualObjects(error.domain, NSError.ZMUserSessionErrorDomain);
         [expectation fulfill];
     }];
     
@@ -182,7 +182,7 @@
     id token = [[PreLoginAuthenticationObserverToken alloc] initWithAuthenticationStatus:self.authenticationStatus handler:^(enum PreLoginAuthenticationEventObjc event, NSError *error) {
         XCTAssertEqual(event, PreLoginAuthenticationEventObjcLoginCodeRequestDidFail);
         XCTAssertEqual(error.code, (long) ZMUserSessionInvalidPhoneNumber);
-        XCTAssertEqualObjects(error.domain, ZMUserSessionErrorDomain);
+        XCTAssertEqualObjects(error.domain, NSError.ZMUserSessionErrorDomain);
         [expectation fulfill];
     }];
     

--- a/Tests/Source/Synchronization/Transcoders/ZMPhoneNumberVerificationTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMPhoneNumberVerificationTranscoderTests.m
@@ -362,7 +362,7 @@
     __block BOOL notificationCalled = NO;
     //expect
     id token = [ZMUserSessionRegistrationNotification addObserverInContext:self.authenticationStatus withBlock:^(ZMUserSessionRegistrationNotificationType event, NSError *error) {
-        XCTAssertEqualObjects(error.domain, ZMUserSessionErrorDomain);
+        XCTAssertEqualObjects(error.domain, NSError.ZMUserSessionErrorDomain);
         XCTAssertEqual(error.code, (long) ZMUserSessionUnknownError);
         XCTAssertEqual(event, ZMRegistrationNotificationPhoneNumberVerificationDidFail);
         notificationCalled = YES;
@@ -395,7 +395,7 @@
     __block BOOL notificationCalled = NO;
     //expect
     id token = [ZMUserSessionRegistrationNotification addObserverInContext:self.authenticationStatus withBlock:^(ZMUserSessionRegistrationNotificationType event, NSError *error) {
-        XCTAssertEqualObjects(error.domain, ZMUserSessionErrorDomain);
+        XCTAssertEqualObjects(error.domain, NSError.ZMUserSessionErrorDomain);
         XCTAssertEqual(error.code, (long) ZMUserSessionInvalidPhoneNumberVerificationCode);
         XCTAssertEqual(event, ZMRegistrationNotificationPhoneNumberVerificationDidFail);
         notificationCalled = YES;

--- a/Tests/Source/Synchronization/Transcoders/ZMRegistrationTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMRegistrationTranscoderTests.m
@@ -411,7 +411,7 @@
     id token = [ZMUserSessionRegistrationNotification addObserverInContext:self.authenticationStatus withBlock:^(ZMUserSessionRegistrationNotificationType event, NSError *error) {
         XCTAssertEqual(event, ZMRegistrationNotificationRegistrationDidFail);
         XCTAssertEqual(error.code, (long) ZMUserSessionUnknownError);
-        XCTAssertEqual(error.domain, ZMUserSessionErrorDomain);
+        XCTAssertEqualObjects(error.domain, NSError.ZMUserSessionErrorDomain);
         [expectation fulfill];
     } ];
 
@@ -443,7 +443,7 @@
     id token = [ZMUserSessionRegistrationNotification addObserverInContext:self.authenticationStatus withBlock:^(ZMUserSessionRegistrationNotificationType event, NSError *error) {
         XCTAssertEqual(event, ZMRegistrationNotificationRegistrationDidFail);
         XCTAssertEqual(error.code, (long) ZMUserSessionInvalidEmail);
-        XCTAssertEqual(error.domain, ZMUserSessionErrorDomain);
+        XCTAssertEqualObjects(error.domain, NSError.ZMUserSessionErrorDomain);
         [expectation fulfill];
     } ];
     
@@ -473,7 +473,7 @@
     id token = [ZMUserSessionRegistrationNotification addObserverInContext:self.authenticationStatus withBlock:^(ZMUserSessionRegistrationNotificationType event, NSError *error) {
         XCTAssertEqual(event, ZMRegistrationNotificationRegistrationDidFail);
         XCTAssertEqual(error.code, (long) ZMUserSessionInvalidPhoneNumber);
-        XCTAssertEqual(error.domain, ZMUserSessionErrorDomain);
+        XCTAssertEqualObjects(error.domain, NSError.ZMUserSessionErrorDomain);
         [expectation fulfill];
     } ];
     

--- a/Tests/Source/UserSession/UnauthenticatedSessionTests.swift
+++ b/Tests/Source/UserSession/UnauthenticatedSessionTests.swift
@@ -195,7 +195,7 @@ public final class UnauthenticatedSessionTests: ZMTBaseTest {
         // then
         XCTAssertEqual(observer.authenticationDidSucceedEvents, 0)
         XCTAssertEqual(observer.authenticationDidFailEvents.count, 1)
-        XCTAssertEqual(observer.authenticationDidFailEvents[0].localizedDescription, NSError.userSessionErrorWith(.needsCredentials, userInfo:nil).localizedDescription)
+        XCTAssertEqual(observer.authenticationDidFailEvents[0].localizedDescription, NSError(code: .needsCredentials, userInfo:nil).localizedDescription)
     }
     
     func testThatDuringLoginItThrowsErrorWhenOffline() {
@@ -208,7 +208,7 @@ public final class UnauthenticatedSessionTests: ZMTBaseTest {
         // then
         XCTAssertEqual(observer.authenticationDidSucceedEvents, 0)
         XCTAssertEqual(observer.authenticationDidFailEvents.count, 1)
-        XCTAssertEqual(observer.authenticationDidFailEvents[0].localizedDescription, NSError.userSessionErrorWith(.networkError, userInfo:nil).localizedDescription)
+        XCTAssertEqual(observer.authenticationDidFailEvents[0].localizedDescription, NSError(code: .networkError, userInfo:nil).localizedDescription)
     }
 
     func testThatItParsesCookieDataAndDoesCallTheDelegateIfTheCookieIsValidAndThereIsAUserIdKeyUser() {

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -363,6 +363,8 @@
 		F19F4F4D1E646C3C00F4D8FF /* UserProfileImageUpdateStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F19F4F4C1E646C3C00F4D8FF /* UserProfileImageUpdateStatusTests.swift */; };
 		F19F4F4F1E6575F700F4D8FF /* UserProfileImageOwner.swift in Sources */ = {isa = PBXBuildFile; fileRef = F19F4F4E1E6575F700F4D8FF /* UserProfileImageOwner.swift */; };
 		F1A94BD21F010287003083D9 /* UnauthenticatedSession+Login.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A94BD11F010287003083D9 /* UnauthenticatedSession+Login.swift */; };
+		F1C1F3EE1FCF0C85007273E3 /* ZMUserSessionErrorCode+Localized.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C1F3ED1FCF0C85007273E3 /* ZMUserSessionErrorCode+Localized.swift */; };
+		F1C1F3F01FCF18C5007273E3 /* NSError+Localized.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C1F3EF1FCF18C5007273E3 /* NSError+Localized.swift */; };
 		F1C51FE71FB49660009C2269 /* RegistrationStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C51FE61FB49660009C2269 /* RegistrationStatus.swift */; };
 		F1C51FE91FB4A9C7009C2269 /* TeamRegistrationStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C51FE81FB4A9C7009C2269 /* TeamRegistrationStrategy.swift */; };
 		F905C47F1E79A86A00AF34A5 /* WireCallCenterV3Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F905C47E1E79A86A00AF34A5 /* WireCallCenterV3Tests.swift */; };
@@ -941,6 +943,8 @@
 		F19F4F4C1E646C3C00F4D8FF /* UserProfileImageUpdateStatusTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserProfileImageUpdateStatusTests.swift; sourceTree = "<group>"; };
 		F19F4F4E1E6575F700F4D8FF /* UserProfileImageOwner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserProfileImageOwner.swift; sourceTree = "<group>"; };
 		F1A94BD11F010287003083D9 /* UnauthenticatedSession+Login.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UnauthenticatedSession+Login.swift"; sourceTree = "<group>"; };
+		F1C1F3ED1FCF0C85007273E3 /* ZMUserSessionErrorCode+Localized.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSessionErrorCode+Localized.swift"; sourceTree = "<group>"; };
+		F1C1F3EF1FCF18C5007273E3 /* NSError+Localized.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSError+Localized.swift"; sourceTree = "<group>"; };
 		F1C51FE61FB49660009C2269 /* RegistrationStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationStatus.swift; sourceTree = "<group>"; };
 		F1C51FE81FB4A9C7009C2269 /* TeamRegistrationStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamRegistrationStrategy.swift; sourceTree = "<group>"; };
 		F905C47E1E79A86A00AF34A5 /* WireCallCenterV3Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WireCallCenterV3Tests.swift; sourceTree = "<group>"; };
@@ -1573,6 +1577,8 @@
 				F9CA51B51B345F39003AA83A /* ZMStoredLocalNotification.m */,
 				3E05F253192A50CC00F22D80 /* NSError+ZMUserSession.m */,
 				3E05F254192A50CC00F22D80 /* NSError+ZMUserSessionInternal.h */,
+				F1C1F3EF1FCF18C5007273E3 /* NSError+Localized.swift */,
+				F1C1F3ED1FCF0C85007273E3 /* ZMUserSessionErrorCode+Localized.swift */,
 				16DCAD641B0F9447008C1DD9 /* NSURL+LaunchOptions.h */,
 				16DCAD651B0F9447008C1DD9 /* NSURL+LaunchOptions.m */,
 				54F0A0931B3018D7003386BC /* ProxiedRequestsStatus.swift */,
@@ -2525,6 +2531,7 @@
 				F95706541DE5D1CC0087442C /* SearchUserImageStrategy.swift in Sources */,
 				BF2A9D5D1D6B63DB00FA7DBC /* StoreUpdateEvent.swift in Sources */,
 				09C77C531BA6C77000E2163F /* UserClientRequestStrategy.swift in Sources */,
+				F1C1F3EE1FCF0C85007273E3 /* ZMUserSessionErrorCode+Localized.swift in Sources */,
 				549815CD1A432BC700A7CE2E /* ZMBlacklistDownloader.m in Sources */,
 				F96C8E7A1D7DCCE8004B6D87 /* LocalNotificationDispatcher+Messages.swift in Sources */,
 				549815CE1A432BC700A7CE2E /* ZMBlacklistVerificator.m in Sources */,
@@ -2607,6 +2614,7 @@
 				F9AB00221F0CDAF00037B437 /* FileRelocator.swift in Sources */,
 				166A8BF31E015F3B00F5EEEA /* WireCallCenterV3Factory.swift in Sources */,
 				5498161E1A432BC800A7CE2E /* ZMPushToken.m in Sources */,
+				F1C1F3F01FCF18C5007273E3 /* NSError+Localized.swift in Sources */,
 				5467F1C41E0AE2EF008C1745 /* KeyValueStore.swift in Sources */,
 				0932EA481AE5514100D1BFD1 /* ZMPhoneNumberVerificationTranscoder.m in Sources */,
 				5467F1C61E0AE421008C1745 /* KeyValueStore+AccessToken.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

There are some errors that we show to the user and we want them to be localized.

### Causes

There was a method called `LocalizedDescriptionStringFromZMUserSessionErrorCode` which actually produced a description that is not localized and only usable for debugging purposes.

### Solutions

Added strings for all errors that we currently show in team registration flow.
