### PR TITLE
Add missing . in localizations string builder method

### DIFF
--- a/Source/Notifications/Push notifications/PushNotificationCategory.swift
+++ b/Source/Notifications/Push notifications/PushNotificationCategory.swift
@@ -23,7 +23,7 @@ import Foundation
 fileprivate extension String {
     
     var localizedPushAction: String {
-        return Bundle(for: ZMUserSession.self).localizedString(forKey: "push.notification.action\(self)", value: "", table: "Push")
+        return Bundle(for: ZMUserSession.self).localizedString(forKey: "push.notification.action.\(self)", value: "", table: "Push")
     }
     
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Localization is broken for push notification actions.

### Causes

Localization strings are build using helper method which was missing a `.`.

### Solutions

Add missing `.`