### PR TITLE
Do not crash on inactive SE push

### DIFF
--- a/Source/UserSession/ZMUserSession+Push.swift
+++ b/Source/UserSession/ZMUserSession+Push.swift
@@ -117,8 +117,11 @@ extension ZMUserSession: PushDispatcherOptionalClient {
     public func receivedPushNotification(with payload: [AnyHashable: Any],
                                          from source: ZMPushNotficationType,
                                          completion: ZMPushNotificationCompletionHandler?) {
+        guard let syncMoc = self.syncManagedObjectContext else {
+            return
+        }
         
-        self.syncManagedObjectContext.performGroupedBlock {
+        syncMoc.performGroupedBlock {
             let notAuthenticated = !self.isAuthenticated()
             
             if notAuthenticated {

--- a/Source/UserSession/ZMUserSession+Push.swift
+++ b/Source/UserSession/ZMUserSession+Push.swift
@@ -108,9 +108,10 @@ extension ZMUserSession: PushDispatcherOptionalClient {
 
     public func mustHandle(payload: [AnyHashable: Any]) -> Bool {
         requireInternal(Thread.isMainThread, "Should be on main thread")
-        let moc = self.managedObjectContext
-        requireInternal(moc != nil, "MOC should be set")
-        return payload.isPayload(for: ZMUser.selfUser(in: moc!))
+        guard let moc = self.managedObjectContext else {
+            return false
+        }
+        return payload.isPayload(for: ZMUser.selfUser(in: moc))
     }
     
     public func receivedPushNotification(with payload: [AnyHashable: Any],


### PR DESCRIPTION
## What's new in this PR?

### Issues

The client seem to crash when receieving the push and try to forward it to one of the user sessions.

### Causes

The user session, that is managed by the session manager, can be deactivated and deallocated in case of memory pressure. The moment when the user session is torn down and deallocated is separated in time.

The push that app receives from APNS is proposed to all existing user sessions that where created by the session manager. The session manager keeps the weak references to all user sessions that are still in memory.

The client seem to crash when receieving the push and try to forward it to the user session that was torn down, but was not deallocated yet.

### Solutions

As a temporary solution to allow users to keep receiving the pushes the client will check if the user session was not torn down yet before trying to process the push.

Long-term solution would involve investigating why the user session stays retained after it was torn down.