### PR TITLE
Use voip session for calling messages

### DIFF
--- a/Source/Synchronization/Strategies/CallingRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/CallingRequestStrategy.swift
@@ -48,11 +48,11 @@ public final class CallingRequestStrategy : NSObject, RequestStrategy {
     }
     
     public func nextRequest() -> ZMTransportRequest? {
-        if let request = self.callConfigRequestSync.nextRequest() {
-            return request
-        }
+        let request = self.callConfigRequestSync.nextRequest() ?? genericMessageStrategy.nextRequest()
         
-        return genericMessageStrategy.nextRequest()
+        request?.forceToVoipSession()
+       
+        return request
     }
     
     public func dropPendingCallMessages(for conversation: ZMConversation) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Calling message weren't delivered while app is in background in some cases.

### Causes

Calling messages weren't being sent on the voip session, which means they are sent on the background session.

### Solutions

Mark calling messages to be sent on the voip session.