### PR TITLE
Adjust expected error label for team invitations

### DIFF
--- a/Source/Synchronization/Strategies/TeamInvitationRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/TeamInvitationRequestStrategy.swift
@@ -37,7 +37,7 @@ extension InviteResult {
             self = InviteResult.failure(email: email, error: .noIdentity)
         case 403 where label == "no-email":
             self = InviteResult.failure(email: email, error: .noEmail)
-        case 409 where label == "already-registered":
+        case 409 where label == "email-exists":
             self = InviteResult.failure(email: email, error: .alreadyRegistered)
         default:
             self = InviteResult.failure(email: email, error: .unknown)

--- a/Tests/Source/Synchronization/Strategies/TeamInvitationRequestStrategyTests.swift
+++ b/Tests/Source/Synchronization/Strategies/TeamInvitationRequestStrategyTests.swift
@@ -113,7 +113,7 @@ class TeamInvitationRequestStrategyTests: MessagingTest {
                              (403, "invalid-email"),
                              (403, "no-identity"),
                              (403, "no-email"),
-                             (409, "already-registered"),
+                             (409, "email-exists"),
                              (404, "unknown-error")]
         
         let responses : [ZMTransportResponse] = responseCases.map { value in


### PR DESCRIPTION
## What's new in this PR?

* The error label in case an email is already registered on Wire was wrong.

