### PR TITLE
Remove VoiceChannel.ignore()

### DIFF
--- a/Source/Calling/CallKitDelegate.swift
+++ b/Source/Calling/CallKitDelegate.swift
@@ -266,7 +266,7 @@ extension CallKitDelegate {
         callController.request(transaction) { [weak self] (error) in
             if let error = error {
                 self?.log("Cannot end call: \(error)")
-                conversation.voiceChannel?.endCall()
+                conversation.voiceChannel?.leave()
             }
         }
     }
@@ -399,7 +399,7 @@ extension CallKitDelegate : CXProviderDelegate {
         }
         
         calls.removeValue(forKey: action.callUUID)
-        call.conversation.voiceChannel?.endCall()
+        call.conversation.voiceChannel?.leave()
         action.fulfill()
     }
     
@@ -496,16 +496,6 @@ extension ZMConversation {
         }
     }
     
-}
-
-extension VoiceChannel {
-    
-    func endCall() {
-        switch state {
-        case .incoming: ignore()
-        default: leave()
-        }
-    }
 }
 
 @available(iOS 10.0, *)

--- a/Source/Calling/VoiceChannel.swift
+++ b/Source/Calling/VoiceChannel.swift
@@ -67,7 +67,6 @@ public protocol CallActions : NSObjectProtocol {
     func mute(_ muted: Bool, userSession: ZMUserSession)
     func join(video: Bool, userSession: ZMUserSession) -> Bool
     func leave(userSession: ZMUserSession)
-    func ignore(userSession: ZMUserSession)
     func continueByDecreasingConversationSecurity(userSession: ZMUserSession)
     func leaveAndKeepDegradedConversationSecurity(userSession: ZMUserSession)
 }
@@ -77,7 +76,6 @@ public protocol CallActionsInternal : NSObjectProtocol {
     
     func join(video: Bool) -> Bool
     func leave()
-    func ignore()
     
 }
 

--- a/Source/Calling/VoiceChannelV3.swift
+++ b/Source/Calling/VoiceChannelV3.swift
@@ -156,14 +156,6 @@ extension VoiceChannelV3 : CallActions {
         }
     }
     
-    public func ignore(userSession: ZMUserSession) {
-        if userSession.callNotificationStyle == .callKit, #available(iOS 10.0, *) {
-            userSession.callKitDelegate?.requestEndCall(in: conversation!)
-        } else {
-            return ignore()
-        }
-    }
-    
 }
 
 extension VoiceChannelV3 : CallActionsInternal {
@@ -190,15 +182,12 @@ extension VoiceChannelV3 : CallActionsInternal {
               let remoteID = conv.remoteIdentifier
         else { return }
         
-        self.callCenter?.closeCall(conversationId: remoteID)
-    }
-    
-    public func ignore() {
-        guard let conv = conversation,
-              let remoteID = conv.remoteIdentifier
-        else { return }
-        
-        self.callCenter?.rejectCall(conversationId: remoteID)
+        switch state {
+        case .incoming:
+            callCenter?.rejectCall(conversationId: remoteID)
+        default:
+            callCenter?.closeCall(conversationId: remoteID)
+        }
     }
     
 }

--- a/Source/UserSession/ZMUserSession+Actions.swift
+++ b/Source/UserSession/ZMUserSession+Actions.swift
@@ -74,7 +74,7 @@ extension ZMUserSession {
         let conversation = notification.conversation(in: managedObjectContext)
         
         managedObjectContext.perform { 
-            conversation?.voiceChannel?.ignore(userSession: self)
+            conversation?.voiceChannel?.leave(userSession: self)
             activity?.end()
             completionHandler()
         }

--- a/Tests/Source/Integration/CallingV3Tests.swift
+++ b/Tests/Source/Integration/CallingV3Tests.swift
@@ -87,7 +87,7 @@ class CallingV3Tests : IntegrationTest {
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
     }
     
-    func selfDropCall(){
+    func selfLeaveCall(){
         let convIdRef = self.conversationIdRef
         let userIdRef = self.selfUser.identifier.cString(using: .utf8)
         userSession?.enqueueChanges {
@@ -99,20 +99,6 @@ class CallingV3Tests : IntegrationTest {
                                              contextRef: self.wireCallCenterRef)
         }
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-    }
-    
-    func selfIgnoreCall(){
-        let convIdRef = self.conversationIdRef
-        let userIdRef = self.selfUser.identifier.cString(using: .utf8)
-        userSession?.performChanges{
-            self.conversationUnderTest.voiceChannel?.ignore()
-            WireSyncEngine.closedCallHandler(reason: WCALL_REASON_STILL_ONGOING,
-                                             conversationId: convIdRef,
-                                             messageTime: 0,
-                                             userId: userIdRef,
-                                             contextRef: self.wireCallCenterRef)
-        }
-        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout:0.5))
     }
     
     func otherStartCall(user: ZMUser, isVideoCall: Bool = false, shouldRing: Bool = true) {
@@ -192,7 +178,7 @@ class CallingV3Tests : IntegrationTest {
         stateObserver.checkLastNotificationHasCallState(.outgoing(degraded: false))
         
         // when
-        selfDropCall()
+        selfLeaveCall()
         closeCall(user: self.localSelfUser, reason: .canceled)
         
         // then
@@ -219,7 +205,7 @@ class CallingV3Tests : IntegrationTest {
         stateObserver.changes = []
 
         // when
-        selfDropCall()
+        selfLeaveCall()
         
         // then
         XCTAssertEqual(stateObserver.changes.count, 1)
@@ -247,7 +233,7 @@ class CallingV3Tests : IntegrationTest {
         stateObserver.changes = []
         
         // when
-        selfDropCall()
+        selfLeaveCall()
         
         // then
         XCTAssertEqual(stateObserver.changes.count, 1)
@@ -298,7 +284,7 @@ class CallingV3Tests : IntegrationTest {
         // (4) self user leaves
         //
         // when
-        selfDropCall()
+        selfLeaveCall()
         closeCall(user: self.localSelfUser, reason: .canceled)
         
         // then
@@ -347,7 +333,7 @@ class CallingV3Tests : IntegrationTest {
         // (4) self user leaves
         //
         // when
-        selfDropCall()
+        selfLeaveCall()
         closeCall(user: self.localSelfUser, reason: .canceled)
         
         // then
@@ -458,7 +444,7 @@ class CallingV3Tests : IntegrationTest {
         
         // (2) we ignore
         // when
-        selfIgnoreCall()
+        selfLeaveCall()
         
         // then
         XCTAssertEqual(stateObserver.changes.count, 2)
@@ -483,7 +469,7 @@ class CallingV3Tests : IntegrationTest {
         // (1) other user joins and we ignore
         // when
         otherStartCall(user: user)
-        selfIgnoreCall()
+        selfLeaveCall()
         
         // then
         XCTAssertEqual(stateObserver.changes.count, 2)
@@ -518,7 +504,7 @@ class CallingV3Tests : IntegrationTest {
         
         // (2) Self ignores call
         // and when
-        selfIgnoreCall()
+        selfLeaveCall()
         
         // then
         XCTAssertEqual(convObserver!.notifications.count, 1)
@@ -574,7 +560,7 @@ class CallingV3Tests : IntegrationTest {
         
         // (3) selfUser user ends call
         // and when
-        selfDropCall()
+        selfLeaveCall()
         
         // then
         XCTAssertEqual(convObserver!.notifications.count, 2)
@@ -605,7 +591,7 @@ class CallingV3Tests : IntegrationTest {
         otherStartCall(user: user)
         
         // Self ignores call
-        selfIgnoreCall()
+        selfLeaveCall()
         
         // Other user ends call
         closeCall(user: user, reason: .canceled)
@@ -629,7 +615,7 @@ class CallingV3Tests : IntegrationTest {
         otherStartCall(user: user)
         
         // Self ignores call
-        selfIgnoreCall()
+        selfLeaveCall()
         
         // Other user ends call
         closeCall(user: user, reason: .canceled)


### PR DESCRIPTION
## What's new in this PR?

### Issues

We weren't calling `VoiceChannel.ignore()` for dismissing incoming calls.

### Solutions

Simplify the `VoiceChannel`interface by letting `VoiceChannel.leave()` handle both ignoring an incoming call and leaving an ongoing call.