### PR TITLE
Fix local push notifications not being shown when performing background fetches

### DIFF
--- a/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
@@ -303,6 +303,8 @@ previouslyReceivedEventIDsCollection:(id<PreviouslyReceivedEventIDsCollection>)e
     NSUUID *latestEventId = [self processUpdateEventsAndReturnLastNotificationIDFromPayload:response.payload syncStrategy:self.syncStrategy];
 
     if (operationStatus.operationState == SyncEngineOperationStateBackgroundFetch) {
+        // This call affects the `isFetchingStreamInBackground` property and should never preceed
+        // the call to `processUpdateEventsAndReturnLastNotificationIDFromPayload:syncStrategy`.
         [self updateBackgroundFetchResultWithResponse:response];
     }
     


### PR DESCRIPTION
## What's new in this PR?

We were not using the correct `ZMUpdateEventSource` value when performing a background fetch (triggered by the OS). As a result of this a user high this an update event for a new message (for example when on bad network) the app might perform a background fetch at a later point where we will fetch the message but we will never present a local notification to the user.