### PR TITLE
Fix/mention notification copy

### DIFF
--- a/Source/Notifications/Push notifications/Notification Types/LocalNotificationContentType.swift
+++ b/Source/Notifications/Push notifications/Notification Types/LocalNotificationContentType.swift
@@ -31,7 +31,13 @@ public enum LocalNotificationContentType : Equatable {
             return .ephemeral(isMention: message.textMessageData?.isMentioningSelf ?? false)
         }
         
-        if let messageData = message.textMessageData, let text = messageData.messageText , !text.isEmpty {
+        if let messageData = message.textMessageData, var text = messageData.messageText , !text.isEmpty {
+            // strip @ symbol from mentions
+            messageData.mentions
+                .compactMap { Range($0.range, in: text)?.lowerBound }
+                .sorted(by: >)
+                .forEach { text.remove(at: $0) }
+            
             return .text(text, isMention: messageData.isMentioningSelf)
         }
         

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests.swift
@@ -48,6 +48,7 @@ class ZMLocalNotificationTests: MessagingTest {
 
         syncMOC.performGroupedBlockAndWait {
             self.selfUser = ZMUser.selfUser(in: self.syncMOC)
+            self.selfUser.name = "Bob"
             self.selfUser.remoteIdentifier = UUID.create()
             self.syncMOC.saveOrRollback()
         }


### PR DESCRIPTION
## What's new in this PR?

This PR adds changes to remove the `@` symbol from mentions in notification body text. 