### PR TITLE
Fix push token registration

### DIFF
--- a/Source/Synchronization/Strategies/PushTokenStrategy.swift
+++ b/Source/Synchronization/Strategies/PushTokenStrategy.swift
@@ -165,7 +165,7 @@ extension PushTokenStrategy : ZMUpstreamTranscoder {
                 notificationsTracker?.registerTokenMismatch()
 
                 // Make sure UI tries to get re-register a new one
-                NotificationInContext(name: ZMUserSession.resetPushTokenNotificationName,
+                NotificationInContext(name: ZMUserSession.registerCurrentPushTokenNotificationName,
                                       context: managedObjectContext.notificationContext,
                                       object: nil,
                                       userInfo: nil).post()

--- a/Source/UserSession/ZMUserSession+Push.swift
+++ b/Source/UserSession/ZMUserSession+Push.swift
@@ -43,10 +43,10 @@ extension Dictionary {
 
 extension ZMUserSession {
 
-    static let resetPushTokenNotificationName = Notification.Name(rawValue: "ZMUserSessionResetPushTokensNotification")
+    @objc public static let registerCurrentPushTokenNotificationName = Notification.Name(rawValue: "ZMUserSessionResetPushTokensNotification")
 
-    @objc public func registerForPushTokenResetNotification() {
-        NotificationCenter.default.addObserver(self, selector: #selector(ZMUserSession.resetPushToken), name: ZMUserSession.resetPushTokenNotificationName, object: nil)
+    @objc public func registerForRegisteringPushTokenNotification() {
+        NotificationCenter.default.addObserver(self, selector: #selector(ZMUserSession.registerCurrentPushToken), name: ZMUserSession.registerCurrentPushTokenNotificationName, object: nil)
     }
 
     func setPushKitToken(_ data: Data) {
@@ -73,7 +73,7 @@ extension ZMUserSession {
         }
     }
 
-    @objc func resetPushToken() {
+    @objc public func registerCurrentPushToken() {
         managedObjectContext.performGroupedBlock {
             self.sessionManager.updatePushToken(for: self)
         }

--- a/Source/UserSession/ZMUserSession+Push.swift
+++ b/Source/UserSession/ZMUserSession+Push.swift
@@ -85,7 +85,11 @@ extension ZMUserSession {
         let syncMOC = managedObjectContext.zm_sync!
         syncMOC.performGroupedBlock {
             guard let selfClient = ZMUser.selfUser(in: syncMOC).selfClient() else { return }
-            guard let pushToken = selfClient.pushToken else { return }
+            guard let pushToken = selfClient.pushToken else {
+                // If we don't have any push token, then try to register it again
+                self.sessionManager.updatePushToken(for: self)
+                return
+            }
             selfClient.pushToken = pushToken.markToDownload()
             syncMOC.saveOrRollback()
         }

--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -579,6 +579,9 @@ ZM_EMPTY_ASSERTING_INIT()
 - (void)didRegisterUserClient:(UserClient *)userClient
 {
     self.transportSession.pushChannel.clientID = userClient.remoteIdentifier;
+    // If during registration user allowed notifications,
+    // The push token can only be registered after client registration
+    [self registerCurrentPushToken];
 }
 
 @end

--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -242,7 +242,7 @@ ZM_EMPTY_ASSERTING_INIT()
         self.commonContactsCache = [[NSCache alloc] init];
         self.commonContactsCache.name = @"ZMUserSession commonContactsCache";
         
-        [self registerForPushTokenResetNotification];
+        [self registerForRegisteringPushTokenNotification];
         [self registerForBackgroundNotifications];
         [self registerForRequestToOpenConversationNotification];
         

--- a/Tests/Source/Calling/CallKitDelegateTests.swift
+++ b/Tests/Source/Calling/CallKitDelegateTests.swift
@@ -49,9 +49,10 @@ class MockSessionManager : NSObject, WireSyncEngine.SessionManagerType {
     func configureUserNotifications() {
         
     }
-    
+
+    @objc public var updatePushTokenCalled = false
     func updatePushToken(for session: ZMUserSession) {
-        
+        updatePushTokenCalled = true
     }
     
     deinit {

--- a/Tests/Source/Synchronization/Strategies/PushTokenStrategyTests.swift
+++ b/Tests/Source/Synchronization/Strategies/PushTokenStrategyTests.swift
@@ -313,7 +313,7 @@ extension PushTokenStrategyTests {
 
     func testThatItDownloadsTokensAndResetsIfNotValid() {
         // Should be fired when we have to reupload the token
-        expectation(forNotification: ZMUserSession.resetPushTokenNotificationName, object: nil, handler: nil)
+        expectation(forNotification: ZMUserSession.registerCurrentPushTokenNotificationName, object: nil, handler: nil)
 
         self.syncMOC.performGroupedAndWait { _ in
             // given

--- a/Tests/Source/UserSession/ZMUserSessionTests.m
+++ b/Tests/Source/UserSession/ZMUserSessionTests.m
@@ -214,7 +214,8 @@
     id pushChannel = [OCMockObject niceMockForProtocol:@protocol(ZMPushChannel)];
     id transportSession = [OCMockObject niceMockForClass:ZMTransportSession.class];
     id cookieStorage = [OCMockObject niceMockForClass:ZMPersistentCookieStorage.class];
-    
+    id sessionManager = [[MockSessionManager alloc] init];
+
     // expect
     [[pushChannel expect] setClientID:userClient.remoteIdentifier];
     [[[transportSession stub] andReturn:pushChannel] pushChannel];
@@ -230,11 +231,17 @@
                                                                      application:self.application
                                                                       appVersion:@"00000"
                                                                    storeProvider:self.storeProvider];
+    userSession.sessionManager = sessionManager;
+    XCTAssertFalse([(MockSessionManager *)sessionManager updatePushTokenCalled]);
     [userSession didRegisterUserClient:userClient];
     
     // then
     [pushChannel verify];
     [transportSession verify];
+
+    XCTAssert([self waitForAllGroupsToBeEmptyWithTimeout:0.5]);
+    XCTAssertTrue([(MockSessionManager *)sessionManager updatePushTokenCalled]);
+
     [userSession tearDown];
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

The push token was not registered during fresh login and it was not possible to recover by resetting the push token from Settings.

### Causes

We were getting the push token before user client was registered and since we could not save it anywhere it was discarded. Trying to reset token from UI would also fail because it expected to have a token on user client.

### Solutions

When client is registered during login we register push token again which will trigger the request to register it with backend. When validating push token we also try to register it if it's not there yet.
