### PR TITLE
Include callkit logs into voice log

### DIFF
--- a/Source/Calling/FlowManager.swift
+++ b/Source/Calling/FlowManager.swift
@@ -33,7 +33,6 @@ public protocol FlowManagerType {
     
     func setVideoCaptureDevice(_ device : CaptureDevice, for conversationId: UUID)
     func reportNetworkChanged()
-    func appendLog(for conversationId : UUID, message : String)
 }
 
 @objc
@@ -64,10 +63,6 @@ public class FlowManager : NSObject, FlowManagerType {
         avsFlowManager?.setVideoCaptureDevice(device.deviceIdentifier, forConversation: conversationId.transportString())
     }
     
-    public func appendLog(for conversationId : UUID, message : String) {
-        avsFlowManager?.appendLog(forConversation: conversationId.transportString(), message: message)
-    }
-
 }
 
 extension FlowManager : AVSFlowManagerDelegate {

--- a/Source/Calling/ZMCallFlowRequestStrategy.h
+++ b/Source/Calling/ZMCallFlowRequestStrategy.h
@@ -36,7 +36,6 @@
                    applicationStatus:(id<ZMApplicationStatus>)applicationStatus
                          application:(id<ZMApplication>)application;
 
-- (void)appendLogForConversationID:(NSUUID *)conversationID message:(NSString *)message;
 - (void)tearDown;
 
 @end

--- a/Source/Calling/ZMCallFlowRequestStrategy.m
+++ b/Source/Calling/ZMCallFlowRequestStrategy.m
@@ -33,7 +33,6 @@ static NSString *ZMLogTag ZM_UNUSED = @"Calling";
 @property (nonatomic) NSNotificationQueue *voiceGainNotificationQueue;
 @property (nonatomic) BOOL pushChannelIsOpen;
 @property (nonatomic, readonly, weak) NSManagedObjectContext *uiManagedObjectContext;
-@property (nonatomic, strong) dispatch_queue_t avsLogQueue;
 @property (nonatomic, readonly, weak) id<ZMApplication> application;
 @property (nonatomic) id pushChannelObserverToken;
 
@@ -70,7 +69,6 @@ static NSString *ZMLogTag ZM_UNUSED = @"Calling";
                                                  [self pushChannelDidChange:note];
                                              }];
         self.pushChannelIsOpen = NO;
-        self.avsLogQueue = dispatch_queue_create("AVSLog", DISPATCH_QUEUE_SERIAL);
     }
     return self;
 }
@@ -93,13 +91,6 @@ static NSString *ZMLogTag ZM_UNUSED = @"Calling";
 - (ZMTransportRequest *)nextRequestIfAllowed
 {
     return nil;
-}
-
-- (void)appendLogForConversationID:(NSUUID *)conversationID message:(NSString *)message;
-{
-    dispatch_async(self.avsLogQueue, ^{
-        [self.flowManager appendLogFor:conversationID message:message];
-    });
 }
 
 - (void)pushChannelDidChange:(NotificationInContext *)note

--- a/Source/Public/ZMUserSession.h
+++ b/Source/Public/ZMUserSession.h
@@ -51,14 +51,6 @@
 @class ManagedObjectContextDirectory;
 @class TopConversationsDirectory;
 
-@protocol ZMAVSLogObserver <NSObject>
-@required
-- (void)logMessage:(NSString *)msg;
-@end
-
-@protocol ZMAVSLogObserverToken <NSObject>
-@end
-
 extern NSString * const ZMLaunchedWithPhoneVerificationCodeNotificationName;
 extern NSString * const ZMPhoneVerificationCodeKey;
 extern NSString * const ZMUserSessionResetPushTokensNotificationName;
@@ -138,18 +130,6 @@ extern NSString * const ZMUserSessionResetPushTokensNotificationName;
 
 @end
 
-
-
-@interface ZMUserSession (AVSLogging)
-
-/// Add observer for AVS logging
-+ (id<ZMAVSLogObserverToken>)addAVSLogObserver:(id<ZMAVSLogObserver>)observer;
-/// Remove observer for AVS logging
-+ (void)removeAVSLogObserver:(id<ZMAVSLogObserverToken>)token;
-
-+ (void)appendAVSLogMessageForConversation:(ZMConversation *)conversation withMessage:(NSString *)message;
-
-@end
 
 @interface ZMUserSession (Calling)
 

--- a/Source/SessionManager/SessionManager+AVS.swift
+++ b/Source/SessionManager/SessionManager+AVS.swift
@@ -1,0 +1,46 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+fileprivate let AVSLogMessageNotification = Notification.Name("AVSLogMessageNotification")
+
+@objc
+public protocol AVSLogger: class {
+    
+    @objc(logMessage:)
+    func log(message : String)
+    
+}
+
+public extension SessionManager {
+    
+    @objc
+    static func addLogger(_ logger : AVSLogger) -> Any? {
+        return SelfUnregisteringNotificationCenterToken(NotificationCenter.default.addObserver(forName: AVSLogMessageNotification, object: nil, queue: nil) { [weak logger] (note) in
+            guard let message = note.userInfo?["message"] as? String else { return }
+            logger?.log(message: message)
+        })
+    }
+    
+    @objc
+    static func logAVS(message: String) {
+        NotificationCenter.default.post(name: AVSLogMessageNotification, object: nil, userInfo: ["message" : message])
+    }
+    
+}

--- a/Source/SessionManager/SessionManager+AVS.swift
+++ b/Source/SessionManager/SessionManager+AVS.swift
@@ -31,7 +31,7 @@ public protocol AVSLogger: class {
 public extension SessionManager {
     
     @objc
-    static func addLogger(_ logger : AVSLogger) -> Any? {
+    static func addLogger(_ logger : AVSLogger) -> Any {
         return SelfUnregisteringNotificationCenterToken(NotificationCenter.default.addObserver(forName: AVSLogMessageNotification, object: nil, queue: nil) { [weak logger] (note) in
             guard let message = note.userInfo?["message"] as? String else { return }
             logger?.log(message: message)

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -634,7 +634,7 @@ public protocol LocalNotificationResponder : class {
             // Should be set to true when CallKit is used. Then AVS will not start
             // the audio before the audio session is active
             authenticatedSessionFactory.mediaManager.setUiStartsAudio(true)
-            callKitDelegate = CallKitDelegate(sessionManager: self, flowManager: authenticatedSessionFactory.flowManager, mediaManager: authenticatedSessionFactory.mediaManager)
+            callKitDelegate = CallKitDelegate(sessionManager: self, mediaManager: authenticatedSessionFactory.mediaManager)
         }
     }
     

--- a/Source/UserSession/ZMUserSession+Internal.h
+++ b/Source/UserSession/ZMUserSession+Internal.h
@@ -43,9 +43,9 @@
 
 @protocol FlowManagerType;
 
-extern NSString * const ZMAppendAVSLogNotificationName;
 
 @interface ZMUserSession (AuthenticationStatus)
+
 @property (nonatomic, readonly) UserProfileUpdateStatus *userProfileUpdateStatus;
 @property (nonatomic, readonly) ZMClientRegistrationStatus *clientRegistrationStatus;
 @property (nonatomic, readonly) ClientUpdateStatus *clientUpdateStatus;

--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -44,7 +44,6 @@
 NSString * const ZMPhoneVerificationCodeKey = @"code";
 NSNotificationName const ZMLaunchedWithPhoneVerificationCodeNotificationName = @"ZMLaunchedWithPhoneVerificationCode";
 NSNotificationName const ZMRequestToOpenSyncConversationNotificationName = @"ZMRequestToOpenSyncConversation";
-NSString * const ZMAppendAVSLogNotificationName = @"AVSLogMessageNotification";
 NSNotificationName const ZMUserSessionResetPushTokensNotificationName = @"ZMUserSessionResetPushTokensNotification";
 
 static NSString * const AppstoreURL = @"https://itunes.apple.com/us/app/zeta-client/id930944768?ls=1&mt=8";
@@ -733,39 +732,6 @@ static NSString * const IsOfflineKey = @"IsOfflineKey";
 @end
 
 
-
-@implementation ZMUserSession (AVSLogging)
-
-+ (id<ZMAVSLogObserverToken>)addAVSLogObserver:(id<ZMAVSLogObserver>)observer;
-{
-    ZM_WEAK(observer);
-    return (id<ZMAVSLogObserverToken>)[[NSNotificationCenter defaultCenter] addObserverForName:ZMAppendAVSLogNotificationName
-                                                                                        object:nil
-                                                                                         queue:nil
-                                                                                    usingBlock:^(NSNotification * _Nonnull note) {
-                                                                                        ZM_STRONG(observer);
-                                                                                        [observer logMessage:note.userInfo[@"message"]];
-                                                                                    }];
-}
-
-+ (void)removeAVSLogObserver:(id<ZMAVSLogObserverToken>)token;
-{
-    [[NSNotificationCenter defaultCenter] removeObserver:token];
-}
-
-+ (void)appendAVSLogMessageForConversation:(ZMConversation *)conversation withMessage:(NSString *)message;
-{
-    NSDictionary *userInfo = @{@"message" :message};
-    if (conversation.managedObjectContext == nil) {
-        return;
-    }
-    [[[NotificationInContext alloc] initWithName:ZMAppendAVSLogNotificationName
-                                        context:conversation.managedObjectContext.notificationContext
-                                         object:conversation
-                                       userInfo:userInfo] post];
-}
-
-@end
 
 @implementation ZMUserSession (Calling)
 

--- a/Tests/Source/Calling/CallKitDelegateTests.swift
+++ b/Tests/Source/Calling/CallKitDelegateTests.swift
@@ -243,7 +243,6 @@ class CallKitDelegateTest: MessagingTest {
         self.sut = WireSyncEngine.CallKitDelegate(provider: callKitProvider,
                                                   callController: callKitController,
                                                   sessionManager: mockSessionManager,
-                                                  flowManager: flowManager,
                                                   mediaManager: nil)
         
         CallKitDelegateTestsMocking.mockUserSession(self.mockUserSession)
@@ -297,7 +296,6 @@ class CallKitDelegateTest: MessagingTest {
         sut = WireSyncEngine.CallKitDelegate(provider: callKitProvider,
                                              callController: callKitController,
                                              sessionManager: mockSessionManager,
-                                             flowManager: FlowManagerMock(),
                                              mediaManager: nil)
         
         // when

--- a/Tests/Source/SessionManager/SessionManagerAVSTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerAVSTests.swift
@@ -37,7 +37,7 @@ class SessionManagerAVSTests: ZMTBaseTest {
         // given
         let logMessage = "123"
         let logger = TestAVSLogger()
-        var token = SessionManager.addLogger(logger)
+        var token : Any? = SessionManager.addLogger(logger)
         XCTAssertNotNil(token)
         
         // when

--- a/Tests/Source/SessionManager/SessionManagerAVSTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerAVSTests.swift
@@ -1,0 +1,70 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+import WireTesting
+
+@testable import WireSyncEngine
+
+class TestAVSLogger : AVSLogger {
+    
+    var messages : [String] = []
+    
+    func log(message: String) {
+        messages.append(message)
+    }
+    
+}
+
+class SessionManagerAVSTests: ZMTBaseTest {
+        
+    func testLoggersReceiveLogMessages() {
+        // given
+        let logMessage = "123"
+        let logger = TestAVSLogger()
+        var token = SessionManager.addLogger(logger)
+        XCTAssertNotNil(token)
+        
+        // when
+        SessionManager.logAVS(message: logMessage)
+        
+        // then
+        XCTAssertEqual(logger.messages, [logMessage])
+        
+        // cleanup
+        token = nil
+    }
+    
+    func testThatLogAVSMessagePostsNotification() {
+        // given
+        let logMessage = "123"
+        
+        // expect
+        expectation(forNotification: "AVSLogMessageNotification", object: nil) { (note) -> Bool in
+            let message = note.userInfo?["message"] as? String
+            return message == logMessage
+        }
+        
+        // when
+        SessionManager.logAVS(message: logMessage)
+        
+        // then
+        XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
+    }
+    
+}

--- a/Tests/Source/UserSession/ZMUserSessionTests.m
+++ b/Tests/Source/UserSession/ZMUserSessionTests.m
@@ -1292,8 +1292,6 @@
 @end
 
 
-
-
 @implementation ZMUserSessionTests (RequestToOpenConversation)
 
 - (void)testThatItCallsTheDelegateWhenRequestedToOpenAConversation
@@ -1330,52 +1328,6 @@
 @interface ZMCallFlowRequestStrategy (FlowManagerDelegate) <AVSFlowManagerDelegate>
 @end
 
-@implementation ZMUserSessionTests (AVSLogObserver)
-
-- (void)testThatSubscriberIsNotRetained
-{
-    // given
-    id token = nil;
-    id __weak weakLogObserver = nil;
-    @autoreleasepool {
-        id logObserver = [OCMockObject mockForProtocol:@protocol(ZMAVSLogObserver)];
-        
-        token = [ZMUserSession addAVSLogObserver:logObserver];
-        
-        // when
-        weakLogObserver = logObserver;
-        XCTAssertNotNil(weakLogObserver);
-        logObserver = nil;
-    }
-    // then
-    XCTAssertNil(weakLogObserver);
-    [ZMUserSession removeAVSLogObserver:token];
-}
-
-- (void)testThatLogCallbackIsNotTriggeredAfterUnsubscribe
-{
-    // given
-    __block ZMConversation *conversation;
-    [self.syncMOC performGroupedBlockAndWait:^{
-        conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
-        [self.syncMOC saveOrRollback];
-    }];
-    
-    NSString *testMessage = @"Sample AVS Log";
-    id logObserver = [OCMockObject mockForProtocol:@protocol(ZMAVSLogObserver)];
-    [[logObserver reject] logMessage:nil];
-    
-    id token = [ZMUserSession addAVSLogObserver:logObserver];
-    [ZMUserSession removeAVSLogObserver:token];
-    
-    // when
-    [ZMUserSession appendAVSLogMessageForConversation:conversation withMessage:testMessage];
-    
-    // then
-    [logObserver verify];
-}
-
-@end
 
 @implementation ZMUserSessionTests (Transport)
 

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		160C314A1E82AC170012E4BC /* OperationStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160C31491E82AC170012E4BC /* OperationStatusTests.swift */; };
 		1618B4101DE5FAD4003F015C /* ZMUserSession+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 3EC2357F192B617700B72C21 /* ZMUserSession+Internal.h */; };
 		1621D2711D770FB1007108C2 /* ZMSyncStateDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1621D2701D770FB1007108C2 /* ZMSyncStateDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		162A81D4202B453000F6200C /* SessionManager+AVS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 162A81D3202B453000F6200C /* SessionManager+AVS.swift */; };
+		162A81D6202B5BC600F6200C /* SessionManagerAVSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 162A81D5202B5BC600F6200C /* SessionManagerAVSTests.swift */; };
 		162DEE111F87B9800034C8F9 /* ZMUserSession+Calling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 162DEE101F87B9800034C8F9 /* ZMUserSession+Calling.swift */; };
 		1632C4B21F0E91FE007BE89D /* EmailRegistrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5454A69B1AEFA01D0022AFA4 /* EmailRegistrationTests.m */; };
 		1632C4B31F0FD270007BE89D /* LoginFlowTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 54FC8A0F192CD55000D3C016 /* LoginFlowTests.m */; };
@@ -568,6 +570,8 @@
 		160C31491E82AC170012E4BC /* OperationStatusTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperationStatusTests.swift; sourceTree = "<group>"; };
 		1621D26E1D77098B007108C2 /* WireRequestStrategy.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WireRequestStrategy.framework; path = Carthage/Build/iOS/WireRequestStrategy.framework; sourceTree = "<group>"; };
 		1621D2701D770FB1007108C2 /* ZMSyncStateDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZMSyncStateDelegate.h; sourceTree = "<group>"; };
+		162A81D3202B453000F6200C /* SessionManager+AVS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionManager+AVS.swift"; sourceTree = "<group>"; };
+		162A81D5202B5BC600F6200C /* SessionManagerAVSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManagerAVSTests.swift; sourceTree = "<group>"; };
 		162DEE101F87B9800034C8F9 /* ZMUserSession+Calling.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMUserSession+Calling.swift"; sourceTree = "<group>"; };
 		163495841F010AF0004E80DB /* UnauthenticatedSession+Registration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UnauthenticatedSession+Registration.swift"; sourceTree = "<group>"; };
 		1634958A1F0254CB004E80DB /* SessionManager+ServerConnection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SessionManager+ServerConnection.swift"; sourceTree = "<group>"; };
@@ -2001,6 +2005,7 @@
 			isa = PBXGroup;
 			children = (
 				F159F4131F1E3134001B7D80 /* SessionManagerTests.swift */,
+				162A81D5202B5BC600F6200C /* SessionManagerAVSTests.swift */,
 				87DF28C61F680495007E1702 /* PushDispatcherTests.swift */,
 			);
 			path = SessionManager;
@@ -2034,6 +2039,7 @@
 				1634958A1F0254CB004E80DB /* SessionManager+ServerConnection.swift */,
 				8717DFA61F6EF44E0087EFE4 /* SessionManager+Push.swift */,
 				165BB94B2004D6490077EFD5 /* SessionManager+UserActivity.swift */,
+				162A81D3202B453000F6200C /* SessionManager+AVS.swift */,
 				8751DA011F66A826000D308B /* PushDispatcher.swift */,
 			);
 			path = SessionManager;
@@ -2474,6 +2480,7 @@
 				545F601C1D6C336D00C2C55B /* AddressBookSearchTests.swift in Sources */,
 				87DF28C71F680495007E1702 /* PushDispatcherTests.swift in Sources */,
 				5476E3BD19A77C6900E68BAD /* PushChannelTests.m in Sources */,
+				162A81D6202B5BC600F6200C /* SessionManagerAVSTests.swift in Sources */,
 				5474C80C1921309400185A3A /* MessagingTestTests.m in Sources */,
 				F99298591BE110490058D42F /* ZMClientRegistrationStatusTests.m in Sources */,
 				F1ACD2CD201F6E070089BEF6 /* ConversationsTests.m in Sources */,
@@ -2740,6 +2747,7 @@
 				54BFDF681BDA6F9A0034A3DB /* HistorySynchronizationStatus.swift in Sources */,
 				5498161D1A432BC800A7CE2E /* ZMTypingUsers.m in Sources */,
 				BF4BA0321E89085E00AE99DC /* SearchDirectoryUserIDTable.swift in Sources */,
+				162A81D4202B453000F6200C /* SessionManager+AVS.swift in Sources */,
 				F9ABE8501EFD568B00D83214 /* TeamDownloadRequestStrategy+Events.swift in Sources */,
 				168CF42B20079A02009FCB89 /* TeamInvitationRequestStrategy.swift in Sources */,
 				F98EDCF31D82B924001E65CB /* ZMLocalNotificationSet.swift in Sources */,


### PR DESCRIPTION
### Issues

The logs for CallKit weren't ending up in the voice log.

### Causes

 The CallKitDelegate was using a method for logging on the flow manager which had been de-activated.

## Notes

- Deleted the deactivated method from the FlowManager type.
- Cleaned up a few places were the flow manager was used for logging.
- Moved the AVS logging methods from the ZMUserSession to the SessionManager. 

