### PR TITLE
Fix Callstate compare function not including .establishedDataChannel

### DIFF
--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -147,6 +147,8 @@ public enum CallState : Equatable {
             return lDegraded == rDegraded
         case (.none, .none):
             fallthrough
+        case (.establishedDataChannel, .establishedDataChannel):
+            fallthrough
         case (.established, .established):
             fallthrough
         case (.terminating, .terminating):

--- a/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -405,12 +405,28 @@ class WireCallCenterV3Tests: MessagingTest {
         }
     }
     
-    func testThatCBRIsEnabledOnAudioCBRChangeHandler() {
+    func testThatCBRIsEnabledOnAudioCBRChangeHandler_whenCallIsEstablished() {
         // given
         let context = Unmanaged.passUnretained(self.sut).toOpaque()
         WireSyncEngine.incomingCallHandler(conversationId: oneOnOneConversationIDRef, messageTime: 0, userId: otherUserIDRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         WireSyncEngine.establishedCallHandler(conversationId: oneOnOneConversationIDRef, userId: otherUserIDRef, contextRef: context)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        // when
+        WireSyncEngine.constantBitRateChangeHandler(userId: otherUserIDRef, enabled: 1, contextRef: context)
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        // then
+        XCTAssertTrue(sut.isContantBitRate(conversationId: oneOnOneConversationID))
+    }
+    
+    func testThatCBRIsEnabledOnAudioCBRChangeHandler_whenDataChannelIsEstablished() {
+        // given
+        let context = Unmanaged.passUnretained(self.sut).toOpaque()
+        WireSyncEngine.incomingCallHandler(conversationId: oneOnOneConversationIDRef, messageTime: 0, userId: otherUserIDRef, isVideoCall: 0, shouldRing: 1, contextRef: context)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        WireSyncEngine.dataChannelEstablishedHandler(conversationId: oneOnOneConversationIDRef, userId: otherUserIDRef, contextRef: context)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // when


### PR DESCRIPTION
### Issues

comparing CallState.establishedDataChannel always returns false.

### Solutions

Fix compare function