### PR TITLE
Fix notifications background processing

### DIFF
--- a/Source/SessionManager/SessionManager+Push.swift
+++ b/Source/SessionManager/SessionManager+Push.swift
@@ -85,7 +85,7 @@ extension SessionManager: PKPushRegistryDelegate {
         
         guard let accountId = payload.dictionaryPayload.accountId(),
               let account = self.accountManager.account(with: accountId),
-              let activity = BackgroundActivityFactory.shared.startBackgroundActivity(withName: "Process PushKit payload [\(payload.stringIdentifier)]", expirationHandler: { [weak self] in
+              let activity = BackgroundActivityFactory.shared.startBackgroundActivity(withName: "Process PushKit \(payload.stringIdentifier)", expirationHandler: { [weak self] in
                 log.debug("Processing push payload expired")
                 self?.notificationsTracker?.registerProcessingExpired()
               }) else {

--- a/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
@@ -185,7 +185,7 @@ previouslyReceivedEventIDsCollection:(id<PreviouslyReceivedEventIDsCollection>)e
     ZMLogWithLevelAndTag(ZMLogLevelInfo, ZMTAG_EVENT_PROCESSING, @"Downloaded %lu event(s)", (unsigned long)parsedEvents.count);
     
     [syncStrategy processUpdateEvents:parsedEvents ignoreBuffer:YES];
-    [self.pushNotificationStatus didFetchEventIds:eventIds finished:!self.listPaginator.hasMoreToFetch];
+    [self.pushNotificationStatus didFetchEventIds:eventIds lastEventId:latestEventId finished:!self.listPaginator.hasMoreToFetch];
     
     [tp warnIfLongerThanInterval];
     return latestEventId;

--- a/Tests/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoderTests.m
@@ -773,7 +773,7 @@ static NSString * const LastUpdateEventIDStoreKey = @"LastUpdateEventID";
     }];
 
     // expect
-    [(PushNotificationStatus *)[self.mockPushNotificationStatus expect] didFetchEventIds:eventIds finished:YES];
+    [(PushNotificationStatus *)[self.mockPushNotificationStatus expect] didFetchEventIds:eventIds lastEventId:OCMOCK_ANY finished:YES];
 
     XCTAssertNotNil(request);
 
@@ -796,7 +796,7 @@ static NSString * const LastUpdateEventIDStoreKey = @"LastUpdateEventID";
         }];
 
         // expect
-        [(PushNotificationStatus *)[self.mockPushNotificationStatus expect] didFetchEventIds:eventIds finished:NO];
+        [(PushNotificationStatus *)[self.mockPushNotificationStatus expect] didFetchEventIds:eventIds lastEventId:OCMOCK_ANY finished:NO];
 
         XCTAssertNotNil(request);
         [request completeWithResponse:response];
@@ -815,7 +815,7 @@ static NSString * const LastUpdateEventIDStoreKey = @"LastUpdateEventID";
         }];
 
         // expect
-        [(PushNotificationStatus *)[self.mockPushNotificationStatus expect] didFetchEventIds:eventIds finished:YES];
+        [(PushNotificationStatus *)[self.mockPushNotificationStatus expect] didFetchEventIds:eventIds lastEventId:OCMOCK_ANY finished:YES];
 
         XCTAssertNotNil(request);
         [request completeWithResponse:response];

--- a/Tests/Source/Synchronization/ZMOperationLoopTests.m
+++ b/Tests/Source/Synchronization/ZMOperationLoopTests.m
@@ -948,7 +948,7 @@
     WaitForAllGroupsToBeEmpty(1.0);
     
     // when
-    [self.pushNotificationStatus didFetchEventIds:@[notificationID] finished:YES];
+    [self.pushNotificationStatus didFetchEventIds:@[notificationID] lastEventId:notificationID finished:YES];
     
     XCTAssertTrue([self waitForCustomExpectationsWithTimeout:0.5]);
 }
@@ -973,7 +973,7 @@
     
     // when
     [self.callEventStatus scheduledCallEventForProcessing];
-    [self.pushNotificationStatus didFetchEventIds:@[notificationID] finished:YES];
+    [self.pushNotificationStatus didFetchEventIds:@[notificationID] lastEventId:notificationID finished:YES];
     WaitForAllGroupsToBeEmpty(1.0);
     
     XCTAssertFalse(completionHandlerHasBeenCalled);

--- a/Tests/Source/UserSession/PushNotificationStatusTests.swift
+++ b/Tests/Source/UserSession/PushNotificationStatusTests.swift
@@ -75,8 +75,7 @@ class PushNotificationStatusTests: MessagingTest {
         sut.fetch(eventId: eventId2) { }
         
         // when
-        syncMOC.zm_lastNotificationID = eventId1
-        sut.didFetch(eventIds: [eventId1], finished: true)
+        sut.didFetch(eventIds: [eventId1], lastEventId: eventId1, finished: true)
         
         // then
         XCTAssertEqual(sut.status, .inProgress)
@@ -88,8 +87,7 @@ class PushNotificationStatusTests: MessagingTest {
         sut.fetch(eventId: eventId) { }
         
         // when
-        syncMOC.zm_lastNotificationID = eventId
-        sut.didFetch(eventIds: [eventId], finished: true)
+        sut.didFetch(eventIds: [eventId], lastEventId: eventId, finished: true)
         
         // then
         XCTAssertEqual(sut.status, .done)
@@ -101,8 +99,7 @@ class PushNotificationStatusTests: MessagingTest {
         sut.fetch(eventId: eventId) { }
         
         // when
-        syncMOC.zm_lastNotificationID = eventId
-        sut.didFetch(eventIds: [eventId], finished: false)
+        sut.didFetch(eventIds: [eventId], lastEventId: eventId, finished: false)
         
         // then
         XCTAssertEqual(sut.status, .done)
@@ -114,7 +111,7 @@ class PushNotificationStatusTests: MessagingTest {
         sut.fetch(eventId: eventId) { }
         
         // when
-        sut.didFetch(eventIds: [], finished: true)
+        sut.didFetch(eventIds: [], lastEventId: eventId, finished: true)
         
         // then
         XCTAssertEqual(sut.status, .done)
@@ -142,8 +139,7 @@ class PushNotificationStatusTests: MessagingTest {
         }
         
         // when
-        syncMOC.zm_lastNotificationID = eventId
-        sut.didFetch(eventIds: [eventId], finished: false)
+        sut.didFetch(eventIds: [eventId], lastEventId: eventId, finished: false)
         
         // then
         XCTAssertEqual(sut.status, .done)
@@ -160,8 +156,7 @@ class PushNotificationStatusTests: MessagingTest {
         }
         
         // when
-        syncMOC.zm_lastNotificationID = eventId
-        sut.didFetch(eventIds: [eventId], finished: true)
+        sut.didFetch(eventIds: [eventId], lastEventId: eventId, finished: true)
         
         // then
         XCTAssertEqual(sut.status, .done)
@@ -179,7 +174,7 @@ class PushNotificationStatusTests: MessagingTest {
         }
         
         // when
-        sut.didFetch(eventIds: [], finished: true)
+        sut.didFetch(eventIds: [], lastEventId: eventId, finished: true)
         
         // then
         XCTAssertEqual(sut.status, .done)


### PR DESCRIPTION
## What's new in this PR?

### Issues

We have noticed that when a user receives multiple push notifications in one go (e.g. coming back online) the background tasks would not get finished correctly.

### Causes

PushKit expects us to call completion handler when we are done processing push payload. In our case we call this when notification stream has been downloaded and all events were processed. 

When there are multiple pushes coming in one go we get all the needed information by fetching notification stream only once. To make sure we don't miss any events we keep track of what we received from pushes and what was downloaded from notification stream inside `PushNotificationStatus`. The logic was not working correctly because we would save the last notification ID AFTER we do calculations of what events were fetched. This caused a bug that completion handler of only the first push payload would be called, but others would just linger on until background tasks start expiring. 

### Solutions

Instead of relying on `managedObjectContext.zm_lastNotificationID` we pass the last notification identifier after calculating it.

### Note

Also changed the name of push notification background task to make it easier to parse.