### PR TITLE
Fix call timer getting on every time someone joins a call 

### DIFF
--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -607,7 +607,11 @@ public struct CallEvent {
                                                                                      members: [CallMember(userId: userId!, audioEstablished: false)],
                                                                                      callCenter: self)
         case .established:
-            establishedDate = Date()
+            // WORKAROUND: the call established handler will is called once for every participant in a
+            // group call. Until that's no longer the case we must take care to only set establishedDate once.
+            if self.callState(conversationId: conversationId) != .established {
+                establishedDate = Date()
+            }
             
             if isVideoCall(conversationId: conversationId) {
                 avsWrapper.setVideoSendActive(userId: conversationId, active: true)

--- a/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -220,6 +220,27 @@ class WireCallCenterV3Tests: MessagingTest {
         XCTAssertNotNil(sut.establishedDate)
     }
     
+    func testThatTheEstablishedHandlerDoesntSetTheStartTimeIfCallIsAlreadyEstablished() {
+        // given
+        WireSyncEngine.incomingCallHandler(conversationId: conversationIDRef, messageTime: 0, userId: otherUserIDRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        XCTAssertNil(sut.establishedDate)
+        
+        // call is established
+        WireSyncEngine.establishedCallHandler(conversationId: conversationIDRef, userId: otherUserIDRef, contextRef: context)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        XCTAssertNotNil(sut.establishedDate)
+        let previousEstablishedDate = sut.establishedDate
+        spinMainQueue(withTimeout: 0.1)
+        
+        // when
+        WireSyncEngine.establishedCallHandler(conversationId: conversationIDRef, userId: otherUserIDRef, contextRef: context)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        // then
+        XCTAssertEqual(sut.establishedDate, previousEstablishedDate)
+    }
+    
     func testThatTheClosedCallHandlerPostsTheRightNotification() {
         // given
         WireSyncEngine.incomingCallHandler(conversationId: conversationIDRef, messageTime: 0, userId: otherUserIDRef, isVideoCall: 0, shouldRing: 1, contextRef: context)


### PR DESCRIPTION
### Issues

Call timer gets reset when someone joins a call.

### Causes

The `establishedDate` gets updated when the established-call-handler is called. In group calls that once per call participants which has the effect that timer gets reset when some joins the call.

### Solutions

Work around this behaviour by no updating `establishedDate` if the call is already established.