### PR TITLE
Only open websocket in the background when a call is active

### DIFF
--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -570,7 +570,7 @@ public struct CallEvent {
         callSnapshots.removeValue(forKey: conversationId)
     }
     
-    fileprivate func createSnapshot(callState : CallState, members: [AVSCallMember], callStarter: UUID?, video: Bool, for conversationId: UUID) {
+    internal func createSnapshot(callState : CallState, members: [AVSCallMember], callStarter: UUID?, video: Bool, for conversationId: UUID) {
         guard let moc = uiMOC,
               let conversation = ZMConversation(remoteID: conversationId, createIfNeeded: false, in: moc)
         else { return }
@@ -848,6 +848,17 @@ public struct CallEvent {
         }
         
         return callStates
+    }
+    
+    public var activeCalls: [UUID: CallState] {
+        return nonIdleCalls.filter({ key, callState in
+            switch callState {
+            case .established, .establishedDataChannel:
+                return true
+            default:
+                return false
+            }
+        })
     }
     
     /// Returns conversations with active calls

--- a/Source/UserSession/CallStateObserver.swift
+++ b/Source/UserSession/CallStateObserver.swift
@@ -77,8 +77,8 @@ extension CallStateObserver : WireCallCenterCallStateObserver, WireCallCenterMis
             
             let uiManagedObjectContext = self.syncManagedObjectContext.zm_userInterface
             uiManagedObjectContext?.performGroupedBlock {
-                if let noneIdleCallCount = uiManagedObjectContext?.zm_callCenter?.nonIdleCalls.count {
-                    self.callInProgress = noneIdleCallCount > 0
+                if let activeCallCount = uiManagedObjectContext?.zm_callCenter?.activeCalls.count {
+                    self.callInProgress = activeCallCount > 0
                 }
             }
             

--- a/Tests/Source/Calling/WireCallCenterV3Mock.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Mock.swift
@@ -102,6 +102,7 @@ public class WireCallCenterV3Mock : WireCallCenterV3 {
     
     public let mockAVSWrapper : MockAVSWrapper
     public var mockNonIdleCalls : [UUID : CallState] = [:]
+    public var mockActiveCalls : [UUID : CallState] = [:]
     
     var mockMembers : [AVSCallMember] {
         set {
@@ -140,6 +141,10 @@ public class WireCallCenterV3Mock : WireCallCenterV3 {
         
     public override var nonIdleCalls : [UUID : CallState ] {
         return mockNonIdleCalls
+    }
+    
+    public override var activeCalls: [UUID : CallState] {
+        return mockActiveCalls
     }
     
     public required init(userId: UUID, clientId: String, avsWrapper: AVSWrapperType? = nil, uiMOC: NSManagedObjectContext, flowManager: FlowManagerType, analytics: AnalyticsType? = nil, transport: WireCallCenterTransport) {

--- a/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -611,6 +611,30 @@ class WireCallCenterV3Tests: MessagingTest {
         XCTAssertFalse(sut.isContantBitRate(conversationId: oneOnOneConversationID))
     }
     
+    func testThatActiveCallsOnlyIncludeExpectedCallStates() {
+        // given
+        let activeCallStates: [CallState] = [CallState.established,
+                                             CallState.establishedDataChannel]
+        
+        let nonActiveCallStates: [CallState] = [CallState.incoming(video: false, shouldRing: false, degraded: false),
+                                           CallState.outgoing(degraded: false),
+                                           CallState.answered(degraded: false),
+                                           CallState.terminating(reason: CallClosedReason.normal),
+                                           CallState.none,
+                                           CallState.unknown]
+        
+        // then
+        for callState in nonActiveCallStates {
+            sut.createSnapshot(callState: callState, members: [], callStarter: nil, video: false, for: groupConversation.remoteIdentifier!)
+            XCTAssertEqual(sut.activeCalls.count, 0)
+        }
+        
+        for callState in activeCallStates {
+            sut.createSnapshot(callState: callState, members: [], callStarter: nil, video: false, for: groupConversation.remoteIdentifier!)
+            XCTAssertEqual(sut.activeCalls.count, 1)
+        }
+    }
+    
 }
 
 // MARK: - Ignoring Calls


### PR DESCRIPTION
## What's new in this PR?

### Issues

The web socket was misbehaving during calls preventing call events to be processed.

### Causes

The web socket will fail if the app is in the background and the user is not connected to the active call since sockets will eventually close in the background. VoIP sockets are not working since iOS 10.

### Solutions

Don't allow the web socket to be open unless the user is participating in the call.