### PR TITLE
Use integration as default tag

### DIFF
--- a/Source/UserSession/Search/SearchTask.swift
+++ b/Source/UserSession/Search/SearchTask.swift
@@ -322,7 +322,7 @@ extension SearchTask {
         let url = NSURLComponents()
         url.path = "/services"
         
-        url.queryItems = [URLQueryItem(name: "tags", value: "tutorial"), URLQueryItem(name: "start", value: query.trimmingCharacters(in: .whitespacesAndNewlines))]
+        url.queryItems = [URLQueryItem(name: "tags", value: "integration"), URLQueryItem(name: "start", value: query.trimmingCharacters(in: .whitespacesAndNewlines))]
         let urlStr = url.string?.replacingOccurrences(of: "+", with: "%2B") ?? ""
         return ZMTransportRequest(getFromPath: urlStr)
     }

--- a/Tests/Source/UserSession/SearchTaskTests.swift
+++ b/Tests/Source/UserSession/SearchTaskTests.swift
@@ -688,7 +688,7 @@ class SearchTaskTests : MessagingTest {
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then
-        XCTAssertEqual(mockTransportSession.receivedRequests().first?.path, "/services?tags=tutorial&start=Steve%20O'Hara%20%26%20S%C3%B6hne")
+        XCTAssertEqual(mockTransportSession.receivedRequests().first?.path, "/services?tags=integration&start=Steve%20O'Hara%20%26%20S%C3%B6hne")
     }
     
     func testThatItCallsCompletionHandlerForServicesSearch() {


### PR DESCRIPTION
## What's new in this PR?

New tag is necessary, since the BE is searching the integrations first by the tag, and then by the provider. This creates the issue that the BE is fetching first 100 services for tag `tutorial` and then filtering them by the provider. Sometimes the services are in the second part of the list, so the result is returned empty from the backend.
