### PR TITLE
Extract creation of initial user session into separate method

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -338,7 +338,7 @@ public protocol LocalNotificationResponder : class {
         callCenterObserverToken = WireCallCenterV3.addGlobalCallStateObserver(observer: self)
     }
     
-    public func start(with launchOptions: LaunchOptions) {
+    public func start(launchOptions: LaunchOptions) {
         if let account = accountManager.selectedAccount {
             selectInitialAccount(account, launchOptions: launchOptions)
         } else {

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -184,7 +184,6 @@ public protocol LocalNotificationResponder : class {
         analytics: AnalyticsType?,
         delegate: SessionManagerDelegate?,
         application: ZMApplication,
-        launchOptions: LaunchOptions,
         blacklistDownloadInterval : TimeInterval,
         completion: @escaping (SessionManager) -> Void
         ) {

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -196,7 +196,6 @@ public protocol LocalNotificationResponder : class {
                 analytics: analytics,
                 delegate: delegate,
                 application: application,
-                launchOptions: launchOptions,
                 blacklistDownloadInterval: blacklistDownloadInterval
             ))
             
@@ -214,7 +213,6 @@ public protocol LocalNotificationResponder : class {
         analytics: AnalyticsType?,
         delegate: SessionManagerDelegate?,
         application: ZMApplication,
-        launchOptions: LaunchOptions,
         blacklistDownloadInterval : TimeInterval
         ) {
         
@@ -244,8 +242,7 @@ public protocol LocalNotificationResponder : class {
             analytics: analytics,
             reachability: reachability,
             delegate: delegate,
-            application: application,
-            launchOptions: launchOptions
+            application: application
         )
         
         self.blacklistVerificator = ZMBlacklistVerificator(checkInterval: blacklistDownloadInterval,
@@ -285,7 +282,6 @@ public protocol LocalNotificationResponder : class {
         reachability: ReachabilityProvider & TearDownCapable,
         delegate: SessionManagerDelegate?,
         application: ZMApplication,
-        launchOptions: LaunchOptions,
         dispatchGroup: ZMSDispatchGroup? = nil
         ) {
 
@@ -340,7 +336,9 @@ public protocol LocalNotificationResponder : class {
         
         postLoginAuthenticationToken = PostLoginAuthenticationNotification.addObserver(self, queue: self.groupQueue)
         callCenterObserverToken = WireCallCenterV3.addGlobalCallStateObserver(observer: self)
-        
+    }
+    
+    public func start(with launchOptions: LaunchOptions) {
         if let account = accountManager.selectedAccount {
             selectInitialAccount(account, launchOptions: launchOptions)
         } else {

--- a/Tests/Source/Integration/IntegrationTest.swift
+++ b/Tests/Source/Integration/IntegrationTest.swift
@@ -226,9 +226,10 @@ extension IntegrationTest {
             reachability: reachability,
             delegate: self,
             application: application,
-            launchOptions: [:],
             dispatchGroup: self.dispatchGroup
         )
+        
+        sessionManager?.start(launchOptions: [:])
         
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -46,16 +46,19 @@ class SessionManagerTests: IntegrationTest {
             reachability: reachability
         )
         
-        return SessionManager(
+        let sessionManager = SessionManager(
             appVersion: "0.0.0",
             authenticatedSessionFactory: authenticatedSessionFactory,
             unauthenticatedSessionFactory: unauthenticatedSessionFactory,
             reachability: reachability,
             delegate: delegate,
             application: application,
-            launchOptions: [:],
             dispatchGroup: dispatchGroup
         )
+        
+        sessionManager.start(launchOptions: [:])
+        
+        return sessionManager
     }
     
     override func tearDown() {

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -135,7 +135,6 @@ class SessionManagerTests: IntegrationTest {
                               analytics: nil,
                               delegate: nil,
                               application: application,
-                              launchOptions: [:],
                               blacklistDownloadInterval : 60) { sessionManager in
                                 
                                 let environment = ZMBackendEnvironment(type: .staging)
@@ -151,6 +150,7 @@ class SessionManagerTests: IntegrationTest {
                                 )
                                 
                                 sessionManager.authenticatedSessionFactory = authenticatedSessionFactory
+                                sessionManager.start(launchOptions: [:])
                                 
                                 // WHEN
                                 createToken = sessionManager.addSessionManagerCreatedSessionObserver(observer)
@@ -197,7 +197,6 @@ class SessionManagerTests: IntegrationTest {
                               analytics: nil,
                               delegate: nil,
                               application: application,
-                              launchOptions: [:],
                               blacklistDownloadInterval : 60) { sessionManager in
                                 
                                 let environment = ZMBackendEnvironment(type: .staging)
@@ -213,6 +212,7 @@ class SessionManagerTests: IntegrationTest {
                                 )
                                 
                                 sessionManager.authenticatedSessionFactory = authenticatedSessionFactory
+                                sessionManager.start(launchOptions: [:])
                                 
                                 // WHEN
                                 destroyToken = sessionManager.addSessionManagerDestroyedSessionObserver(observer)
@@ -259,7 +259,6 @@ class SessionManagerTests: IntegrationTest {
                               analytics: nil,
                               delegate: nil,
                               application: application,
-                              launchOptions: [:],
                               blacklistDownloadInterval : 60) { sessionManager in
                                 
                                 let environment = ZMBackendEnvironment(type: .staging)
@@ -275,6 +274,7 @@ class SessionManagerTests: IntegrationTest {
                                 )
                                 
                                 sessionManager.authenticatedSessionFactory = authenticatedSessionFactory
+                                sessionManager.start(launchOptions: [:])
                                 
                                 // WHEN
                                 destroyToken = sessionManager.addSessionManagerDestroyedSessionObserver(observer)
@@ -571,7 +571,6 @@ class SessionManagerTests_MultiUserSession: IntegrationTest {
                               analytics: nil,
                               delegate: nil,
                               application: application,
-                              launchOptions: [:],
                               blacklistDownloadInterval : 60) { sessionManager in
                                 
                                 let environment = ZMBackendEnvironment(type: .staging)
@@ -587,6 +586,7 @@ class SessionManagerTests_MultiUserSession: IntegrationTest {
                                 )
                                 
                                 sessionManager.authenticatedSessionFactory = authenticatedSessionFactory
+                                sessionManager.start(launchOptions: [:])
                                 
                                 sessionManager.loadSession(for: account) { userSession in
                                     realSessionManager = sessionManager
@@ -626,7 +626,6 @@ class SessionManagerTests_MultiUserSession: IntegrationTest {
                        analytics: nil,
                        delegate: nil,
                        application: application,
-                       launchOptions: [:],
                        blacklistDownloadInterval : 60) { sessionManager in
                         
                         let environment = ZMBackendEnvironment(type: .staging)
@@ -642,6 +641,7 @@ class SessionManagerTests_MultiUserSession: IntegrationTest {
                         )
                         
                         sessionManager.authenticatedSessionFactory = authenticatedSessionFactory
+                        sessionManager.start(launchOptions: [:])
 
             sessionManager.withSession(for: account) { userSession in
                 realSessionManager = sessionManager


### PR DESCRIPTION
### Issues

In some cases the app would get stuck on the launch screen

### Causes

This would happen when the selected account was logged out. During the launch sequence the SessionManager would inform its delegate that the current account is logged out before reaching the end of the init method. This caused problems since the delegate (`AppRootViewController`) didn't yet have a reference to the session manager at this point.

### Solutions

Delay the creation of the user session by extracting it from init method into a separate method. An alternative solution would be to include the `SessionManager` in all the delegate methods.