### PR TITLE
Don't insert read receipt system messages twice

### DIFF
--- a/Source/Synchronization/Transcoders/ZMConversationTranscoder.swift
+++ b/Source/Synchronization/Transcoders/ZMConversationTranscoder.swift
@@ -74,8 +74,11 @@ extension ZMConversationTranscoder {
               let sender = ZMUser(remoteID: senderUUID, createIfNeeded: false, in: managedObjectContext)
         else { return }
         
-        conversation.hasReadReceiptsEnabled = readReceiptMode > 0
-        conversation.appendMessageReceiptModeChangedMessage(fromUser: sender, timestamp: serverTimestamp, enabled: conversation.hasReadReceiptsEnabled)
+        let newValue = readReceiptMode > 0
+        guard newValue != conversation.hasReadReceiptsEnabled else { return }
+        
+        conversation.hasReadReceiptsEnabled = newValue
+        conversation.appendMessageReceiptModeChangedMessage(fromUser: sender, timestamp: serverTimestamp, enabled: newValue)
     }
 }
 

--- a/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.swift
+++ b/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.swift
@@ -411,6 +411,7 @@ extension ZMConversationTranscoderTests_Swift {
     func testThatItInsertsSystemMessageDisabled_WhenReceivingReceiptModeUpdateEvent() {
         self.syncMOC.performAndWait {
             // GIVEN
+            conversation.hasReadReceiptsEnabled = true
             let event = receiptModeUpdateEvent(enabled: false)
             
             // WHEN

--- a/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.swift
+++ b/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.swift
@@ -367,6 +367,8 @@ extension ZMConversationTranscoderTests_Swift : ZMSyncStateDelegate {
 
 extension ZMConversationTranscoderTests_Swift {
     
+    // MARK: Receipt Mode
+    
     func receiptModeUpdateEvent(enabled: Bool) -> ZMUpdateEvent {
         let payload = [
             "from": self.user.remoteIdentifier!.transportString(),
@@ -420,6 +422,22 @@ extension ZMConversationTranscoderTests_Swift {
         }
     }
     
+    func testThatItDoesntInsertsSystemMessage_WhenReceivingReceiptModeUpdateEventWhichHasAlreadybeenApplied() {
+        self.syncMOC.performAndWait {
+            // GIVEN
+            conversation.hasReadReceiptsEnabled = true
+            let event = receiptModeUpdateEvent(enabled: true)
+            
+            // WHEN
+            self.sut.processEvents([event], liveEvents: true, prefetchResult: nil)
+            
+            // THEN
+            XCTAssertEqual(self.conversation?.messages.count, 0)
+        }
+    }
+    
+    // MARK: Access Mode
+    
     func testThatItHandlesAccessModeUpdateEvent() {
         self.syncMOC.performAndWait {
 
@@ -450,6 +468,8 @@ extension ZMConversationTranscoderTests_Swift {
             XCTAssertEqual(self.conversation.accessRole, newAccessRole)
         }
     }
+    
+    // MARK: Message Timer
     
     func testThatItHandlesMessageTimerUpdateEvent_Value() {
         syncMOC.performGroupedBlockAndWait {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Read receipt system message would appear twice when you toggle the read receipt in a group.

### Causes

The receipt mode update event will appear twice, first as the response from the request to change the setting and later from the notification stream.

### Solutions

Discard update receipt mode events when the change has already been applied.