### PR TITLE
More robust check against duplicate events

### DIFF
--- a/Source/Synchronization/Transcoders/ZMConversationTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMConversationTranscoder.m
@@ -471,7 +471,7 @@ static NSString *const ConversationTeamManagedKey = @"managed";
             [self processDestructionTimerUpdateEvent:event inConversation:conversation];
             break;
         case ZMUpdateEventTypeConversationReceiptModeUpdate:
-            [self processReceiptModeUpdate:event inConversation:conversation];
+            [self processReceiptModeUpdate:event inConversation:conversation lastServerTimestamp:previousLastServerTimestamp];
         default:
             break;
     }

--- a/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.swift
+++ b/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.swift
@@ -411,7 +411,6 @@ extension ZMConversationTranscoderTests_Swift {
     func testThatItInsertsSystemMessageDisabled_WhenReceivingReceiptModeUpdateEvent() {
         self.syncMOC.performAndWait {
             // GIVEN
-            conversation.hasReadReceiptsEnabled = true
             let event = receiptModeUpdateEvent(enabled: false)
             
             // WHEN
@@ -426,8 +425,8 @@ extension ZMConversationTranscoderTests_Swift {
     func testThatItDoesntInsertsSystemMessage_WhenReceivingReceiptModeUpdateEventWhichHasAlreadybeenApplied() {
         self.syncMOC.performAndWait {
             // GIVEN
-            conversation.hasReadReceiptsEnabled = true
             let event = receiptModeUpdateEvent(enabled: true)
+            conversation.lastServerTimeStamp = event.timeStamp()
             
             // WHEN
             self.sut.processEvents([event], liveEvents: true, prefetchResult: nil)


### PR DESCRIPTION
## What's new in this PR?

### Issues

We still had issues with duplicate `receipt-mode` events if toggled back and forth.

### Causes

Filtering out events that doesn't change the value only works the duplicated events come in one by one.

### Solutions

Verify the events have newer timestamp than previously processed events.