### PR TITLE
Checking if user imports backup of the account that is logged in

### DIFF
--- a/Source/SessionManager/SessionManager+Backup.swift
+++ b/Source/SessionManager/SessionManager+Backup.swift
@@ -30,6 +30,7 @@ extension SessionManager {
     // MARK: - Export
     
     enum BackupError: Error {
+        case notAuthenticated
         case noActiveAccount
         case compressionError
         case invalidFileExtension
@@ -66,14 +67,16 @@ extension SessionManager {
     /// Restores the account database from the Wire iOS database back up file.
     /// @param completion called when the restoration is ended. If success, Result.success with the new restored account
     /// is called.
-    public func restoreFromBackup(at location: URL, with userId: UUID, completion: @escaping RestoreResultClosure) {
+    public func restoreFromBackup(at location: URL, completion: @escaping RestoreResultClosure) {
         func complete(_ result: VoidResult) {
             DispatchQueue.main.async(group: dispatchGroup) {
-                completion(.success)
+                completion(result)
             }
         }
-        
-        // Verify the imported file has the correct file extension (`wireiosbackup`).
+
+        guard let userId = unauthenticatedSession?.authenticationStatus.authenticatedUserIdentifier else { return completion(.failure(BackupError.notAuthenticated)) }
+
+        // Verify the imported file has the correct file extension.
         guard location.pathExtension == BackupMetadata.fileExtension else { return completion(.failure(BackupError.invalidFileExtension)) }
         
         SessionManager.compressionQueue.async(group: dispatchGroup) { [weak self] in

--- a/Source/UnauthenticatedSession/UnauthenticatedSession.swift
+++ b/Source/UnauthenticatedSession/UnauthenticatedSession.swift
@@ -28,6 +28,8 @@ public protocol UnauthenticatedSessionDelegate: class {
 }
 
 @objc public protocol UserInfoParser: class {
+    @objc(userIdentifierFromResponse:)
+    func userIdentifier(from response: ZMTransportResponse) -> UUID?
     @objc(accountExistsLocallyFromResponse:)
     func accountExistsLocally(from response: ZMTransportResponse) -> Bool
     @objc(parseUserInfoFromResponse:)
@@ -94,6 +96,14 @@ public class UnauthenticatedSession: NSObject {
 // MARK: - UserInfoParser
 
 extension UnauthenticatedSession: UserInfoParser {
+    public func userIdentifier(from response: ZMTransportResponse) -> UUID? {
+        guard let info = response.extractUserInfo() else {
+            log.warn("Failed to parse UserInfo from response: \(response)")
+            return nil;
+        }
+        return info.identifier
+    }
+
     public func accountExistsLocally(from response: ZMTransportResponse) -> Bool {
         guard let info = response.extractUserInfo() else {
             log.warn("Failed to parse UserInfo from response: \(response)")

--- a/Source/UnauthenticatedSession/ZMAuthenticationStatus.h
+++ b/Source/UnauthenticatedSession/ZMAuthenticationStatus.h
@@ -69,6 +69,7 @@ typedef NS_ENUM(NSUInteger, ZMAuthenticationPhase) {
 @property (nonatomic, readonly) BOOL needsCredentialsToLogin;
 
 @property (nonatomic, readonly) ZMAuthenticationPhase currentPhase;
+@property (nonatomic, readonly) NSUUID *authenticatedUserIdentifier;
 @property (nonatomic) NSData *profileImageData;
 
 @property (nonatomic) NSData *authenticationCookieData;

--- a/Source/UnauthenticatedSession/ZMAuthenticationStatus.m
+++ b/Source/UnauthenticatedSession/ZMAuthenticationStatus.m
@@ -65,6 +65,14 @@ static NSString* ZMLogTag ZM_UNUSED = @"Authentication";
     return self.internalLoginCredentials;
 }
 
+- (NSUUID *)authenticatedUserIdentifier
+{
+    if (self.authenticationResponse != nil) {
+        return [self.userInfoParser userIdentifierFromResponse:self.authenticationResponse];
+    }
+    return nil;
+}
+
 - (void)resetLoginAndRegistrationStatus
 {
     [self stopLoginTimer];

--- a/Tests/Source/Synchronization/Transcoders/MockUserInfoParser.swift
+++ b/Tests/Source/Synchronization/Transcoders/MockUserInfoParser.swift
@@ -34,4 +34,11 @@
         parsedResponses.append(response)
     }
 
+    public var userId: UUID?
+    public var userIdentifierCalled = 0
+    public func userIdentifier(from response: ZMTransportResponse) -> UUID? {
+        userIdentifierCalled += 1
+        return userId
+    }
+
 }

--- a/Tests/Source/UserSession/UnauthenticatedSessionTests.swift
+++ b/Tests/Source/UserSession/UnauthenticatedSessionTests.swift
@@ -252,6 +252,20 @@ public final class UnauthenticatedSessionTests: ZMTBaseTest {
         XCTAssertTrue(exists)
         XCTAssertEqual(mockDelegate.existingAccountsCalled, 1)
     }
+
+    func testThatItExtractsUserIdentifierFromResponse() throws {
+        // given
+        let userId = UUID.create()
+        let cookie = "zuid=wjCWn1Y1pBgYrFCwuU7WK2eHpAVY8Ocu-rUAWIpSzOcvDVmYVc9Xd6Ovyy-PktFkamLushbfKgBlIWJh6ZtbAA==.1721442805.u.7eaaa023.08326f5e-3c0f-4247-a235-2b4d93f921a4; Expires=Sun, 21-Jul-2024 09:06:45 GMT; Domain=wire.com; HttpOnly; Secure"
+        let response = try createResponse(cookie: cookie, userId: userId, userIdKey: "id")
+
+        // when
+        let authenticatedUserID = sut.userIdentifier(from: response)
+
+        // then
+        XCTAssertEqual(authenticatedUserID, userId)
+    }
+
     
     func testThatItParsesCookieDataAndDoesCallTheDelegateIfTheCookieIsValidAndThereIsAUserIdKeyUser() throws {
         // given

--- a/Tests/Source/UserSession/ZMAuthenticationStatusTests.m
+++ b/Tests/Source/UserSession/ZMAuthenticationStatusTests.m
@@ -731,6 +731,40 @@
     XCTAssertEqual(self.userInfoParser.accountExistsLocallyCalled, 1);
 }
 
+- (void)testThatItExtractsUserIdentifierFromLoginResponse
+{
+    // expect
+    XCTestExpectation *expectation = [self expectationWithDescription:@"notification"];
+    ZM_WEAK(self);
+    self.authenticationCallback = ^(enum PreLoginAuthenticationEventObjc event, NSError *error) {
+        ZM_STRONG(self);
+        XCTAssertEqual(event, PreLoginAuthenticationEventObjcReadyToImportBackupNewAccount);
+        XCTAssertNil(error);
+        [expectation fulfill];
+    };
+
+    // given
+    NSString *email = @"gfdgfgdfg@fds.sgf";
+    NSString *password = @"#$4tewt343$";
+    NSUUID *userID = [NSUUID createUUID];
+    self.userInfoParser.userId = userID;
+    ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:nil HTTPStatus:200 transportSessionError:nil];
+
+    // when
+    [self performPretendingUiMocIsSyncMoc:^{
+        [self.sut prepareForLoginWithCredentials:[ZMEmailCredentials credentialsWithEmail:email password:password]];
+    }];
+
+    [self.sut loginSucceededWithResponse:response];
+    WaitForAllGroupsToBeEmpty(0.5);
+
+    // then
+    XCTAssertEqual(self.sut.currentPhase, ZMAuthenticationPhaseWaitingToImportBackup);
+    XCTAssertTrue([self waitForCustomExpectationsWithTimeout:0]);
+    XCTAssertEqualObjects(self.sut.authenticatedUserIdentifier, userID);
+    XCTAssertEqual(self.userInfoParser.userIdentifierCalled, 1);
+
+}
 
 @end
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

There could be a situation that after logging in the user selects backup of a different account. We should prevent that because the app will not function properly. 

### Solutions

We store the login response inside `ZMAuthenticationStatus`, so we just extract it and pass down to data model for verification.

### Notes

This simplifies the API from UI side as it needs to just make sure that the user is logged in at this point and pass the URL of the backup file.
