### PR TITLE
Filter invalid events before forwarding to consumers

### DIFF
--- a/Tests/Source/Synchronization/ZMSyncStrategyTests.m
+++ b/Tests/Source/Synchronization/ZMSyncStrategyTests.m
@@ -119,6 +119,15 @@
 {
     [super setUp];
     
+    ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
+    selfUser.remoteIdentifier = self.userIdentifier;
+    
+    ZMConversation *selfConversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
+    selfConversation.remoteIdentifier = self.userIdentifier;
+    selfConversation.conversationType = ZMConversationTypeSelf;
+    
+    [self.syncMOC saveOrRollback];
+    
     self.mockDispatcher = [OCMockObject mockForClass:[LocalNotificationDispatcher class]];
     [(LocalNotificationDispatcher *)[self.mockDispatcher stub] tearDown];
     [(LocalNotificationDispatcher *)[self.mockDispatcher stub] processEvents:OCMOCK_ANY liveEvents:YES prefetchResult:OCMOCK_ANY];


### PR DESCRIPTION
## Background

Generic message update path

1. ZMUpdateEvent arrives
 - on websocket
 - via notifications stream
 - decrypted in event decoder
 
2. Update events are processed by all event consumers
  - CallingRequestStrategy, ZMEventConsumer, PushTokenStrategy, ClientMessageTranscoder, ...
  
  Relevant for generic messages are CallingRequestStrategy, ClientMessageTranscoder, AvailabilityRequestStrategy
  
    
## Problem

Validating the generic message in every event consumer is quickly getting out of control.

## Solution 

We should introduce a validation (filter) step before we give the update event to the event consumers.
 