### PR TITLE
Fixed service images update propagation; warnings

### DIFF
--- a/Source/Data Model/ServiceUser.swift
+++ b/Source/Data Model/ServiceUser.swift
@@ -81,14 +81,17 @@ public final class ServiceDetails: NSObject {
 
 public extension ServiceUser {
     fileprivate func requestToAddService(to conversation: ZMConversation) -> ZMTransportRequest {
-        guard let remoteIdentifier = conversation.remoteIdentifier else {
+        guard let remoteIdentifier = conversation.remoteIdentifier,
+              let providerIdentifier = self.providerIdentifier,
+              let serviceIdentifier = self.serviceIdentifier
+        else {
             fatal("conversation is not synced with the backend")
         }
         
         let path = "/conversations/\(remoteIdentifier.transportString())/bots"
         
-        let payload: NSDictionary = ["provider": self.providerIdentifier,
-                                     "service": self.serviceIdentifier,
+        let payload: NSDictionary = ["provider": providerIdentifier,
+                                     "service": serviceIdentifier,
                                      "locale": NSLocale.formattedLocaleIdentifier()]
         
         return ZMTransportRequest(path: path, method: .methodPOST, payload: payload as ZMTransportData)

--- a/Source/UserSession/Search/SearchDirectory.swift
+++ b/Source/UserSession/Search/SearchDirectory.swift
@@ -69,6 +69,7 @@ public class SearchDirectory : NSObject {
     func observeSearchUsers(_ result : SearchResult) {
         let searchUserObserverCenter = userSession.managedObjectContext.searchUserObserverCenter
         result.directory.forEach(searchUserObserverCenter.addSearchUser)
+        result.services.flatMap { $0 as? ZMSearchUser }.forEach(searchUserObserverCenter.addSearchUser)
     }
     
     func requestSearchUserProfileImages(_ result : SearchResult) {

--- a/Source/UserSession/Search/SearchResult.swift
+++ b/Source/UserSession/Search/SearchResult.swift
@@ -59,7 +59,7 @@ extension SearchResult {
             return nil
         }
         
-        let searchUsersServices = ZMSearchUser.users(withPayloadArray: servicesPayload, userSession: userSession) as? [ServiceUser] ?? []
+        let searchUsersServices = ZMSearchUser.users(withPayloadArray: servicesPayload, userSession: userSession) ?? []
         
         contacts = []
         teamMembers = []


### PR DESCRIPTION
## What's new in this PR?

### Issues

The service user image updates where not propagated.

### Causes

The issue happened since the service users where not added to the list of observed search users.

Additionally, fixed the warnings introduced with services release.