### PR TITLE
Process each event completely before processing the next one

### DIFF
--- a/Source/Synchronization/ZMSyncStrategy+EventProcessing.swift
+++ b/Source/Synchronization/ZMSyncStrategy+EventProcessing.swift
@@ -41,9 +41,11 @@ extension ZMSyncStrategy: ZMUpdateEventConsumer {
             
             Logging.eventProcessing.info("Consuming: [\n\(decryptedUpdateEvents.map({ "\tevent: \(ZMUpdateEvent.eventTypeString(for: $0.type) ?? "Unknown")" }).joined(separator: "\n"))\n]")
             
-            for eventConsumer in self.eventConsumers {
-                autoreleasepool {
-                    eventConsumer.processEvents(decryptedUpdateEvents, liveEvents: true, prefetchResult: prefetchResult)
+            autoreleasepool {
+                for event in decryptedUpdateEvents {
+                    for eventConsumer in self.eventConsumers {
+                        eventConsumer.processEvents([event], liveEvents: true, prefetchResult: prefetchResult)
+                    }
                 }
             }
             

--- a/Source/Synchronization/ZMSyncStrategy+EventProcessing.swift
+++ b/Source/Synchronization/ZMSyncStrategy+EventProcessing.swift
@@ -40,12 +40,10 @@ extension ZMSyncStrategy: ZMUpdateEventConsumer {
             let prefetchResult = syncMOC.executeFetchRequestBatchOrAssert(fetchRequest)
             
             Logging.eventProcessing.info("Consuming: [\n\(decryptedUpdateEvents.map({ "\tevent: \(ZMUpdateEvent.eventTypeString(for: $0.type) ?? "Unknown")" }).joined(separator: "\n"))\n]")
-            
-            autoreleasepool {
-                for event in decryptedUpdateEvents {
-                    for eventConsumer in self.eventConsumers {
-                        eventConsumer.processEvents([event], liveEvents: true, prefetchResult: prefetchResult)
-                    }
+        
+            for event in decryptedUpdateEvents {
+                for eventConsumer in self.eventConsumers {
+                    eventConsumer.processEvents([event], liveEvents: true, prefetchResult: prefetchResult)
                 }
             }
             

--- a/Tests/Source/Synchronization/ZMSyncStrategyTests.m
+++ b/Tests/Source/Synchronization/ZMSyncStrategyTests.m
@@ -851,7 +851,7 @@
     }
 }
 
-- (void)expectSyncObjectsToProcessEvents:(BOOL)process liveEvents:(BOOL)liveEvents decryptEvents:(BOOL)decyptEvents returnIDsForPrefetching:(BOOL)returnIDs withEvents:(id)events;
+- (void)expectSyncObjectsToProcessEvents:(BOOL)process liveEvents:(BOOL)liveEvents decryptEvents:(BOOL)decyptEvents returnIDsForPrefetching:(BOOL)returnIDs withEvents:(NSArray *)events;
 {
     NOT_USED(decyptEvents);
     
@@ -861,9 +861,9 @@
         }
         
         if (process) {
-            [[obj expect] processEvents:[OCMArg checkWithBlock:^BOOL(NSArray *receivedEvents) {
-                return [receivedEvents isEqualToArray:events];
-            }] liveEvents:liveEvents prefetchResult:OCMOCK_ANY];
+            for (id event in events) {
+                [[obj expect] processEvents:@[event] liveEvents:YES prefetchResult:OCMOCK_ANY];
+            }
         } else {
             [[obj reject] processEvents:OCMOCK_ANY liveEvents:liveEvents prefetchResult:OCMOCK_ANY];
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Read receipt events would not be processed after coming back online.

### Causes

When processing a batch of events we would first process all the `message-add` events and then continue with all the `conversation-update` events. This results in the read receipt status for a conversations being out of sync while processing the message events since the conversation events (read receipt events) haven't been applied yet.

### Solutions

Let all event consumers process an event before continuing to process the next event.