### PR TITLE
SSO login: do not require email and password for device management

### DIFF
--- a/Source/E2EE/ZMUserSession+OTR.m
+++ b/Source/E2EE/ZMUserSession+OTR.m
@@ -30,17 +30,6 @@
 
 @implementation ZMUserSession (OTR)
 
-- (void)deleteClient:(UserClient *)client
-{
-    [client markForDeletion];
-    [client.managedObjectContext saveOrRollback];
-    
-    [self.syncManagedObjectContext performGroupedBlock:^{
-        [self.clientUpdateStatus deleteClientsWithCredentials:self.clientRegistrationStatus.emailCredentials];
-        [ZMRequestAvailableNotification notifyNewRequestsAvailable:self];
-    }];
-}
-
 - (void)fetchAllClients
 {
     [self.syncManagedObjectContext performGroupedBlock:^{
@@ -50,12 +39,10 @@
 }
 
 
-- (void)deleteClients:(NSArray<UserClient *> *)clients withCredentials:(ZMEmailCredentials *)emailCredentials
+- (void)deleteClient:(UserClient *)client withCredentials:(ZMEmailCredentials *)emailCredentials
 {
-    for (UserClient *client in clients){
-        [client markForDeletion];
-    }
-    [[clients.firstObject managedObjectContext] saveOrRollback];
+    [client markForDeletion];
+    [[client managedObjectContext] saveOrRollback];
     
     [self.syncManagedObjectContext performGroupedBlock:^{
         [self.clientUpdateStatus deleteClientsWithCredentials:emailCredentials];

--- a/Source/Public/ZMUserSession+OTR.h
+++ b/Source/Public/ZMUserSession+OTR.h
@@ -21,7 +21,7 @@
 
 @class UserClient;
 
-
+NS_ASSUME_NONNULL_BEGIN
 
 @protocol ZMClientUpdateObserver <NSObject>
 
@@ -35,22 +35,18 @@
 
 @interface ZMUserSession (OTR)
 
-/// Deletes selfUser clients from the BE if there are too many clients on startup
-- (void)deleteClient:(UserClient *)client;
-
 /// Fetch all selfUser clients to manage them from the settings screen
 /// The current client must be already registered
 /// Calling this method without a registered client will throw an error
 - (void)fetchAllClients;
 
-
 /// Deletes selfUser clients from the BE when managing them from the settings screen
-- (void)deleteClients:(NSArray<UserClient *> *)clients withCredentials:(ZMEmailCredentials *)emailCredentials;
-
+- (void)deleteClient:(UserClient *)client withCredentials:(nullable ZMEmailCredentials *)emailCredentials;
 
 /// Adds an observer that is notified when the selfUser clients were successfully fetched and deleted
 /// Returns a token that needs to be stored as long the observer should be active.
 - (id)addClientUpdateObserver:(id<ZMClientUpdateObserver>)observer;
 
-
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Source/Synchronization/Strategies/UserClientRequestFactory.swift
+++ b/Source/Synchronization/Strategies/UserClientRequestFactory.swift
@@ -158,11 +158,21 @@ public final class UserClientRequestFactory {
     }
     
     /// Password needs to be set
-    public func deleteClientRequest(_ client: UserClient, credentials: ZMEmailCredentials) -> ZMUpstreamRequest {
-        let payload = [
-            "email" : credentials.email!,
-            "password" : credentials.password!
-        ]
+    public func deleteClientRequest(_ client: UserClient, credentials: ZMEmailCredentials?) -> ZMUpstreamRequest {
+        let payload: [AnyHashable: Any]
+        
+        if let credentials = credentials,
+            let email = credentials.email,
+            let password = credentials.password {
+            payload = [
+                "email" : email,
+                "password" : password
+            ]
+        }
+        else {
+            payload = [:]
+        }
+        
         let request =  ZMTransportRequest(path: "/clients/\(client.remoteIdentifier!)", method: ZMTransportRequestMethod.methodDELETE, payload: payload as ZMTransportData)
         return ZMUpstreamRequest(keys: Set(arrayLiteral: ZMUserClientMarkedToDeleteKey), transportRequest: request)
     }

--- a/Source/Synchronization/Strategies/UserClientRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/UserClientRequestStrategy.swift
@@ -99,7 +99,7 @@ public final class UserClientRequestStrategy: ZMObjectSyncStrategy, ZMObjectStra
             return fetchAllClientsSync.nextRequest()
         }
         
-        if clientUpdateStatus.currentPhase == .deletingClients && clientUpdateStatus.credentials != nil {
+        if clientUpdateStatus.currentPhase == .deletingClients {
             if let request =  deleteSync.nextRequest() {
                 return request
             }
@@ -149,8 +149,8 @@ public final class UserClientRequestStrategy: ZMObjectSyncStrategy, ZMObjectStra
                     fatal("Couldn't create request for new pre keys: \(e)")
                 }
             case _ where keys.contains(ZMUserClientMarkedToDeleteKey):
-                if clientUpdateStatus.currentPhase == ClientUpdatePhase.deletingClients && clientUpdateStatus.credentials != nil {
-                    request = requestsFactory.deleteClientRequest(managedObject, credentials: clientUpdateStatus.credentials!)
+                if clientUpdateStatus.currentPhase == ClientUpdatePhase.deletingClients {
+                    request = requestsFactory.deleteClientRequest(managedObject, credentials: clientUpdateStatus.credentials)
                 }
                 else {
                     fatal("No email credentials in memory")
@@ -250,7 +250,7 @@ public final class UserClientRequestStrategy: ZMObjectSyncStrategy, ZMObjectStra
                 case "client-not-found":
                     errorCode = .clientToDeleteNotFound
                     break
-                case "invalid-credentials":
+                case "invalid-credentials", "missing-auth":
                     errorCode = .invalidCredentials
                     break
                 default:

--- a/Source/UserSession/ZMClientRegistrationStatus.m
+++ b/Source/UserSession/ZMClientRegistrationStatus.m
@@ -110,7 +110,8 @@ static NSString *ZMLogTag ZM_UNUSED = @"Authentication";
      ZMClientRegistrationPhaseWaitingForSelfUser
      [We fetch the selfUser]
                 |
-     [User has email address?]      --> NO  --> ZMClientRegistrationPhaseWaitingForEmailVerfication
+     [User has email address,
+      and it's not the SSO user]    --> NO  --> ZMClientRegistrationPhaseWaitingForEmailVerfication
                                                 [user adds email and password, we fetch user from BE]
                                             --> ZMClientRegistrationPhaseUnregistered
                                                 [Client is registered]
@@ -208,7 +209,10 @@ static NSString *ZMLogTag ZM_UNUSED = @"Authentication";
 
 - (BOOL)isAddingEmailNecessary
 {
-    return ![self.managedObjectContext registeredOnThisDevice] && self.isWaitingForSelfUserEmail;
+    ZMUser *selfUser = [ZMUser selfUserInContext:self.managedObjectContext];
+    return ![self.managedObjectContext registeredOnThisDevice] &&
+            self.isWaitingForSelfUserEmail &&
+           !selfUser.usesCompanyLogin;
 }
 
 - (void)prepareForClientRegistration

--- a/Tests/Source/E2EE/ConversationTests+OTR.m
+++ b/Tests/Source/E2EE/ConversationTests+OTR.m
@@ -1928,7 +1928,7 @@
     // (2) selfUser deletes remote selfUser client
     {
         [self.userSession performChanges:^{
-            [self.userSession deleteClients:@[otherSelfClient] withCredentials:[ZMEmailCredentials credentialsWithEmail:IntegrationTest.SelfUserEmail password:IntegrationTest.SelfUserPassword]];
+            [self.userSession deleteClient:otherSelfClient withCredentials:[ZMEmailCredentials credentialsWithEmail:IntegrationTest.SelfUserEmail password:IntegrationTest.SelfUserPassword]];
         }];
         WaitForAllGroupsToBeEmpty(0.5);
         
@@ -2105,7 +2105,7 @@
     WaitForAllGroupsToBeEmpty(1.0);
     
     [self.userSession performChanges:^{
-        [self.userSession deleteClients:@[notSelfClient] withCredentials:[ZMEmailCredentials credentialsWithEmail:IntegrationTest.SelfUserEmail password:IntegrationTest.SelfUserPassword]];
+        [self.userSession deleteClient:notSelfClient withCredentials:[ZMEmailCredentials credentialsWithEmail:IntegrationTest.SelfUserEmail password:IntegrationTest.SelfUserPassword]];
     }];
     WaitForAllGroupsToBeEmpty(1.0);
     

--- a/Tests/Source/Integration/ClientManagementTests.m
+++ b/Tests/Source/Integration/ClientManagementTests.m
@@ -149,7 +149,7 @@
 
     // when
     [self.userSession performChanges:^{
-        [self.userSession deleteClients:@[fetchClients.firstObject] withCredentials:credentials];
+        [self.userSession deleteClient:fetchClients.firstObject withCredentials:credentials];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
     

--- a/Tests/Source/Integration/LoginFlowTests.m
+++ b/Tests/Source/Integration/LoginFlowTests.m
@@ -768,7 +768,7 @@ extern NSTimeInterval DebugLoginFailureTimerOverride;
                     return [client.remoteIdentifier isEqualToString:idToDelete];
                 }];
                 XCTAssertNotNil(clientToDelete);
-                [self.userSession deleteClient:clientToDelete];
+                [self.userSession deleteClient:clientToDelete withCredentials:nil];
             }];
         }
         else if (event == PostLoginAuthenticationEventObjCClientRegistrationDidSucceed) {

--- a/Tests/Source/UserSession/ZMClientRegistrationStatusTests.m
+++ b/Tests/Source/UserSession/ZMClientRegistrationStatusTests.m
@@ -366,6 +366,18 @@
     XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseUnregistered);
 }
 
+- (void)testThatItDoesNotRequireEmailRegistrationForTeamUser
+{
+    // given
+    ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
+    selfUser.remoteIdentifier = [NSUUID UUID];
+    selfUser.emailAddress = nil;
+    selfUser.phoneNumber = nil;
+    selfUser.usesCompanyLogin = YES;
+    
+    // then
+    XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseUnregistered);
+}
 
 @end
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

Some necessary changes in order to allow SSO to work:

- Do not require adding email when signing in first time. Before we needed to add email in order to register the first client.
- Change the way we delete the clients, try without credentials first, and ask for login/password in case of an error.

Accompanying UI PR is also coming.