### PR TITLE
Expose method to clear backups folder

### DIFF
--- a/Source/SessionManager/SessionManager+Backup.swift
+++ b/Source/SessionManager/SessionManager+Backup.swift
@@ -93,13 +93,13 @@ extension SessionManager {
     // MARK: - Helper
     
     /// Deletes all previously exported and imported backups.
-    public static func clearPreviousBackups(group: ZMSDispatchGroup? = nil) {
-        StorageStack.clearBackupDirectory()
+    public static func clearPreviousBackups(dispatchGroup: ZMSDispatchGroup? = nil) {
+        StorageStack.clearBackupDirectory(dispatchGroup: dispatchGroup)
     }
     
     private static func unzippedBackupURL(for url: URL) -> URL {
         let filename = url.deletingPathExtension().lastPathComponent
-        return StorageStack.importsDirectory.appendingPathExtension(filename)
+        return StorageStack.importsDirectory.appendingPathComponent(filename)
     }
     
     private static func compress(backup: StorageStack.BackupInfo) throws -> URL {

--- a/Source/SessionManager/SessionManager+Backup.swift
+++ b/Source/SessionManager/SessionManager+Backup.swift
@@ -92,6 +92,11 @@ extension SessionManager {
     
     // MARK: - Helper
     
+    /// Deletes all previously exported and imported backups.
+    public static func clearPreviousBackups(group: ZMSDispatchGroup? = nil) {
+        StorageStack.clearBackupDirectory()
+    }
+    
     private static func unzippedBackupURL(for url: URL) -> URL {
         let filename = url.deletingPathExtension().lastPathComponent
         return StorageStack.importsDirectory.appendingPathExtension(filename)

--- a/Tests/Source/SessionManager/SessionManagerTests+Backup.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests+Backup.swift
@@ -159,9 +159,11 @@ class SessionManagerTests_Backup: IntegrationTest {
         let moc = sessionManager!.activeUserSession!.managedObjectContext!
         let userId = ZMUser.selfUser(in: moc).remoteIdentifier!
         XCTAssertNil(restoreAcount(withIdentifier: userId, from: url).error)
+        XCTAssert(FileManager.default.fileExists(atPath: StorageStack.backupsDirectory.path))
+        XCTAssert(FileManager.default.fileExists(atPath: StorageStack.importsDirectory.path))
         
         // When
-        SessionManager.clearPreviousBackups(group: dispatchGroup)
+        SessionManager.clearPreviousBackups(dispatchGroup: dispatchGroup)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.2))
         
         // Then


### PR DESCRIPTION
## What's new in this PR?

* Expose method to clear backups folder so we don't have to use methods on `StorageStack` from the UI.
* Fix imports directory folder name.
* Add tests.