### PR TITLE
Allow mute action for notification for non-team users

### DIFF
--- a/Resources/Base.lproj/Push.strings
+++ b/Resources/Base.lproj/Push.strings
@@ -213,6 +213,7 @@
 "push.notification.action.message.reply" = "Reply";
 "push.notification.action.message.reply.button.title" = "Send";
 "push.notification.action.message.reply.placeholder" = "Type a Message";
+"push.notification.action.conversation.mute" = "Mute";
 "push.notification.action.message.like" = "♥";
 
 "push.notification.action.call.accept" = "Accept";

--- a/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification.swift
+++ b/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification.swift
@@ -69,7 +69,7 @@ open class ZMLocalNotification: NSObject {
         self.type = builder.notificationType
         self.title = builder.titleText()
         self.body = builder.bodyText().escapingPercentageSymbols
-        self.category = builder.notificationType.category
+        self.category = builder.notificationType.category(hasTeam: builder.userInfo()?.teamName != nil)
         self.sound = builder.notificationType.sound
         self.userInfo = builder.userInfo()
         self.id = userInfo?.messageNonce ?? UUID()

--- a/Source/Notifications/Push notifications/Notification Types/LocalNotificationType+Configuration.swift
+++ b/Source/Notifications/Push notifications/Notification Types/LocalNotificationType+Configuration.swift
@@ -18,9 +18,26 @@
 
 import Foundation
 
+extension PushNotificationCategory {
+    func addMuteIfNeeded(hasTeam: Bool) -> PushNotificationCategory {
+        guard !hasTeam else {
+            return self
+        }
+        
+        switch self {
+        case .conversation:
+            return .conversationWithMute
+        case .conversationWithLike:
+            return .conversationWithLikeAndMute
+        default:
+            return self
+        }
+    }
+}
+
 extension LocalNotificationType {
     
-    var category: String {
+    func category(hasTeam: Bool) -> String {
         let category: PushNotificationCategory
         
         switch self {
@@ -31,24 +48,24 @@ extension LocalNotificationType {
             case .terminating(reason: .timeout):
                 category = .missedCall
             default :
-                category = .conversation
+                category = PushNotificationCategory.conversation.addMuteIfNeeded(hasTeam: hasTeam)
             }
         case .event(let eventType):
             switch eventType {
             case .connectionRequestPending, .conversationCreated:
                 category = .connect
             default:
-                category = .conversation
+                category = PushNotificationCategory.conversation.addMuteIfNeeded(hasTeam: hasTeam)
             }
         case .message(let contentType):
             switch contentType {
             case .audio, .video, .fileUpload, .image, .text, .location:
-                category = .conversationIncludingLike
+                category = PushNotificationCategory.conversationWithLike.addMuteIfNeeded(hasTeam: hasTeam)
             default:
-                category = .conversation
+                category = PushNotificationCategory.conversation.addMuteIfNeeded(hasTeam: hasTeam)
             }
         case .failedMessage:
-            category = .conversation
+            category = PushNotificationCategory.conversation.addMuteIfNeeded(hasTeam: hasTeam)
         }
         
         return category.rawValue

--- a/Source/Notifications/Push notifications/Notification Types/NotificationAction.swift
+++ b/Source/Notifications/Push notifications/Notification Types/NotificationAction.swift
@@ -107,6 +107,7 @@ extension NotificationAction {
 enum ConversationNotificationAction: String, NotificationAction {
     case open = "conversationOpenAction"
     case reply = "conversationDirectReplyAction"
+    case mute = "conversationMuteAction"
     case like = "messageLikeAction"
     case connect = "acceptConnectAction"
 
@@ -114,6 +115,7 @@ enum ConversationNotificationAction: String, NotificationAction {
         switch self {
         case .open: return "message.open"
         case .reply: return "message.reply"
+        case .mute: return "conversation.mute"
         case .like: return "message.like"
         case .connect: return "connection.accept"
         }

--- a/Source/Notifications/Push notifications/Notification Types/PushNotificationCategory.swift
+++ b/Source/Notifications/Push notifications/Notification Types/PushNotificationCategory.swift
@@ -23,21 +23,19 @@ import UserNotifications
  * The categories of notifications supported by the app.
  */
 
-enum PushNotificationCategory: String {
+enum PushNotificationCategory: String, CaseIterable {
     
     case incomingCall = "incomingCallCategory"
     case missedCall = "missedCallCategory"
     case conversation = "conversationCategory"
-    case conversationIncludingLike = "conversationCategoryWithLike"
+    case conversationWithMute = "conversationCategoryWithMute"
+    case conversationWithLike = "conversationCategoryWithLike"
+    case conversationWithLikeAndMute = "conversationCategoryWithLikeAndMute"
     case connect = "connectCategory"
 
     /// All the supported categories.
     static var allCategories: Set<UNNotificationCategory> {
-        let categories = [PushNotificationCategory.incomingCall,
-                          PushNotificationCategory.missedCall,
-                          PushNotificationCategory.conversation,
-                          PushNotificationCategory.conversationIncludingLike,
-                          PushNotificationCategory.connect].map(\.userNotificationCategory)
+        let categories = PushNotificationCategory.allCases.map(\.userNotificationCategory)
 
         return Set(categories)
     }
@@ -51,8 +49,12 @@ enum PushNotificationCategory: String {
             return [CallNotificationAction.callBack, CallNotificationAction.message]
         case .conversation:
             return [ConversationNotificationAction.reply]
-        case .conversationIncludingLike:
+        case .conversationWithMute:
+            return [ConversationNotificationAction.reply, ConversationNotificationAction.mute]
+        case .conversationWithLike:
             return [ConversationNotificationAction.reply, ConversationNotificationAction.like]
+        case .conversationWithLikeAndMute:
+            return [ConversationNotificationAction.reply, ConversationNotificationAction.like, ConversationNotificationAction.mute]
         case .connect:
             return [ConversationNotificationAction.connect]
         }

--- a/Source/UserSession/ZMUserSession+Actions.swift
+++ b/Source/UserSession/ZMUserSession+Actions.swift
@@ -84,7 +84,19 @@ private let zmLog = ZMSLog(tag: "Push")
             completionHandler()
         }
     }
-        
+    
+    public func muteConversation(with userInfo: NotificationUserInfo, completionHandler: @escaping () -> Void) {
+        let activity = BackgroundActivityFactory.sharedInstance().backgroundActivity(withName: "Mute Conversation Action Handler")
+        let conversation = userInfo.conversation(in: managedObjectContext)
+
+        managedObjectContext.perform {
+            conversation?.mutedMessageTypes = .all
+            self.managedObjectContext.saveOrRollback()
+            activity?.end()
+            completionHandler()
+        }
+    }
+    
     public  func reply(with userInfo: NotificationUserInfo, message: String, completionHandler: @escaping () -> Void) {
         guard
             !message.isEmpty,

--- a/Source/UserSession/ZMUserSession+Push.swift
+++ b/Source/UserSession/ZMUserSession+Push.swift
@@ -209,6 +209,8 @@ extension ZMUserSession: UNUserNotificationCenterDelegate {
             ignoreCall(with: userInfo, completionHandler: completionHandler)
         case CallNotificationAction.accept.rawValue:
             acceptCall(with: userInfo, completionHandler: completionHandler)
+        case ConversationNotificationAction.mute.rawValue:
+            muteConversation(with: userInfo, completionHandler: completionHandler)
         case ConversationNotificationAction.like.rawValue:
             likeMessage(with: userInfo, completionHandler: completionHandler)
         case ConversationNotificationAction.reply.rawValue:

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationForTests_CallState.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationForTests_CallState.swift
@@ -108,7 +108,7 @@ class ZMLocalNotificationTests_CallState : MessagingTest {
         // then
         XCTAssertEqual(note.title, "Callie")
         XCTAssertEqual(note.body, "called")
-        XCTAssertEqual(note.category, WireSyncEngine.PushNotificationCategory.conversation.rawValue)
+        XCTAssertEqual(note.category, WireSyncEngine.PushNotificationCategory.conversationWithMute.rawValue)
         XCTAssertEqual(note.sound, .newMessage)
     }
     

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_Message.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_Message.swift
@@ -558,4 +558,32 @@ extension ZMLocalNotificationTests_Message {
         XCTAssertEqual(bodyForEditNote(groupConversationWithoutName, sender: sender, text: "Edited Text"), "Super User in a conversation: Edited Text")
         XCTAssertEqual(bodyForEditNote(invalidConversation, sender: sender, text: "Edited Text"), "Super User in a conversation: Edited Text")
     }
+    
+    func testThatItGeneratesTheNotificationWithoutMuteInTheTeam() {
+        self.syncMOC.performGroupedAndWait { _ in
+            // GIVEN
+            let team = Team.insertNewObject(in: self.syncMOC)
+            team.name = "Wire Amazing Team"
+            let user = ZMUser.selfUser(in: self.syncMOC)
+            _ = Member.getOrCreateMember(for: user, in: team, context: self.syncMOC)
+            self.syncMOC.saveOrRollback()
+        }
+        
+        XCTAssert(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        // WHEN
+        let note = textNotification(self.oneOnOneConversation, sender: sender, text: "Hello", isEphemeral: false)!
+        
+        // THEN
+        XCTAssertEqual(note.category, "conversationCategoryWithLike")
+    
+    }
+    
+    func testThatItGeneratesTheNotificationWithMuteForNormalUser() {
+        // WHEN
+        let note = textNotification(oneOnOneConversation, sender: sender, text: "Hello", isEphemeral: false)!
+        
+        // THEN
+        XCTAssertEqual(note.category, "conversationCategoryWithLikeAndMute")
+    }
 }

--- a/Tests/Source/UserSession/ZMUserSessionTests+PushNotifications.swift
+++ b/Tests/Source/UserSession/ZMUserSessionTests+PushNotifications.swift
@@ -64,6 +64,21 @@ class ZMUserSessionTests_PushNotifications: ZMUserSessionTestsBase {
         XCTAssertTrue(sender.isConnected)
     }
 
+    func testThatItMutesAndDoesNotShowConversation_ForPushNotificationCategoryConversationWithMuteAction() {
+        // given
+        let userInfo = userInfoWithConversation()
+        let conversation = userInfo.conversation(in: uiMOC)!
+        simulateLoggedInUser()
+
+        // when
+        handle(conversationAction: .mute, category: .conversation, userInfo: userInfo)
+
+        // then
+        XCTAssertNil(mockSessionManager.lastRequestToShowConversation)
+        XCTAssertNil(mockSessionManager.lastRequestToShowConversationsList)
+        XCTAssertEqual(conversation.mutedMessageTypes, .all)
+    }
+
     func testThatItAddsLike_ForPushNotificationCategoryConversationWithLikeAction() {
         // given
         let userInfo = userInfoWithConversation(hasMessage: true)


### PR DESCRIPTION
## What's new in this PR?

### Issues

The mute action should be displayed for the non-team users only. Team users must see no action.