### PR TITLE
Fix flaky test

### DIFF
--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -320,7 +320,7 @@ class SessionManagerTests: IntegrationTest {
                               analytics: nil,
                               delegate: nil,
                               application: application,
-                              environment: sessionManager!.environment,
+                              environment: BackendEnvironment.mockEnvironment,
                               blacklistDownloadInterval : 60) { _ in
                                 sessionManagerExpectation.fulfill()
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

`testThatSessionManagerSetsUpAPNSEnvironmentOnLaunch` test seems to be crashing test suite lately. For no good reason there is a force-unwrap that depends on Integration test SessionManager to be created.

### Solutions

Use mock environment directly

