### PR TITLE
Provide a fallback for localized caller name

### DIFF
--- a/Source/Calling/CallKitDelegate.swift
+++ b/Source/Calling/CallKitDelegate.swift
@@ -462,27 +462,28 @@ extension ZMConversation {
         return localizedCallerName(with: ZMUser.selfUser(in: managedObjectContext))
     }
     
-    func localizedCallerName(with user: ZMUser) -> String? {
+    func localizedCallerName(with user: ZMUser) -> String {
         
         let conversationName = self.userDefinedName
         let callerName : String? = user.name
+        var result : String? = nil
         
         switch conversationType {
         case .group:
             if let conversationName = conversationName, let callerName = callerName {
-                return String.localizedStringWithFormat("callkit.call.started.group".pushFormatString, callerName, conversationName)
+                result = String.localizedStringWithFormat("callkit.call.started.group".pushFormatString, callerName, conversationName)
             } else if let conversationName = conversationName {
-                return String.localizedStringWithFormat("callkit.call.started.group.nousername".pushFormatString, conversationName)
+                result = String.localizedStringWithFormat("callkit.call.started.group.nousername".pushFormatString, conversationName)
             } else if let callerName = callerName {
-                return String.localizedStringWithFormat("callkit.call.started.group.noconversationname".pushFormatString, callerName)
-            } else {
-                return String.localizedStringWithFormat("callkit.call.started.group.nousername.noconversationname".pushFormatString)
+                result = String.localizedStringWithFormat("callkit.call.started.group.noconversationname".pushFormatString, callerName)
             }
         case .oneOnOne:
-            return connectedUser?.displayName
+            result = connectedUser?.displayName
         default:
-            return nil
+            break
         }
+        
+        return result ?? String.localizedStringWithFormat("callkit.call.started.group.nousername.noconversationname".pushFormatString)
     }
     
 }

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationLocalizationTests.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationLocalizationTests.swift
@@ -25,7 +25,7 @@ class ZMLocalNotificationLocalizationTests: ZMLocalNotificationTests {
     func testThatItLocalizesCallkitCallerName() {
         
         let result: (ZMUser, ZMConversation) -> String = {
-            $1.localizedCallerName(with: $0)!
+            $1.localizedCallerName(with: $0)
         }
         
         // then


### PR DESCRIPTION
## What's new in this PR?

### Issues

Sometimes it could happen that a user receives an incoming call via CallKit, but the caller name is a cryptic identification string.

### Causes

This happens in situations when the conversation in which the call is being made is unknown to the client. There already exists localisation measures to deal with missing caller/conversation names, however this logic is never reached. It depends on knowing the `conversationType`, which unfortunately is indeterminate.

### Solutions

Provide a fallback string for CallKit in the case that no other suitable string was found. This fallback is "Someone calling in a conversation".

