### PR TITLE
Tracking calling test coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  status:
+    project:
+      calling:
+        flags: calling
+
+flags:
+  calling:
+    paths:
+      - Source/Calling/
+      - Source/Synchronization/Strategies/CallingRequestStrategy.swift
+      - Source/UserSession/ZMUserSession+Calling.swift
+      - Source/Notifications/Push notifications/Notification Types/ZMLocalNotification+Calling.swift
+      - Source/Notifications/Push notifications/LocalNotificationDispatcher+Calling.swift

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,8 +7,4 @@ coverage:
 flags:
   calling:
     paths:
-      - Source/Calling/
-      - Source/Synchronization/Strategies/CallingRequestStrategy.swift
-      - Source/UserSession/ZMUserSession+Calling.swift
-      - Source/Notifications/Push notifications/Notification Types/ZMLocalNotification+Calling.swift
-      - Source/Notifications/Push notifications/LocalNotificationDispatcher+Calling.swift
+      - "Sources/**/*[C|c]alling*"


### PR DESCRIPTION
## What's new in this PR?

### Issues

Most of the calling code is in SyncEngine and we would like to track test coverage better. This PR adds a label to Codecov.io in the same way as with https://github.com/wireapp/wire-ios-data-model/pull/546

## Notes

It's a bit suboptimal to have to list files related to calling in `codecov.yml`, need to think a bit what could be a better approach for this. Maybe simply doing a regexp `*[c|C]alling*` would work just as well.
