### PR TITLE
ZIOS-9527: Added reachability check when logging with phone.

### DIFF
--- a/Source/UnauthenticatedSession/UnauthenticatedSession+Login.swift
+++ b/Source/UnauthenticatedSession/UnauthenticatedSession+Login.swift
@@ -56,8 +56,13 @@ extension UnauthenticatedSession {
         } catch {
             return false
         }
+            
+        if !self.reachability.mayBeReachable {
+            authenticationStatus.notifyAuthenticationDidFail(NSError(code: .networkError, userInfo:nil))
+        } else {
+            authenticationStatus.prepareForRequestingPhoneVerificationCode(forLogin: phoneNumber)
+        }
         
-        authenticationStatus.prepareForRequestingPhoneVerificationCode(forLogin: phoneNumber)
         RequestAvailableNotification.notifyNewRequestsAvailable(nil)
         return true
     }

--- a/Tests/Source/UserSession/UnauthenticatedSessionTests.swift
+++ b/Tests/Source/UserSession/UnauthenticatedSessionTests.swift
@@ -198,7 +198,7 @@ public final class UnauthenticatedSessionTests: ZMTBaseTest {
         XCTAssertEqual(observer.authenticationDidFailEvents[0].localizedDescription, NSError(code: .needsCredentials, userInfo:nil).localizedDescription)
     }
     
-    func testThatDuringLoginItThrowsErrorWhenOffline() {
+    func testThatDuringLoginWithEmailItThrowsErrorWhenOffline() {
         let observer = TestAuthenticationObserver(unauthenticatedSession: sut)
         // given
         reachability.mayBeReachable = false
@@ -211,6 +211,19 @@ public final class UnauthenticatedSessionTests: ZMTBaseTest {
         XCTAssertEqual(observer.authenticationDidFailEvents[0].localizedDescription, NSError(code: .networkError, userInfo:nil).localizedDescription)
     }
 
+    func testThatDuringLoginWithPhoneNumberItThrowsErrorWhenOffline() {
+        let observer = TestAuthenticationObserver(unauthenticatedSession: sut)
+        // given
+        reachability.mayBeReachable = false
+        // when
+        sut.login(with: ZMPhoneCredentials(phoneNumber: "+49111111111111", verificationCode: "1234"))
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        // then
+        XCTAssertEqual(observer.authenticationDidSucceedEvents, 0)
+        XCTAssertEqual(observer.authenticationDidFailEvents.count, 1)
+        XCTAssertEqual(observer.authenticationDidFailEvents[0].localizedDescription, NSError(code: .networkError, userInfo:nil).localizedDescription)
+    }
+    
     func testThatItParsesCookieDataAndDoesCallTheDelegateIfTheCookieIsValidAndThereIsAUserIdKeyUser() {
         // given
         let userId = UUID.create()


### PR DESCRIPTION
## What's new in this PR?

### Issues

There was no control over login requests made without an internet connection, so the app was going into a requests loop because of the lack of connection.

### Solutions

I've added the same reachability checks that are made with email login. I've also added a new test.