### PR TITLE
Fix: app icon badge number does not show notification

### DIFF
--- a/Source/Public/ZMUserSession.h
+++ b/Source/Public/ZMUserSession.h
@@ -47,6 +47,7 @@
 @protocol LocalStoreProviderProtocol;
 @protocol FlowManagerType;
 @protocol SessionManagerType;
+@protocol LocalStoreProviderProtocol;
 
 @class ManagedObjectContextDirectory;
 @class TopConversationsDirectory;
@@ -76,6 +77,7 @@ extern NSString * const ZMUserSessionResetPushTokensNotificationName;
                           appVersion:(NSString *)appVersion
                        storeProvider:(id<LocalStoreProviderProtocol>)storeProvider;
 
+@property (nonatomic, readonly) id <LocalStoreProviderProtocol> storeProvider;
 @property (nonatomic, weak) id<SessionManagerType> sessionManager;
 @property (nonatomic, weak) id<ZMRequestsToOpenViewsDelegate> requestToOpenViewDelegate;
 @property (nonatomic, weak) id<ZMThirdPartyServicesDelegate> thirdPartyServicesDelegate;

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -54,7 +54,7 @@ public protocol SessionManagerType : class {
     var callNotificationStyle: CallNotificationStyle { get }
     
     func withSession(for account: Account, perform completion: @escaping (ZMUserSession)->())
-    func updateAppIconBadge()
+    func updateAppIconBadge(accountID: UUID, unreadCount: Int)
 
 }
 
@@ -843,12 +843,10 @@ extension SessionManager: ZMConversationListObserver {
         }
     }
     
-    public func updateAppIconBadge() {
+    public func updateAppIconBadge(accountID: UUID, unreadCount: Int) {
         DispatchQueue.main.async {
-            for (accountID, session) in self.backgroundUserSessions {
-                let account = self.accountManager.account(with: accountID)
-                account?.unreadConversationCount = Int(ZMConversation.unreadConversationCount(in: session.managedObjectContext))
-            }
+            let account = self.accountManager.account(with: accountID)
+            account?.unreadConversationCount = unreadCount
             self.application.applicationIconBadgeNumber = self.accountManager.totalUnreadCount
         }
     }

--- a/Source/UserSession/ZMUserSession+Push.swift
+++ b/Source/UserSession/ZMUserSession+Push.swift
@@ -90,7 +90,9 @@ extension ZMUserSession: PushDispatcherOptionalClient {
         guard let syncMoc = self.syncManagedObjectContext else {
             return
         }
-        
+
+        let accountID = self.storeProvider.userIdentifier;
+
         syncMoc.performGroupedBlock {
             let notAuthenticated = !self.isAuthenticated()
             
@@ -103,7 +105,8 @@ extension ZMUserSession: PushDispatcherOptionalClient {
             // once notification processing is finished, it's safe to update the badge
             let completionHandler: ZMPushNotificationCompletionHandler = { result in
                 completion?(result)
-                self.sessionManager?.updateAppIconBadge()
+                let unreadCount = Int(ZMConversation.unreadConversationCount(in: syncMoc))
+                self.sessionManager?.updateAppIconBadge(accountID: accountID, unreadCount: unreadCount)
             }
             
             self.operationLoop.fetchEvents(fromPushChannelPayload: payload, completionHandler: completionHandler, source: source)

--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -59,7 +59,6 @@ static NSString * const AppstoreURL = @"https://itunes.apple.com/us/app/zeta-cli
 @property (nonatomic) ZMStoredLocalNotification *pendingLocalNotification;
 @property (nonatomic) LocalNotificationDispatcher *localNotificationDispatcher;
 @property (nonatomic) NSMutableArray* observersToken;
-@property (nonatomic) id <LocalStoreProviderProtocol> storeProvider;
 @property (nonatomic) ApplicationStatusDirectory *applicationStatusDirectory;
 
 @property (nonatomic) TopConversationsDirectory *topConversationsDirectory;
@@ -149,7 +148,7 @@ ZM_EMPTY_ASSERTING_INIT()
 {
     self = [super init];
     if(self) {
-        self.storeProvider = storeProvider;
+        _storeProvider = storeProvider;
         self.observersToken = [[NSMutableArray alloc] init];
         
         self.appVersion = appVersion;
@@ -301,7 +300,7 @@ ZM_EMPTY_ASSERTING_INIT()
     }];
     
     NSManagedObjectContext *uiMoc = self.managedObjectContext;
-    self.storeProvider = nil;
+    _storeProvider = nil;
     
     BOOL shouldWaitOnUiMoc = !([NSOperationQueue currentQueue] == [NSOperationQueue mainQueue] && uiMoc.concurrencyType == NSMainQueueConcurrencyType);
     

--- a/Tests/Source/Calling/CallKitDelegateTests.swift
+++ b/Tests/Source/Calling/CallKitDelegateTests.swift
@@ -42,7 +42,7 @@ class MockSessionManager : NSObject, WireSyncEngine.SessionManagerType {
         }
     }
     
-    func updateAppIconBadge() {
+    func updateAppIconBadge(accountID: UUID, unreadCount: Int) {
         
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

The app icon was not showing unread conversation for the first notification you get. Only after second one it shows up.

### Causes

Unread conversations were counted when notification stream is done fetching. This was done in UI context, but at that point the changes are not yet saved and merged into UI context. So in this situation unread count on UI context is still 0, while on sync context there are unread conversations

### Solutions

Calculate the unread count in sync context and pass the number back to UI for updating the badge.
