### PR TITLE
Nil profile picture identifiers on 4xx responses

### DIFF
--- a/Source/Synchronization/Strategies/UserImageAssetUpdateStrategy.swift
+++ b/Source/Synchronization/Strategies/UserImageAssetUpdateStrategy.swift
@@ -167,8 +167,17 @@ extension UserImageAssetUpdateStrategy: ZMDownstreamTranscoder {
         return ZMTransportRequest.imageGet(fromPath: path)
     }
     
-    public func delete(_ object: ZMManagedObject!, with response: ZMTransportResponse!, downstreamSync: ZMObjectSync!) {}
-    
+    public func delete(_ object: ZMManagedObject!, with response: ZMTransportResponse!, downstreamSync: ZMObjectSync!) {
+        guard let whitelistSync = downstreamSync as? ZMDownstreamObjectSyncWithWhitelist else { return }
+        guard let user = object as? ZMUser else { return }
+
+        switch size(for: whitelistSync) {
+        case .preview?: user.previewProfileAssetIdentifier = nil
+        case .complete?: user.completeProfileAssetIdentifier = nil
+        default: break
+        }
+    }
+
     public func update(_ object: ZMManagedObject!, with response: ZMTransportResponse!, downstreamSync: ZMObjectSync!) {
         guard let whitelistSync = downstreamSync as? ZMDownstreamObjectSyncWithWhitelist else { return }
         guard let user = object as? ZMUser else { return }

--- a/Source/UserSession/Search/ZMSearchUser+UserSession.m
+++ b/Source/UserSession/Search/ZMSearchUser+UserSession.m
@@ -122,7 +122,7 @@
 {
     if(response.result == ZMTransportResponseStatusSuccess) {
         NSData *imageData = response.imageData ?: response.rawData;
-        if(imageData != 0) {
+        if (imageData != 0) {
             [[ZMSearchUser searchUserToMediumImageCache] setObject:imageData forKey:remoteIdentifier];
             [userSession.managedObjectContext performGroupedBlock:^{
                 [self setAndNotifyNewMediumImageData:imageData searchUserObserverCenter:userSession.managedObjectContext.searchUserObserverCenter];


### PR DESCRIPTION
## What's in this PR?

* We were not resetting the local `previewProfileAssetIdentifier` or `completeProfileAssetIdentifier` of a user when receiving a non-success response.
