### PR TITLE
Don't re-create the CallkitDelegate if it already exists

### DIFF
--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -520,6 +520,10 @@ ZM_EMPTY_ASSERTING_INIT()
             break;
         case ZMCallNotificationStyleCallKit:
         {
+            if (self.callKitDelegate != nil) {
+                return; // Don't re-create the CallKitDelegate if it already exists
+            }
+            
             CXProvider *provider = [[CXProvider alloc] initWithConfiguration:[CallKitDelegate providerConfiguration]];
             CXCallController *callController = [[CXCallController alloc] initWithQueue:dispatch_get_main_queue()];
             


### PR DESCRIPTION
### Issues

An incoming Callkit call will fail if the is app opened while the call is ongoing.

### Causes

We currently re-configure the `callNotificationStyle` when we load UI. The reason for this is probably to cover case that Callkit needs be disabled when you add a second account. This re-configuring will destroy and re-create the `CallKitDelegate` for users with only one account and fail any ongoing calls.

### Solutions

Don't re-create the `CallkitDelegate` if it already exists.