### PR TITLE
Don't move conversation to top when access mode changes

### DIFF
--- a/Source/Synchronization/Transcoders/ZMConversationTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMConversationTranscoder.m
@@ -389,6 +389,7 @@ static NSString *const ConversationTeamManagedKey = @"managed";
         case ZMUpdateEventTypeConversationMemberUpdate:
         case ZMUpdateEventTypeConversationMemberLeave:
         case ZMUpdateEventTypeConversationRename:
+        case ZMUpdateEventTypeConversationAccessModeUpdate:
             return NO;
 
         default:


### PR DESCRIPTION
### Issues

A change to the access mode of conversation would move it to the top of the conversation list.

### Causes

All updates event update `lastModifiedDate` on conversation unless explicitly stated not to.

### Solutions

Add `ZMUpdateEventType.accessModeUpdate` to the list of ignored events.