### PR TITLE
[Feature] SSO Links

### DIFF
--- a/Source/Registration/Company/CompanyLoginErrorCode.swift
+++ b/Source/Registration/Company/CompanyLoginErrorCode.swift
@@ -19,6 +19,15 @@
 import Foundation
 
 /**
+ * Errors that can occur when requesting a company login session from a link.
+ */
+
+public enum ConmpanyLoginRequestError: Error, Equatable {
+    /// The SSO link provided by the user was invalid.
+    case invalidLink
+}
+
+/**
  * Errors that can occur within the company login flow.
  */
 

--- a/Source/Registration/Company/CompanyLoginRequester.swift
+++ b/Source/Registration/Company/CompanyLoginRequester.swift
@@ -22,6 +22,7 @@ extension URL {
     enum Host {
         static let connect = "connect"
         static let login = "login"
+        static let startSSO = "start-sso"
     }
     enum Path {
         static let success = "success"

--- a/Source/SessionManager/SessionManagerURLHandler.swift
+++ b/Source/SessionManager/SessionManagerURLHandler.swift
@@ -138,9 +138,10 @@ extension URLAction {
         switch self {
         case .companyLoginSuccess(let userInfo):
             unauthenticatedSession.authenticationStatus.loginSucceeded(with: userInfo)
-        case .companyLoginFailure:
+        case .startCompanyLogin(let code):
+            unauthenticatedSession.authenticationStatus.notifyCompanyLoginCodeDidBecomeAvailable(code)
+        case .companyLoginFailure, .warnInvalidCompanyLogin:
             break // no-op (error should be handled in UI)
-
         default:
             fatalError("This action cannot be executed with an unauthenticated session.")
         }
@@ -200,10 +201,10 @@ public final class SessionManagerURLHandler: NSObject {
         }
     }
 
-    fileprivate func handle(action: URLAction, in unauthenticatedSessio: UnauthenticatedSession) {
+    fileprivate func handle(action: URLAction, in unauthenticatedSession: UnauthenticatedSession) {
         delegate?.sessionManagerShouldExecuteURLAction(action) { shouldExecute in
             if shouldExecute {
-                action.execute(in: unauthenticatedSessio)
+                action.execute(in: unauthenticatedSession)
             }
         }
     }

--- a/Source/SessionManager/SessionManagerURLHandler.swift
+++ b/Source/SessionManager/SessionManagerURLHandler.swift
@@ -23,6 +23,9 @@ public enum URLAction: Equatable {
     case companyLoginSuccess(userInfo: UserInfo)
     case companyLoginFailure(error: CompanyLoginError)
 
+    case startCompanyLogin(code: UUID)
+    case warnInvalidCompanyLogin(error: ConmpanyLoginRequestError)
+
     var requiresAuthentication: Bool {
         switch self {
         case .connectBot: return true
@@ -45,6 +48,13 @@ extension URLAction {
         }
         
         switch host {
+        case URL.Host.startSSO:
+            if let uuidCode = url.pathComponents.last.flatMap(CompanyLoginRequestDetector.requestCode) {
+                self = .startCompanyLogin(code: uuidCode)
+            } else {
+                self = .warnInvalidCompanyLogin(error: .invalidLink)
+            }
+
         case URL.Host.connect:
             guard let service = components.query(for: "service"),
                 let provider = components.query(for: "provider"),

--- a/Source/UserSession/PreLoginAuthenticationNotification.swift
+++ b/Source/UserSession/PreLoginAuthenticationNotification.swift
@@ -38,6 +38,9 @@ extension ZMAuthenticationStatus : NotificationContext { } // Mark ZMAuthenticat
 
     /// Invoked when we have provided correct credentials and have an opportunity to import backup
     @objc optional func authenticationReadyToImportBackup(existingAccount: Bool)
+
+    /// A company login code did become availble. This means that the user clicked an SSO link with a valid code.
+    @objc optional func companyLoginCodeDidBecomeAvailable(_ code: UUID)
 }
 
 private enum PreLoginAuthenticationEvent {
@@ -47,6 +50,7 @@ private enum PreLoginAuthenticationEvent {
     case authenticationDidSucceed
     case loginCodeRequestDidFail(NSError)
     case loginCodeRequestDidSucceed
+    case companyLoginCodeDidBecomeAvailable(UUID)
 }
 
 @objc public class PreLoginAuthenticationNotification : NSObject {
@@ -83,6 +87,8 @@ private enum PreLoginAuthenticationEvent {
                 observer.authenticationDidFail?(error)
             case .authenticationDidSucceed:
                 observer.authenticationDidSucceed?()
+            case .companyLoginCodeDidBecomeAvailable(let code):
+                observer.companyLoginCodeDidBecomeAvailable?(code)
             }
         }
     }
@@ -118,6 +124,10 @@ public extension ZMAuthenticationStatus {
     
     @objc public func notifyLoginCodeRequestDidSucceed() {
         PreLoginAuthenticationNotification.notify(of: .loginCodeRequestDidSucceed, context: self)
+    }
+
+    @objc public func notifyCompanyLoginCodeDidBecomeAvailable(_ code: UUID) {
+        PreLoginAuthenticationNotification.notify(of: .companyLoginCodeDidBecomeAvailable(code), context: self)
     }
 }
 

--- a/Tests/Source/Integration/IntegrationTest.swift
+++ b/Tests/Source/Integration/IntegrationTest.swift
@@ -619,9 +619,9 @@ extension IntegrationTest : SessionManagerDelegate {
         // no-op
     }
     
-    public func sessionManagerWillLogout(error: Error?, userSessionCanBeTornDown: @escaping () -> Void) {
+    public func sessionManagerWillLogout(error: Error?, userSessionCanBeTornDown: (() -> Void)?) {
         self.userSession = nil
-        userSessionCanBeTornDown()
+        userSessionCanBeTornDown?()
     }
 
     public func sessionManagerDidBlacklistCurrentVersion() {

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -1052,11 +1052,57 @@ extension SessionManagerTests {
     }
 }
 
+class MockSessionManagerURLHandlerDelegate: NSObject, SessionManagerURLHandlerDelegate  {
+
+    var allowedAction: URLAction?
+
+    func sessionManagerShouldExecuteURLAction(_ action: URLAction, callback: @escaping (Bool) -> Void) {
+        callback(action == allowedAction)
+    }
+
+}
+
+extension SessionManagerTests {
+
+    func testThatItLogsOutWithCompanyLoginURL() {
+        // GIVEN
+        let id = UUID(uuidString: "1E628B42-4C83-49B7-B2B4-EF27BFE503EF")!
+        let url = URL(string: "wire://start-sso/wire-\(id)")!
+
+        sut = createManager()
+
+        let urlDelegate = MockSessionManagerURLHandlerDelegate()
+        urlDelegate.allowedAction = URLAction.startCompanyLogin(code: id)
+        sut?.urlHandler.delegate = urlDelegate
+
+        // WHEN
+        let logoutExpectation = expectation(description: "The company login flow starts when the user adds .")
+
+        delegate.onLogout = { error in
+            let loginCode = error?.userInfo[SessionManager.companyLoginCodeKey]
+            XCTAssertEqual(loginCode as? UUID, id)
+            XCTAssertEqual(error?.userSessionErrorCode, .addAccountRequested)
+            logoutExpectation.fulfill()
+        }
+
+        sut?.urlHandler.openURL(url, options: [:])
+
+        // THEN
+        XCTAssertTrue(self.waitForCustomExpectations(withTimeout: 2))
+
+        // CLEANUP
+        self.sut!.tearDownAllBackgroundSessions()
+    }
+
+}
+
 // MARK: - Mocks
 class SessionManagerTestDelegate: SessionManagerDelegate {
-    
-    func sessionManagerWillLogout(error: Error?, userSessionCanBeTornDown: @escaping () -> Void) {
-        userSessionCanBeTornDown()
+
+    var onLogout: ((NSError?) -> Void)?
+    func sessionManagerWillLogout(error: Error?, userSessionCanBeTornDown: (() -> Void)?) {
+        onLogout?(error as NSError?)
+        userSessionCanBeTornDown?()
     }
     
     func sessionManagerDidFailToLogin(account: Account?, error: Error) {
@@ -1084,7 +1130,7 @@ class SessionManagerTestDelegate: SessionManagerDelegate {
     func sessionManagerWillMigrateLegacyAccount() {
         // no op
     }
-    
+
 }
 
 class SessionManagerObserverMock: SessionManagerCreatedSessionObserver, SessionManagerDestroyedSessionObserver {

--- a/Tests/Source/SessionManager/SessionManagerURLHandlerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerURLHandlerTests.swift
@@ -105,4 +105,39 @@ final class SessionManagerURLHandlerTests: MessagingTest {
         XCTAssertEqual(delegate.calls.count, 1)
         XCTAssertEqual(delegate.calls[0].0, .connectBot(serviceUser: expectedUserData))
     }
+
+    func testThatItParsesCompanyLoginLink() {
+        // given
+        let id = UUID(uuidString: "4B1BEDB9-8899-4855-96AF-6CCED6F6F638")!
+        let url = URL(string: "wire://start-sso/wire-\(id)")!
+
+        // when
+        let action = URLAction(url: url)
+
+        // then
+        XCTAssertEqual(action, .startCompanyLogin(code: id))
+    }
+
+    func testThatItDiscardsInvalidCompanyLoginLink() {
+        // given
+        let url = URL(string: "wire://start-sso/wire-4B1BEDB9-8899-4855-96AF")!
+
+        // when
+        let action = URLAction(url: url)
+
+        // then
+        XCTAssertEqual(action, .warnInvalidCompanyLogin(error: .invalidLink))
+    }
+
+    func testThatItDiscardsCompanyLoginLinkWithExtraContent() {
+        // given
+        let id = UUID(uuidString: "4B1BEDB9-8899-4855-96AF-6CCED6F6F638")!
+        let url = URL(string: "wire://start-sso/wire-\(id)/content")!
+
+        // when
+        let action = URLAction(url: url)
+
+        // then
+        XCTAssertEqual(action, .warnInvalidCompanyLogin(error: .invalidLink))
+    }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

We want to be able to start the SSO flow when the user taps a special link. The detailed breakdown can be found at https://github.com/wireapp/ios-architecture/issues/64.

This PR holds all the approved changes made for this feature.

### Solutions

- [x] Implement SSO link parsing https://github.com/wireapp/wire-ios-sync-engine/pull/956
- [x] Handle valid SSO link clicks in session manager https://github.com/wireapp/wire-ios-sync-engine/pull/957 