### PR TITLE
Extend API to tell which account is being migrated

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -31,7 +31,8 @@ public typealias LaunchOptions = [UIApplicationLaunchOptionsKey : Any]
     func sessionManagerDidFailToLogin(account: Account?, error : Error)
     func sessionManagerWillLogout(error : Error?, userSessionCanBeTornDown: @escaping () -> Void)
     func sessionManagerWillOpenAccount(_ account: Account, userSessionCanBeTornDown: @escaping () -> Void)
-    func sessionManagerWillStartMigratingLocalStore()
+    func sessionManagerWillMigrateAccount(_ account: Account)
+    func sessionManagerWillMigrateLegacyAccount()
     func sessionManagerDidBlacklistCurrentVersion()
 }
 
@@ -311,7 +312,7 @@ public protocol LocalNotificationResponder : class {
             // In order to do so we open the old database and get the user identifier.
             LocalStoreProvider.fetchUserIDFromLegacyStore(
                 in: sharedContainerURL,
-                migration: { [weak self] in self?.delegate?.sessionManagerWillStartMigratingLocalStore() },
+                migration: { [weak self] in self?.delegate?.sessionManagerWillMigrateLegacyAccount() },
                 completion: { [weak self] identifier in
                     guard let `self` = self else { return }
                     identifier.apply(self.migrateAccount)
@@ -498,7 +499,7 @@ public protocol LocalNotificationResponder : class {
                     applicationContainer: self.sharedContainerURL,
                     userIdentifier: account.userIdentifier,
                     dispatchGroup: self.dispatchGroup,
-                    migration: { [weak self] in self?.delegate?.sessionManagerWillStartMigratingLocalStore() },
+                    migration: { [weak self] in self?.delegate?.sessionManagerWillMigrateAccount(account) },
                     completion: { provider in
                         let userSession = self.startBackgroundSession(for: account, with: provider)
                         completion(userSession)

--- a/Tests/Source/Integration/IntegrationTest.swift
+++ b/Tests/Source/Integration/IntegrationTest.swift
@@ -520,7 +520,11 @@ extension IntegrationTest : SessionManagerDelegate {
         }
     }
     
-    public func sessionManagerWillStartMigratingLocalStore() {
+    public func sessionManagerWillMigrateLegacyAccount() {
+        // no-op
+    }
+    
+    public func sessionManagerWillMigrateAccount(_ account: Account) {
         // no-op
     }
     

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -1010,8 +1010,12 @@ class SessionManagerTestDelegate: SessionManagerDelegate {
     }
     
     var startedMigrationCalled = false
-    func sessionManagerWillStartMigratingLocalStore() {
+    func sessionManagerWillMigrateAccount(_ account: Account) {
         startedMigrationCalled = true
+    }
+    
+    func sessionManagerWillMigrateLegacyAccount() {
+        // no op
     }
     
 }


### PR DESCRIPTION
### Issues

You would sometimes end up being stuck on the migration screen which never goes away.

### Causes

On app app launch migration happens with the following steps:

`activateUserSession(for account: Account) ` is called . 

This will cause the following delegate methods to be called:
- `sessionManagerWillOpenAccount` - UI shows loading screen
- `sessionManagerWillStartMigratingLocalStore`  UI shows migration screen
-  `sessionManagerActivated(userSession:)` UI shows main app UI

However if you have already launched the app and you receive an APNS on a second account which requires migration the following will happen.

`withSession(for account: Account)` is called.

This will cause the following delegate method to be called:
`sessionManagerWillStartMigratingLocalStore` UI shows migration screen.

So since we never call `sessionManagerActivated(userSession:)` when starting a background session the app is stuck on the migration screen.

### Solutions

Only show the migration screen for when the account we are loading is migrating. in order for for the UI to do that we must add a `account` parameter to the migration delegate method.