### PR TITLE
Avoid double timer system messages

### DIFF
--- a/Source/Synchronization/Transcoders/ZMConversationTranscoder.swift
+++ b/Source/Synchronization/Transcoders/ZMConversationTranscoder.swift
@@ -47,7 +47,8 @@ extension ZMConversationTranscoder {
             timeout = nil
         }
         
-        if user.isSelfUser && conversation.messageDestructionTimeout == timeout {
+        if user.isSelfUser && (conversation.messageDestructionTimeout == timeout
+            || (conversation.messageDestructionTimeout == nil && timeout == .synced(.none))) {
             return
         }
         

--- a/Source/Synchronization/Transcoders/ZMConversationTranscoder.swift
+++ b/Source/Synchronization/Transcoders/ZMConversationTranscoder.swift
@@ -35,17 +35,25 @@ extension ZMConversationTranscoder {
     public func processDestructionTimerUpdate(event: ZMUpdateEvent, in conversation: ZMConversation) {
         precondition(event.type == .conversationMessageTimerUpdate, "invalid update event type")
         guard let payload = event.payload["data"] as? [String : AnyHashable],
-            let senderUUID = event.senderUUID() else { return }
+            let senderUUID = event.senderUUID(),
+            let user = ZMUser(remoteID: senderUUID, createIfNeeded: false, in: managedObjectContext) else { return }
+        
+        var timeout: MessageDestructionTimeout?
+        
         if let timeoutIntegerValue = payload["message_timer"] as? Int64 {
             // Backend is sending the miliseconds, we need to convert to seconds.
-            let timeoutValue = MessageDestructionTimeoutValue(rawValue: TimeInterval(timeoutIntegerValue / 1000))
-            conversation.messageDestructionTimeout = .synced(timeoutValue)
+            timeout = .synced(MessageDestructionTimeoutValue(rawValue: TimeInterval(timeoutIntegerValue / 1000)))
         } else {
-            conversation.messageDestructionTimeout = nil
+            timeout = nil
         }
         
-        if let user = ZMUser(remoteID: senderUUID, createIfNeeded: false, in: managedObjectContext),
-            let timestamp = event.timeStamp() {
+        if user.isSelfUser && conversation.messageDestructionTimeout == timeout {
+            return
+        }
+        
+        conversation.messageDestructionTimeout = timeout
+        
+        if let timestamp = event.timeStamp() {
             let timer = conversation.messageDestructionTimeoutValue
             let message = conversation.appendMessageTimerUpdateMessage(fromUser: user, timer: timer, timestamp: timestamp)
             localNotificationDispatcher.process(message)

--- a/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.swift
+++ b/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.swift
@@ -465,7 +465,7 @@ extension ZMConversationTranscoderTests_Swift {
         }
     }
     
-    func testThatItDiscardsDoubleSystemMessageWhenSyncedTumeoutChanges_Value() {
+    func testThatItDiscardsDoubleSystemMessageWhenSyncedTimeoutChanges_Value() {
         
         syncMOC.performGroupedBlockAndWait {
             XCTAssertNil(self.conversation.messageDestructionTimeout)
@@ -503,7 +503,7 @@ extension ZMConversationTranscoderTests_Swift {
         }
     }
     
-    func testThatItDiscardsDoubleSystemMessageWhenSyncedTumeoutChanges_NoValue() {
+    func testThatItDiscardsDoubleSystemMessageWhenSyncedTimeoutChanges_NoValue() {
         
         syncMOC.performGroupedBlockAndWait {
             XCTAssertNil(self.conversation.messageDestructionTimeout)

--- a/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.swift
+++ b/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.swift
@@ -464,6 +464,99 @@ extension ZMConversationTranscoderTests_Swift {
             XCTAssertEqual(self.localNotificationDispatcher.processedMessages.last, message)
         }
     }
+    
+    func testThatItDiscardsDoubleSystemMessageWhenSyncedTumeoutChanges_Value() {
+        
+        syncMOC.performGroupedBlockAndWait {
+            XCTAssertNil(self.conversation.messageDestructionTimeout)
+            
+            // Given
+            let messageTimerMillis = 31536000000
+            let messageTimer = MessageDestructionTimeoutValue(rawValue: TimeInterval(messageTimerMillis / 1000))
+            let selfUser = ZMUser.selfUser(in: self.syncMOC)
+            selfUser.remoteIdentifier = UUID.create()
+            
+            let payload: [String: Any] = [
+                "from": selfUser.remoteIdentifier!.transportString(),
+                "conversation": self.conversation!.remoteIdentifier!.transportString(),
+                "time": NSDate().transportString(),
+                "data": ["message_timer": messageTimerMillis],
+                "type": "conversation.message-timer-update"
+            ]
+            
+            let event = ZMUpdateEvent(fromEventStreamPayload: payload as ZMTransportData, uuid: nil)!
+            
+            // WHEN
+            self.sut?.processEvents([event], liveEvents: true, prefetchResult: nil) //First event
+            
+            XCTAssertEqual(self.conversation?.messageDestructionTimeout!, MessageDestructionTimeout.synced(messageTimer))
+            guard let firstMessage = self.conversation?.messages.lastObject as? ZMSystemMessage else { return XCTFail() }
+            XCTAssertEqual(firstMessage.systemMessageType, .messageTimerUpdate)
+            XCTAssertEqual(self.localNotificationDispatcher.processedMessages.last, firstMessage)
+            
+            self.sut?.processEvents([event], liveEvents: true, prefetchResult: nil) //Second duplicated event
+            
+            // THEN
+            XCTAssertEqual(self.conversation?.messageDestructionTimeout!, MessageDestructionTimeout.synced(messageTimer))
+            guard let secondMessage = self.conversation?.messages.lastObject as? ZMSystemMessage else { return XCTFail() }
+            XCTAssertEqual(firstMessage, secondMessage) //Check that no other messages are appended in the conversation
+        }
+    }
+    
+    func testThatItDiscardsDoubleSystemMessageWhenSyncedTumeoutChanges_NoValue() {
+        
+        syncMOC.performGroupedBlockAndWait {
+            XCTAssertNil(self.conversation.messageDestructionTimeout)
+            
+            // Given
+            let valuedMessageTimerMillis = 31536000000
+            let valuedMessageTimer = MessageDestructionTimeoutValue(rawValue: TimeInterval(valuedMessageTimerMillis / 1000))
+            
+            let selfUser = ZMUser.selfUser(in: self.syncMOC)
+            selfUser.remoteIdentifier = UUID.create()
+            
+            let valuedPayload: [String: Any] = [
+                "from": selfUser.remoteIdentifier!.transportString(),
+                "conversation": self.conversation!.remoteIdentifier!.transportString(),
+                "time": NSDate().transportString(),
+                "data": ["message_timer": valuedMessageTimerMillis],
+                "type": "conversation.message-timer-update"
+            ]
+            
+            let payload: [String: Any] = [
+                "from": selfUser.remoteIdentifier!.transportString(),
+                "conversation": self.conversation!.remoteIdentifier!.transportString(),
+                "time": NSDate().transportString(),
+                "data": ["message_timer": 0],
+                "type": "conversation.message-timer-update"
+            ]
+            
+            let valuedEvent = ZMUpdateEvent(fromEventStreamPayload: valuedPayload as ZMTransportData, uuid: nil)!
+            let event = ZMUpdateEvent(fromEventStreamPayload: payload as ZMTransportData, uuid: nil)!
+            
+            // WHEN
+            
+            //First event with valued timer
+            self.sut?.processEvents([valuedEvent], liveEvents: true, prefetchResult: nil)
+            XCTAssertEqual(self.conversation?.messageDestructionTimeout!, MessageDestructionTimeout.synced(valuedMessageTimer))
+            
+            //Second event with timer = nil
+            self.sut?.processEvents([event], liveEvents: true, prefetchResult: nil)
+            XCTAssertNil(self.conversation?.messageDestructionTimeout)
+        
+            guard let firstMessage = self.conversation?.messages.lastObject as? ZMSystemMessage else { return XCTFail() }
+            XCTAssertEqual(firstMessage.systemMessageType, .messageTimerUpdate)
+            XCTAssertEqual(self.localNotificationDispatcher.processedMessages.last, firstMessage)
+        
+            //Third event with timer = nil
+            self.sut?.processEvents([event], liveEvents: true, prefetchResult: nil)
+            
+            // THEN
+            XCTAssertNil(self.conversation?.messageDestructionTimeout)
+            guard let secondMessage = self.conversation?.messages.lastObject as? ZMSystemMessage else { return XCTFail() }
+            XCTAssertEqual(firstMessage, secondMessage) //Check that no other messages are appended in the conversation
+        }
+    }
 }
 
 


### PR DESCRIPTION
## What's new in this PR?

When a user changes the timer of a conversation, the system message is appended twice. This is because SE is considering the change sent from `ZMTransportSession`. I'm discarding the message if there are changes and if they're made by the current user.

**Problem**: this solution doesn't work with _Off_ - in this case, the change is not ignored because here `.none` is different than `nil`:
https://github.com/wireapp/wire-ios-sync-engine/blob/4bef033b9ee20872d9c69b03c9e6682b550b6d10/Source/Synchronization/Transcoders/ZMConversationTranscoder.swift#L50-L52