### PR TITLE
Fix/scroll to message

### DIFF
--- a/Source/UserSession/ZMUserSession+Actions.swift
+++ b/Source/UserSession/ZMUserSession+Actions.swift
@@ -54,17 +54,20 @@ private let zmLog = ZMSLog(tag: "Push")
     }
     
     func showContent(for userInfo: NotificationUserInfo) {
-        if let conversation = userInfo.conversation(in: managedObjectContext) {
-            
-            if let message = userInfo.message(in: conversation, managedObjectContext: managedObjectContext) as? ZMClientMessage,
-                let textMessageData = message.textMessageData, textMessageData.isMentioningSelf {
-                showConversation(conversation, at: conversation.firstUnreadMessageMentioningSelf)
-            } else {
-                showConversation(conversation)
-            }
-            
-        } else {
+        
+        guard let conversation = userInfo.conversation(in: managedObjectContext) else {
             sessionManager?.showConversationList(in: self)
+            return
+        }
+        
+        guard let message = userInfo.message(in: conversation, managedObjectContext: managedObjectContext) as? ZMClientMessage else {
+            return showConversation(conversation)
+        }
+        
+        if let textMessageData = message.textMessageData, textMessageData.isMentioningSelf {
+            showConversation(conversation, at: conversation.firstUnreadMessageMentioningSelf)
+        } else {
+            showConversation(conversation, at: message)
         }
     }
         

--- a/Tests/Source/UserSession/ZMUserSessionTests+PushNotifications.swift
+++ b/Tests/Source/UserSession/ZMUserSessionTests+PushNotifications.swift
@@ -106,6 +106,19 @@ class ZMUserSessionTests_PushNotifications: ZMUserSessionTestsBase {
         XCTAssertEqual(mockSessionManager.lastRequestToShowConversation?.0, sut)
         XCTAssertEqual(mockSessionManager.lastRequestToShowConversation?.1.remoteIdentifier, userInfo.conversationID!)
     }
+    
+    func testThatItCallsShowConversationAtMessage_ForPushNotificationCategoryConversation() {
+        // given
+        let userInfo = userInfoWithConversation(hasMessage: true)
+        
+        // when
+        handle(conversationAction: nil, category: .conversation, userInfo: userInfo)
+        
+        // then
+        XCTAssertEqual(mockSessionManager.lastRequestToShowMessage?.0, sut)
+        XCTAssertEqual(mockSessionManager.lastRequestToShowMessage?.1.remoteIdentifier, userInfo.conversationID!)
+        XCTAssertEqual(mockSessionManager.lastRequestToShowMessage?.2.nonce, userInfo.messageNonce!)
+    }
 
     func testThatItCallsShowConversationAndAcceptsCall_ForPushNotificationCategoryIncomingCallWithAcceptAction() {
         // given


### PR DESCRIPTION
## What's new in this PR?

### Issues

Tapping on a notification does not scroll that message into view, if the conversation was already loaded.

### Causes

We were only scrolling to first unread mentions if the notification was for a mention. Otherwise we just show the conversation.

### Solutions

Also scroll to the message for non mention notifications.
