### PR TITLE
Only refetch conversations you are still a member of

### DIFF
--- a/Source/Synchronization/ZMHotFixDirectory+Swift.swift
+++ b/Source/Synchronization/ZMHotFixDirectory+Swift.swift
@@ -133,7 +133,7 @@ import Foundation
     
     /// Marks all group conversations to be refetched.
     public static func refetchGroupConversations(_ context: NSManagedObjectContext) {
-        let predicate = NSPredicate(format: "conversationType == %d", ZMConversationType.group.rawValue)
+        let predicate = NSPredicate(format: "conversationType == %d AND lastServerSyncedActiveParticipants CONTAINS %@", ZMConversationType.group.rawValue, ZMUser.selfUser(in: context))
         refetchConversations(matching: predicate, in: context)
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

When we need to re-fetch group conversations after upgrading it can need quite a lot of requests.

### Solutions

Exclude groups which you are no longer a member of.