### PR TITLE
Added logic to persist the timer system message on datamodel

### DIFF
--- a/Source/Synchronization/Transcoders/ZMConversationTranscoder.swift
+++ b/Source/Synchronization/Transcoders/ZMConversationTranscoder.swift
@@ -34,12 +34,17 @@ extension ZMConversationTranscoder {
     @objc (processDestructionTimerUpdateEvent:inConversation:)
     public func processDestructionTimerUpdate(event: ZMUpdateEvent, in conversation: ZMConversation) {
         precondition(event.type == .conversationMessageTimerUpdate, "invalid update event type")
-        guard let payload = event.payload["data"] as? [String : AnyHashable] else { return }
+        guard let payload = event.payload["data"] as? [String : AnyHashable],
+            let senderUUID = event.senderUUID() else { return }
         if let timeoutIntegerValue = payload["message_timer"] as? Int {
             let timeoutValue = MessageDestructionTimeoutValue(rawValue: TimeInterval(timeoutIntegerValue))
             conversation.messageDestructionTimeout = .synced(timeoutValue)
         } else {
             conversation.messageDestructionTimeout = nil
+        }
+        
+        if let user = ZMUser(remoteID: senderUUID, createIfNeeded: false, in: managedObjectContext), !user.isSelfUser {
+            conversation.appendMessageTimerUpdateMessage(fromUser: user, timer: conversation.messageDestructionTimeoutValue)
         }
     }
 

--- a/Source/Synchronization/Transcoders/ZMConversationTranscoder.swift
+++ b/Source/Synchronization/Transcoders/ZMConversationTranscoder.swift
@@ -43,8 +43,11 @@ extension ZMConversationTranscoder {
             conversation.messageDestructionTimeout = nil
         }
         
-        if let user = ZMUser(remoteID: senderUUID, createIfNeeded: false, in: managedObjectContext), !user.isSelfUser {
-            conversation.appendMessageTimerUpdateMessage(fromUser: user, timer: conversation.messageDestructionTimeoutValue)
+        if let user = ZMUser(remoteID: senderUUID, createIfNeeded: false, in: managedObjectContext),
+            let timestamp = event.timeStamp(),
+            !user.isSelfUser {
+            let timer = conversation.messageDestructionTimeoutValue
+            conversation.appendMessageTimerUpdateMessage(fromUser: user, timer: timer, timestamp: timestamp)
         }
     }
 

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_Event.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_Event.swift
@@ -348,7 +348,7 @@ class ZMLocalNotificationTests_Event: ZMLocalNotificationTests {
     
     func testThatItCreatesANotificationForMessageTimerUpdateSystemMessages() {
         // given
-        let message = groupConversation.appendMessageTimerUpdateMessage(fromUser: otherUser1, timer: 86400)
+        let message = groupConversation.appendMessageTimerUpdateMessage(fromUser: otherUser1, timer: 86400, timestamp: Date())
         message.sender = otherUser1
 
         // when
@@ -362,7 +362,7 @@ class ZMLocalNotificationTests_Event: ZMLocalNotificationTests {
     func testThatItCreatesANotificationForMessageTimerUpdateSystemMessages_NoUserName() {
         // given
         otherUser1.name = ""
-        let message = groupConversation.appendMessageTimerUpdateMessage(fromUser: otherUser1, timer: 86400)
+        let message = groupConversation.appendMessageTimerUpdateMessage(fromUser: otherUser1, timer: 86400, timestamp: Date())
         message.sender = otherUser1
         
         // when
@@ -375,7 +375,7 @@ class ZMLocalNotificationTests_Event: ZMLocalNotificationTests {
     
     func testThatItCreatesANotificationForMessageTimerUpdateSystemMessages_NoConversationName() {
         // given
-        let message = groupConversationWithoutName.appendMessageTimerUpdateMessage(fromUser: otherUser1, timer: 86400)
+        let message = groupConversationWithoutName.appendMessageTimerUpdateMessage(fromUser: otherUser1, timer: 86400, timestamp: Date())
         message.sender = otherUser1
         
         // when
@@ -389,7 +389,7 @@ class ZMLocalNotificationTests_Event: ZMLocalNotificationTests {
     func testThatItCreatesANotificationForMessageTimerUpdateSystemMessages_NoUserName_NoConversationName() {
         // given
         otherUser1.name = ""
-        let message = groupConversationWithoutName.appendMessageTimerUpdateMessage(fromUser: otherUser1, timer: 86400)
+        let message = groupConversationWithoutName.appendMessageTimerUpdateMessage(fromUser: otherUser1, timer: 86400, timestamp: Date())
         message.sender = otherUser1
         
         // when


### PR DESCRIPTION
## What's new in this PR?

Added call to `appendMessageTimerUpdateMessage()` method of `ZMConversation`, so in this way we can persist locally the system message for timer changes.

## Needs release with

- [ ] https://github.com/wireapp/wire-ios-data-model/pull/502
