### PR TITLE
Bots adding error handling

### DIFF
--- a/Source/Data Model/ServiceUser.swift
+++ b/Source/Data Model/ServiceUser.swift
@@ -166,9 +166,27 @@ public enum AddBotError: Int, Error {
     case botRejected
 }
 
+
 public enum AddBotResult {
     case success(conversation: ZMConversation)
     case failure(error: AddBotError)
+}
+
+extension AddBotError {
+    init?(response: ZMTransportResponse) {
+        switch response.httpStatus {
+        case 201:
+            return nil
+        case 403:
+            self = .tooManyParticipants
+        case 419:
+            self = .botRejected
+        case 502:
+            self = .botNotResponding
+        default:
+            self = .general
+        }
+    }
 }
 
 public extension ZMConversation {
@@ -182,7 +200,7 @@ public extension ZMConversation {
                   let userAddEventPayload = responseDictionary["event"] as? ZMTransportData,
                   let event = ZMUpdateEvent(fromEventStreamPayload: userAddEventPayload, uuid: nil) else {
                     zmLog.error("Wrong response for adding a bot: \(response)")
-                    completion?(AddBotError.general) // TODO: differentiate the possible errors
+                    completion?(AddBotError(response: response))
                     return
             }
             

--- a/Tests/Source/Data Model/ServiceUserTests.swift
+++ b/Tests/Source/Data Model/ServiceUserTests.swift
@@ -138,4 +138,49 @@ public final class ServiceUserTests : IntegrationTest {
         // then
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
     }
+    
+    func testThatItDetectsTheSuccessResponse() {
+        // GIVEN
+        let response = ZMTransportResponse(payload: nil, httpStatus: 201, transportSessionError: nil)
+        // WHEN
+        let error = AddBotError(response: response)
+        // THEN
+        XCTAssertEqual(error, nil)
+    }
+    
+    func testThatItDetectsTheConversationFullResponse() {
+        // GIVEN
+        let response = ZMTransportResponse(payload: nil, httpStatus: 403, transportSessionError: nil)
+        // WHEN
+        let error = AddBotError(response: response)
+        // THEN
+        XCTAssertEqual(error, .tooManyParticipants)
+    }
+    
+    func testThatItDetectsBotRejectedResponse() {
+        // GIVEN
+        let response = ZMTransportResponse(payload: nil, httpStatus: 419, transportSessionError: nil)
+        // WHEN
+        let error = AddBotError(response: response)
+        // THEN
+        XCTAssertEqual(error, .botRejected)
+    }
+    
+    func testThatItDetectsBotNotResponding() {
+        // GIVEN
+        let response = ZMTransportResponse(payload: nil, httpStatus: 502, transportSessionError: nil)
+        // WHEN
+        let error = AddBotError(response: response)
+        // THEN
+        XCTAssertEqual(error, .botNotResponding)
+    }
+    
+    func testThatItDetectsGeneralError() {
+        // GIVEN
+        let response = ZMTransportResponse(payload: nil, httpStatus: 500, transportSessionError: nil)
+        // WHEN
+        let error = AddBotError(response: response)
+        // THEN
+        XCTAssertEqual(error, .general)
+    }
 }


### PR DESCRIPTION
It is necessary to differentiate the different error causes from the call to add the bot to the conversation.