### PR TITLE
Fixed blacklist parsing crash

### DIFF
--- a/Source/UserSession/Blacklist.swift
+++ b/Source/UserSession/Blacklist.swift
@@ -1,0 +1,33 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+@objc public class Blacklist: NSObject {
+    public let minVersion: String
+    public let excludedVersions: [String]
+    
+    public init?(json: [AnyHashable: Any]) {
+        guard let minVersion = json["min_version"] as? String,
+            let excludedVersions = json["exclude"] as? [String] else {
+            return nil
+        }
+        self.minVersion = minVersion
+        self.excludedVersions = excludedVersions
+    }
+}

--- a/Source/UserSession/ZMBlacklistDownloader.m
+++ b/Source/UserSession/ZMBlacklistDownloader.m
@@ -143,8 +143,14 @@ static NSString * const ExcludeVersionsKey = @"exclude";
         self.env = env;
         self.inBackground = NO;
         self.queue = dispatch_queue_create("ZMBlacklistDownloader", DISPATCH_QUEUE_SERIAL);
-        self.excludedVersions = [userDefaults objectForKey:ExcludeVersionsKey];
-        self.minVersion = [self.userDefaults objectForKey:MinVersionKey];
+        id excludedVersions = [userDefaults objectForKey:ExcludeVersionsKey];
+        if ([excludedVersions isKindOfClass:[NSArray class]]) {
+            self.excludedVersions = excludedVersions;
+        }
+        id minVersion = [self.userDefaults objectForKey:MinVersionKey];
+        if ([minVersion isKindOfClass:[NSString class]]) {
+            self.minVersion = minVersion;
+        }
         self.completionHandler = completionHandler;
         self.dateOfLastSuccessfulDownload = nil;
         self.dateOfLastUnsuccessfulDownload = nil;

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -309,6 +309,7 @@
 		8754B84A1F73C25400EC02AD /* ConversationListChangeInfo+UserSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8754B8491F73C25400EC02AD /* ConversationListChangeInfo+UserSession.swift */; };
 		8754B84C1F73C38900EC02AD /* MessageChangeInfo+UserSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8754B84B1F73C38900EC02AD /* MessageChangeInfo+UserSession.swift */; };
 		8766853C1F2A1AA00031081B /* UnauthenticatedSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8766853A1F2A1A860031081B /* UnauthenticatedSessionTests.swift */; };
+		878ACB4620ADBBAA0016E68A /* Blacklist.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878ACB4520ADBBAA0016E68A /* Blacklist.swift */; };
 		878B823820A1DCE7007455CA /* HTMLString.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 878B823720A1DCE7007455CA /* HTMLString.framework */; };
 		878B823920A1DCF6007455CA /* HTMLString.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 878B823720A1DCE7007455CA /* HTMLString.framework */; };
 		878B823A20A1DD00007455CA /* HTMLString.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 878B823720A1DCE7007455CA /* HTMLString.framework */; };
@@ -888,6 +889,7 @@
 		8754B8491F73C25400EC02AD /* ConversationListChangeInfo+UserSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ConversationListChangeInfo+UserSession.swift"; sourceTree = "<group>"; };
 		8754B84B1F73C38900EC02AD /* MessageChangeInfo+UserSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MessageChangeInfo+UserSession.swift"; sourceTree = "<group>"; };
 		8766853A1F2A1A860031081B /* UnauthenticatedSessionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnauthenticatedSessionTests.swift; sourceTree = "<group>"; };
+		878ACB4520ADBBAA0016E68A /* Blacklist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Blacklist.swift; sourceTree = "<group>"; };
 		878B823720A1DCE7007455CA /* HTMLString.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = HTMLString.framework; path = Carthage/Build/iOS/HTMLString.framework; sourceTree = "<group>"; };
 		8796343F1F7BEA4700FC79BA /* DispatchQueue+SerialAsync.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DispatchQueue+SerialAsync.swift"; sourceTree = "<group>"; };
 		879634411F7BEC5100FC79BA /* DispatchQueueSerialAsyncTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DispatchQueueSerialAsyncTests.swift; sourceTree = "<group>"; };
@@ -2186,6 +2188,7 @@
 				F9FD798519EE742600D70FCD /* ZMBlacklistDownloader.h */,
 				54FEAAA81BC7BB9C002DE521 /* ZMBlacklistDownloader+Testing.h */,
 				F9FD798619EE742600D70FCD /* ZMBlacklistDownloader.m */,
+				878ACB4520ADBBAA0016E68A /* Blacklist.swift */,
 				F9FD798B19EE9B9A00D70FCD /* ZMBlacklistVerificator.h */,
 				540818A51BCA647D00257CA7 /* ZMBlacklistVerificator+Testing.h */,
 				F9FD798C19EE9B9A00D70FCD /* ZMBlacklistVerificator.m */,
@@ -2691,6 +2694,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1660AA0B1ECCAF4E0056D403 /* SearchRequest.swift in Sources */,
+				878ACB4620ADBBAA0016E68A /* Blacklist.swift in Sources */,
 				166A8BF91E02C7D500F5EEEA /* ZMHotFix+PendingChanges.swift in Sources */,
 				F9E577211E77EC6D0065EFE4 /* WireCallCenterV3+Notifications.swift in Sources */,
 				092083401BA95EE100F82B29 /* UserClientRequestFactory.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

When the blacklist JSON contains the version number formatted as the number and not the string, the Wire app would crash. Moreover, it would continue crashing even if the blacklist file is fixed.

### Causes

The blacklist parsing was written in ObjC, and it was easy to miss the wrong type passed around.

### Solutions

~Add the type check in Obj-C~ Rewrite the JSON parsing in Swift and fix the problem in 3 lines of code.

I had to remove some tests that imply that in case of failure the download callback has to be called: it is wrong, since the receiver of the download callback is not checking the data passed in it.

Whole thing better be rewritten in Swift.
