### PR TITLE
Fix/ephemeral bundling

### DIFF
--- a/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification.swift
+++ b/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification.swift
@@ -93,8 +93,12 @@ open class ZMLocalNotification: NSObject {
             content.userInfo = userInfo.storage
         }
 
+        // only group non ephemeral messages
         if let conversationID = self.conversationID {
-            content.threadIdentifier = conversationID.transportString()
+            switch self.type {
+            case .message(.ephemeral): break
+            default: content.threadIdentifier = conversationID.transportString()
+            }            
         }
 
         return content

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_Message.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_Message.swift
@@ -99,6 +99,17 @@ class ZMLocalNotificationTests_Message : ZMLocalNotificationTests {
         XCTAssertEqual(note2?.content.body, "Someone sent you a message")
     }
     
+    func testThatItDoesNotSetThreadIdentifierForEphemeralMessages() {
+        // given
+        let note = textNotification(oneOnOneConversation, sender: sender, isEphemeral: true)
+        
+        // then
+        XCTAssertNotNil(note)
+        XCTAssertEqual(note!.content.title, "")
+        XCTAssertEqual(note!.content.body, "Someone sent you a message")
+        XCTAssertEqual(note!.content.threadIdentifier, "")
+    }
+    
     func testItCreatesMessageNotificationsCorrectly(){
         
         //    "push.notification.add.message.oneonone" = "%1$@";


### PR DESCRIPTION
## What's new in this PR?

### Issues

Notifications for ephemeral messages were being grouped with non ephemeral messages from the same conversation, making it possible to see who sent the message.

### Causes

Notifications are grouped by conversation.

### Solutions

If the message is ephemeral, don't set the `threadIdentifier` of the `UNNotificationContent` object. This will cause a new group of notifications to appear, containing only ephemeral messages (regardless of sender or conversation).