### PR TITLE
ZIOS-10333: Receiving a call into a muted conversation doesn't bring it to the top of the conversation list

### DIFF
--- a/Source/UserSession/CallStateObserver.swift
+++ b/Source/UserSession/CallStateObserver.swift
@@ -160,10 +160,9 @@ extension CallStateObserver : WireCallCenterCallStateObserver, WireCallCenterMis
     }
     
     private func updateConversation(_ conversation: ZMConversation, with callState: CallState, timestamp: Date?) {
-        guard !conversation.isSilenced else { return }
         switch callState {
         case .incoming(_, shouldRing: true, degraded: _):
-            if conversation.isArchived {
+            if conversation.isArchived && !conversation.isSilenced {
                 conversation.isArchived = false
             }
             


### PR DESCRIPTION
## What's new in this PR?

### Issues

When receiving a call into a silenced conversation, it's not moved to the top of the conversation list.

### Solutions

I've changed the conditions inside the `updateConversation` method, so now the update is fired for all conversations, and conversations are unarchived if they're actually archived and not silenced.