### PR TITLE
Send notification when detect more than 1 removed participant

### DIFF
--- a/Source/Public/ZMUserSession.h
+++ b/Source/Public/ZMUserSession.h
@@ -67,6 +67,7 @@ extern NSString * const ZMLaunchedWithPhoneVerificationCodeNotificationName;
 extern NSString * const ZMPhoneVerificationCodeKey;
 extern NSString * const ZMUserSessionResetPushTokensNotificationName;
 extern NSString * const ZMTransportRequestLoopNotificationName;
+extern NSString * const ZMPotentialErrorDetectedNotificationName;
 
 /// The main entry point for the WireSyncEngine API.
 ///

--- a/Source/Synchronization/Transcoders/ZMConversationTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMConversationTranscoder.m
@@ -794,6 +794,13 @@ static NSString *const ConversationTeamManagedKey = @"managed";
         [self processEvents:@[event] liveEvents:YES prefetchResult:nil];
     }
     
+    // NOTE: internal debug notification
+    if (conversation.unsyncedInactiveParticipants.count > 1) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[NSNotificationCenter defaultCenter] postNotificationName:ZMPotentialErrorDetectedNotificationName object:nil userInfo:nil];
+        });
+    }
+    
     if ([keysToParse isEqualToSet:[NSSet setWithObject:ZMConversationUserDefinedNameKey]]) {
         return NO;
     }

--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -48,6 +48,7 @@ NSNotificationName const ZMRequestToOpenSyncConversationNotificationName = @"ZMR
 NSString * const ZMAppendAVSLogNotificationName = @"AVSLogMessageNotification";
 NSNotificationName const ZMUserSessionResetPushTokensNotificationName = @"ZMUserSessionResetPushTokensNotification";
 NSNotificationName const ZMTransportRequestLoopNotificationName = @"ZMTransportRequestLoopNotificationName";
+NSNotificationName const ZMPotentialErrorDetectedNotificationName = @"ZMPotentialErrorDetectedNotificationName";
 
 static NSString * const AppstoreURL = @"https://itunes.apple.com/us/app/zeta-client/id930944768?ls=1&mt=8";
 


### PR DESCRIPTION
## What's new in this PR?

Send a notification when we detect more than one locally removed group participants. In the UI we only support removing participants one by one so this should only happen if something is out of sync.
