### PR TITLE
Allow user properties slow sync

### DIFF
--- a/Source/UserSession/SyncStatus.swift
+++ b/Source/UserSession/SyncStatus.swift
@@ -124,6 +124,9 @@ extension Notification.Name {
     }
     
     public func forceSlowSync() {
+        // Refetch user settings.
+        ZMUser.selfUser(in: managedObjectContext).needsPropertiesUpdate = true
+        // Set the status.
         currentSyncPhase = SyncPhase.fetchingLastUpdateEventID.nextPhase!
         syncStateDelegate.didStartSync()
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Set user properties to be fetched on slow sync. 

NB: the properties would be fetched after the slow sync itself is ended.

## Dependencies

- [ ] https://github.com/wireapp/wire-ios-data-model/pull/622