### PR TITLE
Feature/ephemeral notification copy

### DIFF
--- a/Resources/Base.lproj/Push.strings
+++ b/Resources/Base.lproj/Push.strings
@@ -29,11 +29,14 @@
 // content in the alert body.
 
 "push.notification.default" = "New message";
-"push.notification.ephemeral" = "Someone sent you a message";
-"push.notification.ephemeral.mention" = "Someone mentioned you";
 
 // Push Title: [Conversation Name] in [Team Name]
 "push.notification.title" = "%1$@ in %2$@";
+
+// Ephemeral
+"push.notification.ephemeral.title" = "Someone";
+"push.notification.ephemeral" = "Sent a message";
+"push.notification.ephemeral.mention" = "Mentioned you";
 
 // 2 Components: Sender, Message
 "push.notification.add.message.group" = "%1$@: %2$@";

--- a/Source/Notifications/Push notifications/Notification Types/LocalNotificationType+Localization.swift
+++ b/Source/Notifications/Push notifications/Notification Types/LocalNotificationType+Localization.swift
@@ -21,6 +21,8 @@ import Foundation
 // These are the "base" keys for messages. We append to these for the specific case.
 //
 private let ZMPushStringDefault             = "default"
+
+private let ZMPushStringEphemeralTitle      = "ephemeral.title"
 private let ZMPushStringEphemeral           = "ephemeral"
 
 // Title with team name
@@ -163,14 +165,16 @@ extension LocalNotificationType {
             arguments.append(senderName)
         }
         
-        return String.localizedStringWithFormat(localizationKey.pushFormatString, arguments: arguments)
+        return .localizedStringWithFormat(localizationKey.pushFormatString, arguments: arguments)
     }
     
     public func titleText(selfUser: ZMUser, conversation : ZMConversation? = nil) -> String? {
         
         if case .message(let contentType) = self {
             switch contentType {
-            case .ephemeral, .hidden:
+            case .ephemeral:
+                return .localizedStringWithFormat(ZMPushStringEphemeralTitle.pushFormatString)
+            case .hidden:
                 return nil
             default:
                 break
@@ -181,7 +185,7 @@ extension LocalNotificationType {
         let conversationName = conversation?.meaningfulDisplayName
         
         if let conversationName = conversationName, let teamName = teamName {
-            return String.localizedStringWithFormat(ZMPushStringTitle.pushFormatString, arguments: [conversationName, teamName])
+            return .localizedStringWithFormat(ZMPushStringTitle.pushFormatString, arguments: [conversationName, teamName])
         } else if let conversationName = conversationName {
             return conversationName
         } else if let teamName = teamName {
@@ -234,7 +238,7 @@ extension LocalNotificationType {
                 let key = baseKey + "." + MentionKey
                 return .localizedStringWithFormat(key.pushFormatString)
             case .ephemeral, .hidden:
-                return String.localizedStringWithFormat(baseKey.pushFormatString)
+                return .localizedStringWithFormat(baseKey.pushFormatString)
             case .messageTimerUpdate(let timerString):
                 if let string = timerString {
                     arguments.append(string)
@@ -254,7 +258,7 @@ extension LocalNotificationType {
         }
         
         let localizationKey = [baseKey, conversationTypeKey, senderKey, conversationKey, mentionKey].compactMap({ $0 }).joined(separator: ".")
-        return String.localizedStringWithFormat(localizationKey.pushFormatString, arguments: arguments)
+        return .localizedStringWithFormat(localizationKey.pushFormatString, arguments: arguments)
     }
     
 }

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_Message.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_Message.swift
@@ -83,8 +83,8 @@ class ZMLocalNotificationTests_Message : ZMLocalNotificationTests {
     func testThatItShowsShowsEphemeralStringEvenWhenHidePreviewSettingIsTrue() {
         // given
         let note1 = textNotification(oneOnOneConversation, sender: sender, isEphemeral: true)
-        XCTAssertEqual(note1?.content.title, "")
-        XCTAssertEqual(note1?.content.body, "Someone sent you a message")
+        XCTAssertEqual(note1?.content.title, "Someone")
+        XCTAssertEqual(note1?.content.body, "Sent a message")
         
         // when
         let moc = oneOnOneConversation.managedObjectContext!
@@ -95,8 +95,8 @@ class ZMLocalNotificationTests_Message : ZMLocalNotificationTests {
         let note2 = textNotification(oneOnOneConversation, sender: sender, isEphemeral: true)
         
         // then
-        XCTAssertEqual(note2?.content.title, "")
-        XCTAssertEqual(note2?.content.body, "Someone sent you a message")
+        XCTAssertEqual(note2?.content.title, "Someone")
+        XCTAssertEqual(note2?.content.body, "Sent a message")
     }
     
     func testThatItDoesNotSetThreadIdentifierForEphemeralMessages() {
@@ -105,8 +105,8 @@ class ZMLocalNotificationTests_Message : ZMLocalNotificationTests {
         
         // then
         XCTAssertNotNil(note)
-        XCTAssertEqual(note!.content.title, "")
-        XCTAssertEqual(note!.content.body, "Someone sent you a message")
+        XCTAssertEqual(note!.content.title, "Someone")
+        XCTAssertEqual(note!.content.body, "Sent a message")
         XCTAssertEqual(note!.content.threadIdentifier, "")
     }
     
@@ -124,11 +124,11 @@ class ZMLocalNotificationTests_Message : ZMLocalNotificationTests {
     }
     
     func testThatObfuscatesNotificationsForEphemeralMessages(){
-        XCTAssertEqual(bodyForNote(oneOnOneConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
-        XCTAssertEqual(bodyForNote(groupConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
-        XCTAssertEqual(bodyForNote(groupConversationWithoutUserDefinedName, sender: sender, isEphemeral: true), "Someone sent you a message")
-        XCTAssertEqual(bodyForNote(groupConversationWithoutName, sender: sender, isEphemeral: true), "Someone sent you a message")
-        XCTAssertEqual(bodyForNote(invalidConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
+        [oneOnOneConversation, groupConversation, groupConversationWithoutUserDefinedName, groupConversationWithoutName, invalidConversation].forEach {
+            let note = textNotification($0!, sender: sender, isEphemeral: true)
+            XCTAssertEqual(note?.title, "Someone")
+            XCTAssertEqual(note?.body, "Sent a message")
+        }
     }
     
     func testThatItDuplicatesPercentageSignsInTextAndConversationName() {
@@ -264,7 +264,8 @@ class ZMLocalNotificationTests_Message : ZMLocalNotificationTests {
         let note = textNotification(groupConversation, sender: sender, mentionedUser: selfUser, isEphemeral: true)
         
         // Then
-        XCTAssertEqual(note?.body, "Someone mentioned you")
+        XCTAssertEqual(note?.title, "Someone")
+        XCTAssertEqual(note?.body, "Mentioned you")
     }
 
     func testThatItCreatesPushNotificationForMessageOfUnknownType() {
@@ -342,11 +343,11 @@ extension ZMLocalNotificationTests_Message {
     }
 
     func testThatObfuscatesNotificationsForEphemeralImageMessages(){
-        XCTAssertEqual(bodyForImageNote(oneOnOneConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
-        XCTAssertEqual(bodyForImageNote(groupConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
-        XCTAssertEqual(bodyForImageNote(groupConversationWithoutUserDefinedName, sender: sender, isEphemeral: true), "Someone sent you a message")
-        XCTAssertEqual(bodyForImageNote(groupConversationWithoutName, sender: sender, isEphemeral: true), "Someone sent you a message")
-        XCTAssertEqual(bodyForImageNote(invalidConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
+        [oneOnOneConversation, groupConversation, groupConversationWithoutUserDefinedName, groupConversationWithoutName, invalidConversation].forEach {
+            let note = imageNote($0!, sender: sender, isEphemeral: true)
+            XCTAssertEqual(note?.title, "Someone")
+            XCTAssertEqual(note?.body, "Sent a message")
+        }
     }
 }
 
@@ -452,19 +453,19 @@ extension ZMLocalNotificationTests_Message {
     }
 
     func testThatItCreatesEphemeralFileAddNotificationsCorrectly() {
-        XCTAssertEqual(bodyForAssetNote(.txt, conversation: oneOnOneConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
-        XCTAssertEqual(bodyForAssetNote(.txt, conversation: groupConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
-        XCTAssertEqual(bodyForAssetNote(.txt, conversation: groupConversationWithoutUserDefinedName, sender: sender, isEphemeral: true), "Someone sent you a message")
-        XCTAssertEqual(bodyForAssetNote(.txt, conversation: groupConversationWithoutName, sender: sender, isEphemeral: true), "Someone sent you a message")
-        XCTAssertEqual(bodyForAssetNote(.txt, conversation: invalidConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
+        [oneOnOneConversation, groupConversation, groupConversationWithoutUserDefinedName, groupConversationWithoutName, invalidConversation].forEach {
+            let note = assetNote(.txt, conversation: $0!, sender: sender, isEphemeral: true)
+            XCTAssertEqual(note?.title, "Someone")
+            XCTAssertEqual(note?.body, "Sent a message")
+        }
     }
 
     func testThatItCreatesEphemeralVideoAddNotificationsCorrectly() {
-        XCTAssertEqual(bodyForAssetNote(.video, conversation: oneOnOneConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
-        XCTAssertEqual(bodyForAssetNote(.video, conversation: groupConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
-        XCTAssertEqual(bodyForAssetNote(.video, conversation: groupConversationWithoutUserDefinedName, sender: sender, isEphemeral: true), "Someone sent you a message")
-        XCTAssertEqual(bodyForAssetNote(.video, conversation: groupConversationWithoutName, sender: sender, isEphemeral: true), "Someone sent you a message")
-        XCTAssertEqual(bodyForAssetNote(.video, conversation: invalidConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
+        [oneOnOneConversation, groupConversation, groupConversationWithoutUserDefinedName, groupConversationWithoutName, invalidConversation].forEach {
+            let note = assetNote(.video, conversation: $0!, sender: sender, isEphemeral: true)
+            XCTAssertEqual(note?.title, "Someone")
+            XCTAssertEqual(note?.body, "Sent a message")
+        }
     }
 
     func testThatItCreatesAudioNotificationsCorrectly() {
@@ -509,11 +510,11 @@ extension ZMLocalNotificationTests_Message {
     }
 
     func testThatItCreatesEphemeralKnockNotificationsCorrectly() {
-        XCTAssertEqual(bodyForKnockNote(oneOnOneConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
-        XCTAssertEqual(bodyForKnockNote(groupConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
-        XCTAssertEqual(bodyForKnockNote(groupConversationWithoutUserDefinedName, sender: sender, isEphemeral: true), "Someone sent you a message")
-        XCTAssertEqual(bodyForKnockNote(groupConversationWithoutName, sender: sender, isEphemeral: true), "Someone sent you a message")
-        XCTAssertEqual(bodyForKnockNote(invalidConversation, sender: sender, isEphemeral: true), "Someone sent you a message")
+        [oneOnOneConversation, groupConversation, groupConversationWithoutUserDefinedName, groupConversationWithoutName, invalidConversation].forEach {
+            let note = knockNote($0!, sender: sender, isEphemeral: true)
+            XCTAssertEqual(note?.title, "Someone")
+            XCTAssertEqual(note?.body, "Sent a message")
+        }
     }
 }
 


### PR DESCRIPTION
## What's new in this PR?

Update the copy for ephemeral notifications as requested by design:

![image](https://user-images.githubusercontent.com/28632506/46350154-48754e80-c654-11e8-9919-e7e14ef7e114.png)

