### PR TITLE
Fix/call on inactive account zios 9534

### DIFF
--- a/Source/SessionManager/SessionManager+Push.swift
+++ b/Source/SessionManager/SessionManager+Push.swift
@@ -107,8 +107,7 @@ extension SessionManager {
         
         var foundSession: Bool = false
         self.backgroundUserSessions.forEach { accountId, backgroundSession in
-            if session == backgroundSession,
-                let account = self.accountManager.account(with: accountId) {
+            if session == backgroundSession, let account = self.accountManager.account(with: accountId) {
                 self.select(account) { _ in
                     completion()
                 }


### PR DESCRIPTION
### Issues

If you answered a CallKit from non-active session we didn't switch to this session and show the call UI.

### Causes

We were only switching to the active calling session when the app was entering the foreground.

### Solutions

Start observing the call state in the session manager and switch to the session with the call as soon as you join the call.