### PR TITLE
Don't use CallKit for unknown conversations

### DIFF
--- a/Source/Calling/CallKitDelegate.swift
+++ b/Source/Calling/CallKitDelegate.swift
@@ -265,6 +265,10 @@ extension CallKitDelegate {
             return log("Cannot report incoming call: conversation is missing handle")
         }
         
+        guard !conversation.needsToBeUpdatedFromBackend else {
+            return log("Cannot report incoming call: conversation needs to be updated from backend")
+        }
+        
         let update = CXCallUpdate()
         update.supportsHolding = false
         update.supportsDTMF = false

--- a/Source/UserSession/CallStateObserver.swift
+++ b/Source/UserSession/CallStateObserver.swift
@@ -84,8 +84,12 @@ extension CallStateObserver : WireCallCenterCallStateObserver, WireCallCenterMis
             
             // This will unarchive the conversation when there is an incoming call
             self.updateConversation(conversation, with: callState, timestamp: timestamp)
-
-            if (self.userSession?.callNotificationStyle ?? .callKit) == .pushNotifications {
+            
+            // CallKit depends on a fetched conversation
+            let skipCallKit = conversation.needsToBeUpdatedFromBackend
+            let notificationStyle = self.userSession?.callNotificationStyle ?? .callKit
+            
+            if notificationStyle == .pushNotifications || skipCallKit {
                 self.localNotificationDispatcher.process(callState: callState, in: conversation, caller: caller)
             }
             

--- a/Tests/Source/Calling/CallKitDelegateTests.swift
+++ b/Tests/Source/Calling/CallKitDelegateTests.swift
@@ -719,6 +719,22 @@ class CallKitDelegateTest: MessagingTest {
         XCTAssertEqual(self.callKitProvider.timesReportCallEndedAtCalled, 0)
     }
     
+    func testThatItIgnoresNewIncomingCall_v3_Unfectched_conversation() {
+        // given
+        let conversation = self.conversation()
+        conversation.needsToBeUpdatedFromBackend = true
+        let otherUser = self.otherUser(moc: self.uiMOC)
+        
+        // when
+        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: true, degraded: false), conversation: conversation, caller: otherUser, timestamp: nil, previousCallState: nil)
+        
+        // then
+        XCTAssertEqual(self.callKitProvider.timesReportNewIncomingCallCalled, 0)
+        XCTAssertEqual(self.callKitProvider.timesReportOutgoingCallConnectedAtCalled, 0)
+        XCTAssertEqual(self.callKitProvider.timesReportOutgoingCallStartedConnectingCalled, 0)
+        XCTAssertEqual(self.callKitProvider.timesReportCallEndedAtCalled, 0)
+    }
+    
     func testThatItReportCallEndedAt_v3_Terminating_normal() {
         // given
         let conversation = self.conversation()

--- a/Tests/Source/Calling/CallStateObserverTests.swift
+++ b/Tests/Source/Calling/CallStateObserverTests.swift
@@ -180,7 +180,36 @@ class CallStateObserverTests : MessagingTest {
         XCTAssertEqual(application.scheduledLocalNotifications.count, 1)
     }
     
-    func testThatCallStatesAreForwardedToTheNotificationDispatcher() {
+    func testIncomingCallsInUnfetchedConversationAreForwaredToTheNotificationDispatcher_whenCallStyleIsCallkit() {
+        // given
+        mockCallNotificationStyle = .callKit
+        conversationUI.conversationType = .invalid
+        
+        // when
+        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: true, degraded: false), conversation: conversationUI, caller: senderUI, timestamp: Date(), previousCallState: nil)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        // then
+        XCTAssertEqual(self.application.scheduledLocalNotifications.count, 1)
+    }
+    
+    func testIncomingCallsInUnfetchedConversationAreForwaredToTheNotificationDispatcher_whenCallStyleIsPushNotification() {
+        // given
+        mockCallNotificationStyle = .pushNotifications
+        conversationUI.conversationType = .invalid
+        
+        // when
+        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: true, degraded: false), conversation: conversationUI, caller: senderUI, timestamp: Date(), previousCallState: nil)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        // then
+        XCTAssertEqual(self.application.scheduledLocalNotifications.count, 1)
+    }
+    
+    func testThatIncomingCallsAreForwardedToTheNotificationDispatcher_whenCallStyleIsPushNotification() {
+        // given
+        mockCallNotificationStyle = .pushNotifications
+        
         // when
         sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: true, degraded: false), conversation: conversationUI, caller: senderUI, timestamp: nil, previousCallState: nil)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))

--- a/Tests/Source/MessagingTest.h
+++ b/Tests/Source/MessagingTest.h
@@ -71,6 +71,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) NSURL *accountDirectory;
 @property (nonatomic, readonly) NSMutableArray<ZMUpdateEvent *> *processedUpdateEvents;
 
+@property (nonatomic) CallNotificationStyle mockCallNotificationStyle;
+
 /// reset ui and sync contexts
 - (void)resetUIandSyncContextsAndResetPersistentStore:(BOOL)resetPersistentStore;
 - (void)resetUIandSyncContextsAndResetPersistentStore:(BOOL)resetPersistentStore notificationContentHidden:(BOOL)notificationContentHidden;

--- a/Tests/Source/MessagingTest.m
+++ b/Tests/Source/MessagingTest.m
@@ -153,6 +153,7 @@ static ZMReachability *sharedReachabilityMock = nil;
     self.mockOperationStatus.isInBackground = NO;
     self.mockOperationLoop = [OCMockObject niceMockForClass:ZMOperationLoop.class];
     self.mockSyncStrategy = [OCMockObject niceMockForClass:ZMSyncStrategy.class];
+    self.mockCallNotificationStyle = CallNotificationStylePushNotifications;
     
     [[[self.mockOperationLoop stub] andReturn:self.mockSyncStrategy] syncStrategy];
     
@@ -442,7 +443,7 @@ static ZMReachability *sharedReachabilityMock = nil;
         [[[mockUserSession stub] andReturn:self.sharedContainerURL] sharedContainerURL];
         [[[mockUserSession stub] andReturn:self.mockOperationStatus] operationStatus];
         [(ZMUserSession *)[[mockUserSession stub] andReturn:self.mockOperationLoop] operationLoop];
-        [[[mockUserSession stub] andReturnValue:@(CallNotificationStylePushNotifications)] callNotificationStyle];
+        [[[mockUserSession stub] andReturnValue:@(self.mockCallNotificationStyle)] callNotificationStyle];
 
         [(ZMUserSession *)[[mockUserSession stub] andReturn:self.mockTransportSession] transportSession];
         _mockUserSession = mockUserSession;


### PR DESCRIPTION
## What's new in this PR?

### Issues

Answering a CallKit call in an unknown conversation fails immediately.

### Causes

When the call is answered via the CallKit screen, the `join` method is called on the conversation's `VoiceChannel`. This voice channel object is optional and is computed, however it depends on the `conversationType`, which is undetermined for an unknown conversation. Consequently, the call fails.

### Solutions

We cannot simply fetch the conversation because downstream syncing has been disabled in the background. Instead, we can prevent the CallKit call from appearing, and instead alert the user of the incoming call via APNS. This approach forces the user to open the app, which also gives them the opportunity to see who is calling them (since the CallKit screen would have no information about the caller whatsoever).