### PR TITLE
Join call without video on, CallKit: default no video

### DIFF
--- a/Source/Calling/VoiceChannelV3.swift
+++ b/Source/Calling/VoiceChannelV3.swift
@@ -168,7 +168,7 @@ extension VoiceChannelV3 : CallActionsInternal {
         switch state {
         case .incoming(video: _, shouldRing: _, degraded: let degraded):
             if !degraded {
-                joined = callCenter?.answerCall(conversation: conversation) ?? false
+                joined = callCenter?.answerCall(conversation: conversation, video: video) ?? false
             }
         default:
             joined = self.callCenter?.startCall(conversation: conversation, video: video) ?? false

--- a/Tests/Source/Calling/WireCallCenterV3Mock.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Mock.swift
@@ -24,6 +24,7 @@ public class MockAVSWrapper : AVSWrapperType {
     
     public var startCallArguments: (uuid: UUID, callType: AVSCallType, conversationType: AVSConversationType, useCBR: Bool)?
     public var answerCallArguments: (uuid: UUID, callType: AVSCallType, useCBR: Bool)?
+    public var setVideoStateArguments: (uuid: UUID, videoState: VideoState)?
     public var didCallEndCall = false
     public var didCallRejectCall = false
     public var didCallClose = false
@@ -68,7 +69,7 @@ public class MockAVSWrapper : AVSWrapperType {
     
 
     public func setVideoState(conversationId: UUID, videoState: VideoState) {
-        // do nothing
+        setVideoStateArguments = (conversationId, videoState)
     }
     
     public func received(callEvent: CallEvent) {

--- a/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -268,7 +268,7 @@ class WireCallCenterV3Tests: MessagingTest {
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // when
-        XCTAssertTrue(sut.answerCall(conversation: oneOnOneConversation))
+        XCTAssertTrue(sut.answerCall(conversation: oneOnOneConversation, video: false))
         
         // then
         XCTAssertTrue(mockAVSWrapper.didCallRejectCall)
@@ -281,7 +281,7 @@ class WireCallCenterV3Tests: MessagingTest {
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // when
-        XCTAssertTrue(sut.answerCall(conversation: oneOnOneConversation))
+        XCTAssertTrue(sut.answerCall(conversation: oneOnOneConversation, video: false))
         
         // then
         XCTAssertTrue(mockAVSWrapper.didCallEndCall)
@@ -352,7 +352,7 @@ class WireCallCenterV3Tests: MessagingTest {
         
         checkThatItPostsNotification(expectedCallState: .answered(degraded: false), expectedCallerId: otherUserID, expectedConversationId: oneOnOneConversationID) {
             // when
-            _ = sut.answerCall(conversation: oneOnOneConversation)
+            _ = sut.answerCall(conversation: oneOnOneConversation, video: false)
             
             // then
             XCTAssertEqual(mockAVSWrapper.answerCallArguments?.callType, AVSCallType.normal)
@@ -373,10 +373,40 @@ class WireCallCenterV3Tests: MessagingTest {
         
         checkThatItPostsNotification(expectedCallState: .answered(degraded: false), expectedCallerId: otherUserID, expectedConversationId: groupConversationID) {
             // when
-            _ = sut.answerCall(conversation: groupConversation)
+            _ = sut.answerCall(conversation: groupConversation, video: false)
             
             // then
             XCTAssertEqual(mockAVSWrapper.answerCallArguments?.callType, AVSCallType.audioOnly)
+        }
+    }
+    
+    func testThatItAnswersACall_audioOnly() {
+        // given
+        WireSyncEngine.incomingCallHandler(conversationId: oneOnOneConversationIDRef, messageTime: 0, userId: otherUserIDRef, isVideoCall: 1, shouldRing: 1, contextRef: context)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        checkThatItPostsNotification(expectedCallState: .answered(degraded: false), expectedCallerId: otherUserID, expectedConversationId: oneOnOneConversationID) {
+            // when
+            _ = sut.answerCall(conversation: oneOnOneConversation, video: false)
+            
+            // then
+            XCTAssertEqual(mockAVSWrapper.answerCallArguments?.callType, AVSCallType.normal)
+            XCTAssertEqual(mockAVSWrapper.setVideoStateArguments?.videoState, VideoState.stopped)
+        }
+    }
+    
+    func testThatItAnswersACall_withVideo() {
+        // given
+        WireSyncEngine.incomingCallHandler(conversationId: oneOnOneConversationIDRef, messageTime: 0, userId: otherUserIDRef, isVideoCall: 1, shouldRing: 1, contextRef: context)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        checkThatItPostsNotification(expectedCallState: .answered(degraded: false), expectedCallerId: otherUserID, expectedConversationId: oneOnOneConversationID) {
+            // when
+            _ = sut.answerCall(conversation: oneOnOneConversation, video: true)
+            
+            // then
+            XCTAssertEqual(mockAVSWrapper.answerCallArguments?.callType, AVSCallType.normal)
+            XCTAssertNil(mockAVSWrapper.setVideoStateArguments)
         }
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

When user joins the call, it's not clear if the ongoing call is video or not. Old behavior was that the video was turned on per default, which can confuse the user.

Another undesired behavior was that when user joined from the CallKit, the app was sending the empty video stream.

### Solutions

We set video disabled when joining the call, if we are joining the ongoing call, same goes for the CallKit case.