### PR TITLE
Fix crash when calling without CallKit

### DIFF
--- a/Source/Analytics/Analytics+Push.swift
+++ b/Source/Analytics/Analytics+Push.swift
@@ -26,16 +26,16 @@ extension AnalyticsType {
         attributes["action"] = action.attributeValue
         attributes["conversation_type"] = conversation.conversationType.analyticsType
         attributes["with_service"] = conversation.includesServiceUser ? "true" : "false"
-        tagEvent("contributed", attributes: attributes as [String : NSObject])
+        tagEvent("contributed", attributes: attributes as! [String : NSObject])
     }
     
 }
 
 public extension ZMConversation {
     
-    var ephemeralTrackingAttributes: [String: String] {
+    public var ephemeralTrackingAttributes: [String: Any] {
         let ephemeral = destructionTimeout != .none
-        var attributes = ["is_ephemeral": ephemeral ? "true" : "false"]
+        var attributes: [String: Any] = ["is_ephemeral": ephemeral]
         guard ephemeral else { return attributes }
         attributes["ephemeral_time"] = "\(Int(destructionTimeout.rawValue))"
         return attributes


### PR DESCRIPTION
## What's new in this PR?

### Issues

The app crashes when trying to accept the non-callkit call.

### Causes

The tracking meta generation method `ephemeralTrackingAttributes` was implemented on the same class in extensions in UI and in SE. The problem was that the return type of the method was different, so in the run time the expected return was not matching with the real one.

### Solutions

Remove the implementation of the method from the UI and make the SE method public so there is no possibility of the return type mismatch.

## Dependencies

UI PR must be merged before promoting this changes to UI.
