### PR TITLE
Find the SSO code when it's nested inside a larger string

### DIFF
--- a/Source/Registration/SharedIdentity/SharedIdentitySessionRequestDetector.swift
+++ b/Source/Registration/SharedIdentity/SharedIdentitySessionRequestDetector.swift
@@ -61,12 +61,13 @@ import UIKit
                 return
             }
 
-            guard SharedIdentitySessionRequestDetector.isValidRequestCode(in: text) else {
+            guard let code = SharedIdentitySessionRequestDetector.requestCode(in: text) else {
                 complete(nil)
                 return
             }
 
-            complete(text)
+            let validText = "wire-" + code.uuidString
+            complete(validText)
         }
     }
 
@@ -79,7 +80,11 @@ import UIKit
             return nil
         }
 
-        let codeString = string[prefixRange.upperBound ..< string.endIndex]
+        guard let endIndex = string.index(prefixRange.upperBound, offsetBy: 36, limitedBy: string.endIndex) else {
+            return nil
+        }
+
+        let codeString = string[prefixRange.upperBound ..< endIndex]
         return UUID(uuidString: String(codeString))
     }
 

--- a/Tests/Source/Registration/SharedIdentitySessionRequestDetectorTests.swift
+++ b/Tests/Source/Registration/SharedIdentitySessionRequestDetectorTests.swift
@@ -71,7 +71,31 @@ class SharedIdentitySessionRequestDetectorTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
 
         // THEN
-        XCTAssertEqual(detectedCode, "wire-70488875-13dd-4ba7-9636-a983e1831f5f")
+        XCTAssertEqual(detectedCode, "wire-70488875-13DD-4BA7-9636-A983E1831F5F")
+    }
+
+    func testThatItDetectsCodeInComplexText() {
+        // GIVEN
+        pasteboard.text = """
+        <html>
+            This is your code: ohwowwire-A6AAA905-E42D-4220-A455-CFE8822DB690&nbsp;
+        </html>
+        """
+
+        // WHEN
+        var detectedCode: String?
+        let detectionExpectation = expectation(description: "Detector returns a result")
+
+        detector.detectCopiedRequestCode {
+            detectedCode = $0
+            detectionExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 1, handler: nil)
+
+
+        // THEN
+        XCTAssertEqual(detectedCode, "wire-A6AAA905-E42D-4220-A455-CFE8822DB690")
     }
 
     func testThatItDetectsValidCode_UserInput() {


### PR DESCRIPTION
## What's new in this PR?

### Issues

We identified that some users could mis-copy the code from the e-mail (ex: if iOS also copies a newline after the code), which would prevent automatic code detection from working.

### Solutions

In the method that validates the code text, we:

- look for the `wire-` prefix anywhere in the string
- load the 36 next characters after this (UUID = 32 bytes + 4 dashes)
    - if there are not enough characters, we return `nil`
- validate the loaded characters as a UUID
- return the valid code part of the clipboard when detecting for auto-fill

This is an alternative to using regex, which would be much slower.