### PR TITLE
Background task would not be finished after receiving call messages

### DIFF
--- a/Source/Data Model/NSManagedObjectContext+LastNotificationID.swift
+++ b/Source/Data Model/NSManagedObjectContext+LastNotificationID.swift
@@ -34,7 +34,7 @@ extension NSManagedObjectContext : ZMLastNotificationIDStore {
                     previousValue.compare(withType1: value) != .orderedAscending {
                 return
             }
-            
+            Logging.eventProcessing.debug("Setting zm_lastNotificationID = \( newValue?.transportString() ?? "nil" )")
             self.setPersistentStoreMetadata(newValue?.uuidString, key: lastUpdateEventIDKey)
         }
         

--- a/Source/UserSession/CallEventStatus.swift
+++ b/Source/UserSession/CallEventStatus.swift
@@ -18,6 +18,8 @@
 
 import Foundation
 
+private let zmLog = ZMSLog(tag: "calling")
+
 /// CallEventStatus keep track of call events which are waiting to be processed. this is important to know when
 /// the app is launched via push notification since then we need keep the app running until we've processed all
 /// call events.
@@ -52,10 +54,11 @@ public class CallEventStatus: NSObject {
     @discardableResult
     public func waitForCallEventProcessingToComplete(_ completionHandler: @escaping () -> Void) -> Bool {
         guard callEventsWaitingToBeProcessed != 0 || eventProcessingTimer != nil else {
+            zmLog.debug("CallEventStatus: No active call events, completing")
             completionHandler()
             return false
         }
-        
+        zmLog.debug("CallEventStatus: Active call events, waiting")
         observers.append(completionHandler)
         return true
     }

--- a/Source/UserSession/PushNotificationStatus.swift
+++ b/Source/UserSession/PushNotificationStatus.swift
@@ -66,10 +66,11 @@ open class PushNotificationStatus: NSObject, BackgroundNotificationFetchStatusPr
         
         if lastEventIdIsNewerThan(eventId: eventId){
             // We have already fetched the event and will therefore immediately call the completion handler
+            Logging.eventProcessing.info("Already fetched event with [\(eventId)]")
             return completionHandler()
         }
         
-        Logging.eventProcessing.info("Scheduling to fetch events notified by push")
+        Logging.eventProcessing.info("Scheduling to fetch events notified by push [\(eventId)]")
         
         eventIdRanking.add(eventId)
         completionHandlers[eventId] = completionHandler
@@ -92,6 +93,7 @@ open class PushNotificationStatus: NSObject, BackgroundNotificationFetchStatusPr
         
         Logging.eventProcessing.info("Finished to fetching all available events")
         
+        // We take all events that are older than or equal to zm_lastNotificationID and add highest ranking event ID
         for eventId in completionHandlers.keys.filter({  self.lastEventIdIsNewerThan(eventId: $0) || highestRankingEventId == $0 }) {
             let completionHandler = completionHandlers.removeValue(forKey: eventId)
             completionHandler?()


### PR DESCRIPTION
## What's new in this PR?

### Issues

Looking at logs we noticed this situation:
1. User receives calling message. Background tasks get created and destroyed correctly
2. User receives another calling message. Background tasks get created but never finished
3. Push completion handler for calling message no.2 would never get called and the task would expire eventually.

### Causes

When we receive a calling message we start a 2s timer to make sure all the things inside AVS are initialized. For unknown reason the timer would fire once, but not the second time it was created.

### Solutions

NSTimer works by scheduling things in run loop and it's not obvious what happens when it is used on background queue. In addition all this happens while app is running in background. The solution was to replace NSTimer with `ZMTimer` which is a wrapper around GCD timer api.

## Notes

Added more logging around this part of code.
