### PR TITLE
Fix push strings for message timer update events

### DIFF
--- a/Resources/Base.lproj/Push.strings
+++ b/Resources/Base.lproj/Push.strings
@@ -110,10 +110,15 @@
 "push.notification.member.leave.self.nousername" = "You were removed";
 
 // EPHEMERAL MESSAGE TIMER UPDATE
-"push.notification.message-timer.update" = "%@ set the timed messages to %@";
-"push.notification.message-timer.update.nousername" = "Someone set the timed messages to %@";
-"push.notification.message-timer.update.noconversationname" = "%@ set the timed messages to %@ in a conversation";
-"push.notification.message-timer.update.nousername.noconversationname" = "Someone set the timed messages to %@ in a conversation";
+"push.notification.message-timer.update" = "%@ set the message timer to %@";
+"push.notification.message-timer.update.nousername" = "Someone set the message timer to %@";
+"push.notification.message-timer.update.noconversationname" = "%@ set the message timer to %@ in a conversation";
+"push.notification.message-timer.update.nousername.noconversationname" = "Someone set the message timer to %@ in a conversation";
+
+"push.notification.message-timer.off" = "%@ turned off the message timer";
+"push.notification.message-timer.off.nousername" = "Someone turned off the message timer";
+"push.notification.message-timer.off.noconversationname" = "%@ turned off the message timer in a conversation";
+"push.notification.message-timer.off.nousername.noconversationname" = "Someone turned off the message timer in a conversation";
 
 // VIDEO CALLS
 "push.notification.call.started.video.oneonone" = "is video calling";

--- a/Source/Notifications/Push notifications/Notification Types/LocalNotificationContentType.swift
+++ b/Source/Notifications/Push notifications/Notification Types/LocalNotificationContentType.swift
@@ -25,7 +25,7 @@ public enum LocalNotificationEventType {
 }
 
 public enum LocalNotificationContentType : Equatable {
-    case undefined, image, video, audio, location, fileUpload, knock, text(String), reaction(emoji: String), ephemeral, hidden, participantsRemoved, participantsAdded, messageTimerUpdate(String)
+    case undefined, image, video, audio, location, fileUpload, knock, text(String), reaction(emoji: String), ephemeral, hidden, participantsRemoved, participantsAdded, messageTimerUpdate(String?)
     
     static func typeForMessage(_ message: ZMConversationMessage) -> LocalNotificationContentType? {
         
@@ -67,7 +67,11 @@ public enum LocalNotificationContentType : Equatable {
                 return .participantsRemoved
             case .messageTimerUpdate:
                 let value = MessageDestructionTimeoutValue(rawValue: TimeInterval(systemMessageData.messageTimer.doubleValue))
-                return .messageTimerUpdate(value.displayString ?? "")
+                if value == .none {
+                    return .messageTimerUpdate(nil)
+                } else {
+                    return .messageTimerUpdate(value.displayString)
+                }
             default:
                 return nil
             }

--- a/Source/Notifications/Push notifications/Notification Types/LocalNotificationType+Localization.swift
+++ b/Source/Notifications/Push notifications/Notification Types/LocalNotificationType+Localization.swift
@@ -45,6 +45,7 @@ private let ZMPushStringFailedToSend        = "failed.message"       // "Unable 
 private let ZMPushStringMemberJoin          = "member.join"          // "[senderName] added you"
 private let ZMPushStringMemberLeave         = "member.leave"         // "[senderName] removed you"
 private let ZMPushStringMessageTimerUpdate  = "message-timer.update" // "[senderName] set the timed messages to [duration]
+private let ZMPushStringMessageTimerOff     = "message-timer.off"    // "[senderName] set the timed messages to [duration]
 
 private let ZMPushStringKnock               = "knock"                // "pinged"
 private let ZMPushStringReaction            = "reaction"             // "[emoji] your message"
@@ -100,6 +101,8 @@ extension LocalNotificationType {
                 return ZMPushStringMemberJoin
             case .participantsRemoved:
                 return ZMPushStringMemberLeave
+            case .messageTimerUpdate(nil):
+                return ZMPushStringMessageTimerOff
             case .messageTimerUpdate:
                 return ZMPushStringMessageTimerUpdate
             }
@@ -226,7 +229,9 @@ extension LocalNotificationType {
             case .ephemeral, .hidden:
                 return String.localizedStringWithFormat(baseKey.pushFormatString)
             case .messageTimerUpdate(let timerString):
-                arguments.append(timerString)
+                if let string = timerString {
+                    arguments.append(string)
+                }
                 conversationTypeKey = nil
             case .participantsAdded, .participantsRemoved:
                 conversationTypeKey = nil // System messages don't follow the template and is missing the `group` suffix

--- a/Source/Notifications/Push notifications/Notification Types/LocalNotificationType+Localization.swift
+++ b/Source/Notifications/Push notifications/Notification Types/LocalNotificationType+Localization.swift
@@ -44,8 +44,8 @@ private let ZMPushStringFailedToSend        = "failed.message"       // "Unable 
 
 private let ZMPushStringMemberJoin          = "member.join"          // "[senderName] added you"
 private let ZMPushStringMemberLeave         = "member.leave"         // "[senderName] removed you"
-private let ZMPushStringMessageTimerUpdate  = "message-timer.update" // "[senderName] set the timed messages to [duration]
-private let ZMPushStringMessageTimerOff     = "message-timer.off"    // "[senderName] set the timed messages to [duration]
+private let ZMPushStringMessageTimerUpdate  = "message-timer.update" // "[senderName] set the message timer to [duration]
+private let ZMPushStringMessageTimerOff     = "message-timer.off"    // "[senderName] turned off the message timer
 
 private let ZMPushStringKnock               = "knock"                // "pinged"
 private let ZMPushStringReaction            = "reaction"             // "[emoji] your message"

--- a/Tests/Source/Notifications/PushNotifications/LocalNotificationDispatcherTests.swift
+++ b/Tests/Source/Notifications/PushNotifications/LocalNotificationDispatcherTests.swift
@@ -117,7 +117,7 @@ extension LocalNotificationDispatcherTests {
         XCTAssertEqual(application.scheduledLocalNotifications.count, 1)
         XCTAssertEqual(notificationDelegate.receivedLocalNotifications.count, 0)
         guard let notification = application.scheduledLocalNotifications.first else { return XCTFail() }
-        XCTAssertTrue(notification.alertBody!.contains("User 1 set the timed messages to"))
+        XCTAssertTrue(notification.alertBody!.contains("User 1 set the message timer to"))
     }
 
     func testThatItForwardsNotificationFromMessagesIfActive() {

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_Event.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_Event.swift
@@ -356,7 +356,7 @@ class ZMLocalNotificationTests_Event: ZMLocalNotificationTests {
 
         // then
         XCTAssertNotNil(note)
-        XCTAssertEqual(note?.body, "Other User1 set the timed messages to 1 day")
+        XCTAssertEqual(note?.body, "Other User1 set the message timer to 1 day")
     }
     
     func testThatItCreatesANotificationForMessageTimerUpdateSystemMessages_NoUserName() {
@@ -370,7 +370,7 @@ class ZMLocalNotificationTests_Event: ZMLocalNotificationTests {
         
         // then
         XCTAssertNotNil(note)
-        XCTAssertEqual(note?.body, "Someone set the timed messages to 1 day")
+        XCTAssertEqual(note?.body, "Someone set the message timer to 1 day")
     }
     
     func testThatItCreatesANotificationForMessageTimerUpdateSystemMessages_NoConversationName() {
@@ -383,7 +383,7 @@ class ZMLocalNotificationTests_Event: ZMLocalNotificationTests {
         
         // then
         XCTAssertNotNil(note)
-        XCTAssertEqual(note?.body, "Other User1 set the timed messages to 1 day in a conversation")
+        XCTAssertEqual(note?.body, "Other User1 set the message timer to 1 day in a conversation")
     }
     
     func testThatItCreatesANotificationForMessageTimerUpdateSystemMessages_NoUserName_NoConversationName() {
@@ -397,9 +397,63 @@ class ZMLocalNotificationTests_Event: ZMLocalNotificationTests {
         
         // then
         XCTAssertNotNil(note)
-        XCTAssertEqual(note?.body, "Someone set the timed messages to 1 day in a conversation")
+        XCTAssertEqual(note?.body, "Someone set the message timer to 1 day in a conversation")
     }
+    
+    func testThatItCreatesANotificationForMessageTimerUpdateSystemMessages_Off() {
+        // given
+        let message = groupConversation.appendMessageTimerUpdateMessage(fromUser: otherUser1, timer: 0, timestamp: Date())
+        message.sender = otherUser1
         
+        // when
+        let note = ZMLocalNotification(systemMessage: message)
+        
+        // then
+        XCTAssertNotNil(note)
+        XCTAssertEqual(note?.body, "Other User1 turned off the message timer")
+    }
+    
+    func testThatItCreatesANotificationForMessageTimerUpdateSystemMessages_NoUserName_Off() {
+        // given
+        otherUser1.name = ""
+        let message = groupConversation.appendMessageTimerUpdateMessage(fromUser: otherUser1, timer: 0, timestamp: Date())
+        message.sender = otherUser1
+        
+        // when
+        let note = ZMLocalNotification(systemMessage: message)
+        
+        // then
+        XCTAssertNotNil(note)
+        XCTAssertEqual(note?.body, "Someone turned off the message timer")
+    }
+    
+    func testThatItCreatesANotificationForMessageTimerUpdateSystemMessages_NoConversationName_Off() {
+        // given
+        let message = groupConversationWithoutName.appendMessageTimerUpdateMessage(fromUser: otherUser1, timer: 0, timestamp: Date())
+        message.sender = otherUser1
+        
+        // when
+        let note = ZMLocalNotification(systemMessage: message)
+        
+        // then
+        XCTAssertNotNil(note)
+        XCTAssertEqual(note?.body, "Other User1 turned off the message timer in a conversation")
+    }
+    
+    func testThatItCreatesANotificationForMessageTimerUpdateSystemMessages_NoUserName_NoConversationName_Off() {
+        // given
+        otherUser1.name = ""
+        let message = groupConversationWithoutName.appendMessageTimerUpdateMessage(fromUser: otherUser1, timer: 0, timestamp: Date())
+        message.sender = otherUser1
+        
+        // when
+        let note = ZMLocalNotification(systemMessage: message)
+        
+        // then
+        XCTAssertNotNil(note)
+        XCTAssertEqual(note?.body, "Someone turned off the message timer in a conversation")
+    }
+
     func testThatItAddsATitleIfTheUserIsPartOfATeam() {
         self.syncMOC.performGroupedBlockAndWait {
             


### PR DESCRIPTION
## What's new in this PR?

* Fix push strings for message timer update events.