### PR TITLE
Possible fix for syncing issue

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -847,21 +847,29 @@ extension SessionManager: PostLoginAuthenticationObserver {
 }
 
 extension SessionManager {
-    @objc dynamic fileprivate func applicationDidBecomeActive(_ note: Notification) {
-        notificationsTracker?.dispatchEvent()
-    }
 }
 
-// MARK: - Unread Conversation Count
+// MARK: - Application lifetime notifications
 
-extension SessionManager: ZMConversationListObserver {
-    
+extension SessionManager {
     @objc fileprivate func applicationWillEnterForeground(_ note: Notification) {
+        BackgroundActivityFactory.shared.resume()
+        
         updateAllUnreadCounts()
         
         // Delete expired url scheme verification tokens
         CompanyLoginVerificationToken.flushIfNeeded()
     }
+    
+    @objc fileprivate func applicationDidBecomeActive(_ note: Notification) {
+        notificationsTracker?.dispatchEvent()
+    }
+
+}
+
+// MARK: - Unread Conversation Count
+
+extension SessionManager: ZMConversationListObserver {
     
     public func conversationListDidChange(_ changeInfo: ConversationListChangeInfo) {
         


### PR DESCRIPTION
## What's new in this PR?

### Issues

After https://github.com/wireapp/wire-ios/pull/2970 we have noticed that app stays in syncing mode until the app is force-quit.

### Causes

From logs it seems that background tasks are not created when processing.

### Solutions

If some of the notifications processing expire, we should resume `BackgroundActivityFactory` after coming to foreground. Otherwise no background tasks will be created and we will be stuck.