### PR TITLE
ZIOS-11162: Implement SSO link parsing

### DIFF
--- a/Source/Registration/Company/CompanyLoginErrorCode.swift
+++ b/Source/Registration/Company/CompanyLoginErrorCode.swift
@@ -19,6 +19,15 @@
 import Foundation
 
 /**
+ * Errors that can occur when requesting a company login session from a linl.
+ */
+
+public enum ConmpanyLoginRequestError: Error, Equatable {
+    /// The SSO link provided by the user was invalid.
+    case invalidLink
+}
+
+/**
  * Errors that can occur within the company login flow.
  */
 

--- a/Source/Registration/Company/CompanyLoginErrorCode.swift
+++ b/Source/Registration/Company/CompanyLoginErrorCode.swift
@@ -19,7 +19,7 @@
 import Foundation
 
 /**
- * Errors that can occur when requesting a company login session from a linl.
+ * Errors that can occur when requesting a company login session from a link.
  */
 
 public enum ConmpanyLoginRequestError: Error, Equatable {

--- a/Source/Registration/Company/CompanyLoginRequester.swift
+++ b/Source/Registration/Company/CompanyLoginRequester.swift
@@ -22,6 +22,7 @@ extension URL {
     enum Host {
         static let connect = "connect"
         static let login = "login"
+        static let startSSO = "start-sso"
     }
     enum Path {
         static let success = "success"

--- a/Source/SessionManager/SessionManagerURLHandler.swift
+++ b/Source/SessionManager/SessionManagerURLHandler.swift
@@ -23,6 +23,9 @@ public enum URLAction: Equatable {
     case companyLoginSuccess(userInfo: UserInfo)
     case companyLoginFailure(error: CompanyLoginError)
 
+    case startCompanyLogin(code: UUID)
+    case warnInvalidCompanyLogin(error: ConmpanyLoginRequestError)
+
     var requiresAuthentication: Bool {
         switch self {
         case .connectBot: return true
@@ -45,6 +48,13 @@ extension URLAction {
         }
         
         switch host {
+        case URL.Host.startSSO:
+            if let uuidCode = url.pathComponents.last.flatMap(CompanyLoginRequestDetector.requestCode) {
+                self = .startCompanyLogin(code: uuidCode)
+            } else {
+                self = .warnInvalidCompanyLogin(error: .invalidLink)
+            }
+
         case URL.Host.connect:
             guard let service = components.query(for: "service"),
                 let provider = components.query(for: "provider"),

--- a/Tests/Source/SessionManager/SessionManagerURLHandlerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerURLHandlerTests.swift
@@ -105,4 +105,39 @@ final class SessionManagerURLHandlerTests: MessagingTest {
         XCTAssertEqual(delegate.calls.count, 1)
         XCTAssertEqual(delegate.calls[0].0, .connectBot(serviceUser: expectedUserData))
     }
+
+    func testThatItParsesCompanyLoginLink() {
+        // given
+        let id = UUID(uuidString: "4B1BEDB9-8899-4855-96AF-6CCED6F6F638")!
+        let url = URL(string: "wire://start-sso/wire-\(id)")!
+
+        // when
+        let action = URLAction(url: url)
+
+        // then
+        XCTAssertEqual(action, .startCompanyLogin(code: id))
+    }
+
+    func testThatItDiscardsInvalidCompanyLoginLink() {
+        // given
+        let url = URL(string: "wire://start-sso/wire-4B1BEDB9-8899-4855-96AF")!
+
+        // when
+        let action = URLAction(url: url)
+
+        // then
+        XCTAssertEqual(action, .warnInvalidCompanyLogin(error: .invalidLink))
+    }
+
+    func testThatItDiscardsCompanyLoginLinkWithExtraContent() {
+        // given
+        let id = UUID(uuidString: "4B1BEDB9-8899-4855-96AF-6CCED6F6F638")!
+        let url = URL(string: "wire://start-sso/wire-\(id)/content")!
+
+        // when
+        let action = URLAction(url: url)
+
+        // then
+        XCTAssertEqual(action, .warnInvalidCompanyLogin(error: .invalidLink))
+    }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

We want to be able to parse the SSO code for company login from a link the user clicks. See https://github.com/wireapp/ios-architecture/issues/64 for detailed breakdown.

### Solutions

In the UI, the app delegate calls the `SessionManagerURLHandler` to parse the received URL. We updated it to support the `start-sso` host and parsing for the UUID. We added two actions that the URL can cause: starting the SSO flow or warning the user that the link is invalid.

### Notes

This PR will be merged to the feature branch for this project.