### PR TITLE
BE API for user consent

### DIFF
--- a/Source/Data Model/ZMUser+Consent.swift
+++ b/Source/Data Model/ZMUser+Consent.swift
@@ -1,0 +1,137 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+private let zmLog = ZMSLog(tag: "Network")
+
+enum ConsentType: Int {
+    case marketing = 2
+}
+
+enum ConsentRequestError: Error {
+    case unknown
+}
+
+extension ZMUser {
+    public typealias CompletionFetch = (Result<Bool>) -> Void
+    
+    public func fetchMarketingConsent(in userSession: ZMUserSession,
+                                      completion: @escaping CompletionFetch) {
+        fetchConsent(for: .marketing, in: userSession, completion: completion)
+    }
+    
+    func fetchConsent(for consentType: ConsentType,
+                      in userSession: ZMUserSession,
+                      completion: @escaping CompletionFetch) {
+        
+        func parse(payload: ZMTransportData) -> [ConsentType: Bool] {
+            guard let payloadDict = payload.asDictionary(),
+                    let resultArray = payloadDict["results"] as? [[String: Any]] else {
+                return [:]
+            }
+            
+            var result: [ConsentType: Bool] = [:]
+            
+            resultArray.forEach {
+                guard let type = $0["type"] as? Int,
+                      let value = $0["value"] as? Int,
+                      let consentType = ConsentType(rawValue: type) else {
+                    return
+                }
+                
+                let valueBool = (value == 1)
+                result[consentType] = valueBool
+            }
+            
+            return result
+        }
+        
+        let request = ConsentRequestFactory.fetchConsentRequest()
+        
+        request.add(ZMCompletionHandler(on: managedObjectContext!) { response in
+            
+            guard 200 ... 299 ~= response.httpStatus,
+                  let payload = response.payload
+            else {
+                let error = response.transportSessionError ?? ConsentRequestError.unknown
+                zmLog.debug("Error fetching consent status: \(error)")
+                completion(.failure(error))
+                return
+            }
+            
+            let parsedPayload = parse(payload: payload)
+            let status: Bool = parsedPayload[consentType] ?? false
+            completion(.success(status))
+        })
+        
+        userSession.transportSession.enqueueOneTime(request)
+    }
+    
+    public typealias CompletionSet   = (VoidResult) -> Void
+    public func setMarketingConsent(to value: Bool,
+                                    in userSession: ZMUserSession,
+                                    completion: @escaping CompletionSet) {
+        setConsent(to: value, for: .marketing, in: userSession, completion: completion)
+    }
+    
+    func setConsent(to value: Bool,
+                    for consentType: ConsentType,
+                    in userSession: ZMUserSession,
+                    completion: @escaping CompletionSet) {
+        let request = ConsentRequestFactory.setConsentRequest(for: consentType, value: value)
+        
+        request.add(ZMCompletionHandler(on: managedObjectContext!) { response in
+            
+            guard 200 ... 299 ~= response.httpStatus
+                else {
+                    let error = response.transportSessionError ?? ConsentRequestError.unknown
+                    zmLog.debug("Error setting consent status: \(error)")
+                    completion(.failure(error))
+                    return
+            }
+            
+            completion(.success)
+        })
+        
+        userSession.transportSession.enqueueOneTime(request)
+    }
+}
+
+struct ConsentRequestFactory {
+    static let consentPath = "/self/consent"
+    
+    static func fetchConsentRequest() -> ZMTransportRequest {
+        return .init(getFromPath: consentPath)
+    }
+    
+    static var sourceString: String {
+        return "iOS " + Bundle.main.version
+    }
+    
+    static func setConsentRequest(for consentType: ConsentType, value: Bool) -> ZMTransportRequest {
+        let payload: [String: Any] = [
+            "type": consentType.rawValue,
+            "value": value ? 1:0,
+            "source": sourceString
+        ]
+        return .init(path: consentPath,
+                     method: .methodPUT,
+                     payload: payload as ZMTransportData)
+    }
+}

--- a/Tests/Source/Data Model/ZMUserConsentTests.swift
+++ b/Tests/Source/Data Model/ZMUserConsentTests.swift
@@ -1,0 +1,185 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import XCTest
+@testable import WireSyncEngine
+
+final class ZMUserConsentTests: MessagingTest {
+    var selfUser: ZMUser {
+        let selfUser = ZMUser.selfUser(in: uiMOC)
+        if selfUser.remoteIdentifier == nil {
+            selfUser.remoteIdentifier = UUID()
+        }
+        return selfUser
+    }
+    
+    func testGetRequest() {
+        // given
+        let request = WireSyncEngine.ConsentRequestFactory.fetchConsentRequest()
+        
+        // then
+        XCTAssertEqual(request.method, .methodGET)
+        XCTAssertEqual(request.path, "/self/consent")
+        XCTAssertNil(request.payload)
+    }
+    
+    func testSetRequest_true() {
+        // given
+        let request = WireSyncEngine.ConsentRequestFactory.setConsentRequest(for: .marketing, value: true)
+        // then
+        XCTAssertEqual(request.method, .methodPUT)
+        XCTAssertEqual(request.path, "/self/consent")
+        let expectedPayload: [AnyHashable: Any] = ["type": 2, "value": 1, "source": "iOS 1.0"]
+        XCTAssertEqual(request.payload!.asDictionary()! as NSDictionary, expectedPayload as NSDictionary)
+    }
+    
+    func testSetRequest_false() {
+        // given
+        let request = WireSyncEngine.ConsentRequestFactory.setConsentRequest(for: .marketing, value: false)
+        // then
+        XCTAssertEqual(request.method, .methodPUT)
+        XCTAssertEqual(request.path, "/self/consent")
+        let expectedPayload: [AnyHashable: Any] = ["type": 2, "value": 0, "source": "iOS 1.0"]
+        XCTAssertEqual(request.payload!.asDictionary()! as NSDictionary, expectedPayload as NSDictionary)
+    }
+    
+    func testThatItCanParseResponse() {
+        typealias PayloadPair = ([String: Any], Bool)
+        
+        let pairs: [PayloadPair] =
+            [(["results": [["type": "yobobo", "value": 1]]], false),
+             (["results": [["type": 2, "value": 1]]], true),
+             (["results": [["type": 2, "value": 0]]], false),
+             (["results": [["type": 1, "value": 1]]], false),
+             (["results": [["type": 1000, "value": 0], ["type": 2, "value": 1]]], true),
+             (["results": []], false),
+             ([:], false)]
+            
+            pairs.forEach {
+                let payload = ZMUser.parse(consentPayload: $0.0 as ZMTransportData)
+                
+                let value = payload[.marketing] ?? false
+                XCTAssertEqual(value, $0.1)
+            }
+    }
+    
+    func testThatItCanFetchState() {
+        // given
+        mockTransportSession.responseGeneratorBlock = { request in
+            guard request.path == "/self/consent" else { return nil }
+            
+            return ZMTransportResponse(payload: ["results": [["type": 2, "value": 1]]] as ZMTransportData, httpStatus: 200, transportSessionError: nil)
+        }
+        
+        let fetchedData = expectation(description: "fetched data")
+        
+        // when
+        
+        selfUser.fetchMarketingConsent(in: mockUserSession) { result in
+            switch result {
+            case .failure(_):
+                XCTFail()
+            case .success(let result):
+                XCTAssertTrue(result)
+                fetchedData.fulfill()
+            }
+        }
+        
+        XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
+        mockTransportSession.responseGeneratorBlock = nil
+        mockTransportSession.resetReceivedRequests()
+    }
+    
+    func testThatItFailsOnInvalidOperation_get() {
+        // given
+        mockTransportSession.responseGeneratorBlock = { request in
+            guard request.path == "/self/consent" else { return nil }
+            
+            return ZMTransportResponse(payload: ["label": "invalid-op"] as ZMTransportData, httpStatus: 403, transportSessionError: nil)
+        }
+        
+        let receivedError = expectation(description: "received error")
+        // when
+        
+        selfUser.fetchMarketingConsent(in: mockUserSession) { result in
+            switch result {
+            case .failure(let error):
+                XCTAssertEqual(error as! WireSyncEngine.ConsentRequestError, WireSyncEngine.ConsentRequestError.unknown)
+                receivedError.fulfill()
+            case .success(_):
+                XCTFail()
+            }
+        }
+        
+        XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
+        mockTransportSession.responseGeneratorBlock = nil
+        mockTransportSession.resetReceivedRequests()
+    }
+    
+    func testThatItCanSetTheState() {
+        // given
+        mockTransportSession.responseGeneratorBlock = { request in
+            guard request.path == "/self/consent" else { return nil }
+            
+            return ZMTransportResponse(payload: nil, httpStatus: 200, transportSessionError: nil)
+        }
+        
+        let successExpectation = expectation(description: "set is successful")
+        // when
+        
+        selfUser.setMarketingConsent(to: true, in: self.mockUserSession) { result in
+            switch result {
+            case .failure(_):
+                XCTFail()
+            case .success:
+                successExpectation.fulfill()
+            }
+        }
+        
+        XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
+        mockTransportSession.responseGeneratorBlock = nil
+        mockTransportSession.resetReceivedRequests()
+    }
+    
+    func testThatItFailsOnInvalidOperation_set() {
+        // given
+        mockTransportSession.responseGeneratorBlock = { request in
+            guard request.path == "/self/consent" else { return nil }
+            
+            return ZMTransportResponse(payload: ["label": "invalid-op"] as ZMTransportData, httpStatus: 403, transportSessionError: nil)
+        }
+        
+        let receivedError = expectation(description: "received error")
+        // when
+        
+        selfUser.setMarketingConsent(to: true, in: self.mockUserSession) { result in
+            switch result {
+            case .failure(let error):
+                XCTAssertEqual(error as! WireSyncEngine.ConsentRequestError, WireSyncEngine.ConsentRequestError.unknown)
+                receivedError.fulfill()
+            case .success(_):
+                XCTFail()
+            }
+        }
+        
+        XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
+        mockTransportSession.responseGeneratorBlock = nil
+        mockTransportSession.resetReceivedRequests()
+    }
+}

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -309,6 +309,7 @@
 		8754B84C1F73C38900EC02AD /* MessageChangeInfo+UserSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8754B84B1F73C38900EC02AD /* MessageChangeInfo+UserSession.swift */; };
 		8766853C1F2A1AA00031081B /* UnauthenticatedSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8766853A1F2A1A860031081B /* UnauthenticatedSessionTests.swift */; };
 		878ACB4820AEFB980016E68A /* ZMUser+Consent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878ACB4720AEFB980016E68A /* ZMUser+Consent.swift */; };
+		878ACB5920AF12C10016E68A /* ZMUserConsentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878ACB5820AF12C10016E68A /* ZMUserConsentTests.swift */; };
 		878B823820A1DCE7007455CA /* HTMLString.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 878B823720A1DCE7007455CA /* HTMLString.framework */; };
 		878B823920A1DCF6007455CA /* HTMLString.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 878B823720A1DCE7007455CA /* HTMLString.framework */; };
 		878B823A20A1DD00007455CA /* HTMLString.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 878B823720A1DCE7007455CA /* HTMLString.framework */; };
@@ -888,6 +889,7 @@
 		8754B84B1F73C38900EC02AD /* MessageChangeInfo+UserSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MessageChangeInfo+UserSession.swift"; sourceTree = "<group>"; };
 		8766853A1F2A1A860031081B /* UnauthenticatedSessionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnauthenticatedSessionTests.swift; sourceTree = "<group>"; };
 		878ACB4720AEFB980016E68A /* ZMUser+Consent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUser+Consent.swift"; sourceTree = "<group>"; };
+		878ACB5820AF12C10016E68A /* ZMUserConsentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMUserConsentTests.swift; sourceTree = "<group>"; };
 		878B823720A1DCE7007455CA /* HTMLString.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = HTMLString.framework; path = Carthage/Build/iOS/HTMLString.framework; sourceTree = "<group>"; };
 		8796343F1F7BEA4700FC79BA /* DispatchQueue+SerialAsync.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DispatchQueue+SerialAsync.swift"; sourceTree = "<group>"; };
 		879634411F7BEC5100FC79BA /* DispatchQueueSerialAsyncTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DispatchQueueSerialAsyncTests.swift; sourceTree = "<group>"; };
@@ -1526,6 +1528,7 @@
 				16D3FD011E3A5C0D0052A535 /* ZMConversationVoiceChannelRouterTests.swift */,
 				164CB465207CC47700A2010F /* Conversation+ParticipantsTests.swift */,
 				872A2EE71FFFBC3900900B22 /* ServiceUserTests.swift */,
+				878ACB5820AF12C10016E68A /* ZMUserConsentTests.swift */,
 			);
 			path = "Data Model";
 			sourceTree = "<group>";
@@ -2546,6 +2549,7 @@
 				549AEA3F1D636EF3003C0BEC /* AddressBookUploadRequestStrategyTest.swift in Sources */,
 				F96C8E8A1D7F6F8C004B6D87 /* ZMLocalNotificationTests_SystemMessage.swift in Sources */,
 				F925468E1C63B61000CE2D7C /* MessagingTest+EventFactory.m in Sources */,
+				878ACB5920AF12C10016E68A /* ZMUserConsentTests.swift in Sources */,
 				8766853C1F2A1AA00031081B /* UnauthenticatedSessionTests.swift in Sources */,
 				09D7A88A1AE7E591008F190C /* ZMPhoneNumberVerificationTranscoderTests.m in Sources */,
 				542DFEE81DDCA4FD000F5B95 /* UserProfileUpdateRequestStrategyTests.swift in Sources */,

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -308,6 +308,7 @@
 		8754B84A1F73C25400EC02AD /* ConversationListChangeInfo+UserSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8754B8491F73C25400EC02AD /* ConversationListChangeInfo+UserSession.swift */; };
 		8754B84C1F73C38900EC02AD /* MessageChangeInfo+UserSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8754B84B1F73C38900EC02AD /* MessageChangeInfo+UserSession.swift */; };
 		8766853C1F2A1AA00031081B /* UnauthenticatedSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8766853A1F2A1A860031081B /* UnauthenticatedSessionTests.swift */; };
+		878ACB4820AEFB980016E68A /* ZMUser+Consent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878ACB4720AEFB980016E68A /* ZMUser+Consent.swift */; };
 		878B823820A1DCE7007455CA /* HTMLString.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 878B823720A1DCE7007455CA /* HTMLString.framework */; };
 		878B823920A1DCF6007455CA /* HTMLString.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 878B823720A1DCE7007455CA /* HTMLString.framework */; };
 		878B823A20A1DD00007455CA /* HTMLString.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 878B823720A1DCE7007455CA /* HTMLString.framework */; };
@@ -886,6 +887,7 @@
 		8754B8491F73C25400EC02AD /* ConversationListChangeInfo+UserSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ConversationListChangeInfo+UserSession.swift"; sourceTree = "<group>"; };
 		8754B84B1F73C38900EC02AD /* MessageChangeInfo+UserSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MessageChangeInfo+UserSession.swift"; sourceTree = "<group>"; };
 		8766853A1F2A1A860031081B /* UnauthenticatedSessionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnauthenticatedSessionTests.swift; sourceTree = "<group>"; };
+		878ACB4720AEFB980016E68A /* ZMUser+Consent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUser+Consent.swift"; sourceTree = "<group>"; };
 		878B823720A1DCE7007455CA /* HTMLString.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = HTMLString.framework; path = Carthage/Build/iOS/HTMLString.framework; sourceTree = "<group>"; };
 		8796343F1F7BEA4700FC79BA /* DispatchQueue+SerialAsync.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DispatchQueue+SerialAsync.swift"; sourceTree = "<group>"; };
 		879634411F7BEC5100FC79BA /* DispatchQueueSerialAsyncTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DispatchQueueSerialAsyncTests.swift; sourceTree = "<group>"; };
@@ -1339,6 +1341,7 @@
 				168CF4282007840A009FCB89 /* Team+Invite.swift */,
 				D5D10DA3203AE43200145497 /* Conversation+AccessMode.swift */,
 				16168136207790F600BCF33A /* Conversation+Participants.swift */,
+				878ACB4720AEFB980016E68A /* ZMUser+Consent.swift */,
 				3EFFDE481A13B01B00E80E22 /* Push Token */,
 			);
 			path = "Data Model";
@@ -2770,6 +2773,7 @@
 				874F142D1C16FD9700C15118 /* Device.swift in Sources */,
 				CEF2DE7F1DB778F300451642 /* RequestLoopAnalyticsTracker.swift in Sources */,
 				549AEA3D1D6365C1003C0BEC /* ZMUserSession+AddressBook.swift in Sources */,
+				878ACB4820AEFB980016E68A /* ZMUser+Consent.swift in Sources */,
 				F1C51FE71FB49660009C2269 /* RegistrationStatus.swift in Sources */,
 				874A16922052BEC5001C6760 /* UserExpirationObserver.swift in Sources */,
 				F9B71F491CB297ED001DB03F /* ZMUser+UserSession.m in Sources */,


### PR DESCRIPTION
NB: this API is only available on staging backend.

Adds the support for getting and setting the user marketing consent state.

Tests would come as the second PR. Was tested against the real backend.