### PR TITLE
Fix race condition while waiting for call events

### DIFF
--- a/Source/UserSession/CallEventStatus.swift
+++ b/Source/UserSession/CallEventStatus.swift
@@ -46,7 +46,7 @@ public class CallEventStatus: NSObject {
     
     /// Wait for all calling events to be processed and then calls the completion handler.
     ///
-    /// Returns: true if there's was any processed calling events.
+    /// Returns: true if there's was any unprocessed calling events.
     @discardableResult
     public func waitForCallEventProcessingToComplete(_ completionHandler: @escaping () -> Void) -> Bool {
         guard callEventsWaitingToBeProcessed != 0 || eventProcessingTimer != nil else {

--- a/Source/UserSession/CallEventStatus.swift
+++ b/Source/UserSession/CallEventStatus.swift
@@ -44,12 +44,18 @@ public class CallEventStatus: NSObject {
         eventProcessingTimer = nil
     }
     
-    public func waitForCallEventProcessingToComplete(_ completionHandler: @escaping () -> Void) {
-        guard callEventsWaitingToBeProcessed != 0 else {
-            return completionHandler()
+    /// Wait for all calling events to be processed and then calls the completion handler.
+    ///
+    /// Returns: true if there's was any processed calling events.
+    @discardableResult
+    public func waitForCallEventProcessingToComplete(_ completionHandler: @escaping () -> Void) -> Bool {
+        guard callEventsWaitingToBeProcessed != 0 || eventProcessingTimer != nil else {
+            completionHandler()
+            return false
         }
         
         observers.append(completionHandler)
+        return true
     }
     
     public func scheduledCallEventForProcessing() {

--- a/Tests/Source/UserSession/CallEventStatusTests.swift
+++ b/Tests/Source/UserSession/CallEventStatusTests.swift
@@ -44,9 +44,11 @@ class CallEventStatusTests: ZMTBaseTest {
         let processingDidComplete = expectation(description: "processingDidComplete")
         
         // when
-        sut.waitForCallEventProcessingToComplete {
+        let hasUnprocessedCallEvents = sut.waitForCallEventProcessingToComplete {
             processingDidComplete.fulfill()
         }
+        
+        XCTAssertFalse(hasUnprocessedCallEvents)
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
     }
     
@@ -57,12 +59,30 @@ class CallEventStatusTests: ZMTBaseTest {
         
         // expect
         let processingDidComplete = expectation(description: "processingDidComplete")
-        sut.waitForCallEventProcessingToComplete {
+        let hasUnprocessedCallEvents = sut.waitForCallEventProcessingToComplete {
             processingDidComplete.fulfill()
         }
         
         // when
         sut.finishedProcessingCallEvent()
+        XCTAssertTrue(hasUnprocessedCallEvents)
+        XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
+    }
+    
+    func testThatWaitForCallEventCompleteWhenScheduledCallEventIsProcessedWhenTimeoutTimerIsStillRunning() {
+        
+        // given
+        sut.scheduledCallEventForProcessing()
+        sut.finishedProcessingCallEvent()
+        
+        // expect
+        let processingDidComplete = expectation(description: "processingDidComplete")
+        let hasUnprocessedCallEvents = sut.waitForCallEventProcessingToComplete {
+            processingDidComplete.fulfill()
+        }
+        
+        // when
+        XCTAssertTrue(hasUnprocessedCallEvents)
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
     }
 


### PR DESCRIPTION

## What's new in this PR?

### Issues

The app would still get suspended while processing call events in some cases.

### Causes

If `finishedProcessingCallEvent` was called before `waitForCallEventProcessingToComplete` we would not wait for the timeout timer to finish.

### Solutions

Check if we have a timer running in `waitForCallEventProcessingToComplete`.