### PR TITLE
Fix/foreground notifications

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -88,7 +88,7 @@ public protocol SessionManagerSwitchingDelegate: class {
 
 @objc
 public protocol ForegroundNotificationResponder: class {
-    func shouldPresentForegroundNotification(for conversation: UUID) -> Bool
+    func shouldPresentNotification(with userInfo: NotificationUserInfo) -> Bool
 }
 
 /// The `SessionManager` class handles the creation of `ZMUserSession` and `UnauthenticatedSession`

--- a/Source/UserSession/ZMUserSession+Push.swift
+++ b/Source/UserSession/ZMUserSession+Push.swift
@@ -186,14 +186,11 @@ extension ZMUserSession: UNUserNotificationCenterDelegate {
         // foreground notification responder exists on the UI context, so we
         // need to switch to that context
         self.managedObjectContext.perform {
-            guard let conv = userInfo.conversation(in: self.managedObjectContext)?.remoteIdentifier
-            else { return completionHandler([]) }
-            
             let responder = self.sessionManager.foregroundNotificationResponder
-            let shouldPresent = responder?.shouldPresentForegroundNotification(for: conv) ?? true
+            let shouldPresent = responder?.shouldPresentNotification(with: userInfo)
             
             var options = UNNotificationPresentationOptions()
-            if shouldPresent { options = [.alert, .sound] }
+            if shouldPresent ?? true { options = [.alert, .sound] }
             
             completionHandler(options)
         }

--- a/Tests/Source/Notifications/PushNotifications/LocalNotificationDispatcherTests.swift
+++ b/Tests/Source/Notifications/PushNotifications/LocalNotificationDispatcherTests.swift
@@ -412,18 +412,6 @@ extension LocalNotificationDispatcherTests {
     }
 }
 
-
-class MockForegroundNotificationResponder: NSObject, ForegroundNotificationResponder {
-
-    var notificationPermissionRequests: [UUID] = []
-    
-    func shouldPresentForegroundNotification(for conversation: UUID) -> Bool {
-        notificationPermissionRequests.append(conversation)
-        return true
-    }
-}
-
-
 // Helper function inserted by Swift 4.2 migrator.
 fileprivate func convertToUNNotificationSoundName(_ input: String) -> UNNotificationSoundName {
 	return UNNotificationSoundName(rawValue: input)

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -1119,3 +1119,13 @@ class TestReachability: NSObject, ReachabilityProvider, TearDownCapable {
         return NSObject()
     }
 }
+
+class MockForegroundNotificationResponder: NSObject, ForegroundNotificationResponder {
+    
+    var notificationPermissionRequests: [UUID] = []
+    
+    func shouldPresentNotification(with userInfo: NotificationUserInfo) -> Bool {
+        notificationPermissionRequests.append(userInfo.conversationID!)
+        return true
+    }
+}


### PR DESCRIPTION
## What's new in this PR?

Just a small update to the `ForegroundNotificationResponder` protocol. Passing just the conversation ID was too limiting, so instead we pass the entire `NotificationUserInfo` object (it contains the message nonce, the recipient ID, etc...).