### PR TITLE
Fix: Team one-to-one show in group section

### DIFF
--- a/Source/UserSession/Search/SearchTask.swift
+++ b/Source/UserSession/Search/SearchTask.swift
@@ -118,11 +118,11 @@ extension SearchTask {
     }
     
     func conversations(matchingQuery query: String) -> [ZMConversation] {
-        let nonTeamUserPredicate = NSPredicate(format: "%K.@count > 2",
+        let non1to1ConversationPredicate = NSPredicate(format: "%K.@count > 2",
             ZMConversationLastServerSyncedActiveParticipantsKey
         )
 
-        let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [ZMConversation.predicate(forSearchQuery: query), nonTeamUserPredicate])
+        let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [ZMConversation.predicate(forSearchQuery: query), non1to1ConversationPredicate])
 
         let fetchRequest = ZMConversation.sortedFetchRequest(with: predicate)
         fetchRequest?.sortDescriptors = [NSSortDescriptor(key: ZMNormalizedUserDefinedNameKey, ascending: true)]


### PR DESCRIPTION
## What's new in this PR?

This PR is a follow-up of https://github.com/wireapp/wire-ios/pull/2762.

### Issues

1to1 conversation shows up in group section and in the contacts sections

### Causes

1to1 conversations are included in SearchResult.conversations array.

### Solutions

Filter out all 1to1 conversations with TeamMembers.