### PR TITLE
ZIOS-11019: Added read receipts when replying and adding like to a notification

### DIFF
--- a/Source/UserSession/ZMUserSession+Actions.swift
+++ b/Source/UserSession/ZMUserSession+Actions.swift
@@ -136,14 +136,14 @@ private let zmLog = ZMSLog(tag: "Push")
         
         enqueueChanges {
             guard let message = conversation.append(text: message) else { return /* failure */ }
-            self.setReadReceiptIfNeeded(with: userInfo, in: conversation)
+            self.appendReadReceiptIfNeeded(with: userInfo, in: conversation)
             self.messageReplyObserver = ManagedObjectContextChangeObserver(context: self.managedObjectContext, callback: { [weak self] in
                 self?.updateBackgroundTask(with: message)
             })
         }
     }
     
-    private func setReadReceiptIfNeeded(with userInfo: NotificationUserInfo, in conversation: ZMConversation) {
+    private func appendReadReceiptIfNeeded(with userInfo: NotificationUserInfo, in conversation: ZMConversation) {
         if let originalMessage = userInfo.message(in: conversation, managedObjectContext: self.managedObjectContext) as? ZMClientMessage,
             originalMessage.needsReadConfirmation {
             let confirmation = ZMGenericMessage.message(content: ZMConfirmation.confirm(messageId: originalMessage.nonce!, type: .READ))
@@ -196,7 +196,7 @@ private let zmLog = ZMSLog(tag: "Push")
             
         enqueueChanges {
             guard let reaction = ZMMessage.addReaction(.like, toMessage: message) else { return }
-            self.setReadReceiptIfNeeded(with: userInfo, in: conversation)
+            self.appendReadReceiptIfNeeded(with: userInfo, in: conversation)
             self.likeMesssageObserver = ManagedObjectContextChangeObserver(context: self.managedObjectContext, callback: { [weak self] in
                 self?.updateBackgroundTask(with: reaction)
             })

--- a/Source/UserSession/ZMUserSession+Actions.swift
+++ b/Source/UserSession/ZMUserSession+Actions.swift
@@ -109,8 +109,7 @@ private let zmLog = ZMSLog(tag: "Push")
     public  func reply(with userInfo: NotificationUserInfo, message: String, completionHandler: @escaping () -> Void) {
         guard
             !message.isEmpty,
-            let conversation = userInfo.conversation(in: managedObjectContext),
-            let originalMessage = userInfo.message(in: conversation, managedObjectContext: managedObjectContext)
+            let conversation = userInfo.conversation(in: managedObjectContext)
             else { return completionHandler() }
 
         guard let activity = BackgroundActivityFactory.shared.startBackgroundActivity(withName: "DirectReply Action Handler") else {
@@ -137,7 +136,8 @@ private let zmLog = ZMSLog(tag: "Push")
         
         enqueueChanges {
             guard let message = conversation.append(text: message) else { return /* failure */ }
-            if originalMessage.needsReadConfirmation {
+            if let originalMessage = userInfo.message(in: conversation, managedObjectContext: self.managedObjectContext) as? ZMClientMessage,
+                originalMessage.needsReadConfirmation {
                 let confirmation = ZMGenericMessage.message(content: ZMConfirmation.confirm(messageId: originalMessage.nonce!, type: .READ))
                 conversation.appendClientMessage(with: confirmation)
             }

--- a/Source/UserSession/ZMUserSession+Actions.swift
+++ b/Source/UserSession/ZMUserSession+Actions.swift
@@ -136,14 +136,18 @@ private let zmLog = ZMSLog(tag: "Push")
         
         enqueueChanges {
             guard let message = conversation.append(text: message) else { return /* failure */ }
-            if let originalMessage = userInfo.message(in: conversation, managedObjectContext: self.managedObjectContext) as? ZMClientMessage,
-                originalMessage.needsReadConfirmation {
-                let confirmation = ZMGenericMessage.message(content: ZMConfirmation.confirm(messageId: originalMessage.nonce!, type: .READ))
-                conversation.appendClientMessage(with: confirmation)
-            }
+            self.setReadReceiptIfNeeded(with: userInfo, in: conversation)
             self.messageReplyObserver = ManagedObjectContextChangeObserver(context: self.managedObjectContext, callback: { [weak self] in
                 self?.updateBackgroundTask(with: message)
             })
+        }
+    }
+    
+    private func setReadReceiptIfNeeded(with userInfo: NotificationUserInfo, in conversation: ZMConversation) {
+        if let originalMessage = userInfo.message(in: conversation, managedObjectContext: self.managedObjectContext) as? ZMClientMessage,
+            originalMessage.needsReadConfirmation {
+            let confirmation = ZMGenericMessage.message(content: ZMConfirmation.confirm(messageId: originalMessage.nonce!, type: .READ))
+            conversation.appendClientMessage(with: confirmation)
         }
     }
     
@@ -192,6 +196,7 @@ private let zmLog = ZMSLog(tag: "Push")
             
         enqueueChanges {
             guard let reaction = ZMMessage.addReaction(.like, toMessage: message) else { return }
+            self.setReadReceiptIfNeeded(with: userInfo, in: conversation)
             self.likeMesssageObserver = ManagedObjectContextChangeObserver(context: self.managedObjectContext, callback: { [weak self] in
                 self?.updateBackgroundTask(with: reaction)
             })

--- a/Tests/Source/UserSession/ZMUserSessionTests+PushNotifications.swift
+++ b/Tests/Source/UserSession/ZMUserSessionTests+PushNotifications.swift
@@ -208,8 +208,8 @@ class ZMUserSessionTests_PushNotifications: ZMUserSessionTestsBase {
         self.handle(conversationAction: .reply, category: .conversation, userInfo: userInfo, userText: "Hello World")
         
         // then
-        guard let replyMessage = conversation.messages[1] as? ZMClientMessage else { return XCTFail() }
-        guard let confirmationMessage = conversation.messages[2] as? ZMClientMessage else { return XCTFail() }
+        guard let replyMessage = conversation.messages[1] as? ZMClientMessage,
+            let confirmationMessage = conversation.messages[2] as? ZMClientMessage else { return XCTFail() }
         XCTAssertEqual(conversation.messages.count, 3)
         XCTAssertTrue(originalMessage.isText)
         XCTAssertTrue(replyMessage.isText)

--- a/Tests/Source/UserSession/ZMUserSessionTests+PushNotifications.swift
+++ b/Tests/Source/UserSession/ZMUserSessionTests+PushNotifications.swift
@@ -217,6 +217,29 @@ class ZMUserSessionTests_PushNotifications: ZMUserSessionTestsBase {
         XCTAssertTrue(confirmationMessage.genericMessage?.hasConfirmation() ?? false)
     }
 
+    func testThatItAppendsReadReceipt_ForPushNotificationCategoryConversationWithLikeAction() {
+        // given
+        self.simulateLoggedInUser()
+        self.sut.operationStatus.isInBackground = true
+        
+        let userInfo = userInfoWithConversation(hasMessage: true)
+        let conversation = userInfo.conversation(in: self.uiMOC)!
+        
+        guard let originalMessage = conversation.messages[0] as? ZMClientMessage else { return XCTFail() }
+        ZMUser.selfUser(in: uiMOC).readReceiptsEnabled = true
+        originalMessage.genericMessage?.setExpectsReadConfirmation(true)?.data().apply(originalMessage.add)
+        
+        // when
+        handle(conversationAction: .like, category: .conversation, userInfo: userInfo)
+        
+        // then
+        guard let confirmationMessage = conversation.messages[1] as? ZMClientMessage else { return XCTFail() }
+        XCTAssertEqual(conversation.messages.count, 2)
+        XCTAssertFalse(confirmationMessage.isText)
+        XCTAssertEqual(originalMessage.reactions.count, 1)
+        XCTAssertTrue(confirmationMessage.genericMessage?.hasConfirmation() ?? false)
+    }
+    
     func testThatOnLaunchItCallsShowConversationList_ForPushNotificationCategoryConversationWithoutConversation() {
         // given
         simulateLoggedInUser()

--- a/Tests/Source/UserSession/ZMUserSessionTests+PushNotifications.swift
+++ b/Tests/Source/UserSession/ZMUserSessionTests+PushNotifications.swift
@@ -191,6 +191,31 @@ class ZMUserSessionTests_PushNotifications: ZMUserSessionTestsBase {
         XCTAssertEqual(conversation.messages.count, 1);
         XCTAssertNil(mockSessionManager.lastRequestToShowConversation)
     }
+    
+    func testThatItAppendsReadReceipt_ForPushNotificationCategoryConversationWithDirectReplyAction() {
+        // given
+        self.simulateLoggedInUser()
+        self.sut.operationStatus.isInBackground = true
+        
+        let userInfo = userInfoWithConversation(hasMessage: true)
+        let conversation = userInfo.conversation(in: self.uiMOC)!
+        
+        guard let originalMessage = conversation.messages[0] as? ZMClientMessage else { return XCTFail() }
+        ZMUser.selfUser(in: uiMOC).readReceiptsEnabled = true
+        originalMessage.genericMessage?.setExpectsReadConfirmation(true)?.data().apply(originalMessage.add)
+        
+        // when
+        self.handle(conversationAction: .reply, category: .conversation, userInfo: userInfo, userText: "Hello World")
+        
+        // then
+        guard let replyMessage = conversation.messages[1] as? ZMClientMessage else { return XCTFail() }
+        guard let confirmationMessage = conversation.messages[2] as? ZMClientMessage else { return XCTFail() }
+        XCTAssertEqual(conversation.messages.count, 3)
+        XCTAssertTrue(originalMessage.isText)
+        XCTAssertTrue(replyMessage.isText)
+        XCTAssertFalse(confirmationMessage.isText)
+        XCTAssertTrue(confirmationMessage.genericMessage?.hasConfirmation() ?? false)
+    }
 
     func testThatOnLaunchItCallsShowConversationList_ForPushNotificationCategoryConversationWithoutConversation() {
         // given


### PR DESCRIPTION
## What's new in this PR?

### Issues

Read receipts were not sent after replying and adding a like to a notification.

### Solutions

I've added the logic to send them if needed.