### PR TITLE
Added simple block for offline check

### DIFF
--- a/Source/UnauthenticatedSession/UnauthenticatedSession+Login.swift
+++ b/Source/UnauthenticatedSession/UnauthenticatedSession+Login.swift
@@ -40,7 +40,7 @@ extension UnauthenticatedSession {
         if credentials.isInvalid {
             authenticationStatus.notifyAuthenticationDidFail(NSError(code: .needsCredentials, userInfo: nil))
         } else {
-            whenReachable {
+            authenticationErrorIfNotReachable {
                 self.authenticationStatus.prepareForLogin(with: credentials)
                 RequestAvailableNotification.notifyNewRequestsAvailable(nil)
             }
@@ -57,7 +57,7 @@ extension UnauthenticatedSession {
             return false
         }
 
-        whenReachable {
+        authenticationErrorIfNotReachable {
             self.authenticationStatus.prepareForRequestingPhoneVerificationCode(forLogin: phoneNumber)
             RequestAvailableNotification.notifyNewRequestsAvailable(nil)
         }

--- a/Source/UnauthenticatedSession/UnauthenticatedSession+Login.swift
+++ b/Source/UnauthenticatedSession/UnauthenticatedSession+Login.swift
@@ -39,12 +39,12 @@ extension UnauthenticatedSession {
         
         if credentials.isInvalid {
             authenticationStatus.notifyAuthenticationDidFail(NSError(code: .needsCredentials, userInfo: nil))
-        } else if !self.reachability.mayBeReachable {
-            authenticationStatus.notifyAuthenticationDidFail(NSError(code: .networkError, userInfo:nil))
         } else {
-            self.authenticationStatus.prepareForLogin(with: credentials)
+            whenReachable {
+                self.authenticationStatus.prepareForLogin(with: credentials)
+                RequestAvailableNotification.notifyNewRequestsAvailable(nil)
+            }
         }
-        RequestAvailableNotification.notifyNewRequestsAvailable(nil)
     }
     
     /// Requires a phone verification code for login. Returns NO if the phone number was invalid
@@ -56,14 +56,11 @@ extension UnauthenticatedSession {
         } catch {
             return false
         }
-            
-        if !self.reachability.mayBeReachable {
-            authenticationStatus.notifyAuthenticationDidFail(NSError(code: .networkError, userInfo:nil))
-        } else {
-            authenticationStatus.prepareForRequestingPhoneVerificationCode(forLogin: phoneNumber)
+
+        whenReachable {
+            self.authenticationStatus.prepareForRequestingPhoneVerificationCode(forLogin: phoneNumber)
+            RequestAvailableNotification.notifyNewRequestsAvailable(nil)
         }
-        
-        RequestAvailableNotification.notifyNewRequestsAvailable(nil)
         return true
     }
     

--- a/Source/UnauthenticatedSession/UnauthenticatedSession+Registration.swift
+++ b/Source/UnauthenticatedSession/UnauthenticatedSession+Registration.swift
@@ -70,7 +70,7 @@ extension UnauthenticatedSession {
             return
         }
 
-        whenReachable {
+        authenticationErrorIfNotReachable {
             self.authenticationStatus.prepareForRegistration(of: user)
             RequestAvailableNotification.notifyNewRequestsAvailable(nil)
         }
@@ -78,7 +78,7 @@ extension UnauthenticatedSession {
     
     @objc
     public func requestPhoneVerificationCodeForRegistration(_ phoneNumber: String) {
-        whenReachable {
+        authenticationErrorIfNotReachable {
             self.authenticationStatus.prepareForRequestingPhoneVerificationCode(forRegistration: phoneNumber)
             RequestAvailableNotification.notifyNewRequestsAvailable(nil)
         }

--- a/Source/UnauthenticatedSession/UnauthenticatedSession+Registration.swift
+++ b/Source/UnauthenticatedSession/UnauthenticatedSession+Registration.swift
@@ -69,15 +69,19 @@ extension UnauthenticatedSession {
             ZMUserSessionRegistrationNotification.notifyRegistrationDidFail(NSError(code: .needsCredentials, userInfo: nil), context: authenticationStatus)
             return
         }
-        
-        authenticationStatus.prepareForRegistration(of: user)
-        RequestAvailableNotification.notifyNewRequestsAvailable(nil)
+
+        whenReachable {
+            self.authenticationStatus.prepareForRegistration(of: user)
+            RequestAvailableNotification.notifyNewRequestsAvailable(nil)
+        }
     }
     
     @objc
     public func requestPhoneVerificationCodeForRegistration(_ phoneNumber: String) {
-        authenticationStatus.prepareForRequestingPhoneVerificationCode(forRegistration: phoneNumber)
-        RequestAvailableNotification.notifyNewRequestsAvailable(nil)
+        whenReachable {
+            self.authenticationStatus.prepareForRequestingPhoneVerificationCode(forRegistration: phoneNumber)
+            RequestAvailableNotification.notifyNewRequestsAvailable(nil)
+        }
     }
     
     @objc

--- a/Source/UnauthenticatedSession/UnauthenticatedSession.swift
+++ b/Source/UnauthenticatedSession/UnauthenticatedSession.swift
@@ -79,7 +79,7 @@ public class UnauthenticatedSession: NSObject {
         tornDown = true
     }
 
-    func whenReachable(_ block: () -> ()) {
+    func authenticationErrorIfNotReachable(_ block: () -> ()) {
         if self.reachability.mayBeReachable {
             block()
         } else {

--- a/Source/UnauthenticatedSession/UnauthenticatedSession.swift
+++ b/Source/UnauthenticatedSession/UnauthenticatedSession.swift
@@ -79,6 +79,13 @@ public class UnauthenticatedSession: NSObject {
         tornDown = true
     }
 
+    func whenReachable(_ block: () -> ()) {
+        if self.reachability.mayBeReachable {
+            block()
+        } else {
+            authenticationStatus.notifyAuthenticationDidFail(NSError(code: .networkError, userInfo:nil))
+        }
+    }
 }
 
 // MARK: - UserInfoParser


### PR DESCRIPTION
## What's new in this PR?

### Issues

If we have airplane mode turned on during registration the requests are being retried continuously. When logging in we check for reachability and show error instead.

### Solutions

Unify checks for reachability in both login and registration.
