### PR TITLE
Refetch group conversations in teams to get new permission data

### DIFF
--- a/Source/Synchronization/ZMHotFixDirectory.m
+++ b/Source/Synchronization/ZMHotFixDirectory.m
@@ -115,6 +115,14 @@ static NSString* ZMLogTag ZM_UNUSED = @"HotFix";
                      patchCode:^(__unused NSManagedObjectContext *context) {
                          [ZMHotFixDirectory restartSlowSync:context];
                      }],
+
+                    /// We need to refetch all team conversations to get data about access levels that were
+                    /// introduced after implementing wireless users funtionality.
+                    [ZMHotFixPatch
+                     patchWithVersion:@"146.0.0"
+                     patchCode:^(__unused NSManagedObjectContext *context) {
+                         [ZMHotFixDirectory refetchTeamGroupConversations:context];
+                     }],
                     ];
     });
     return patches;

--- a/Tests/Source/Synchronization/ZMHotFixDirectoryTests.swift
+++ b/Tests/Source/Synchronization/ZMHotFixDirectoryTests.swift
@@ -1,0 +1,75 @@
+////
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+import WireTesting
+@testable import WireSyncEngine
+
+class ZMHotFixDirectoryTests: MessagingTest {
+
+    func testThatOnlyTeamConversationsAreUpdated() {
+        // given
+        let g1 = ZMConversation.insertNewObject(in: self.syncMOC)
+        g1.conversationType = .group
+        XCTAssertFalse(g1.needsToBeUpdatedFromBackend)
+
+        let g2 = ZMConversation.insertNewObject(in: self.syncMOC)
+        g2.conversationType = .group
+        g2.team = Team.insertNewObject(in: self.syncMOC)
+        XCTAssertFalse(g2.needsToBeUpdatedFromBackend)
+
+        // when
+        ZMHotFixDirectory.refetchTeamGroupConversations(self.syncMOC)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // then
+        XCTAssertFalse(g1.needsToBeUpdatedFromBackend)
+        XCTAssertTrue(g2.needsToBeUpdatedFromBackend)
+    }
+
+    func testThatOnlyGroupTeamConversationsAreUpdated() {
+        // given
+        let team = Team.insertNewObject(in: self.syncMOC)
+
+        let c1 = ZMConversation.insertNewObject(in: self.syncMOC)
+        c1.conversationType = .oneOnOne
+        c1.team = team
+        XCTAssertFalse(c1.needsToBeUpdatedFromBackend)
+
+        let c2 = ZMConversation.insertNewObject(in: self.syncMOC)
+        c2.conversationType = .connection
+        c2.team = team
+        XCTAssertFalse(c2.needsToBeUpdatedFromBackend)
+
+
+        let c3 = ZMConversation.insertNewObject(in: self.syncMOC)
+        c3.conversationType = .group
+        c3.team = team
+        XCTAssertFalse(c3.needsToBeUpdatedFromBackend)
+
+        // when
+        ZMHotFixDirectory.refetchTeamGroupConversations(self.syncMOC)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // then
+        XCTAssertFalse(c1.needsToBeUpdatedFromBackend)
+        XCTAssertFalse(c2.needsToBeUpdatedFromBackend)
+        XCTAssertTrue(c3.needsToBeUpdatedFromBackend)
+    }
+}

--- a/Tests/Source/Synchronization/ZMHotFixTests.swift
+++ b/Tests/Source/Synchronization/ZMHotFixTests.swift
@@ -1,0 +1,48 @@
+////
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+class ZMHotFixTests_Integration: MessagingTest {
+
+    func testThatOnlyTeamConversationsAreUpdated() {
+        // given
+        let g1 = ZMConversation.insertNewObject(in: self.syncMOC)
+        g1.conversationType = .group
+        XCTAssertFalse(g1.needsToBeUpdatedFromBackend)
+
+        let g2 = ZMConversation.insertNewObject(in: self.syncMOC)
+        g2.conversationType = .group
+        g2.team = Team.insertNewObject(in: self.syncMOC)
+        XCTAssertFalse(g2.needsToBeUpdatedFromBackend)
+
+        self.syncMOC.setPersistentStoreMetadata("146.0", key: "lastSavedVersion")
+        let sut = ZMHotFix(syncMOC: self.syncMOC)
+
+        // when
+        self.performIgnoringZMLogError {
+            sut?.applyPatches(forCurrentVersion: "147.0")
+            XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        }
+
+        // then
+        XCTAssertFalse(g1.needsToBeUpdatedFromBackend)
+        XCTAssertTrue(g2.needsToBeUpdatedFromBackend)
+    }
+
+}

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -357,6 +357,9 @@
 		EFC8281C1FB343B600E27E21 /* EmailVerificationStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFC8281B1FB343B600E27E21 /* EmailVerificationStrategy.swift */; };
 		EFC8281E1FB34F9600E27E21 /* EmailVerificationStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFC8281D1FB34F9600E27E21 /* EmailVerificationStrategyTests.swift */; };
 		EFC828221FB356CE00E27E21 /* RegistrationStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFC828211FB356CE00E27E21 /* RegistrationStatusTests.swift */; };
+		F11E35D62040172200D4D5DB /* ZMHotFixTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11E35D52040172200D4D5DB /* ZMHotFixTests.swift */; };
+		F132C105203F02C700C58933 /* ZMConversationTranscoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 54294A1F19472D4E007BE3CE /* ZMConversationTranscoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F132C114203F20AB00C58933 /* ZMHotFixDirectoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F132C113203F20AB00C58933 /* ZMHotFixDirectoryTests.swift */; };
 		F148F6671FB9AA7600BD6909 /* TeamToRegister.swift in Sources */ = {isa = PBXBuildFile; fileRef = F148F6661FB9AA7600BD6909 /* TeamToRegister.swift */; };
 		F148F6691FBAF55800BD6909 /* TeamRegistrationStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F148F6681FBAF55800BD6909 /* TeamRegistrationStrategyTests.swift */; };
 		F148F66B1FBAFAF600BD6909 /* RegistrationStatusTestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F148F66A1FBAFAF600BD6909 /* RegistrationStatusTestHelper.swift */; };
@@ -950,6 +953,8 @@
 		EFC8281B1FB343B600E27E21 /* EmailVerificationStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailVerificationStrategy.swift; sourceTree = "<group>"; };
 		EFC8281D1FB34F9600E27E21 /* EmailVerificationStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailVerificationStrategyTests.swift; sourceTree = "<group>"; };
 		EFC828211FB356CE00E27E21 /* RegistrationStatusTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegistrationStatusTests.swift; sourceTree = "<group>"; };
+		F11E35D52040172200D4D5DB /* ZMHotFixTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMHotFixTests.swift; sourceTree = "<group>"; };
+		F132C113203F20AB00C58933 /* ZMHotFixDirectoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMHotFixDirectoryTests.swift; sourceTree = "<group>"; };
 		F14417221FD946F100CB2850 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Push.strings"; sourceTree = "<group>"; };
 		F14417231FD946F200CB2850 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "zh-Hant"; path = "zh-Hant.lproj/Push.stringsdict"; sourceTree = "<group>"; };
 		F14417241FD946F200CB2850 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/ZMLocalizable.strings"; sourceTree = "<group>"; };
@@ -1828,6 +1833,8 @@
 				85D858D72B109C5D9A85645B /* ZMOperationLoopTests.m */,
 				54F7217C19A62225009A8AF5 /* ZMUpdateEventsBufferTests.m */,
 				F95ECF501B94BD05009F91BA /* ZMHotFixTests.m */,
+				F11E35D52040172200D4D5DB /* ZMHotFixTests.swift */,
+				F132C113203F20AB00C58933 /* ZMHotFixDirectoryTests.swift */,
 				54A227D51D6604A5009414C0 /* SynchronizationMocks.swift */,
 			);
 			path = Synchronization;
@@ -2140,6 +2147,7 @@
 				54D175241ADE9449001AA338 /* ZMUserSession+Authentication.h in Headers */,
 				F98DD6D31ABB2F7C001D58CF /* ZMUserSession+UserNotificationCategories.h in Headers */,
 				09D7CE641AE94D4200CC5F45 /* ZMCredentials+Internal.h in Headers */,
+				F132C105203F02C700C58933 /* ZMConversationTranscoder.h in Headers */,
 				F98EDCEC1D82B924001E65CB /* UILocalNotification+StringProcessing.h in Headers */,
 				0932EA461AE5514100D1BFD1 /* ZMPhoneNumberVerificationTranscoder.h in Headers */,
 				F19F1D311EFBCBD300275E27 /* ZMLoginTranscoder.h in Headers */,
@@ -2560,6 +2568,7 @@
 				544913B41B0247700044DE36 /* ZMCredentialsTests.m in Sources */,
 				F9B171F81C0F00E700E6EEC6 /* ClientUpdateStatusTests.swift in Sources */,
 				3ED972FB1A0A65D800BAFC61 /* ZMBlacklistVerificatorTest.m in Sources */,
+				F132C114203F20AB00C58933 /* ZMHotFixDirectoryTests.swift in Sources */,
 				5463C897193F3C74006799DE /* ZMTimingTests.m in Sources */,
 				1660AA0F1ECE0C870056D403 /* SearchResultTests.swift in Sources */,
 				54A3ACC31A261603008AF8DF /* BackgroundTests.m in Sources */,
@@ -2585,6 +2594,7 @@
 				16AD86B81F7292EB00E4C797 /* TypingChange.swift in Sources */,
 				16D3FCDF1E365ABC0052A535 /* CallStateObserverTests.swift in Sources */,
 				85D85EEDD5DD19FB747ED4A5 /* MockModelObjectContextFactory.m in Sources */,
+				F11E35D62040172200D4D5DB /* ZMHotFixTests.swift in Sources */,
 				545434A219AB6975003892D9 /* ZMRegistrationTranscoderTests.m in Sources */,
 				545FC3341A5B003A005EEA26 /* ObjectTranscoderTests.m in Sources */,
 				1632C4B31F0FD270007BE89D /* LoginFlowTests.m in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

After introduction of permissions for guests in conversations we need to download current permissions for all existing conversations

### Solutions

Added a hotfix to mark all team group conversations as needed to be updated from backend.

