### PR TITLE
change notification title from  “in Team” to “Team”

### DIFF
--- a/Resources/Base.lproj/Push.strings
+++ b/Resources/Base.lproj/Push.strings
@@ -33,8 +33,6 @@
 
 // Push Title: [Conversation Name] in [Team Name]
 "push.notification.title" = "%1$@ in %2$@";
-"push.notification.title.noconversationname" = "in %1$@";
-"push.notification.title.noteamname" = "%1$@";
 
 // 2 Components: Sender, Message
 "push.notification.add.message.group" = "%1$@: %2$@";

--- a/Source/Notifications/Push notifications/Helpers/ZMLocalNotificationLocalization.m
+++ b/Source/Notifications/Push notifications/Helpers/ZMLocalNotificationLocalization.m
@@ -228,28 +228,18 @@ static NSString *const NoTeamNameKey = @"noteamname";
 
 - (NSString *)localizedStringWithConversationName:(NSString *)conversationName teamName:(NSString *)teamName
 {
-    NSMutableArray *arguments = [NSMutableArray array];
-    NSString *key = self;
-    
-    if (conversationName == nil) {
-        key = [key stringByAppendingPathExtension:NoConversationNameKey];
+    if (conversationName && teamName) {
+        return localizedStringWithKeyAndArguments(ZMPushLocalizedString(self), @[conversationName, teamName]);
+    }
+    else if (conversationName) {
+        return conversationName;
+    }
+    else if (teamName) {
+        return teamName;
     }
     else {
-        [arguments addObject:conversationName];
-    }
-    
-    if (teamName == nil) {
-        key = [key stringByAppendingPathExtension:NoTeamNameKey];
-    }
-    else {
-        [arguments addObject:teamName];
-    }
-    
-    if (arguments.count == 0) {
         return nil;
     }
-    
-    return localizedStringWithKeyAndArguments(ZMPushLocalizedString(key), arguments);
 }
 
 - (NSString *)localizedCallKitStringWithUser:(ZMUser *)user conversation:(ZMConversation *)conversation;

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationLocalizationTests.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationLocalizationTests.swift
@@ -33,7 +33,7 @@ class ZMLocalNotificationLocalizationTests: ZMLocalNotificationTests {
         // then
         XCTAssertEqual(result(conversationName, teamName), "iOS Team in Wire")
         XCTAssertEqual(result(conversationName, nil), "iOS Team")
-        XCTAssertEqual(result(nil, teamName), "in Wire")
+        XCTAssertEqual(result(nil, teamName), "Wire")
         XCTAssertNil(result(nil, nil))
     }
     


### PR DESCRIPTION
## What's new in this PR?

The notification title "in Team" (occurs when we have a team name, but no conversation name) has been changed to simply "Team". Two push string keys were removed since we only need localization when we have both the conversation name and the team name. Since we don't call these push strings anymore, we won't have issues with missing translations.