### PR TITLE
Fix push token registration

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -202,8 +202,9 @@ public protocol ForegroundNotificationResponder: class {
     
     public var callKitDelegate : CallKitDelegate?
     
-    private static let runOnce: Void = {
+    private static let runOnce: () -> Void = {
         BuildType.setupBuildTypes()
+        return {}
     }()
     
     /// The entry point for SessionManager; call this instead of the initializers.
@@ -220,6 +221,7 @@ public protocol ForegroundNotificationResponder: class {
         ) {
         
         token = FileManager.default.executeWhenFileSystemIsAccessible {
+            runOnce()
             completion(SessionManager(
                 appVersion: appVersion,
                 mediaManager: mediaManager,

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -202,6 +202,10 @@ public protocol ForegroundNotificationResponder: class {
     
     public var callKitDelegate : CallKitDelegate?
     
+    private static let runOnce: Void = {
+        BuildType.setupBuildTypes()
+    }()
+    
     /// The entry point for SessionManager; call this instead of the initializers.
     ///
     public static func create(
@@ -214,8 +218,8 @@ public protocol ForegroundNotificationResponder: class {
         blacklistDownloadInterval: TimeInterval,
         completion: @escaping (SessionManager) -> Void
         ) {
+        
         token = FileManager.default.executeWhenFileSystemIsAccessible {
-            BuildType.setupBuildTypes()
             completion(SessionManager(
                 appVersion: appVersion,
                 mediaManager: mediaManager,

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -202,10 +202,6 @@ public protocol ForegroundNotificationResponder: class {
     
     public var callKitDelegate : CallKitDelegate?
     
-    private static let runOnce: Void = {
-        BuildType.setupBuildTypes()
-    }()
-    
     /// The entry point for SessionManager; call this instead of the initializers.
     ///
     public static func create(
@@ -218,8 +214,8 @@ public protocol ForegroundNotificationResponder: class {
         blacklistDownloadInterval: TimeInterval,
         completion: @escaping (SessionManager) -> Void
         ) {
-        
         token = FileManager.default.executeWhenFileSystemIsAccessible {
+            BuildType.setupBuildTypes()
             completion(SessionManager(
                 appVersion: appVersion,
                 mediaManager: mediaManager,

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -365,8 +365,7 @@ class SessionManagerTests_Teams: IntegrationTest {
         super.setUp()
         createSelfUserAndConversation()
     }
-
-
+    
     
     func testThatItUpdatesAccountAfterLoginWithTeamName() {
         // given

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -307,6 +307,30 @@ class SessionManagerTests: IntegrationTest {
         // THEN
         XCTAssertEqual([account1.userIdentifier], observer.destroyedUserSessions)
     }
+
+    func testThatSessionManagerSetsUpAPNSEnvironmentOnLaunch() {
+        // GIVEN
+        guard let mediaManager = mediaManager, let application = application else { return XCTFail() }
+
+        let sessionManagerExpectation = self.expectation(description: "Session manager and session is loaded")
+
+        // WHEN
+        SessionManager.create(appVersion: "0.0.0",
+                              mediaManager: mediaManager,
+                              analytics: nil,
+                              delegate: nil,
+                              application: application,
+                              environment: sessionManager!.environment,
+                              blacklistDownloadInterval : 60) { _ in
+                                sessionManagerExpectation.fulfill()
+        }
+        XCTAssertTrue(self.waitForCustomExpectations(withTimeout: 0.5))
+
+
+        // THEN
+        let environment = ZMAPNSEnvironment()
+        XCTAssertNotNil(environment.appIdentifier)
+    }
 }
 
 extension IntegrationTest {
@@ -341,7 +365,8 @@ class SessionManagerTests_Teams: IntegrationTest {
         super.setUp()
         createSelfUserAndConversation()
     }
-    
+
+
     
     func testThatItUpdatesAccountAfterLoginWithTeamName() {
         // given


### PR DESCRIPTION
## What's new in this PR?

### Issues

It seems recent changes in #884 broke push token registration for new accounts.

### Causes

Before push token can be registered we need to setup APNS environments by calling `BuildType.setupBuildTypes()`. There was a static var to do it, but according to [docs](https://docs.swift.org/swift-book/LanguageGuide/Properties.html):
> Stored type properties are lazily initialized on their first access. 

However since the variable was never accessed it was never initialized.
