### PR TITLE
Don't show group created push for team one-to-one conversations

### DIFF
--- a/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification+Events.swift
+++ b/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification+Events.swift
@@ -191,6 +191,10 @@ private class ConversationCreateEventNotificationBuilder: EventNotificationBuild
         return LocalNotificationType.event(.conversationCreated)
     }
     
+    override func shouldCreateNotification() -> Bool {
+        return super.shouldCreateNotification() && conversation?.conversationType == .group
+    }
+    
 }
 
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

When team member starts a one-to-one conversation the other side would see a "<Name> created a group conversation".

### Causes

Team one-to-one conversation are group conversation under the hood so they will generate `conversation.create` events.

### Solutions

Add an additional check to verify that the new conversation is actually a group conversation.