### PR TITLE
Add a hotfix for syncing read receipts setting after upgrading

### DIFF
--- a/Source/Synchronization/ZMHotFixDirectory+Swift.swift
+++ b/Source/Synchronization/ZMHotFixDirectory+Swift.swift
@@ -137,6 +137,11 @@ import Foundation
         refetchConversations(matching: predicate, in: context)
     }
     
+    public static func refetchUserProperties(_ context: NSManagedObjectContext) {
+        ZMUser.selfUser(in: context).needsPropertiesUpdate = true
+        context.enqueueDelayedSave()
+    }
+    
     /// Marks all conversations to be refetched.
     public static func refetchAllConversations(_ context: NSManagedObjectContext) {
         refetchConversations(matching: NSPredicate(value: true), in: context)

--- a/Source/Synchronization/ZMHotFixDirectory.m
+++ b/Source/Synchronization/ZMHotFixDirectory.m
@@ -146,6 +146,14 @@ static NSString* ZMLogTag ZM_UNUSED = @"HotFix";
                      patchCode:^(NSManagedObjectContext *context) {
                          [ZMHotFixDirectory refetchAllConversations:context];
                      }],
+                    
+                    /// We need to refetch all group conversations and the self-user-read-receipt setting after the introduction of read receipts.
+                    [ZMHotFixPatch
+                     patchWithVersion:@"213.1.4"
+                     patchCode:^(NSManagedObjectContext *context) {
+                         [ZMHotFixDirectory refetchUserProperties:context];
+                         [ZMHotFixDirectory refetchGroupConversations:context];
+                     }],
                     ];
     });
     return patches;


### PR DESCRIPTION
## What's new in this PR?

We need to slow sync group conversations and the self user read receipt setting after upgrading to a version which supports read receipts. This fixes the edge case were the read receipt setting is turned on in a conversation before the user has had the chance to upgrade Wire.