### PR TITLE
Enabled logging

### DIFF
--- a/WireSyncEngine.xcodeproj/xcshareddata/xcschemes/WireSyncEngine.xcscheme
+++ b/WireSyncEngine.xcodeproj/xcshareddata/xcschemes/WireSyncEngine.xcscheme
@@ -106,11 +106,6 @@
             isEnabled = "NO">
          </EnvironmentVariable>
          <EnvironmentVariable
-            key = "OS_ACTIVITY_MODE"
-            value = "disable"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
             key = "ZM_TESTING"
             value = "1"
             isEnabled = "YES">


### PR DESCRIPTION
## What's new in this PR?

### Issues

When running tests the console would not contain any network calls.

### Causes

After moving to new logging system we were muting the output of os_log with an environment variable. This was a leftover from a bug in Xcode 8 that would print enormous amount of information to the console.

