### PR TITLE
Fix wrong localization key for missed calls

### DIFF
--- a/Source/Notifications/Push notifications/Notification Types/LocalNotificationType+Localization.swift
+++ b/Source/Notifications/Push notifications/Notification Types/LocalNotificationType+Localization.swift
@@ -132,8 +132,6 @@ extension LocalNotificationType {
         
         if case .failedMessage = self {
             return nil
-        } else if sender.isSelfUser {
-            return SelfKey
         } else if sender.name == nil || sender.name.isEmpty {
             return NoUserNameKey
         }

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationForTests_CallState.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationForTests_CallState.swift
@@ -142,6 +142,23 @@ class ZMLocalNotificationTests_CallState : MessagingTest {
         XCTAssertEqual(note.soundName, ZMCustomSound.notificationNewMessageSoundName())
     }
     
+    func testMissedCallFromSelfUser() {
+        
+        // given
+        let state: CallState = .terminating(reason: .timeout)
+        let caller = ZMUser.selfUser(in: uiMOC)
+        caller.name = "SelfUser"
+        
+        // when
+        guard let note = ZMLocalNotification(callState: state, conversation: conversation, caller: caller) else { return XCTFail("Did not create notification") }
+        
+        // then
+        XCTAssertEqual(note.title, "Callie")
+        XCTAssertEqual(note.body, "called")
+        XCTAssertEqual(note.category, ZMMissedCallCategory)
+        XCTAssertEqual(note.soundName, ZMCustomSound.notificationNewMessageSoundName())
+    }
+    
     func testThatItAddsATitleIfTheUserIsPartOfATeam() {
         self.syncMOC.performGroupedBlockAndWait {
             


### PR DESCRIPTION
### Issues

When receiving a push about missed called from your second device it would contain a localization key.

### Causes

Missed calls from your self was calculated to have the key `push.notification.call.missed.group.self` which doesn't exist. The `self` suffix for a localization key actually only exists for adding and removing participants.

### Solutions 

Remove logic which adds `self` when the sender is the self user. This case is already handled by special case for adding and removing participants.
