### PR TITLE
ZIOS-11130: Added UNNotificationContent extension to redact content info

### DIFF
--- a/Source/UserSession/ZMUserSession+Push.swift
+++ b/Source/UserSession/ZMUserSession+Push.swift
@@ -282,3 +282,9 @@ extension ZMUserSession: UNUserNotificationCenterDelegate {
     }
     
 }
+
+fileprivate extension UNNotificationContent {
+    override open var description: String {
+        return "<\(type(of:self)); threadIdentifier: \(self.threadIdentifier); content: redacted>"
+    }
+}


### PR DESCRIPTION
## What's new in this PR?

Added extension inside `ZMUserSession+Push` for `UNNotificationContent` in order to provide logs just with the information needed for debugging.