### PR TITLE
Fix/timed message system message

### DIFF
--- a/Source/Synchronization/Transcoders/ZMConversationTranscoder.swift
+++ b/Source/Synchronization/Transcoders/ZMConversationTranscoder.swift
@@ -46,7 +46,17 @@ extension ZMConversationTranscoder {
         
         if let user = ZMUser(remoteID: senderUUID, createIfNeeded: false, in: managedObjectContext),
             let timestamp = event.timeStamp() {
-            let timer = conversation.hasSyncedMessageDestructionTimeout ? conversation.messageDestructionTimeoutValue : 0
+            
+            let timer: TimeInterval
+            
+            // system message timer should reflect the synced value, not local
+            if let timeout = conversation.messageDestructionTimeout,
+             case let .synced(value) = timeout {
+                timer = value.rawValue
+            } else {
+                timer = 0
+            }
+            
             let message = conversation.appendMessageTimerUpdateMessage(fromUser: user, timer: timer, timestamp: timestamp)
             localNotificationDispatcher.process(message)
         }

--- a/Source/Synchronization/Transcoders/ZMConversationTranscoder.swift
+++ b/Source/Synchronization/Transcoders/ZMConversationTranscoder.swift
@@ -46,7 +46,7 @@ extension ZMConversationTranscoder {
         
         if let user = ZMUser(remoteID: senderUUID, createIfNeeded: false, in: managedObjectContext),
             let timestamp = event.timeStamp() {
-            let timer = conversation.messageDestructionTimeoutValue
+            let timer = conversation.hasSyncedMessageDestructionTimeout ? conversation.messageDestructionTimeoutValue : 0
             let message = conversation.appendMessageTimerUpdateMessage(fromUser: user, timer: timer, timestamp: timestamp)
             localNotificationDispatcher.process(message)
         }

--- a/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.swift
+++ b/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.swift
@@ -439,8 +439,6 @@ extension ZMConversationTranscoderTests_Swift {
         
         syncMOC.performGroupedBlockAndWait {
             XCTAssertNotNil(self.conversation.messageDestructionTimeout)
-            XCTAssertTrue(self.conversation.hasLocalMessageDestructionTimeout)
-            XCTAssertTrue(self.conversation.hasSyncedMessageDestructionTimeout)
             
             // "turn off" synced timeout
             let payload: [String: Any] = [

--- a/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.swift
+++ b/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.swift
@@ -426,6 +426,46 @@ extension ZMConversationTranscoderTests_Swift {
             XCTAssertEqual(self.localNotificationDispatcher.processedMessages.last, message)
         }
     }
+    
+    func testThatItGeneratesCorrectSystemMessageWhenSyncedTimeoutTurnedOff() {
+        // GIVEN: local & synced timeouts exist
+        syncMOC.performGroupedBlockAndWait {
+            self.conversation.messageDestructionTimeout = .local(.fiveMinutes)
+        }
+        
+        syncMOC.performGroupedBlockAndWait {
+            self.conversation.messageDestructionTimeout = .synced(.oneHour)
+        }
+        
+        syncMOC.performGroupedBlockAndWait {
+            XCTAssertNotNil(self.conversation.messageDestructionTimeout)
+            XCTAssertTrue(self.conversation.hasLocalMessageDestructionTimeout)
+            XCTAssertTrue(self.conversation.hasSyncedMessageDestructionTimeout)
+            
+            // "turn off" synced timeout
+            let payload: [String: Any] = [
+                "from": self.user!.remoteIdentifier!.transportString(),
+                "conversation": self.conversation!.remoteIdentifier!.transportString(),
+                "time": NSDate().transportString(),
+                "data": ["message_timer": 0],
+                "type": "conversation.message-timer-update"
+            ]
+            
+            let event = ZMUpdateEvent(fromEventStreamPayload: payload as ZMTransportData, uuid: nil)!
+            
+            // WHEN
+            self.sut?.processEvents([event], liveEvents: true, prefetchResult: nil)
+            
+            // THEN: the local timeout still exists
+            XCTAssertEqual(self.conversation?.messageDestructionTimeout!, MessageDestructionTimeout.local(.fiveMinutes))
+            guard let message = self.conversation?.messages.lastObject as? ZMSystemMessage else { return XCTFail() }
+            XCTAssertEqual(message.systemMessageType, .messageTimerUpdate)
+            
+            // but the system message timer reflects the update to the synced timeout
+            XCTAssertEqual(0, message.messageTimer)
+            XCTAssertEqual(self.localNotificationDispatcher.processedMessages.last, message)
+        }
+    }
 }
 
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

If a local timeout has been set (to say, 5 minutes), then setting a global timer to the value `none` generates a system message stating "you set the timed messages to 5 minutes" instead of "you set the timed messages to Off".

### Causes

The system message is created when `ZMConversationTranscoder` processes the `conversationMessageTimerUpdate` event. After having set the `messageDestructionTimeout` to `.synced(0)`, the timer value for the system message is read from `messageDestructionTimeoutValue`. This returns (as specified in the [DataModel](https://github.com/wireapp/wire-ios-data-model/blob/cc158917ee9d10c1895f57e95807f1364e0abaf0/Source/Model/Conversation/ZMConversation%2BEphemeral.swift#L176)) first the nonzero synced timeout value, else the nonzero local timeout value, or finally 0. Although we have cleared the sync timeout, the local one still exists and its value is passed on to the system message.

### Solutions

Instead of getting the first available timeout value, check that `messageDestructionTimeout` is a synced timeout and pass its value (or 0 if the timeout is local) to the system message.