### PR TITLE
Improve notifications tracking

### DIFF
--- a/Source/SessionManager/PushDispatcher.swift
+++ b/Source/SessionManager/PushDispatcher.swift
@@ -177,13 +177,8 @@ public final class PushDispatcher: NSObject {
     // -application:didReceiveRemoteNotification:completionHandler:
     public func didReceiveRemoteNotification(_ payload: [AnyHashable: Any],
                                              fetchCompletionHandler: @escaping (UIBackgroundFetchResult)->()) {
-        self.notificationsTracker?.registerReceivedPush()
-        let handler: (UIBackgroundFetchResult)->() = {
-            self.notificationsTracker?.registerNotificationProcessingCompleted()
-            fetchCompletionHandler($0)
-        }
         self.remoteNotificationHandler.didReceiveRemoteNotification(payload,
-                                                                    fetchCompletionHandler: handler)
+                                                                    fetchCompletionHandler: fetchCompletionHandler)
     }
 }
 

--- a/Source/SessionManager/PushDispatcher.swift
+++ b/Source/SessionManager/PushDispatcher.swift
@@ -177,8 +177,13 @@ public final class PushDispatcher: NSObject {
     // -application:didReceiveRemoteNotification:completionHandler:
     public func didReceiveRemoteNotification(_ payload: [AnyHashable: Any],
                                              fetchCompletionHandler: @escaping (UIBackgroundFetchResult)->()) {
+        self.notificationsTracker?.registerReceivedPush()
+        let handler: (UIBackgroundFetchResult)->() = {
+            self.notificationsTracker?.registerNotificationProcessingCompleted()
+            fetchCompletionHandler($0)
+        }
         self.remoteNotificationHandler.didReceiveRemoteNotification(payload,
-                                                                    fetchCompletionHandler: fetchCompletionHandler)
+                                                                    fetchCompletionHandler: handler)
     }
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

After shipping tracking of push notifications processing (#664) we have noticed several discrepancies in numbers.

### Causes

It is not very obvious which code path for fetching notification stream only happens when processing push notifications. There is another code path (that might not be used anymore) which handles notifications coming from AppDelegate instead of through PushKit framework.

### Solutions

Registering start of fetching stream when we create a `ZMTransportRequest` and registering finish when the completion handler is called.
Also added tracking to the codepath that is going through the AppDelegate. I assume it is not used anymore (all VoIP notifications go through PushKit), but just for completeness sake it would be good to have it there as well.
