### PR TITLE
Fixed setting the conversation timer to OFF

### DIFF
--- a/Source/Data Model/Conversation+MessageDestructionTimeout.swift
+++ b/Source/Data Model/Conversation+MessageDestructionTimeout.swift
@@ -76,9 +76,16 @@ fileprivate struct MessageDestructionTimeoutRequestFactory {
     
     static func set(timeout: Int, for conversation: ZMConversation) -> ZMTransportRequest {
         guard let identifier = conversation.remoteIdentifier?.transportString() else { fatal("conversation inserted on backend") }
-        // Backend expects the timer to be in miliseconds, we store it in seconds.
-        let timeoutInMS: Int64 = Int64(timeout) * 1000
-        let payload = ["message_timer": timeoutInMS]
+        
+        let payload: [AnyHashable: Any?]
+        if timeout == 0 {
+            payload = ["message_timer": nil]
+        }
+        else {
+            // Backend expects the timer to be in miliseconds, we store it in seconds.
+            let timeoutInMS: Int64 = Int64(timeout) * 1000
+            payload = ["message_timer": timeoutInMS]
+        }
         return .init(path: "/conversations/\(identifier)/message-timer", method: .methodPUT, payload: payload as ZMTransportData)
     }
 

--- a/Tests/Source/Integration/ConversationTests+MessageTimer.swift
+++ b/Tests/Source/Integration/ConversationTests+MessageTimer.swift
@@ -72,6 +72,11 @@ class ConversationMessageTimerTests: IntegrationTest {
         setGlobalTimeout(for: sut, timeout: .none)
 
         // then
+        guard let request = mockTransportSession.receivedRequests().first else {
+            XCTFail()
+            return
+        }
+        XCTAssertNotNil(request.payload?.asDictionary()?["message_timer"] as? NSNull)
         XCTAssertNil(sut.messageDestructionTimeout)
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

According to the BE API, to set the timer off we must set it to NULL value.