### PR TITLE
Do not fail silently when SSO success URL callback is not valid

### DIFF
--- a/Source/SessionManager/SessionManagerURLHandler.swift
+++ b/Source/SessionManager/SessionManagerURLHandler.swift
@@ -70,16 +70,19 @@ extension URLAction {
             switch pathComponents[1] {
             case "success":
                 guard let cookieString = components.query(for: "cookie") else {
-                    return nil
+                    self = .companyLoginFailure(errorLabel: SessionManagerURLHandlerError.missingRequiredParameter)
+                    return
                 }
 
                 guard let userIDString = components.query(for: "user_id"),
                     let userID = UUID(uuidString: userIDString) else {
-                    return nil
+                        self = .companyLoginFailure(errorLabel: SessionManagerURLHandlerError.missingRequiredParameter)
+                        return
                 }
 
                 guard let cookieData = HTTPCookie.extractCookieData(from: cookieString, url: url) else {
-                    return nil
+                    self = .companyLoginFailure(errorLabel: SessionManagerURLHandlerError.invalidCookie)
+                    return
                 }
 
                 let userInfo = UserInfo(identifier: userID, cookieData: cookieData)

--- a/Source/SessionManager/SessionManagerURLHandlerError.swift
+++ b/Source/SessionManager/SessionManagerURLHandlerError.swift
@@ -1,0 +1,33 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/**
+ * Error that occur when processing URL actions.
+ */
+
+public enum SessionManagerURLHandlerError {
+
+    /// The URL is missing a required parameter.
+    static let missingRequiredParameter: String = "-2063"
+
+    /// Invalid access credentials.
+    static let invalidCookie: String = "-67700"
+
+}

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -275,6 +275,7 @@
 		54F7217E19A62225009A8AF5 /* ZMUpdateEventsBufferTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 54F7217C19A62225009A8AF5 /* ZMUpdateEventsBufferTests.m */; };
 		54FEAAA91BC7BB9C002DE521 /* ZMBlacklistDownloader+Testing.h in Headers */ = {isa = PBXBuildFile; fileRef = 54FEAAA81BC7BB9C002DE521 /* ZMBlacklistDownloader+Testing.h */; };
 		54FF64291F73D00C00787EF2 /* NSManagedObjectContext+AuthenticationStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54FF64281F73D00C00787EF2 /* NSManagedObjectContext+AuthenticationStatus.swift */; };
+		5E0AA1A821076B6C0020F96B /* SessionManagerURLHandlerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0AA1A721076B6C0020F96B /* SessionManagerURLHandlerError.swift */; };
 		5E0EB1F421008C1900B5DC2B /* CompanyLoginRequester.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0EB1F321008C1900B5DC2B /* CompanyLoginRequester.swift */; };
 		5E0EB1F72100A14A00B5DC2B /* CompanyLoginRequesterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0EB1F52100A13200B5DC2B /* CompanyLoginRequesterTests.swift */; };
 		5E0EB1F92100A46F00B5DC2B /* MockCompanyLoginRequesterDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0EB1F82100A46F00B5DC2B /* MockCompanyLoginRequesterDelegate.swift */; };
@@ -847,6 +848,7 @@
 		54FC8A0F192CD55000D3C016 /* LoginFlowTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LoginFlowTests.m; sourceTree = "<group>"; };
 		54FEAAA81BC7BB9C002DE521 /* ZMBlacklistDownloader+Testing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ZMBlacklistDownloader+Testing.h"; sourceTree = "<group>"; };
 		54FF64281F73D00C00787EF2 /* NSManagedObjectContext+AuthenticationStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+AuthenticationStatus.swift"; sourceTree = "<group>"; };
+		5E0AA1A721076B6C0020F96B /* SessionManagerURLHandlerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManagerURLHandlerError.swift; sourceTree = "<group>"; };
 		5E0EB1F321008C1900B5DC2B /* CompanyLoginRequester.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanyLoginRequester.swift; sourceTree = "<group>"; };
 		5E0EB1F52100A13200B5DC2B /* CompanyLoginRequesterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanyLoginRequesterTests.swift; sourceTree = "<group>"; };
 		5E0EB1F82100A46F00B5DC2B /* MockCompanyLoginRequesterDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCompanyLoginRequesterDelegate.swift; sourceTree = "<group>"; };
@@ -2132,6 +2134,7 @@
 				162A81D3202B453000F6200C /* SessionManager+AVS.swift */,
 				F130BF272062C05600DBE261 /* SessionManager+Backup.swift */,
 				8737D553209217BD00E5A4AF /* SessionManagerURLHandler.swift */,
+				5E0AA1A721076B6C0020F96B /* SessionManagerURLHandlerError.swift */,
 			);
 			path = SessionManager;
 			sourceTree = "<group>";
@@ -2730,6 +2733,7 @@
 				54A0A6311BCE9864001A3A4C /* ZMHotFix.m in Sources */,
 				F19F4F3C1E604AA700F4D8FF /* UserImageAssetUpdateStrategy.swift in Sources */,
 				164EAF9C1F4455FA00B628C4 /* ZMUserSession+Actions.swift in Sources */,
+				5E0AA1A821076B6C0020F96B /* SessionManagerURLHandlerError.swift in Sources */,
 				BF2ADA001F41A3DF000980E8 /* SessionFactories.swift in Sources */,
 				F9410F651DE49C13007451FF /* PushTokenStrategy.swift in Sources */,
 				54A2C9F31DAFBA3300FFD2A0 /* NSManagedObjectContext+EventDecoder.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

Before this PR, we were dismissing the URL action if the callback was not valid. This means that when the users were redirected to the app from a seemingly valid URL, we would not show an alert to tell them something went wrong. 

This is a problem for troubleshooting issues, as we would have no context.

### Solutions

When decoding the `URLAction`, we return a company login error when the company login success could not be processed.

The error codes were borrowed from actual error codes from Apple to make sure we avoid conflicts, and are as follows:

| Wire | Apple Equivalent | Raw Value |
|------|------------------|-----------|
| SessionManagerURLHandlerError.missingRequiredParameter | CarbonCore.missingRequiredParameterErr | -2063 |
| SessionManagerURLHandlerError.invalidCookie | Security. errSecInvalidAccessCredentials | -67700 |