### PR TITLE
Dispatch to the correct thread

### DIFF
--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -258,7 +258,7 @@ ZM_EMPTY_ASSERTING_INIT()
             }
         }];
         
-        self.userExpirationObserver = [[UserExpirationObserver alloc] init];
+        self.userExpirationObserver = [[UserExpirationObserver alloc] initWithManagedObjectContext:self.managedObjectContext];
         
         [ZMRequestAvailableNotification notifyNewRequestsAvailable:self];
     }

--- a/Tests/Source/UserSession/UserExpirationObserverTests.swift
+++ b/Tests/Source/UserSession/UserExpirationObserverTests.swift
@@ -44,7 +44,17 @@ extension XCTestCase {
 }
 
 public class UserExpirationObserverTests: MessagingTest {
-    let sut = UserExpirationObserver()
+    var sut: UserExpirationObserver!
+    
+    override public func setUp() {
+        super.setUp()
+        sut = UserExpirationObserver(managedObjectContext: self.uiMOC)
+    }
+    
+    override public func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
     
     func testThatItIgnoresNonExpiringUsers() {
         // given
@@ -112,7 +122,7 @@ public class UserExpirationObserverTests: MessagingTest {
     func testThatItDoesNotRetainItself() {
         weak var sut: UserExpirationObserver?
         autoreleasepool {
-            let localSut = UserExpirationObserver()
+            let localSut = UserExpirationObserver(managedObjectContext: self.uiMOC)
             // given
             let user = ZMUser.insertNewObject(in: self.uiMOC)
             user.name = "User"


### PR DESCRIPTION
It appears that ZMTimer is calling it's callback on the background thread. Now the call is dispatched to the correct thread.