### PR TITLE
Removed unused code for checking if the database exists

### DIFF
--- a/Source/Public/ZMUserSession+Authentication.h
+++ b/Source/Public/ZMUserSession+Authentication.h
@@ -37,8 +37,6 @@
 /// Delete cookies etc. and logout the current user.
 - (void)closeAndDeleteCookie:(BOOL)deleteCookie;
 
-- (BOOL)hadHistoryAtLastLogin;
-
 @end
 
 

--- a/Source/UserSession/AccountStatus.swift
+++ b/Source/UserSession/AccountStatus.swift
@@ -33,7 +33,6 @@ public final class AccountStatus : NSObject, ZMInitialSyncCompletionObserver {
     var initialSyncToken: Any?
     
     public fileprivate (set) var accountState : AccountState = .activated
-    public var hadHistoryBeforeSync : Bool
     
     public func initialSyncCompleted() {
         self.managedObjectContext.performGroupedBlock {
@@ -79,19 +78,11 @@ public final class AccountStatus : NSObject, ZMInitialSyncCompletionObserver {
     
     @objc public init(managedObjectContext: NSManagedObjectContext) {
         self.managedObjectContext = managedObjectContext
-        self.hadHistoryBeforeSync = AccountStatus.hasHistory(in: managedObjectContext)
         
         super.init()
         
         self.initialSyncToken = ZMUserSession.addInitialSyncCompletionObserver(self, context: managedObjectContext)
         self.authenticationToken = PostLoginAuthenticationNotification.addObserver(self, context: managedObjectContext)
-    }
-    
-    private static func hasHistory(in managedObjectContext: NSManagedObjectContext) -> Bool {
-        let convRequest = NSFetchRequest<ZMConversation>(entityName:ZMConversation.entityName())
-        guard let convCount = try? managedObjectContext.count(for: convRequest) else { return false }
-        let hasHistory = convCount > 1
-        return hasHistory
     }
 }
 

--- a/Source/UserSession/ZMUserSession+Authentication.m
+++ b/Source/UserSession/ZMUserSession+Authentication.m
@@ -28,7 +28,6 @@
 #import <WireSyncEngine/WireSyncEngine-Swift.h>
 
 static NSString *ZMLogTag ZM_UNUSED = @"Authentication";
-static NSString *const HasHistoryKey = @"hasHistory";
 
 @implementation ZMUserSession (Authentication)
 
@@ -52,11 +51,6 @@ static NSString *const HasHistoryKey = @"hasHistory";
 - (BOOL)needsToRegisterClient
 {
     return true;
-}
-
-- (BOOL)hadHistoryAtLastLogin
-{
-    return self.accountStatus.hadHistoryBeforeSync;
 }
 
 - (void)deleteUserKeychainItems;

--- a/Tests/Source/Integration/LoginFlowTests.m
+++ b/Tests/Source/Integration/LoginFlowTests.m
@@ -374,30 +374,6 @@ extern NSTimeInterval DebugLoginFailureTimerOverride;
     DebugLoginFailureTimerOverride = 0;
 }
 
-- (void)testThatWhenWeLoginItChecksForTheHistory
-{
-    // given
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
-        [session insertGroupConversationWithSelfUser:self.selfUser otherUsers:@[]];
-        [session insertGroupConversationWithSelfUser:self.selfUser otherUsers:@[]];
-    }];
-    
-    XCTAssertTrue([self login]);
-    XCTAssertFalse(self.userSession.hadHistoryAtLastLogin);
-    
-    // when
-    [self destroySessionManager];
-    [self deleteAuthenticationCookie];
-    [self createSessionManager];
-    
-    WaitForAllGroupsToBeEmpty(0.5);
-    XCTAssertTrue([self login]);
-
-    // then
-    XCTAssertTrue(self.userSession.hadHistoryAtLastLogin);
-    WaitForAllGroupsToBeEmpty(0.5);
-}
-
 @end
 
 


### PR DESCRIPTION
- This was used before when we used to show the new device / no history screen after the user was fully signed in.
- Now the ZMUserSession is not created yet when the screen must be displayed.