### PR TITLE
Move isAuthenticated to BackendEnvironmentProvider

### DIFF
--- a/Source/SessionManager/BackendEnvironmentProvider+Cookie.swift
+++ b/Source/SessionManager/BackendEnvironmentProvider+Cookie.swift
@@ -18,16 +18,13 @@
 
 import WireTransport
 
-extension Account {
-
-    func cookieStorage(for environment: BackendEnvironmentProvider) -> ZMPersistentCookieStorage {
-        let backendURL = environment.backendURL.host!
-        return ZMPersistentCookieStorage(forServerName: backendURL, userIdentifier: userIdentifier)
+extension BackendEnvironmentProvider {
+    func cookieStorage(for account: Account) -> ZMPersistentCookieStorage {
+        let backendURL = self.backendURL.host!
+        return ZMPersistentCookieStorage(forServerName: backendURL, userIdentifier: account.userIdentifier)
     }
     
-    
-    public func isAuthenticated(with environment: BackendEnvironmentProvider) -> Bool {
-        return cookieStorage(for: environment).authenticationCookieData != nil
+    public func isAuthenticated(_ account: Account) -> Bool {
+        return cookieStorage(for: account).authenticationCookieData != nil
     }
-
 }

--- a/Source/SessionManager/SessionFactories.swift
+++ b/Source/SessionManager/SessionFactories.swift
@@ -55,7 +55,7 @@ open class AuthenticatedSessionFactory {
         let transportSession = ZMTransportSession(
             baseURL: environment.backendURL,
             websocketURL: environment.backendWSURL,
-            cookieStorage: account.cookieStorage(for: environment),
+            cookieStorage: environment.cookieStorage(for: account),
             reachability: reachability,
             initialAccessToken: nil,
             applicationGroupIdentifier: nil

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -496,7 +496,7 @@ public protocol ForegroundNotificationResponder: class {
          - completion: called when session is loaded or when session fails to load
      */
     internal func loadSession(for account: Account?, completion: @escaping (ZMUserSession?) -> Void) {
-        guard let authenticatedAccount = account, authenticatedAccount.isAuthenticated(with: environment) else {
+        guard let authenticatedAccount = account, environment.isAuthenticated(authenticatedAccount) else {
             completion(nil)
             createUnauthenticatedSession()
             delegate?.sessionManagerDidFailToLogin(account: account, error: NSError(code: .accessTokenExpired, userInfo: account?.loginCredentials?.dictionaryRepresentation))
@@ -509,7 +509,7 @@ public protocol ForegroundNotificationResponder: class {
     public func deleteAccountData(for account: Account) {
         log.debug("Deleting the data for \(account.userName) -- \(account.userIdentifier)")
         
-        account.cookieStorage(for: environment).deleteKeychainItems()
+        environment.cookieStorage(for: account).deleteKeychainItems()
         
         let accountID = account.userIdentifier
         self.accountManager.remove(account)

--- a/Source/UnauthenticatedSession/UnauthenticatedSession.swift
+++ b/Source/UnauthenticatedSession/UnauthenticatedSession.swift
@@ -103,7 +103,7 @@ extension UnauthenticatedSession: UserInfoParser {
 
     public func upgradeToAuthenticatedSession(with userInfo: UserInfo) {
         let account = Account(userName: "", userIdentifier: userInfo.identifier)
-        let cookieStorage = account.cookieStorage(for: transportSession.environment)
+        let cookieStorage = transportSession.environment.cookieStorage(for: account)
         cookieStorage.authenticationCookieData = userInfo.cookieData
         self.authenticationStatus.authenticationCookieData = userInfo.cookieData
         self.delegate?.session(session: self, createdAccount: account)

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -91,7 +91,7 @@ class SessionManagerTests: IntegrationTest {
         guard let sharedContainer = Bundle.main.appGroupIdentifier.map(FileManager.sharedContainerDirectory) else { return XCTFail() }
         let manager = AccountManager(sharedDirectory: sharedContainer)
         let account = Account(userName: "", userIdentifier: currentUserIdentifier)
-        account.cookieStorage(for: sessionManager!.environment).authenticationCookieData = NSData.secureRandomData(ofLength: 16)
+        sessionManager!.environment.cookieStorage(for: account).authenticationCookieData = NSData.secureRandomData(ofLength: 16)
         manager.addAndSelect(account)
 
         var completed = false
@@ -122,7 +122,7 @@ class SessionManagerTests: IntegrationTest {
         
         // GIVEN
         let account = self.createAccount()
-        account.cookieStorage(for: sessionManager!.environment).authenticationCookieData = NSData.secureRandomData(ofLength: 16)
+        sessionManager!.environment.cookieStorage(for: account).authenticationCookieData = NSData.secureRandomData(ofLength: 16)
         
         guard let mediaManager = mediaManager, let application = application else { return XCTFail() }
         
@@ -185,7 +185,7 @@ class SessionManagerTests: IntegrationTest {
         
         // GIVEN
         let account = self.createAccount()
-        account.cookieStorage(for: sessionManager!.environment).authenticationCookieData = NSData.secureRandomData(ofLength: 16)
+        sessionManager!.environment.cookieStorage(for: account).authenticationCookieData = NSData.secureRandomData(ofLength: 16)
         
         guard let mediaManager = mediaManager, let application = application else { return XCTFail() }
         
@@ -245,10 +245,10 @@ class SessionManagerTests: IntegrationTest {
         
         // GIVEN
         let account1 = self.createAccount()
-        account1.cookieStorage(for: sessionManager!.environment).authenticationCookieData = NSData.secureRandomData(ofLength: 16)
+        sessionManager!.environment.cookieStorage(for: account1).authenticationCookieData = NSData.secureRandomData(ofLength: 16)
         
         let account2 = self.createAccount(with: UUID.create())
-        account2.cookieStorage(for: sessionManager!.environment).authenticationCookieData = NSData.secureRandomData(ofLength: 16)
+        sessionManager!.environment.cookieStorage(for: account2).authenticationCookieData = NSData.secureRandomData(ofLength: 16)
         
         guard let mediaManager = mediaManager, let application = application else { return XCTFail() }
         
@@ -572,7 +572,7 @@ class SessionManagerTests_MultiUserSession: IntegrationTest {
     func testThatItDoesNotUnloadActiveUserSessionFromMemoryWarning() {
         // GIVEN
         let account = self.createAccount()
-        account.cookieStorage(for: sessionManager!.environment).authenticationCookieData = NSData.secureRandomData(ofLength: 16)
+        sessionManager!.environment.cookieStorage(for: account).authenticationCookieData = NSData.secureRandomData(ofLength: 16)
         
         guard let mediaManager = mediaManager, let application = application else { return XCTFail() }
         
@@ -628,7 +628,7 @@ class SessionManagerTests_MultiUserSession: IntegrationTest {
     func testThatItUnloadBackgroundUserSessionFromMemoryWarning() {
         // GIVEN
         let account = self.createAccount()
-        account.cookieStorage(for: sessionManager!.environment).authenticationCookieData = NSData.secureRandomData(ofLength: 16)
+        sessionManager!.environment.cookieStorage(for: account).authenticationCookieData = NSData.secureRandomData(ofLength: 16)
         
         guard let mediaManager = mediaManager, let application = application else { return XCTFail() }
         
@@ -771,7 +771,7 @@ class SessionManagerTests_MultiUserSession: IntegrationTest {
         let manager = self.sessionManager!.accountManager
         let account = Account(userName: "Test Account", userIdentifier: currentUserIdentifier)
         manager.addOrUpdate(account)
-        account.cookieStorage(for: sessionManager!.environment).authenticationCookieData = NSData.secureRandomData(ofLength: 16)
+        sessionManager!.environment.cookieStorage(for: account).authenticationCookieData = NSData.secureRandomData(ofLength: 16)
         manager.addAndSelect(account)
         
         var session: ZMUserSession! = nil
@@ -943,11 +943,11 @@ class SessionManagerTests_MultiUserSession: IntegrationTest {
         // GIVEN
         let manager = sessionManager!.accountManager
         let account1 = Account(userName: "Test Account 1", userIdentifier: currentUserIdentifier)
-        account1.cookieStorage(for: sessionManager!.environment).authenticationCookieData = NSData.secureRandomData(ofLength: 16)
+        sessionManager!.environment.cookieStorage(for: account1).authenticationCookieData = NSData.secureRandomData(ofLength: 16)
         
         manager.addOrUpdate(account1)
         let account2 = Account(userName: "Test Account 2", userIdentifier: UUID())
-        account2.cookieStorage(for: sessionManager!.environment).authenticationCookieData = NSData.secureRandomData(ofLength: 16)
+        sessionManager!.environment.cookieStorage(for: account2).authenticationCookieData = NSData.secureRandomData(ofLength: 16)
         manager.addOrUpdate(account2)
         
         // Make account 1 the active session

--- a/Tests/Source/UserSession/UnauthenticatedSessionTests.swift
+++ b/Tests/Source/UserSession/UnauthenticatedSessionTests.swift
@@ -266,7 +266,7 @@ public final class UnauthenticatedSessionTests: ZMTBaseTest {
 
         // then
         XCTAssertEqual(account.userIdentifier, userId)
-        XCTAssertNotNil(account.cookieStorage(for: transportSession.environment).authenticationCookieData)
+        XCTAssertNotNil(transportSession.environment.cookieStorage(for: account).authenticationCookieData)
     }
 
     func testThatItParsesCookieDataAndDoesCallTheDelegateIfTheCookieIsValidAndThereIsAUserIdKeyId() throws {
@@ -279,7 +279,7 @@ public final class UnauthenticatedSessionTests: ZMTBaseTest {
 
         // then
         XCTAssertEqual(account.userIdentifier, userId)
-        XCTAssertNotNil(account.cookieStorage(for: transportSession.environment).authenticationCookieData)
+        XCTAssertNotNil(transportSession.environment.cookieStorage(for: account).authenticationCookieData)
     }
 
     func testThatItDoesNotParseAnAccountWithWrongUserIdKey() {

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -348,7 +348,7 @@
 		BF2A9D5D1D6B63DB00FA7DBC /* StoreUpdateEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2A9D5A1D6B63DB00FA7DBC /* StoreUpdateEvent.swift */; };
 		BF2A9D611D6C70EA00FA7DBC /* ZMEventModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = BF2A9D5F1D6C70EA00FA7DBC /* ZMEventModel.xcdatamodeld */; };
 		BF2ADA001F41A3DF000980E8 /* SessionFactories.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2AD9FF1F41A3DF000980E8 /* SessionFactories.swift */; };
-		BF2ADA021F41A450000980E8 /* Account+Cookie.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2ADA011F41A450000980E8 /* Account+Cookie.swift */; };
+		BF2ADA021F41A450000980E8 /* BackendEnvironmentProvider+Cookie.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2ADA011F41A450000980E8 /* BackendEnvironmentProvider+Cookie.swift */; };
 		BF325E9D1EC067D600772145 /* RequestLoopAnalyticsTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF325E9C1EC067D600772145 /* RequestLoopAnalyticsTrackerTests.swift */; };
 		BF36DDF11E8BACD400D61310 /* ZMUserSession+OperationLoop.h in Headers */ = {isa = PBXBuildFile; fileRef = BF36DDF01E8BACD400D61310 /* ZMUserSession+OperationLoop.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF3C1B1720DBE254001CE126 /* Conversation+MessageDestructionTimeout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF3C1B1620DBE254001CE126 /* Conversation+MessageDestructionTimeout.swift */; };
@@ -949,7 +949,7 @@
 		BF2A9D5A1D6B63DB00FA7DBC /* StoreUpdateEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StoreUpdateEvent.swift; path = Decoding/StoreUpdateEvent.swift; sourceTree = "<group>"; };
 		BF2A9D601D6C70EA00FA7DBC /* ZMEventModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = ZMEventModel.xcdatamodel; sourceTree = "<group>"; };
 		BF2AD9FF1F41A3DF000980E8 /* SessionFactories.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionFactories.swift; sourceTree = "<group>"; };
-		BF2ADA011F41A450000980E8 /* Account+Cookie.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Account+Cookie.swift"; sourceTree = "<group>"; };
+		BF2ADA011F41A450000980E8 /* BackendEnvironmentProvider+Cookie.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "BackendEnvironmentProvider+Cookie.swift"; sourceTree = "<group>"; };
 		BF325E9C1EC067D600772145 /* RequestLoopAnalyticsTrackerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestLoopAnalyticsTrackerTests.swift; sourceTree = "<group>"; };
 		BF36DDF01E8BACD400D61310 /* ZMUserSession+OperationLoop.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ZMUserSession+OperationLoop.h"; sourceTree = "<group>"; };
 		BF3C1B1620DBE254001CE126 /* Conversation+MessageDestructionTimeout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Conversation+MessageDestructionTimeout.swift"; sourceTree = "<group>"; };
@@ -2113,7 +2113,6 @@
 			isa = PBXGroup;
 			children = (
 				F159F4151F1E4C4C001B7D80 /* LocalStoreProvider.swift */,
-				BF2ADA011F41A450000980E8 /* Account+Cookie.swift */,
 				BF2AD9FF1F41A3DF000980E8 /* SessionFactories.swift */,
 				F19F1D371EFBF61800275E27 /* SessionManager.swift */,
 				16FF474B1F0D54B20044C491 /* SessionManager+Logs.swift */,
@@ -2122,6 +2121,7 @@
 				165BB94B2004D6490077EFD5 /* SessionManager+UserActivity.swift */,
 				162A81D3202B453000F6200C /* SessionManager+AVS.swift */,
 				F130BF272062C05600DBE261 /* SessionManager+Backup.swift */,
+				BF2ADA011F41A450000980E8 /* BackendEnvironmentProvider+Cookie.swift */,
 				8737D553209217BD00E5A4AF /* SessionManagerURLHandler.swift */,
 			);
 			path = SessionManager;
@@ -2718,7 +2718,7 @@
 				549816291A432BC800A7CE2E /* ZMConnectionTranscoder.m in Sources */,
 				54C8A39C1F7536DB004961DF /* ZMOperationLoop+Notifications.swift in Sources */,
 				5EC2C58F2137F5EE00C6CE35 /* CallClosedReason.swift in Sources */,
-				BF2ADA021F41A450000980E8 /* Account+Cookie.swift in Sources */,
+				BF2ADA021F41A450000980E8 /* BackendEnvironmentProvider+Cookie.swift in Sources */,
 				5EFE9C15212AB138007932A6 /* UnregisteredUser+Payload.swift in Sources */,
 				160C31271E6434500012E4BC /* OperationStatus.swift in Sources */,
 				165911531DEF38EC007FA847 /* CallStateObserver.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

Moved the isAuthenticated check that depends on the backend URL to `BackendEnvironmentProvider `. Seems to be cleaner solution, but in the end just swapping 2 arguments.