### PR TITLE
Improve notifications tracking

### DIFF
--- a/Source/Analytics/NotificationsTracker.swift
+++ b/Source/Analytics/NotificationsTracker.swift
@@ -33,6 +33,7 @@ import WireDataModel
             return "notifications_" + rawValue
         }
     }
+    private let isolationQueue = DispatchQueue(label: "NotificationsProcessing")
 
     weak var analytics: AnalyticsType?
     @objc public init(analytics: AnalyticsType) {
@@ -56,17 +57,21 @@ import WireDataModel
     }
 
     private func increment(attribute: Attributes, by amount: Double = 1) {
-        var currentAttributes = analytics?.persistedAttributes(for: eventName) ?? [:]
-        var value = (currentAttributes[attribute.identifier] as? Double) ?? 0
-        value += amount
-        currentAttributes[attribute.identifier] = value as NSObject
-        analytics?.setPersistedAttributes(currentAttributes, for: eventName)
+        isolationQueue.sync {
+            var currentAttributes = analytics?.persistedAttributes(for: eventName) ?? [:]
+            var value = (currentAttributes[attribute.identifier] as? Double) ?? 0
+            value += amount
+            currentAttributes[attribute.identifier] = value as NSObject
+            analytics?.setPersistedAttributes(currentAttributes, for: eventName)
+        }
     }
 
     public func dispatchEvent() {
-        if let analytics = analytics, let attributes = analytics.persistedAttributes(for: eventName), !attributes.isEmpty {
-            analytics.tagEvent(eventName, attributes: attributes)
-            analytics.setPersistedAttributes(nil, for: eventName)
+        isolationQueue.sync {
+            if let analytics = analytics, let attributes = analytics.persistedAttributes(for: eventName), !attributes.isEmpty {
+                analytics.tagEvent(eventName, attributes: attributes)
+                analytics.setPersistedAttributes(nil, for: eventName)
+            }
         }
     }
 }

--- a/Source/Analytics/NotificationsTracker.swift
+++ b/Source/Analytics/NotificationsTracker.swift
@@ -28,6 +28,7 @@ import WireDataModel
         case startedFetchingStream
         case finishedFetchingStream
         case finishedProcessing
+        case processingExpired
 
         var identifier: String {
             return "notifications_" + rawValue
@@ -54,6 +55,10 @@ import WireDataModel
 
     @objc public func registerStartStreamFetching() {
         increment(attribute: .startedFetchingStream)
+    }
+
+    @objc public func registerProcessingExpired() {
+        increment(attribute: .processingExpired)
     }
 
     private func increment(attribute: Attributes, by amount: Double = 1) {

--- a/Source/SessionManager/PushDispatcher.swift
+++ b/Source/SessionManager/PushDispatcher.swift
@@ -162,6 +162,7 @@ public final class PushDispatcher: NSObject {
         pushRegistrant = PushKitRegistrant(didUpdateCredentials: didUpdateToken,
                                            didReceivePayload: callback,
                                            didInvalidateToken: didInvalidateToken)
+        pushRegistrant.notificationsTracker = self.notificationsTracker
         if let token = pushRegistrant.pushToken {
             self.lastKnownPushTokens[.voip] = token
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

After shipping tracking implemented in #664 and looking through data there were some curious discrepancies. 

### Causes

Calls to increment counter values were called from multiple threads but there were no code to handle this.

### Solutions

Added isolation queue so that we would serialize all the calls for incrementing counters. Also added one more counter that tracks how many times the app didn't have enough time to process the notification and the background task expired.
