### PR TITLE
Handle valid SSO link clicks in session manager

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -930,6 +930,11 @@ extension SessionManager {
         return "WireCompanyLoginCode"
     }
 
+    /// The timestamp when the user initiated the request.
+    public static var companyLoginRequestTimestampKey: String {
+        return "WireCompanyLoginTimesta;p"
+    }
+
 }
 
 extension SessionManager : PreLoginAuthenticationObserver {
@@ -949,7 +954,8 @@ extension SessionManager : PreLoginAuthenticationObserver {
     }
 
     public func companyLoginCodeDidBecomeAvailable(_ code: UUID) {
-        addAccount(userInfo: [SessionManager.companyLoginCodeKey: code])
+        addAccount(userInfo: [SessionManager.companyLoginCodeKey: code,
+                              SessionManager.companyLoginRequestTimestampKey: Date()])
     }
 }
 

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -39,7 +39,7 @@ public typealias LaunchOptions = [UIApplication.LaunchOptionsKey : Any]
 
 @objc public protocol SessionManagerDelegate : SessionActivationObserver {
     func sessionManagerDidFailToLogin(account: Account?, error : Error)
-    func sessionManagerWillLogout(error : Error?, userSessionCanBeTornDown: @escaping () -> Void)
+    func sessionManagerWillLogout(error : Error?, userSessionCanBeTornDown: (() -> Void)?)
     func sessionManagerWillOpenAccount(_ account: Account, userSessionCanBeTornDown: @escaping () -> Void)
     func sessionManagerWillMigrateAccount(_ account: Account)
     func sessionManagerWillMigrateLegacyAccount()
@@ -432,9 +432,15 @@ public protocol ForegroundNotificationResponder: class {
         }
     }
     
-    public func addAccount() {
+    public func addAccount(userInfo: [String: Any]? = nil) {
         confirmSwitchingAccount { [weak self] in
-            self?.logoutCurrentSession(deleteCookie: false, error: NSError(code: .addAccountRequested, userInfo: nil))
+            let error = NSError(code: .addAccountRequested, userInfo: userInfo)
+            if self?.unauthenticatedSession != nil {
+                // If the user is already unauthenticated, we dont need to log out the current session
+                self?.delegate?.sessionManagerWillLogout(error: error, userSessionCanBeTornDown: nil)
+            } else {
+                self?.logoutCurrentSession(deleteCookie: false, error: error)
+            }
         }
     }
     
@@ -917,6 +923,15 @@ extension SessionManager : WireCallCenterCallStateObserver {
     
 }
 
+extension SessionManager {
+
+    /// The SSO code provided by the user when clicking their company link. Points to a UUID object.
+    public static var companyLoginCodeKey: String {
+        return "WireCompanyLoginCode"
+    }
+
+}
+
 extension SessionManager : PreLoginAuthenticationObserver {
     
     @objc public func authenticationDidSucceed() {
@@ -931,6 +946,10 @@ extension SessionManager : PreLoginAuthenticationObserver {
         }
         
         delegate?.sessionManagerDidFailToLogin(account: nil, error: error)
+    }
+
+    public func companyLoginCodeDidBecomeAvailable(_ code: UUID) {
+        addAccount(userInfo: [SessionManager.companyLoginCodeKey: code])
     }
 }
 

--- a/Source/SessionManager/SessionManagerURLHandler.swift
+++ b/Source/SessionManager/SessionManagerURLHandler.swift
@@ -138,9 +138,10 @@ extension URLAction {
         switch self {
         case .companyLoginSuccess(let userInfo):
             unauthenticatedSession.authenticationStatus.loginSucceeded(with: userInfo)
-        case .companyLoginFailure:
+        case .startCompanyLogin(let code):
+            unauthenticatedSession.authenticationStatus.notifyCompanyLoginCodeDidBecomeAvailable(code)
+        case .companyLoginFailure, .warnInvalidCompanyLogin:
             break // no-op (error should be handled in UI)
-
         default:
             fatalError("This action cannot be executed with an unauthenticated session.")
         }
@@ -200,10 +201,10 @@ public final class SessionManagerURLHandler: NSObject {
         }
     }
 
-    fileprivate func handle(action: URLAction, in unauthenticatedSessio: UnauthenticatedSession) {
+    fileprivate func handle(action: URLAction, in unauthenticatedSession: UnauthenticatedSession) {
         delegate?.sessionManagerShouldExecuteURLAction(action) { shouldExecute in
             if shouldExecute {
-                action.execute(in: unauthenticatedSessio)
+                action.execute(in: unauthenticatedSession)
             }
         }
     }

--- a/Source/UserSession/PreLoginAuthenticationNotification.swift
+++ b/Source/UserSession/PreLoginAuthenticationNotification.swift
@@ -38,6 +38,9 @@ extension ZMAuthenticationStatus : NotificationContext { } // Mark ZMAuthenticat
 
     /// Invoked when we have provided correct credentials and have an opportunity to import backup
     @objc optional func authenticationReadyToImportBackup(existingAccount: Bool)
+
+    /// A company login code did become availble. This means that the user clicked an SSO link with a valid code.
+    @objc optional func companyLoginCodeDidBecomeAvailable(_ code: UUID)
 }
 
 private enum PreLoginAuthenticationEvent {
@@ -47,6 +50,7 @@ private enum PreLoginAuthenticationEvent {
     case authenticationDidSucceed
     case loginCodeRequestDidFail(NSError)
     case loginCodeRequestDidSucceed
+    case companyLoginCodeDidBecomeAvailable(UUID)
 }
 
 @objc public class PreLoginAuthenticationNotification : NSObject {
@@ -83,6 +87,8 @@ private enum PreLoginAuthenticationEvent {
                 observer.authenticationDidFail?(error)
             case .authenticationDidSucceed:
                 observer.authenticationDidSucceed?()
+            case .companyLoginCodeDidBecomeAvailable(let code):
+                observer.companyLoginCodeDidBecomeAvailable?(code)
             }
         }
     }
@@ -118,6 +124,10 @@ public extension ZMAuthenticationStatus {
     
     @objc public func notifyLoginCodeRequestDidSucceed() {
         PreLoginAuthenticationNotification.notify(of: .loginCodeRequestDidSucceed, context: self)
+    }
+
+    @objc public func notifyCompanyLoginCodeDidBecomeAvailable(_ code: UUID) {
+        PreLoginAuthenticationNotification.notify(of: .companyLoginCodeDidBecomeAvailable(code), context: self)
     }
 }
 

--- a/Tests/Source/Integration/IntegrationTest.swift
+++ b/Tests/Source/Integration/IntegrationTest.swift
@@ -619,9 +619,9 @@ extension IntegrationTest : SessionManagerDelegate {
         // no-op
     }
     
-    public func sessionManagerWillLogout(error: Error?, userSessionCanBeTornDown: @escaping () -> Void) {
+    public func sessionManagerWillLogout(error: Error?, userSessionCanBeTornDown: (() -> Void)?) {
         self.userSession = nil
-        userSessionCanBeTornDown()
+        userSessionCanBeTornDown?()
     }
 
     public func sessionManagerDidBlacklistCurrentVersion() {

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -1052,11 +1052,57 @@ extension SessionManagerTests {
     }
 }
 
+class MockSessionManagerURLHandlerDelegate: NSObject, SessionManagerURLHandlerDelegate  {
+
+    var allowedAction: URLAction?
+
+    func sessionManagerShouldExecuteURLAction(_ action: URLAction, callback: @escaping (Bool) -> Void) {
+        callback(action == allowedAction)
+    }
+
+}
+
+extension SessionManagerTests {
+
+    func testThatItLogsOutWithCompanyLoginURL() {
+        // GIVEN
+        let id = UUID(uuidString: "1E628B42-4C83-49B7-B2B4-EF27BFE503EF")!
+        let url = URL(string: "wire://start-sso/wire-\(id)")!
+
+        sut = createManager()
+
+        let urlDelegate = MockSessionManagerURLHandlerDelegate()
+        urlDelegate.allowedAction = URLAction.startCompanyLogin(code: id)
+        sut?.urlHandler.delegate = urlDelegate
+
+        // WHEN
+        let logoutExpectation = expectation(description: "The company login flow starts when the user adds .")
+
+        delegate.onLogout = { error in
+            let loginCode = error?.userInfo[SessionManager.companyLoginCodeKey]
+            XCTAssertEqual(loginCode as? UUID, id)
+            XCTAssertEqual(error?.userSessionErrorCode, .addAccountRequested)
+            logoutExpectation.fulfill()
+        }
+
+        sut?.urlHandler.openURL(url, options: [:])
+
+        // THEN
+        XCTAssertTrue(self.waitForCustomExpectations(withTimeout: 2))
+
+        // CLEANUP
+        self.sut!.tearDownAllBackgroundSessions()
+    }
+
+}
+
 // MARK: - Mocks
 class SessionManagerTestDelegate: SessionManagerDelegate {
-    
-    func sessionManagerWillLogout(error: Error?, userSessionCanBeTornDown: @escaping () -> Void) {
-        userSessionCanBeTornDown()
+
+    var onLogout: ((NSError?) -> Void)?
+    func sessionManagerWillLogout(error: Error?, userSessionCanBeTornDown: (() -> Void)?) {
+        onLogout?(error as NSError?)
+        userSessionCanBeTornDown?()
     }
     
     func sessionManagerDidFailToLogin(account: Account?, error: Error) {
@@ -1084,7 +1130,7 @@ class SessionManagerTestDelegate: SessionManagerDelegate {
     func sessionManagerWillMigrateLegacyAccount() {
         // no op
     }
-    
+
 }
 
 class SessionManagerObserverMock: SessionManagerCreatedSessionObserver, SessionManagerDestroyedSessionObserver {


### PR DESCRIPTION
## What's new in this PR?

### Issues

We want to be able to start the SSO flow when the user taps a special link. The detailed breakdown can be found at https://github.com/wireapp/ios-architecture/issues/64.

In this PR, we introduce the logic to notify the UI that an SSO login code has been clicked and that we should perform the necessary operations to start the flow.

### Solutions

We add a `companyLoginCodeDidBecomeAvailable` event to the authentication status notifications. When the user taps the link and the UI validated the state (see https://github.com/wireapp/wire-ios/pull/3157), we send the notification with the code from the link to the session manager, who will then start the authentication flow.

To start the flow, it logs out if necessary, and calls the `sessionManagerWillLogout` method with an error containing the SSO code under the `SessionManager. companyLoginCodeKey` user info and with the `addAccountRequested` error code. This will allow the UI to detect this particular case in the authentication responder chain and provide the correct actions.

### Note

This PR will be merged in the feature branch.