### PR TITLE
Add call rejected elsewhere end reason

### DIFF
--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -47,6 +47,8 @@ public enum CallClosedReason : Int32 {
     case stillOngoing
     /// Call was dropped due to the security level degrading
     case securityDegraded
+    /// The call was rejected on another device.
+    case rejectedElsewhere
     /// Call was closed for an unknown reason. This is most likely a bug.
     case unknown
     
@@ -68,6 +70,8 @@ public enum CallClosedReason : Int32 {
             self = .inputOutputError
         case WCALL_REASON_STILL_ONGOING:
             self = .stillOngoing
+        case WCALL_REASON_REJECTED:
+            self = .rejectedElsewhere
         default:
             self = .unknown
         }
@@ -93,6 +97,8 @@ public enum CallClosedReason : Int32 {
             return WCALL_REASON_STILL_ONGOING
         case .securityDegraded:
             return WCALL_REASON_ERROR
+        case .rejectedElsewhere:
+            return WCALL_REASON_REJECTED
         case .unknown:
             return WCALL_REASON_ERROR
         }

--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -661,7 +661,7 @@ public struct CallEvent {
             if self.callState(conversationId: conversationId) == .established {
                 return // Ignore if data channel was established after audio
             }
-        case .terminating(reason: let reason) where reason == .stillOngoing:
+        case .terminating(reason: .stillOngoing):
             callState = .incoming(video: false, shouldRing: false, degraded: isDegraded(conversationId: conversationId))
         default:
             break

--- a/Source/Notifications/Push notifications/LocalNotificationDispatcher+Calling.swift
+++ b/Source/Notifications/Push notifications/LocalNotificationDispatcher+Calling.swift
@@ -26,7 +26,7 @@ public extension LocalNotificationDispatcher {
         switch callState {
         case .terminating(reason: let reason):
             switch reason {
-            case .anweredElsewhere: break
+            case .anweredElsewhere, .rejectedElsewhere: break
             default: return
             }
         default: break

--- a/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification+Calling.swift
+++ b/Source/Notifications/Push notifications/Notification Types/ZMLocalNotification+Calling.swift
@@ -53,7 +53,7 @@ extension ZMLocalNotification {
         
         func shouldCreateNotification() -> Bool {
             switch callState {
-            case .terminating(reason: .anweredElsewhere), .terminating(reason: .normal):
+            case .terminating(reason: .anweredElsewhere), .terminating(reason: .normal), .terminating(reason: .rejectedElsewhere):
                 return false
             case .incoming(video: _, shouldRing: let shouldRing, degraded: _):
                 return shouldRing


### PR DESCRIPTION
## What's new in this PR?

### Issues

The web client sends `WCALL_REASON_REJECTED` call termination reason messages when the user rejects the call on one client so that other clients stop ringing. 

As discussed with @typfel, while we are not going to handle this case yet, we don't want it to appear as an unknown error.