### PR TITLE
Report offline error when adding service while offline

### DIFF
--- a/Source/Data Model/ServiceUser.swift
+++ b/Source/Data Model/ServiceUser.swift
@@ -191,6 +191,11 @@ extension AddBotError {
 
 public extension ZMConversation {
     public func add(serviceUser: ServiceUser, in userSession: ZMUserSession, completion: ((AddBotError?)->())?) {
+        guard userSession.transportSession.reachability.mayBeReachable else {
+            completion?(AddBotError.offline)
+            return
+        }
+        
         let request = serviceUser.requestToAddService(to: self)
         
         request.add(ZMCompletionHandler(on: userSession.managedObjectContext, block: { (response) in


### PR DESCRIPTION
The error is reported correctly now only when the new conversation is created.