### PR TITLE
Fix wcall_init being called multiple times

### DIFF
--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -88,17 +88,19 @@ public protocol AVSWrapperType {
 /// Wraps AVS calls for dependency injection and better testing
 public class AVSWrapper : AVSWrapperType {
 
-    private static var isInitialized = false
     private let handle : UnsafeMutableRawPointer
+    
+    private static var initialize: () -> Void = {
+        let resultValue = wcall_init()
+        if resultValue != 0 {
+            fatal("Failed to initialise AVS (error code: \(resultValue))")
+        }
+        return {}
+    }()
     
     required public init(userId: UUID, clientId: String, observer: UnsafeMutableRawPointer?) {
         
-        if !AVSWrapper.isInitialized {
-            let resultValue = wcall_init()
-            if resultValue != 0 {
-                fatal("Failed to initialise AVS (error code: \(resultValue))")
-            }
-        }
+        AVSWrapper.initialize()
         
         handle = wcall_create(userId.transportString(),
                               clientId,


### PR DESCRIPTION
## What's new in this PR?

### Issues

`wcall_init` was called every time an account was loaded

### Causes

static flag `isInitialized` wasn't set

### Solutions

Wrap `wcall_init` in a static function closure which is only executed once.