### PR TITLE
Updated mock environment to not use HTTPS endpoint

### DIFF
--- a/Tests/Source/Utility/BackendEnvironment+mock.swift
+++ b/Tests/Source/Utility/BackendEnvironment+mock.swift
@@ -20,6 +20,6 @@ import Foundation
 
 public extension BackendEnvironment {
     @objc public static var mockEnvironment: BackendEnvironment {
-        return BackendEnvironment(backendURL: URL(string: "http://example.com")!, backendWSURL: URL(string: "http://example.com")!, blackListURL: URL(string: "http://example.com")!, frontendURL: URL(string: "http://example.com")!)
+        return BackendEnvironment(backendURL: URL(string: "http://example.com")!, backendWSURL: URL(string: "http://example.com")!, blackListURL: URL(string: "https://clientblacklist.wire.com/prod/ios")!, frontendURL: URL(string: "http://example.com")!)
     }
 }

--- a/Tests/Source/Utility/BackendEnvironment+mock.swift
+++ b/Tests/Source/Utility/BackendEnvironment+mock.swift
@@ -20,6 +20,6 @@ import Foundation
 
 public extension BackendEnvironment {
     @objc public static var mockEnvironment: BackendEnvironment {
-        return BackendEnvironment(backendURL: URL(string: "https://example.com")!, backendWSURL: URL(string: "https://example.com")!, blackListURL: URL(string: "https://example.com")!, frontendURL: URL(string: "https://example.com")!)
+        return BackendEnvironment(backendURL: URL(string: "http://example.com")!, backendWSURL: URL(string: "http://example.com")!, blackListURL: URL(string: "http://example.com")!, frontendURL: URL(string: "http://example.com")!)
     }
 }

--- a/Tests/iOS Test Host/Test-Host-Info.plist
+++ b/Tests/iOS Test Host/Test-Host-Info.plist
@@ -26,6 +26,13 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+		<key>NSExceptionAllowsInsecureHTTPLoads</key>
+		<true/>
+	</dict>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>


### PR DESCRIPTION
## What's new in this PR?

### Issues

When looking at logs of failing tests on SyncEngine there were some errors from App Transport Security about invalid certificate. We currently use https://example.com as backend in tests and at the moment a request is made to fetch client blacklist in tests (https://github.com/wireapp/ios-architecture/issues/53). It seems that example.com certificate has expired today and request is failing.

### Causes

It's not clear why tests would crash in this situation and on local machine I could not reproduce this. It does seem however that it's caused by not being able to fetch blacklist. When using non-secure example.com we see tests fail instead of crash.

### Solutions

Use non-secure example.com. A key enabling insecure loads was added to info.plist. Use production endpoint for blacklist fetching. Try to refactor code to avoid doing real network request in the future.
