### PR TITLE
Don't update last modified date for update events of type .messageTimerUpdate

### DIFF
--- a/Source/Synchronization/Transcoders/ZMConversationTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMConversationTranscoder.m
@@ -388,6 +388,7 @@ static NSString *const ConversationTeamManagedKey = @"managed";
         case ZMUpdateEventTypeConversationMemberLeave:
         case ZMUpdateEventTypeConversationRename:
         case ZMUpdateEventTypeConversationAccessModeUpdate:
+        case ZMUpdateEventTypeConversationMessageTimerUpdate:
             return NO;
 
         default:

--- a/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.m
@@ -2879,6 +2879,7 @@ static NSString *const CONVERSATION_ID_REQUEST_PREFIX = @"/conversations?ids=";
     
         NSArray<NSNumber *> *ignoredEventTypes = @[
                                                    @(ZMUpdateEventTypeConversationAccessModeUpdate),
+                                                   @(ZMUpdateEventTypeConversationMessageTimerUpdate),
                                                    @(ZMUpdateEventTypeTeamMemberUpdate),
                                                    @(ZMUpdateEventTypeTeamMemberLeave),
                                                    @(ZMUpdateEventTypeConversationRename)


### PR DESCRIPTION
## What's new in this PR?

* Don't update last modified date for update events of type `.messageTimerUpdate`.