### PR TITLE
Fix authentication issues

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -694,12 +694,16 @@ extension SessionManager: ZMUserObserver {
 
 extension SessionManager: UnauthenticatedSessionDelegate {
 
-    public func session(session: UnauthenticatedSession, updatedCredentials credentials: ZMCredentials) -> Bool {
+    @objc public func update(credentials: ZMCredentials) -> Bool {
         guard let userSession = activeUserSession, let emailCredentials = credentials as? ZMEmailCredentials else { return false }
-        
+
         userSession.setEmailCredentials(emailCredentials)
         RequestAvailableNotification.notifyNewRequestsAvailable(nil)
         return true
+    }
+
+    public func session(session: UnauthenticatedSession, updatedCredentials credentials: ZMCredentials) -> Bool {
+        return update(credentials: credentials)
     }
     
     public func session(session: UnauthenticatedSession, updatedProfileImage imageData: Data) {

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -692,8 +692,9 @@ extension SessionManager: ZMUserObserver {
 
 // MARK: - UnauthenticatedSessionDelegate
 
-extension SessionManager: UnauthenticatedSessionDelegate {
+extension SessionManager {
 
+    /// Needs to be called before we try to register another device because API requires password
     @objc public func update(credentials: ZMCredentials) -> Bool {
         guard let userSession = activeUserSession, let emailCredentials = credentials as? ZMEmailCredentials else { return false }
 
@@ -701,6 +702,9 @@ extension SessionManager: UnauthenticatedSessionDelegate {
         RequestAvailableNotification.notifyNewRequestsAvailable(nil)
         return true
     }
+}
+
+extension SessionManager: UnauthenticatedSessionDelegate {
 
     public func session(session: UnauthenticatedSession, updatedCredentials credentials: ZMCredentials) -> Bool {
         return update(credentials: credentials)

--- a/Source/UnauthenticatedSession/ZMAuthenticationStatus.m
+++ b/Source/UnauthenticatedSession/ZMAuthenticationStatus.m
@@ -251,7 +251,6 @@ static NSString* ZMLogTag ZM_UNUSED = @"Authentication";
         self.loginPhoneNumberThatNeedsAValidationCode = self.registrationPhoneNumberThatNeedsAValidationCode;
         self.registrationPhoneNumberThatNeedsAValidationCode = nil;
         ZMLogDebug(@"current phase: %lu", (unsigned long)self.currentPhase);
-        return;
     }
     
     [self resetLoginAndRegistrationStatus];

--- a/Source/UnauthenticatedSession/ZMAuthenticationStatus.m
+++ b/Source/UnauthenticatedSession/ZMAuthenticationStatus.m
@@ -75,7 +75,6 @@ static NSString* ZMLogTag ZM_UNUSED = @"Authentication";
     self.isWaitingForEmailVerification = NO;
     
     self.duplicateRegistrationEmail = NO;
-    self.duplicateRegistrationPhoneNumber = NO;
 }
 
 - (void)setRegistrationUser:(ZMCompleteRegistrationUser *)registrationUser
@@ -188,11 +187,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"Authentication";
 {
     ZMLogDebug(@"%@", NSStringFromSelector(_cmd));
     self.authenticationCookieData = nil;
-    BOOL wasDuplicated = self.duplicateRegistrationPhoneNumber;
     [self resetLoginAndRegistrationStatus];
-    if(wasDuplicated && credentials.credentialWithPhone) {
-        self.duplicateRegistrationPhoneNumber = YES;
-    }
     self.loginCredentials = credentials;
     self.isWaitingForLogin = YES;
     [self startLoginTimer];
@@ -229,30 +224,14 @@ static NSString* ZMLogTag ZM_UNUSED = @"Authentication";
 - (void)prepareForRegistrationPhoneVerificationWithCredentials:(ZMPhoneCredentials *)phoneCredentials
 {
     ZMLogDebug(@"%@", NSStringFromSelector(_cmd));
-    // if it was duplicated phone, do login instead
-    BOOL wasDuplicated = self.duplicateRegistrationPhoneNumber;
     [self resetLoginAndRegistrationStatus];
-
-    self.duplicateRegistrationPhoneNumber = wasDuplicated;
-    if(wasDuplicated) {
-        self.loginCredentials = phoneCredentials;
-    }
-    else {
-        self.registrationPhoneValidationCredentials = phoneCredentials;
-    }
+    self.registrationPhoneValidationCredentials = phoneCredentials;
     ZMLogDebug(@"current phase: %lu", (unsigned long)self.currentPhase);
 }
 
 - (void)didFailRequestForPhoneRegistrationCode:(NSError *)error
 {
     ZMLogDebug(@"%@", NSStringFromSelector(_cmd));
-    if(error.code == ZMUserSessionPhoneNumberIsAlreadyRegistered) {
-        self.duplicateRegistrationPhoneNumber = YES;
-        self.loginPhoneNumberThatNeedsAValidationCode = self.registrationPhoneNumberThatNeedsAValidationCode;
-        self.registrationPhoneNumberThatNeedsAValidationCode = nil;
-        ZMLogDebug(@"current phase: %lu", (unsigned long)self.currentPhase);
-    }
-    
     [self resetLoginAndRegistrationStatus];
     [ZMUserSessionRegistrationNotification notifyPhoneNumberVerificationCodeRequestDidFail:error context:self];
     ZMLogDebug(@"current phase: %lu", (unsigned long)self.currentPhase);
@@ -332,18 +311,10 @@ static NSString* ZMLogTag ZM_UNUSED = @"Authentication";
 - (void)didFailLoginWithPhone:(BOOL)invalidCredentials
 {
     ZMLogDebug(@"%@ invalid credentials: %d", NSStringFromSelector(_cmd), invalidCredentials);
-    BOOL isDuplicated = self.duplicateRegistrationPhoneNumber;
     [self resetLoginAndRegistrationStatus];
     
-    if(isDuplicated) {
-        NSError *error = [NSError userSessionErrorWithErrorCode:ZMUserSessionPhoneNumberIsAlreadyRegistered userInfo:nil];
-        
-        [ZMUserSessionRegistrationNotification notifyRegistrationDidFail:error context:self];
-    }
-    else {
-        NSError *error = [NSError userSessionErrorWithErrorCode:(invalidCredentials ? ZMUserSessionInvalidCredentials : ZMUserSessionUnknownError) userInfo:nil];
-        [self notifyAuthenticationDidFail:error];
-    }
+    NSError *error = [NSError userSessionErrorWithErrorCode:(invalidCredentials ? ZMUserSessionInvalidCredentials : ZMUserSessionUnknownError) userInfo:nil];
+    [self notifyAuthenticationDidFail:error];
     ZMLogDebug(@"current phase: %lu", (unsigned long)self.currentPhase);
 }
 

--- a/Source/UnauthenticatedSession/ZMAuthenticationStatus_Internal.h
+++ b/Source/UnauthenticatedSession/ZMAuthenticationStatus_Internal.h
@@ -32,7 +32,6 @@
 @property (nonatomic) BOOL completedRegistration;
 
 @property (nonatomic) BOOL duplicateRegistrationEmail;
-@property (nonatomic) BOOL duplicateRegistrationPhoneNumber;
 
 @property (nonatomic) BOOL isWaitingForLogin;
 @property (nonatomic) BOOL canClearCredentials;

--- a/Tests/Source/Synchronization/Transcoders/ZMPhoneNumberVerificationTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMPhoneNumberVerificationTranscoderTests.m
@@ -211,28 +211,6 @@
     XCTAssertEqualObjects(expectedRequest, request);
 }
 
-- (void)testThatIfDuplicatedPhoneNumberGoesToLoginCodeRequestStatus
-{
-    // given
-    NSString *phoneNumber = @"+712434235";
-    [self.authenticationStatus prepareForRequestingPhoneVerificationCodeForRegistration:phoneNumber];
-    
-    ZMTransportRequest *request = [self.sut nextRequest];
-    ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@{@"code": @0,
-                                                                               @"message": @"",
-                                                                               @"label": @"key-exists"}
-                                                                  HTTPStatus:409
-                                                       transportSessionError:nil];
-    
-    //when
-    [request completeWithResponse:response];
-    WaitForAllGroupsToBeEmpty(0.5);
-    
-    // then
-    XCTAssertEqual(self.authenticationStatus.currentPhase, ZMAuthenticationPhaseRequestPhoneVerificationCodeForLogin);
-    XCTAssertEqualObjects(self.authenticationStatus.loginPhoneNumberThatNeedsAValidationCode, phoneNumber);
-}
-
 - (void)testThatIfPhoneVerificationCodeRequestFailsPhoneNumberIsClearedAndCreadentialsAreNotSet
 {
     // given

--- a/Tests/Source/UserSession/ZMAuthenticationStatusTests.m
+++ b/Tests/Source/UserSession/ZMAuthenticationStatusTests.m
@@ -399,21 +399,6 @@
     XCTAssertNil(self.sut.registrationPhoneNumberThatNeedsAValidationCode);
 }
 
-- (void)testThatItRequestsALoginPhoneVerificationCodeWhenRequestingARegistrationPhoneCodeFailsBecauseOfDuplicatedEmail
-{
-    // given
-    NSString *phone = @"+3912345678900";
-    
-    // when
-    [self.sut prepareForRequestingPhoneVerificationCodeForRegistration:phone];
-    [self.sut didFailRequestForPhoneRegistrationCode:[NSError userSessionErrorWithErrorCode:ZMUserSessionPhoneNumberIsAlreadyRegistered userInfo:nil]];
-    
-    // then
-    XCTAssertEqual(self.sut.currentPhase, ZMAuthenticationPhaseRequestPhoneVerificationCodeForLogin);
-    XCTAssertNil(self.sut.registrationPhoneNumberThatNeedsAValidationCode);
-    XCTAssertEqualObjects(self.sut.loginPhoneNumberThatNeedsAValidationCode, phone);
-}
-
 - (void)testThatItResetsWhenFailingTheRequestForPhoneRegistrationCode
 {
     // expect


### PR DESCRIPTION
## What's new in this PR?

### Issues

We currently handle registration with already registered phone/email in a special fashion. This unfortunately is prone to breaking and in fact does from time to time.

### Solutions

We will try to simply return errors as we get them from the server and handle all scenarios in UI.