### PR TITLE
Authentication flow: Added a step for backup import

### DIFF
--- a/Source/Synchronization/Transcoders/ZMLoginTranscoder+Internal.h
+++ b/Source/Synchronization/Transcoders/ZMLoginTranscoder+Internal.h
@@ -31,7 +31,6 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
 
 - (instancetype)initWithGroupQueue:(id<ZMSGroupQueue>)groupQueue
               authenticationStatus:(ZMAuthenticationStatus *)authenticationStatus
-                    userInfoParser:(id<UserInfoParser>)userInfoParser
                timedDownstreamSync:(ZMTimedSingleRequestSync *)timedDownstreamSync
          verificationResendRequest:(ZMSingleRequestSync *)verificationResendRequest NS_DESIGNATED_INITIALIZER;
 

--- a/Source/Synchronization/Transcoders/ZMLoginTranscoder.h
+++ b/Source/Synchronization/Transcoders/ZMLoginTranscoder.h
@@ -33,8 +33,7 @@ NS_ASSUME_NONNULL_BEGIN;
 - (instancetype)init NS_UNAVAILABLE;
 
 - (instancetype)initWithGroupQueue:(id<ZMSGroupQueue>)groupQueue
-              authenticationStatus:(ZMAuthenticationStatus *)authenticationStatus
-                    userInfoParser:(nullable id<UserInfoParser>)userInfoParser;
+              authenticationStatus:(ZMAuthenticationStatus *)authenticationStatus;
 
 @end
 

--- a/Source/Synchronization/Transcoders/ZMLoginTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMLoginTranscoder.m
@@ -38,7 +38,6 @@ NSTimeInterval DefaultPendingValidationLoginAttemptInterval = 5;
 @interface ZMLoginTranscoder () <ZMRequestVerificationEmailObserver>
 
 @property (nonatomic, weak) ZMAuthenticationStatus *authenticationStatus;
-@property (nonatomic, weak) id<UserInfoParser> userInfoParser;
 @property (nonatomic, readonly) ZMSingleRequestSync *verificationResendRequest;
 @property (nonatomic) id emailResendObserverToken;
 @property (nonatomic, weak) id<ZMSGroupQueue> groupQueue;
@@ -50,18 +49,15 @@ NSTimeInterval DefaultPendingValidationLoginAttemptInterval = 5;
 
 - (instancetype)initWithGroupQueue:(id<ZMSGroupQueue>)groupQueue
               authenticationStatus:(ZMAuthenticationStatus *)authenticationStatus
-                    userInfoParser:(id<UserInfoParser>)userInfoParser
 {
     return [self initWithGroupQueue:groupQueue
                authenticationStatus:authenticationStatus
-                     userInfoParser:userInfoParser
                 timedDownstreamSync:nil
           verificationResendRequest:nil];
 }
 
 - (instancetype)initWithGroupQueue:(id<ZMSGroupQueue>)groupQueue
               authenticationStatus:(ZMAuthenticationStatus *)authenticationStatus
-                    userInfoParser:(id<UserInfoParser>)userInfoParser
                timedDownstreamSync:(ZMTimedSingleRequestSync *)timedDownstreamSync
          verificationResendRequest:(ZMSingleRequestSync *)verificationResendRequest
 {
@@ -70,7 +66,6 @@ NSTimeInterval DefaultPendingValidationLoginAttemptInterval = 5;
     if (self != nil) {
         self.groupQueue = groupQueue;
         self.authenticationStatus = authenticationStatus;
-        self.userInfoParser = userInfoParser;
         _timedDownstreamSync = timedDownstreamSync ?: [[ZMTimedSingleRequestSync alloc] initWithSingleRequestTranscoder:self everyTimeInterval:0 groupQueue:groupQueue];
         _verificationResendRequest = verificationResendRequest ?: [[ZMSingleRequestSync alloc] initWithSingleRequestTranscoder:self groupQueue:groupQueue];
         

--- a/Source/Synchronization/Transcoders/ZMLoginTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMLoginTranscoder.m
@@ -215,8 +215,7 @@ NSTimeInterval DefaultPendingValidationLoginAttemptInterval = 5;
     BOOL shouldStartTimer = NO;
     ZMAuthenticationStatus * authenticationStatus = self.authenticationStatus;
     if (response.result == ZMTransportResponseStatusSuccess) {
-        [authenticationStatus loginSucceed];
-        [self.userInfoParser parseUserInfoFromResponse:response];
+        [authenticationStatus loginSucceededWithResponse:response];
     }
     else if (response.result == ZMTransportResponseStatusPermanentError) {
         

--- a/Source/Synchronization/Transcoders/ZMRegistrationTranscoder.h
+++ b/Source/Synchronization/Transcoders/ZMRegistrationTranscoder.h
@@ -28,8 +28,7 @@
 @interface ZMRegistrationTranscoder : NSObject <RequestStrategy>
 
 - (instancetype)initWithGroupQueue:(id<ZMSGroupQueue>)groupQueue
-              authenticationStatus:(ZMAuthenticationStatus *)authenticationStatus
-                    userInfoParser:(id<UserInfoParser>)userInfoParser;
+              authenticationStatus:(ZMAuthenticationStatus *)authenticationStatus;
 
 - (void)resetRegistrationState;
 

--- a/Source/Synchronization/Transcoders/ZMRegistrationTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMRegistrationTranscoder.m
@@ -148,11 +148,7 @@
     NOT_USED(sync);
     ZMAuthenticationStatus *authenticationStatus = self.authenticationStatus;
     if (response.result == ZMTransportResponseStatusSuccess) {
-        BOOL shouldParseUserInfo = authenticationStatus.currentPhase == ZMAuthenticationPhaseRegisterWithPhone;
-        if (shouldParseUserInfo) {
-            [self.userInfoParser parseUserInfoFromResponse:response];
-        }
-        [authenticationStatus didCompleteRegistrationSuccessfully];
+        [authenticationStatus didCompleteRegistrationSuccessfullyWithResponse:response];
     }
     else if (response.result == ZMTransportResponseStatusPermanentError) {
         // if email is duplicated backed return 400 and json with key-exists label

--- a/Source/Synchronization/Transcoders/ZMRegistrationTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMRegistrationTranscoder.m
@@ -31,7 +31,6 @@
 
 @interface  ZMRegistrationTranscoder ()
 
-@property (nonatomic, weak) id<UserInfoParser> userInfoParser;
 @property (nonatomic, readonly) ZMSingleRequestSync *registrationSync;
 @property (nonatomic, weak) ZMAuthenticationStatus *authenticationStatus;
 @property (nonatomic, weak) id<ZMSGroupQueue> groupQueue;
@@ -49,13 +48,11 @@
 
 - (instancetype)initWithGroupQueue:(id<ZMSGroupQueue>)groupQueue
               authenticationStatus:(ZMAuthenticationStatus *)authenticationStatus
-                    userInfoParser:(id<UserInfoParser>)userInfoParser
 {
     self = [super init];
     
     if (self != nil) {
         self.groupQueue = groupQueue;
-        self.userInfoParser = userInfoParser;
         _registrationSync = [ZMSingleRequestSync syncWithSingleRequestTranscoder:self groupQueue:groupQueue];
         self.authenticationStatus = authenticationStatus;
         self.authenticationObserverToken = [authenticationStatus addAuthenticationCenterObserver:self];

--- a/Source/UnauthenticatedSession/UnauthenticatedSession+Login.swift
+++ b/Source/UnauthenticatedSession/UnauthenticatedSession+Login.swift
@@ -29,6 +29,11 @@ extension ZMCredentials {
 }
 
 extension UnauthenticatedSession {
+
+    @objc(continueAfterBackupImportStep)
+    public func continueAfterBackupImportStep() {
+        authenticationStatus.continueAfterBackupImportStep()
+    }
         
     /// Attempt to log in with the given credentials
     @objc(loginWithCredentials:)

--- a/Source/UnauthenticatedSession/UnauthenticatedSession.swift
+++ b/Source/UnauthenticatedSession/UnauthenticatedSession.swift
@@ -60,9 +60,9 @@ public class UnauthenticatedSession: NSObject {
             transportSession: transportSession,
             operationQueue: groupQueue,
             requestStrategies: [
-                ZMLoginTranscoder(groupQueue: groupQueue, authenticationStatus: authenticationStatus, userInfoParser: self),
+                ZMLoginTranscoder(groupQueue: groupQueue, authenticationStatus: authenticationStatus),
                 ZMLoginCodeRequestTranscoder(groupQueue: groupQueue, authenticationStatus: authenticationStatus)!,
-                ZMRegistrationTranscoder(groupQueue: groupQueue, authenticationStatus: authenticationStatus, userInfoParser: self)!,
+                ZMRegistrationTranscoder(groupQueue: groupQueue, authenticationStatus: authenticationStatus)!,
                 ZMPhoneNumberVerificationTranscoder(groupQueue: groupQueue, authenticationStatus: authenticationStatus)!,
                 EmailVerificationStrategy(groupQueue: groupQueue, status: registrationStatus),
                 TeamRegistrationStrategy(groupQueue: groupQueue, status: registrationStatus, userInfoParser: self)

--- a/Source/UnauthenticatedSession/UnauthenticatedSession.swift
+++ b/Source/UnauthenticatedSession/UnauthenticatedSession.swift
@@ -38,7 +38,7 @@ private let log = ZMSLog(tag: "UnauthenticatedSession")
 public class UnauthenticatedSession: NSObject {
     
     public let groupQueue: DispatchGroupQueue
-    public let authenticationStatus: ZMAuthenticationStatus
+    private(set) public var authenticationStatus: ZMAuthenticationStatus!
     public let registrationStatus: RegistrationStatus 
     let reachability: ReachabilityProvider
     private(set) var operationLoop: UnauthenticatedOperationLoop!
@@ -50,12 +50,12 @@ public class UnauthenticatedSession: NSObject {
     init(transportSession: UnauthenticatedTransportSessionProtocol, reachability: ReachabilityProvider, delegate: UnauthenticatedSessionDelegate?) {
         self.delegate = delegate
         self.groupQueue = DispatchGroupQueue(queue: .main)
-        self.authenticationStatus = ZMAuthenticationStatus(groupQueue: groupQueue)
         self.registrationStatus = RegistrationStatus()
         self.transportSession = transportSession
         self.reachability = reachability
         super.init()
 
+        self.authenticationStatus = ZMAuthenticationStatus(groupQueue: groupQueue, userInfoParser: self)
         self.operationLoop = UnauthenticatedOperationLoop(
             transportSession: transportSession,
             operationQueue: groupQueue,

--- a/Source/UnauthenticatedSession/ZMAuthenticationStatus.h
+++ b/Source/UnauthenticatedSession/ZMAuthenticationStatus.h
@@ -30,6 +30,8 @@
 @class ZMPhoneCredentials;
 @class ZMPersistentCookieStorage;
 @class ZMClientRegistrationStatus;
+@class ZMTransportResponse;
+@protocol UserInfoParser;
 
 FOUNDATION_EXPORT NSTimeInterval DebugLoginFailureTimerOverride;
 
@@ -43,6 +45,7 @@ typedef NS_ENUM(NSUInteger, ZMAuthenticationPhase) {
     ZMAuthenticationPhaseUnauthenticated = 0,
     ZMAuthenticationPhaseLoginWithPhone,
     ZMAuthenticationPhaseLoginWithEmail,
+    ZMAuthenticationPhaseWaitingToImportBackup,
     ZMAuthenticationPhaseRequestPhoneVerificationCodeForRegistration,
     ZMAuthenticationPhaseRequestPhoneVerificationCodeForLogin,
     ZMAuthenticationPhaseVerifyPhoneForRegistration,
@@ -61,6 +64,7 @@ typedef NS_ENUM(NSUInteger, ZMAuthenticationPhase) {
 @property (nonatomic, readonly) ZMPhoneCredentials *registrationPhoneValidationCredentials;
 @property (nonatomic, readonly) ZMCompleteRegistrationUser *registrationUser;
 
+@property (nonatomic, readonly) BOOL isWaitingForBackupImport;
 @property (nonatomic, readonly) BOOL completedRegistration;
 @property (nonatomic, readonly) BOOL needsCredentialsToLogin;
 
@@ -69,19 +73,20 @@ typedef NS_ENUM(NSUInteger, ZMAuthenticationPhase) {
 
 @property (nonatomic) NSData *authenticationCookieData;
 
-- (instancetype)initWithGroupQueue:(id<ZMSGroupQueue>)groupQueue;
+- (instancetype)initWithGroupQueue:(id<ZMSGroupQueue>)groupQueue userInfoParser:(id<UserInfoParser>)userInfoParser;
 
 - (id)addAuthenticationCenterObserver:(id<ZMAuthenticationStatusObserver>)observer;
 
 - (void)prepareForRegistrationOfUser:(ZMCompleteRegistrationUser *)user;
 - (void)prepareForLoginWithCredentials:(ZMCredentials *)credentials;
+- (void)continueAfterBackupImportStep;
 - (void)cancelWaitingForEmailVerification;
 - (void)prepareForRequestingPhoneVerificationCodeForRegistration:(NSString *)phone;
 - (void)prepareForRequestingPhoneVerificationCodeForLogin:(NSString *)phone;
 - (void)prepareForRegistrationPhoneVerificationWithCredentials:(ZMPhoneCredentials *)phoneCredentials;
 
 
-- (void)didCompleteRegistrationSuccessfully;
+- (void)didCompleteRegistrationSuccessfullyWithResponse:(ZMTransportResponse *)response;
 - (void)didFailRegistrationWithDuplicatedEmail;
 - (void)didFailRegistrationForOtherReasons:(NSError *)error;
 
@@ -94,8 +99,7 @@ typedef NS_ENUM(NSUInteger, ZMAuthenticationPhase) {
 - (void)didCompletePhoneVerificationSuccessfully;
 - (void)didFailPhoneVerificationForRegistration:(NSError *)error;
 
-
-- (void)loginSucceed; // called just after recieveing successful login response
+- (void)loginSucceededWithResponse:(ZMTransportResponse *)response;
 - (void)didFailLoginWithPhone:(BOOL)invalidCredentials;
 - (void)didFailLoginWithEmailBecausePendingValidation;
 - (void)didFailLoginWithEmail:(BOOL)invalidCredentials;

--- a/Source/UnauthenticatedSession/ZMAuthenticationStatus_Internal.h
+++ b/Source/UnauthenticatedSession/ZMAuthenticationStatus_Internal.h
@@ -29,6 +29,7 @@
 @property (nonatomic) ZMCompleteRegistrationUser *internalRegistrationUser;
 
 @property (nonatomic) BOOL isWaitingForEmailVerification;
+@property (nonatomic) BOOL isWaitingForBackupImport;
 @property (nonatomic) BOOL completedRegistration;
 
 @property (nonatomic) BOOL isWaitingForLogin;

--- a/Source/UserSession/PreLoginAuthenticationNotification.swift
+++ b/Source/UserSession/PreLoginAuthenticationNotification.swift
@@ -36,11 +36,14 @@ extension ZMAuthenticationStatus : NotificationContext { } // Mark ZMAuthenticat
     /// Invoked when the authentication succeeded and the user now has a valid
     @objc optional func authenticationDidSucceed()
 
+    /// Invoked when we have provided correct credentials and have an opportunity to import backup
+    @objc optional func authenticationReadyToImportBackup()
 }
 
 private enum PreLoginAuthenticationEvent {
     
     case authenticationDidFail(error: NSError)
+    case authenticationReadyToImportBackup
     case authenticationDidSucceed
     case loginCodeRequestDidFail(NSError)
     case loginCodeRequestDidSucceed
@@ -72,6 +75,8 @@ private enum PreLoginAuthenticationEvent {
             switch event {
             case .loginCodeRequestDidFail(let error):
                 observer.loginCodeRequestDidFail?(error)
+            case .authenticationReadyToImportBackup:
+                observer.authenticationReadyToImportBackup?()
             case .loginCodeRequestDidSucceed:
                 observer.loginCodeRequestDidSucceed?()
             case .authenticationDidFail(let error):
@@ -97,6 +102,10 @@ public extension ZMAuthenticationStatus {
     
     @objc public func notifyAuthenticationDidFail(_ error: NSError) {
         PreLoginAuthenticationNotification.notify(of: .authenticationDidFail(error: error), context: self)
+    }
+
+    @objc public func notifyAuthenticationReadyToImportBackup() {
+        PreLoginAuthenticationNotification.notify(of: .authenticationReadyToImportBackup, context: self)
     }
     
     @objc public func notifyAuthenticationDidSucceed() {

--- a/Tests/Source/E2EE/UserClientRequestFactoryTests.swift
+++ b/Tests/Source/E2EE/UserClientRequestFactoryTests.swift
@@ -29,11 +29,13 @@ class UserClientRequestFactoryTests: MessagingTest {
     var sut: UserClientRequestFactory!
     var authenticationStatus: ZMAuthenticationStatus!
     var spyKeyStore: SpyUserClientKeyStore!
+    var userInfoParser: MockUserInfoParser!
     
     override func setUp() {
         super.setUp()
         self.spyKeyStore = SpyUserClientKeyStore(accountDirectory: accountDirectory, applicationContainer: sharedContainerURL)
-        self.authenticationStatus = MockAuthenticationStatus()
+        self.userInfoParser = MockUserInfoParser()
+        self.authenticationStatus = MockAuthenticationStatus(userInfoParser: self.userInfoParser)
         self.sut = UserClientRequestFactory(keysStore: self.spyKeyStore)
     }
     
@@ -42,6 +44,7 @@ class UserClientRequestFactoryTests: MessagingTest {
         self.authenticationStatus = nil
         self.sut = nil
         self.spyKeyStore = nil
+        self.userInfoParser = nil
         super.tearDown()
     }
 

--- a/Tests/Source/Integration/IntegrationTest.swift
+++ b/Tests/Source/Integration/IntegrationTest.swift
@@ -415,6 +415,9 @@ extension IntegrationTest {
         
         sessionManager?.unauthenticatedSession?.login(with: credentials)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        sessionManager?.unauthenticatedSession?.continueAfterBackupImportStep()
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
         authenticationObserver = nil
         
         return didSucceed

--- a/Tests/Source/Synchronization/SynchronizationMocks.swift
+++ b/Tests/Source/Synchronization/SynchronizationMocks.swift
@@ -102,14 +102,13 @@ public class MockApplicationStatus : NSObject, ApplicationStatus, DeliveryConfir
     
 }
 
-
 class MockAuthenticationStatus: ZMAuthenticationStatus {
     
     var mockPhase: ZMAuthenticationPhase
     
-    init(phase: ZMAuthenticationPhase = .authenticated) {
+    init(phase: ZMAuthenticationPhase = .authenticated, userInfoParser: UserInfoParser) {
         self.mockPhase = phase
-        super.init(groupQueue: DispatchGroupQueue(queue: .main))
+        super.init(groupQueue: DispatchGroupQueue(queue: .main), userInfoParser: userInfoParser)
     }
     
     override var currentPhase: ZMAuthenticationPhase {

--- a/Tests/Source/Synchronization/Transcoders/ZMLoginCodeRequestTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMLoginCodeRequestTranscoderTests.m
@@ -32,6 +32,7 @@
 
 @property (nonatomic) ZMLoginCodeRequestTranscoder *sut;
 @property (nonatomic) ZMAuthenticationStatus *authenticationStatus;
+@property (nonatomic) MockUserInfoParser *userInfoParser;
 
 @end
 
@@ -41,13 +42,15 @@
     [super setUp];
 
     DispatchGroupQueue *groupQueue = [[DispatchGroupQueue alloc] initWithQueue:dispatch_get_main_queue()];
-    self.authenticationStatus = [[ZMAuthenticationStatus alloc] initWithGroupQueue:groupQueue];
+    self.userInfoParser = [[MockUserInfoParser alloc] init];
+    self.authenticationStatus = [[ZMAuthenticationStatus alloc] initWithGroupQueue:groupQueue userInfoParser:self.userInfoParser];
     self.sut = [[ZMLoginCodeRequestTranscoder alloc] initWithGroupQueue:groupQueue authenticationStatus:self.authenticationStatus];
 }
 
 - (void)tearDown {
     self.authenticationStatus = nil;
     self.sut = nil;
+    self.userInfoParser = nil;
     [super tearDown];
 }
 

--- a/Tests/Source/Synchronization/Transcoders/ZMLoginTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMLoginTranscoderTests.m
@@ -82,21 +82,21 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
 
 - (void)setUp {
     [super setUp];
-    
+
+    self.mockUserInfoParser = [[MockUserInfoParser alloc] init];
+
     self.groupQueue = [[DispatchGroupQueue alloc] initWithQueue:dispatch_get_main_queue()];
     self.originalLoginTimerInterval = DefaultPendingValidationLoginAttemptInterval;
-    self.authenticationStatus = [[ZMAuthenticationStatus alloc] initWithGroupQueue:self.groupQueue];
+    self.authenticationStatus = [[ZMAuthenticationStatus alloc] initWithGroupQueue:self.groupQueue userInfoParser:self.mockUserInfoParser];
 
     self.mockClientRegistrationStatus = [OCMockObject niceMockForClass:[ZMClientRegistrationStatus class]];
     
     self.mockLocale = [OCMockObject niceMockForClass:[NSLocale class]];
     [[[self.mockLocale stub] andReturn:[NSLocale localeWithLocaleIdentifier:@"fr_FR"]] currentLocale];
 
-    self.mockUserInfoParser = [[MockUserInfoParser alloc] init];
-    
+
     self.sut = [[ZMLoginTranscoder alloc] initWithGroupQueue:self.groupQueue
-                                        authenticationStatus:self.authenticationStatus
-                                              userInfoParser:self.mockUserInfoParser];
+                                        authenticationStatus:self.authenticationStatus];
     
     self.testEmailCredentials = [ZMEmailCredentials credentialsWithEmail:TestEmail password:TestPassword];
     self.testPhoneNumberCredentials = [ZMPhoneCredentials credentialsWithPhoneNumber:TestPhoneNumber verificationCode:TestPhoneCode];
@@ -117,7 +117,7 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
 - (void)testThatItCreatesTheTimedRequestSyncWithZeroDelayInDefaultConstructor
 {
     // given
-    ZMLoginTranscoder *sut = [[ZMLoginTranscoder alloc] initWithGroupQueue:self.groupQueue authenticationStatus:self.authenticationStatus userInfoParser:nil];
+    ZMLoginTranscoder *sut = [[ZMLoginTranscoder alloc] initWithGroupQueue:self.groupQueue authenticationStatus:self.authenticationStatus];
     
     // then
     XCTAssertNotNil(sut.timedDownstreamSync);
@@ -132,7 +132,7 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
 - (void)expectAuthenticationSucceedAfter:(void(^)())block;
 {
     id mockAuthStatus = [OCMockObject partialMockForObject:self.authenticationStatus];
-    [[[mockAuthStatus expect] andForwardToRealObject] loginSucceed];
+    [[[mockAuthStatus expect] andForwardToRealObject] loginSucceededWithResponse:OCMOCK_ANY];
     
     // when
     block();

--- a/Tests/Source/Synchronization/Transcoders/ZMLoginTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMLoginTranscoderTests.m
@@ -58,9 +58,6 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
 
 @end
 
-
-
-
 @interface ZMLoginTranscoderTests : MessagingTest
 
 @property (nonatomic) DispatchGroupQueue *groupQueue;
@@ -496,6 +493,8 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
     // when
     [self expectAuthenticationSucceedAfter:^{
         [[self.sut nextRequest] completeWithResponse:response];
+        WaitForAllGroupsToBeEmpty(0.5);
+        [self.authenticationStatus continueAfterBackupImportStep];
         [self.authenticationStatus setAuthenticationCookieData:[@"foo" dataUsingEncoding:NSUTF8StringEncoding]];
         WaitForAllGroupsToBeEmpty(0.5);
     }];
@@ -519,6 +518,8 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
     // when
     [self expectAuthenticationSucceedAfter:^{
         [[self.sut nextRequest] completeWithResponse:response];
+        WaitForAllGroupsToBeEmpty(0.5);
+        [self.authenticationStatus continueAfterBackupImportStep];
         [self.authenticationStatus setAuthenticationCookieData:[@"foo" dataUsingEncoding:NSUTF8StringEncoding]];
         WaitForAllGroupsToBeEmpty(0.5);
     }];

--- a/Tests/Source/Synchronization/Transcoders/ZMPhoneNumberVerificationTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMPhoneNumberVerificationTranscoderTests.m
@@ -26,11 +26,13 @@
 #import "ZMAuthenticationStatus.h"
 #import "ZMCredentials+Internal.h"
 #import "ZMUserSessionRegistrationNotification.h"
+#import "WireSyncEngine_iOS_Tests-Swift.h"
 
 @interface ZMPhoneNumberVerificationTranscoderTests : MessagingTest
 
 @property (nonatomic) ZMPhoneNumberVerificationTranscoder *sut;
 @property (nonatomic) ZMAuthenticationStatus *authenticationStatus;
+@property (nonatomic) MockUserInfoParser *userInfoParser;
 
 @end
 
@@ -40,13 +42,15 @@
     [super setUp];
 
     DispatchGroupQueue *groupQueue = [[DispatchGroupQueue alloc] initWithQueue:dispatch_get_main_queue()];
-    self.authenticationStatus = [[ZMAuthenticationStatus alloc] initWithGroupQueue:groupQueue];
+    self.userInfoParser = [[MockUserInfoParser alloc] init];
+    self.authenticationStatus = [[ZMAuthenticationStatus alloc] initWithGroupQueue:groupQueue userInfoParser:self.userInfoParser];
     self.sut = [[ZMPhoneNumberVerificationTranscoder alloc] initWithGroupQueue:groupQueue authenticationStatus:self.authenticationStatus];
 }
 
 - (void)tearDown {
     self.authenticationStatus = nil;
     self.sut = nil;
+    self.userInfoParser = nil;
     [super tearDown];
 }
 

--- a/Tests/Source/Synchronization/Transcoders/ZMRegistrationTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMRegistrationTranscoderTests.m
@@ -61,12 +61,11 @@
     
     id classMock = [OCMockObject mockForClass:ZMSingleRequestSync.class];
     (void) [[[classMock stub] andReturn:self.registrationDownstreamSync] syncWithSingleRequestTranscoder:OCMOCK_ANY groupQueue:groupQueue];
-    self.authenticationStatus = [[ZMAuthenticationStatus alloc] initWithGroupQueue:groupQueue];
     self.mockUserInfoParser = [[MockUserInfoParser alloc] init];
+    self.authenticationStatus = [[ZMAuthenticationStatus alloc] initWithGroupQueue:groupQueue userInfoParser:self.mockUserInfoParser];
 
     self.sut = (id) [[ZMRegistrationTranscoder alloc] initWithGroupQueue:groupQueue
-                                                    authenticationStatus:self.authenticationStatus
-                                                          userInfoParser:self.mockUserInfoParser];
+                                                    authenticationStatus:self.authenticationStatus];
     [classMock stopMocking];
 }
 

--- a/Tests/Source/UserSession/UnauthenticatedSessionTests.swift
+++ b/Tests/Source/UserSession/UnauthenticatedSessionTests.swift
@@ -27,6 +27,7 @@ public enum PreLoginAuthenticationEventObjc : Int {
     case loginCodeRequestDidFail
     case authenticationDidSucceed
     case authenticationDidFail
+    case readyToImportBackup
 }
 
 public typealias PreLoginAuthenticationObserverHandler = (_ event: PreLoginAuthenticationEventObjc, _ error : NSError?) -> Void
@@ -59,6 +60,10 @@ public class PreLoginAuthenticationObserverToken : NSObject, PreLoginAuthenticat
     
     public func authenticationDidFail(_ error: NSError) {
         handler(.authenticationDidFail, error)
+    }
+
+    public func authenticationReadyToImportBackup() {
+        handler(.readyToImportBackup, nil)
     }
 }
 

--- a/Tests/Source/UserSession/ZMAuthenticationStatusTests.m
+++ b/Tests/Source/UserSession/ZMAuthenticationStatusTests.m
@@ -38,6 +38,7 @@
 
 @property (nonatomic) id registrationObserverToken;
 @property (nonatomic, copy) void(^registrationCallback)(ZMUserSessionRegistrationNotificationType type, NSError *error);
+@property (nonatomic) MockUserInfoParser *userInfoParser;
 
 @end
 
@@ -46,8 +47,9 @@
 - (void)setUp {
     [super setUp];
 
+    self.userInfoParser = [[MockUserInfoParser alloc] init];
     DispatchGroupQueue *groupQueue = [[DispatchGroupQueue alloc] initWithQueue:dispatch_get_main_queue()];
-    self.sut = [[ZMAuthenticationStatus alloc] initWithGroupQueue:groupQueue];
+    self.sut = [[ZMAuthenticationStatus alloc] initWithGroupQueue:groupQueue userInfoParser:self.userInfoParser];
 
     // If a test fires any notification and it's not listening for it, this will fail
     ZM_WEAK(self);
@@ -79,6 +81,7 @@
     self.sut = nil;
     self.authenticationObserverToken = nil;
     self.registrationObserverToken = nil;
+    self.userInfoParser = nil;
     [super tearDown];
 }
 
@@ -140,7 +143,7 @@
     // when
     [self.sut prepareForRegistrationOfUser:regUser];
     [self performPretendingUiMocIsSyncMoc:^{
-        [self.sut didCompleteRegistrationSuccessfully];
+        [self.sut didCompleteRegistrationSuccessfullyWithResponse:nil]; // TODO: pass something here
     }];
     
     XCTAssertTrue([self waitForCustomExpectationsWithTimeout:0.5]);
@@ -327,7 +330,7 @@
     // when
     [self performPretendingUiMocIsSyncMoc:^{
         [self.sut prepareForRegistrationOfUser:[ZMCompleteRegistrationUser registrationUserWithEmail:email password:password]];
-        [self.sut didCompleteRegistrationSuccessfully];
+        [self.sut didCompleteRegistrationSuccessfullyWithResponse:nil]; // TODO: pass something here
     }];
     
     // then


### PR DESCRIPTION
## What's new in this PR?

### Issues

We would like to offer a possibility to restore from backup after login. This needs some changes in the authentication flow to not continue registering clients and in general spinning up CoreData before we import things.

### Solutions

Added one more phase in the authentication - WaitingToImportBackup. It will wait here until a corresponding method is called to continue the regular auth flow. We do this by remembering the response we got after login and not passing it to UserInfoParser (which in turn kicks off authenticated session creation) until we are done with import.

### Notes

Still need to:
- [x] update tests
- [x] write some more for the new scenario