### PR TITLE
ZIOS-10256: Support YouTube API request proxying

### DIFF
--- a/Source/Public/ZMUserSession.h
+++ b/Source/Public/ZMUserSession.h
@@ -159,7 +159,8 @@ extern NSString * const ZMUserSessionResetPushTokensNotificationName;
 
 typedef NS_ENUM (NSInteger, ProxiedRequestType) {
     ProxiedRequestTypeGiphy,
-    ProxiedRequestTypeSoundcloud
+    ProxiedRequestTypeSoundcloud,
+    ProxiedRequestTypeYouTube
 };
 
 @interface ZMUserSession (Proxy)

--- a/Source/Synchronization/Strategies/ProxiedRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/ProxiedRequestStrategy.swift
@@ -28,6 +28,8 @@ extension ProxiedRequestType {
             return "/giphy"
         case .soundcloud:
             return "/soundcloud"
+        case .youTube:
+            return "/youtube"
         }
     }
 }

--- a/Tests/Source/Synchronization/Strategies/ProxiedRequestStrategyTests.swift
+++ b/Tests/Source/Synchronization/Strategies/ProxiedRequestStrategyTests.swift
@@ -65,7 +65,7 @@ class ProxiedRequestStrategyTests: MessagingTest {
     }
 
     func testThatItGeneratesASoundcloudRequest() {
-        
+
         // given
         requestsStatus.add(request: ProxyRequest(type: .soundcloud, path: "/foo/bar", method:.methodGET, callback: { (_,_,_) -> Void in return}))
         
@@ -78,6 +78,24 @@ class ProxiedRequestStrategyTests: MessagingTest {
             XCTAssertEqual(request.path, "/proxy/soundcloud/foo/bar")
             XCTAssertTrue(request.needsAuthentication)
             XCTAssertTrue(request.doesNotFollowRedirects)
+        } else {
+            XCTFail("Empty request")
+        }
+    }
+
+    func testThatItGeneratesAYouTubeRequest() {
+
+        // given
+        requestsStatus.add(request: ProxyRequest(type: .youTube, path: "/foo/bar", method:.methodGET, callback: { (_,_,_) -> Void in return}))
+
+        // when
+        let request : ZMTransportRequest? = self.sut.nextRequest()
+
+        // then
+        if let request = request {
+            XCTAssertEqual(request.method, ZMTransportRequestMethod.methodGET)
+            XCTAssertEqual(request.path, "/proxy/youtube/foo/bar")
+            XCTAssertTrue(request.needsAuthentication)
         } else {
             XCTFail("Empty request")
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

As the UI will start making requests to the YouTube data API, we need to proxy these requests to the backend.

### Solutions

As BE already supports proxying to YouTube, we add the `ProxiedRequestTypeYouTube` with the correct path, and add a test case for this request type.