### PR TITLE
Hotfix: refetch conversations

### DIFF
--- a/Source/Synchronization/ZMHotFixDirectory+Swift.swift
+++ b/Source/Synchronization/ZMHotFixDirectory+Swift.swift
@@ -135,4 +135,13 @@ import Foundation
         context.enqueueDelayedSave()
     }
     
+    /// Marks all group conversations to be refetched.
+    public static func refetchGroupConversations(_ context: NSManagedObjectContext) {
+        let predicate = NSPredicate(format: "conversationType == %d", ZMConversationType.group.rawValue)
+        let request = ZMConversation.sortedFetchRequest(with: predicate)
+        let conversations = context.executeFetchRequestOrAssert(request) as? [ZMConversation]
+        
+        conversations?.forEach { $0.needsToBeUpdatedFromBackend = true }
+        context.enqueueDelayedSave()
+    }
 }

--- a/Source/Synchronization/ZMHotFixDirectory.m
+++ b/Source/Synchronization/ZMHotFixDirectory.m
@@ -131,6 +131,14 @@ static NSString* ZMLogTag ZM_UNUSED = @"HotFix";
                      patchCode:^(NSManagedObjectContext *context) {
                          [ZMHotFixDirectory refetchUsers:context];
                      }],
+                    
+                    
+                    /// We need to refetch all conversations in order to receive the correct status of the message timer.
+                    [ZMHotFixPatch
+                     patchWithVersion:@"175.0.0"
+                     patchCode:^(NSManagedObjectContext *context) {
+                         [ZMHotFixDirectory refetchGroupConversations:context];
+                     }],
                     ];
     });
     return patches;


### PR DESCRIPTION
## What's new in this PR?

### Issues

It's necessary to re-fetch the group conversations to receive the value of the message expiration timer.
