### PR TITLE
Prevent the calls from the future

### DIFF
--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -188,7 +188,9 @@ public class AVSWrapper: AVSWrapperType {
 
     private let missedCallHandler: MissedCallHandler = { conversationId, messageTime, userId, isVideoCall, contextRef in
         zmLog.debug("missedCallHandler: messageTime = \(messageTime)")
-        AVSWrapper.withCallCenter(contextRef, conversationId, messageTime, userId, isVideoCall) {
+        let nonZeroMessageTime: UInt32 = messageTime != 0 ? messageTime : UInt32(Date().timeIntervalSince1970)
+
+        AVSWrapper.withCallCenter(contextRef, conversationId, nonZeroMessageTime, userId, isVideoCall) {
             $0.handleMissedCall(conversationId: $1, messageTime: $2, userId: $3, isVideoCall: $4)
         }
     }
@@ -213,7 +215,9 @@ public class AVSWrapper: AVSWrapperType {
 
     private let closedCallHandler: CloseCallHandler = { reason, conversationId, messageTime, userId, contextRef in
         zmLog.debug("closedCallHandler: messageTime = \(messageTime)")
-        AVSWrapper.withCallCenter(contextRef, reason, conversationId, messageTime) {
+        let nonZeroMessageTime: UInt32 = messageTime != 0 ? messageTime : UInt32(Date().timeIntervalSince1970)
+
+        AVSWrapper.withCallCenter(contextRef, reason, conversationId, nonZeroMessageTime) {
             $0.handleCallEnd(reason: $1, conversationId: $2, messageTime: $3, userId: UUID(rawValue: userId))
         }
     }

--- a/Source/Calling/CallKitDelegate.swift
+++ b/Source/Calling/CallKitDelegate.swift
@@ -301,7 +301,27 @@ extension CallKitDelegate {
         associatedCallUUIDs.forEach { (callUUID) in
             calls.removeValue(forKey: callUUID)
             log("provider.reportCallEndedAt: \(String(describing: timestamp))")
-            provider.reportCall(with: callUUID, endedAt: timestamp, reason: reason)
+            provider.reportCall(with: callUUID, endedAt: timestamp?.clampForCallKit() ?? Date(), reason: reason)
+        }
+    }
+}
+
+fileprivate extension Date {
+    func clampForCallKit() -> Date {
+        let twoWeeksBefore = Calendar.current.date(byAdding: .day, value: -14, to: Date()) ?? Date()
+        
+        return clamp(between: twoWeeksBefore, and: Date())
+    }
+    
+    func clamp(between fromDate: Date, and toDate: Date) -> Date {
+        if timeIntervalSinceReferenceDate < fromDate.timeIntervalSinceReferenceDate {
+            return fromDate
+        }
+        else if timeIntervalSinceReferenceDate > toDate.timeIntervalSinceReferenceDate {
+            return toDate
+        }
+        else {
+            return self
         }
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Users are reporting certain calls being displayed by the iOS calling app as happened in 2067.

## Investigation

From the user-provided logs we've discovered that the calls from the future are most likely caused by the 0 timestamp reported by AVS. However it was not possible to reproduce the issue locally.

## Proposed solution

1. Do not ignore the 0 timestamp reported by AVS, but convert it to current date.
2. Never report calls in the future.
3. Never report calls older than 2 weeks.