### PR TITLE
Do not unarchive silenced conversations when call is incoming

### DIFF
--- a/Source/UserSession/CallStateObserver.swift
+++ b/Source/UserSession/CallStateObserver.swift
@@ -163,6 +163,7 @@ extension CallStateObserver : WireCallCenterCallStateObserver, WireCallCenterMis
     }
     
     private func updateConversation(_ conversation: ZMConversation, with callState: CallState) {
+        guard conversation.isArchived, !conversation.isSilenced else { return }
         switch callState {
         case .incoming(_, shouldRing: true, degraded: _): conversation.isArchived = false
         default: break

--- a/Tests/Source/Calling/CallStateObserverTests.swift
+++ b/Tests/Source/Calling/CallStateObserverTests.swift
@@ -312,5 +312,32 @@ class CallStateObserverTests : MessagingTest {
         // Then
         XCTAssertFalse(conversation.isArchived)
     }
+    
+    func testThatArchivedAndMutedConversationsDoesNotGetUnarchivedForIncomingCalls() {
+        // Given
+        conversation.lastServerTimeStamp = Date()
+        conversation.isArchived = true
+        conversation.isSilenced = true
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        XCTAssert(conversation.isArchived)
+        XCTAssert(conversation.isSilenced)
+        XCTAssertNil(conversation.clearedTimeStamp)
+        
+        // When
+        syncMOC.performGroupedBlock {
+            self.sut.callCenterDidChange(
+                callState: .incoming(video: false, shouldRing: true, degraded: false),
+                conversation: self.conversation,
+                caller: self.sender,
+                timestamp: nil
+            )
+        }
+        
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        // Then
+        XCTAssert(conversation.isArchived)
+        XCTAssert(conversation.isSilenced)
+    }
 
 }


### PR DESCRIPTION
## What's new in this PR?

* Do not unarchive silenced conversations when call is incoming.