### PR TITLE
Added logging to locate the wrong timestamp error

### DIFF
--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -137,7 +137,7 @@ public class AVSWrapper: AVSWrapperType {
         callEvent.data.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) in
             let currentTime = UInt32(callEvent.currentTimestamp.timeIntervalSince1970)
             let serverTime = UInt32(callEvent.serverTimestamp.timeIntervalSince1970)
-            
+            zmLog.debug("wcall_recv_msg: currentTime = \(currentTime), serverTime = \(serverTime)")
             wcall_recv_msg(handle, bytes, callEvent.data.count, currentTime, serverTime, callEvent.conversationId.transportString(), callEvent.userId.transportString(), callEvent.clientId)
         }
     }
@@ -185,6 +185,7 @@ public class AVSWrapper: AVSWrapperType {
     }
 
     private let missedCallHandler: MissedCallHandler = { conversationId, messageTime, userId, isVideoCall, contextRef in
+        zmLog.debug("missedCallHandler: messageTime = \(messageTime)")
         AVSWrapper.withCallCenter(contextRef, conversationId, messageTime, userId, isVideoCall) {
             $0.handleMissedCall(conversationId: $1, messageTime: $2, userId: $3, isVideoCall: $4)
         }
@@ -209,6 +210,7 @@ public class AVSWrapper: AVSWrapperType {
     }
 
     private let closedCallHandler: CloseCallHandler = { reason, conversationId, messageTime, userId, contextRef in
+        zmLog.debug("closedCallHandler: messageTime = \(messageTime)")
         AVSWrapper.withCallCenter(contextRef, reason, conversationId, messageTime) {
             $0.handleCallEnd(reason: $1, conversationId: $2, messageTime: $3, userId: UUID(rawValue: userId))
         }

--- a/Source/Calling/CallKitDelegate.swift
+++ b/Source/Calling/CallKitDelegate.swift
@@ -303,6 +303,7 @@ extension CallKitDelegate {
         
         associatedCallUUIDs.forEach { (callUUID) in
             calls.removeValue(forKey: callUUID)
+            log("provider.reportCallEndedAt: \(String(describing: timestamp))")
             provider.reportCall(with: callUUID, endedAt: timestamp, reason: reason)
         }
     }

--- a/Source/Synchronization/Strategies/CallingRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/CallingRequestStrategy.swift
@@ -139,7 +139,7 @@ extension CallingRequestStrategy : ZMEventConsumer {
                     continue
                 }
                 
-                self.zmLog.debug("received calling message")
+                self.zmLog.debug("received calling message, timestamp \(eventTimestamp), serverTimeDelta \(serverTimeDelta)")
                 
                 let callEvent = CallEvent(data: payload,
                                           currentTimestamp: Date().addingTimeInterval(serverTimeDelta),


### PR DESCRIPTION
## What's new in this PR?

### Issues

Sometimes users see the missed calls from year 2067.

### Causes

It seems like we are using the double timestamp (unix_time * 2) somewhere. I can imagine that we have the code where we already have the correct timestamp, and we are adding the offset to it again.

### Path of the timestamp

1. We receive the call message
2. CallingRequestStrategy is creating the CallEvent with: 
` currentTimestamp = Date().addingTimeInterval(serverTimeDelta)`
`serverTimestamp = eventTimestamp` where 
`eventTimestamp = value of ”time” from ZMUpdateEvent payload`

3. AVSWrapper is forwarding to the AVS 

```
  let currentTime = UInt32(callEvent.currentTimestamp.timeIntervalSince1970)
let serverTime = UInt32(callEvent.serverTimestamp.timeIntervalSince1970)  -> wcall_recv_msg(…., currentTime, serverTime, …) 
```
The signature of wcall_recv_msg is:

```
void wcall_recv_msg(…
		    uint32_t curr_time, /* timestamp in seconds */
		    uint32_t msg_time,  /* timestamp in seconds */..)
```
4. Then AVS is processing the message and gives us the time back:
One of wcall_close_h, wcall_missed_h is notifying about the call ended with msg_time that is passed through AVS
5. Event time is reported to the CallKit with callCenterDidChange -> reportCall with the same timestamp

I've been unable to find the source of the issue. One line seemed suspicious to me:
https://github.com/wireapp/wire-ios-sync-engine/blob/develop/Source/Synchronization/Strategies/CallingRequestStrategy.swift#L145

Since we add the server time drift that we are calculating when receiving the response that contains timestamp from the backend. (see [here](https://github.com/wireapp/wire-ios-sync-engine/blob/develop/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m#L300))

However the time that we are passing to currentTimestamp is not returned back from AVS (as far as I understood the sources). Anyway this is one of the points where we have the logging now.
