### PR TITLE
Fixed tests, because OTR assets can expire with new changes

### DIFF
--- a/Tests/Source/E2EE/ConversationTests+OTR.m
+++ b/Tests/Source/E2EE/ConversationTests+OTR.m
@@ -482,7 +482,7 @@
 
 }
 
-- (void)testThatItOTRAssetCantExpire
+- (void)testThatItOTRAssetCanExpire
 {
     // given
     XCTAssertTrue([self login]);
@@ -504,8 +504,9 @@
     [self spinMainQueueWithTimeout:0.5];
     
     // then
-    XCTAssertFalse(message.isExpired);
-    XCTAssertEqual(message.deliveryState, ZMDeliveryStatePending);
+    XCTAssertTrue(message.isExpired);
+    XCTAssertEqual(message.deliveryState, ZMDeliveryStateFailedToSend);
+    XCTAssertEqual(conversation.conversationListIndicator, ZMConversationListIndicatorExpiredMessage);
 
     [ZMMessage setDefaultExpirationTime:defaultExpirationTime];
     


### PR DESCRIPTION
## What's new in this PR?

Fixed tests due to new changes about assets sending on slow networks - see https://github.com/wireapp/wire-ios-data-model/pull/547 for more info