### PR TITLE
Add API for routing mute requests through callkit

### DIFF
--- a/Source/Calling/CallKitDelegate.swift
+++ b/Source/Calling/CallKitDelegate.swift
@@ -186,6 +186,18 @@ extension CallKitDelegate {
 @available(iOS 10.0, *)
 extension CallKitDelegate {
     
+    func requestMuteCall(in conversation: ZMConversation, muted:  Bool) {
+        guard let existingCallUUID = callUUID(for: conversation) else { return }
+        
+        let action = CXSetMutedCallAction(call: existingCallUUID, muted: muted)
+        
+        callController.request(CXTransaction(action: action)) { [weak self] (error) in
+            if let error = error {
+                self?.log("Cannot update call to muted = \(muted): \(error)")
+            }
+        }
+    }
+    
     func requestJoinCall(in conversation: ZMConversation, video: Bool) {
         
         let existingCallUUID = callUUID(for: conversation)

--- a/Source/Calling/VoiceChannel.swift
+++ b/Source/Calling/VoiceChannel.swift
@@ -64,6 +64,7 @@ public protocol CallProperties : NSObjectProtocol {
 @objc
 public protocol CallActions : NSObjectProtocol {
     
+    func mute(_ muted: Bool, userSession: ZMUserSession)
     func join(video: Bool, userSession: ZMUserSession) -> Bool
     func leave(userSession: ZMUserSession)
     func ignore(userSession: ZMUserSession)

--- a/Source/Calling/VoiceChannelV3.swift
+++ b/Source/Calling/VoiceChannelV3.swift
@@ -106,6 +106,14 @@ public class VoiceChannelV3 : NSObject, VoiceChannel {
 
 extension VoiceChannelV3 : CallActions {
     
+    public func mute(_ muted: Bool, userSession: ZMUserSession) {
+        if userSession.callNotificationStyle == .callKit, #available(iOS 10.0, *) {
+            userSession.callKitDelegate?.requestMuteCall(in: conversation!, muted: muted)
+        } else {
+            userSession.mediaManager.isMicrophoneMuted = muted
+        }
+    }
+    
     public func continueByDecreasingConversationSecurity(userSession: ZMUserSession) {
         guard let conversation = conversation else { return }
         conversation.makeNotSecure()

--- a/Source/UserSession/ZMUserSession+Private.h
+++ b/Source/UserSession/ZMUserSession+Private.h
@@ -28,6 +28,7 @@
 @class AccountStatus;
 @class ApplicationStatusDirectory;
 @class UserExpirationObserver;
+@class AVSMediaManager;
 
 #import "ZMUserSession.h"
 
@@ -56,6 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable) ManagedObjectContextChangeObserver *messageReplyObserver;
 @property (nonatomic, nullable) ManagedObjectContextChangeObserver *likeMesssageObserver;
 @property (nonatomic, nonnull)  UserExpirationObserver *userExpirationObserver;
+@property (nonatomic, readonly) AVSMediaManager *mediaManager;
 
 - (void)tearDown;
 

--- a/Tests/Source/Calling/CallKitDelegateTests.swift
+++ b/Tests/Source/Calling/CallKitDelegateTests.swift
@@ -556,6 +556,26 @@ class CallKitDelegateTest: MessagingTest {
         XCTAssertEqual(action.callUUID, callUUID)
     }
     
+    func testThatReportsMutingOfCall() {
+        // given
+        let conversation = self.conversation(type: .group)
+        let otherUser = self.otherUser(moc: self.uiMOC)
+        
+        mockWireCallCenterV3.mockCallState = .incoming(video: true, shouldRing: true, degraded: false)
+        self.sut.callCenterDidChange(callState: .incoming(video: true, shouldRing: true, degraded: false), conversation: conversation, caller: otherUser, timestamp: Date())
+        let callUUID = sut.callUUID(for: conversation)
+        
+        // when
+        sut.requestMuteCall(in: conversation, muted: true)
+        
+        // then
+        XCTAssertEqual(self.callKitController.timesRequestTransactionCalled, 1)
+        XCTAssertTrue(self.callKitController.requestedTransactions.first!.actions.first! is CXSetMutedCallAction)
+        
+        let action = self.callKitController.requestedTransactions.first!.actions.first! as! CXSetMutedCallAction
+        XCTAssertEqual(action.callUUID, callUUID)
+    }
+    
     // Public API - activity & intents
     
     func userActivityFor(contacts: [INPerson]?, isVideo: Bool = false) -> NSUserActivity {


### PR DESCRIPTION
### Issues

If you mute a call inside the app the mute state wouldn't be reflected in  Callkit.

### Causes

CallKit was never informed that the call was muted when muting from our own call UI.

### Solutions

Router mute actions through Callkit using the `CXSetMutedCallAction`,  similar to how answer and hangup works.