### PR TITLE
Fix completion handler not being executed on the SE moc

### DIFF
--- a/Source/Synchronization/ZMOperatonLoop+Background.swift
+++ b/Source/Synchronization/ZMOperatonLoop+Background.swift
@@ -41,8 +41,11 @@ public extension ZMOperationLoop {
             }
             
             self.pushNotificationStatus.fetch(eventId: nonce, completionHandler: {
-                 self.callEventStatus.waitForCallEventProcessingToComplete {
-                    completionHandler()
+                 self.callEventStatus.waitForCallEventProcessingToComplete { [weak self] in
+                    guard let strongSelf = self else { return }
+                    strongSelf.syncMOC.performGroupedBlock {
+                        completionHandler()
+                    }
                 }
             })
         }

--- a/Source/UserSession/CallEventStatus.swift
+++ b/Source/UserSession/CallEventStatus.swift
@@ -46,6 +46,8 @@ public class CallEventStatus: NSObject {
     
     /// Wait for all calling events to be processed and then calls the completion handler.
     ///
+    /// NOTE it is not guranteed that completion handler is called on the same thread as the caller.
+    ///
     /// Returns: true if there's was any unprocessed calling events.
     @discardableResult
     public func waitForCallEventProcessingToComplete(_ completionHandler: @escaping () -> Void) -> Bool {


### PR DESCRIPTION
## What's new in this PR?

### Issues

App would crash with 

```
*** Terminating app due to uncaught exception 'NSGenericException', reason: '*** Collection <__NSCFSet: 0x283d55dd0> was mutated while being enumerated.'
```

in `unreadConversationCountInContext:`

### Causes

This is indicating the we are executing a count request from the wrong thread. Looking at the stack trace we confirm that it indeed executing the count request on the sync managed object context from the main thread. The stack trace begins from a timer which was newly added to handle processing of call events.

### Solutions

Switch back to sync thread in the completion handler.