### PR TITLE
ZIOS-11185: Fix logging in with a second account

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -435,7 +435,7 @@ public protocol ForegroundNotificationResponder: class {
     public func addAccount(userInfo: [String: Any]? = nil) {
         confirmSwitchingAccount { [weak self] in
             let error = NSError(code: .addAccountRequested, userInfo: userInfo)
-            if self?.unauthenticatedSession != nil {
+            if self?.activeUserSession == nil {
                 // If the user is already unauthenticated, we dont need to log out the current session
                 self?.delegate?.sessionManagerWillLogout(error: error, userSessionCanBeTornDown: nil)
             } else {


### PR DESCRIPTION
## What's new in this PR?

### Issues

When the user tried to log in for the second time, they got stuck in an infinite spinner.

### Causes

In the add account method, we were checking if there was an unauthenticated session to skip the method that fails if there is no active session (because we don't need to tear it down if it doesn't exist) and start the authentication flow directly.

But after you log in for the first time, we keep the unauthenticated session, which means the next time you try to add an account, we're gonna skip the tear down of the active session, which caused the unauthenticated session to try to update the email address of the current account instead of logging in.

### Solutions

Check if there is no active session to skip the active session tear down.

### Notes

We will need to do a patch update of 227.0, because we don't want to include the things that were merged after into the release.