### PR TITLE
Fix not finishing background task if read

### DIFF
--- a/Source/UserSession/ZMUserSession+Actions.swift
+++ b/Source/UserSession/ZMUserSession+Actions.swift
@@ -195,7 +195,7 @@ private let zmLog = ZMSLog(tag: "Push")
     
     func updateBackgroundTask(with message : ZMConversationMessage) {
         switch message.deliveryState {
-        case .sent, .delivered:
+        case .sent, .delivered, .read:
             operationStatus.finishBackgroundTask(withTaskResult: .finished)
         case .failedToSend:
             operationStatus.finishBackgroundTask(withTaskResult: .failed)


### PR DESCRIPTION
## What's new in this PR?

### Issues

Background task would not finish if read

### Causes

Not taking new .read state into account

## Notes

see https://github.com/wireapp/wire-ios-request-strategy/pull/98