### PR TITLE
We should not expect to always get a userId in the close call handler

### DIFF
--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -209,8 +209,8 @@ public class AVSWrapper: AVSWrapperType {
     }
 
     private let closedCallHandler: CloseCallHandler = { reason, conversationId, messageTime, userId, contextRef in
-        AVSWrapper.withCallCenter(contextRef, reason, conversationId, messageTime, userId) {
-            $0.handleCallEnd(reason: $1, conversationId: $2, messageTime: $3, userId: $4)
+        AVSWrapper.withCallCenter(contextRef, reason, conversationId, messageTime) {
+            $0.handleCallEnd(reason: $1, conversationId: $2, messageTime: $3, userId: UUID(rawValue: userId))
         }
     }
 

--- a/Source/Calling/WireCallCenterV3+Events.swift
+++ b/Source/Calling/WireCallCenterV3+Events.swift
@@ -124,7 +124,7 @@ extension WireCallCenterV3 {
      * If messageTime is set to 0, the event wasn't caused by a message therefore we don't have a serverTimestamp.
      */
 
-    func handleCallEnd(reason: CallClosedReason, conversationId: UUID, messageTime: Date?, userId: UUID) {
+    func handleCallEnd(reason: CallClosedReason, conversationId: UUID, messageTime: Date?, userId: UUID?) {
         handleEvent("closed-call") {
             self.handleCallState(callState: .terminating(reason: reason), conversationId: conversationId, userId: userId, messageTime: messageTime)
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Call UI wouldn't dismiss when an outgoing call times out.

### Causes

We were always expecting a userId in the `call closed` handler which we don't get when a call times out.

### Solutions

Make `userId` optional. 
