### PR TITLE
Enable parallel tests

### DIFF
--- a/WireSyncEngine.xcodeproj/xcshareddata/xcschemes/WireSyncEngine.xcscheme
+++ b/WireSyncEngine.xcodeproj/xcshareddata/xcschemes/WireSyncEngine.xcscheme
@@ -44,7 +44,8 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "3E1860C2191A649D000FE027"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ resources:
   - repository: wire-ios-shared-resources
     type: github
     name: wireapp/wire-ios-shared-resources
-    ref: refs/heads/master # Branch to fetch the jobs template from 
+    ref: refs/heads/feature/parallel-tests # Branch to fetch the jobs template from 
     endpoint: wireapp
 
 trigger:


### PR DESCRIPTION
## What's new in this PR?

### Issues

Xcode 10 enables running tests in parallel, trying out if tests are not more flaky because of this

