### PR TITLE
ZIOS-11207: Fix unresponsive SSO link

### DIFF
--- a/Source/Registration/Company/CompanyLoginRequester.swift
+++ b/Source/Registration/Company/CompanyLoginRequester.swift
@@ -105,12 +105,12 @@ public class CompanyLoginRequester {
         backendHost: String,
         callbackScheme: String,
         defaults: UserDefaults = .shared(),
-        session: URLSessionProtocol = URLSession.shared
+        session: URLSessionProtocol? = nil
         ) {
         self.backendHost = backendHost
         self.callbackScheme = callbackScheme
         self.defaults = defaults
-        self.session = session
+        self.session = session ?? URLSession(configuration: .ephemeral)
     }
     
     // MARK: - Token Validation

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -49,7 +49,7 @@ public typealias LaunchOptions = [UIApplication.LaunchOptionsKey : Any]
 @objc
 public protocol UserSessionSource: class {
     var activeUserSession: ZMUserSession? { get }
-    var unauthenticatedSession: UnauthenticatedSession? { get }
+    var activeUnauthenticatedSession: UnauthenticatedSession { get }
 }
 
 @objc
@@ -201,6 +201,10 @@ public protocol ForegroundNotificationResponder: class {
     private static var token: Any?
     
     public var callKitDelegate : CallKitDelegate?
+
+    public var activeUnauthenticatedSession: UnauthenticatedSession {
+        return unauthenticatedSession ?? createUnauthenticatedSession()
+    }
     
     /// The entry point for SessionManager; call this instead of the initializers.
     ///
@@ -556,13 +560,15 @@ public protocol ForegroundNotificationResponder: class {
                                                  unreadCountObserver
         ]
     }
-    
-    fileprivate func createUnauthenticatedSession() {
+
+    @discardableResult
+    fileprivate func createUnauthenticatedSession() -> UnauthenticatedSession {
         log.debug("Creating unauthenticated session")
         self.unauthenticatedSession?.tearDown()
         let unauthenticatedSession = unauthenticatedSessionFactory.session(withDelegate: self)
         self.unauthenticatedSession = unauthenticatedSession
         self.preLoginAuthenticationToken = unauthenticatedSession.addAuthenticationObserver(self)
+        return unauthenticatedSession
     }
     
     fileprivate func configure(session userSession: ZMUserSession, for account: Account) {

--- a/Source/SessionManager/SessionManagerURLHandler.swift
+++ b/Source/SessionManager/SessionManagerURLHandler.swift
@@ -181,13 +181,11 @@ public final class SessionManagerURLHandler: NSObject {
             handle(action: action, in: userSession)
 
         } else {
-
-            guard let unauthenticatedSession = userSessionSource?.unauthenticatedSession else {
+            guard let unauthenticatedSession = userSessionSource?.activeUnauthenticatedSession else {
                 return false
             }
 
             handle(action: action, in: unauthenticatedSession)
-
         }
 
         return true

--- a/Tests/Source/SessionManager/SessionManagerURLHandlerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerURLHandlerTests.swift
@@ -22,10 +22,14 @@ import XCTest
 @testable import WireSyncEngine
 
 class UserSessionSourceDummy: UserSessionSource {
-    weak var activeUserSession: ZMUserSession? = nil
-    weak var unauthenticatedSession: UnauthenticatedSession? = nil
-}
+    var activeUserSession: ZMUserSession? = nil
+    var activeUnauthenticatedSession: UnauthenticatedSession
 
+    init() {
+        activeUnauthenticatedSession = UnauthenticatedSession(transportSession: TestUnauthenticatedTransportSession(), reachability: TestReachability(), delegate: nil)
+    }
+}
+ 
 class OpenerDelegate: SessionManagerURLHandlerDelegate {
     var calls: [(URLAction, (Bool) -> Void)] = []
     func sessionManagerShouldExecuteURLAction(_ action: URLAction, callback: @escaping (Bool) -> Void) {

--- a/Tests/Source/SessionManager/SessionManagerURLHandlerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerURLHandlerTests.swift
@@ -28,6 +28,10 @@ class UserSessionSourceDummy: UserSessionSource {
     init() {
         activeUnauthenticatedSession = UnauthenticatedSession(transportSession: TestUnauthenticatedTransportSession(), reachability: TestReachability(), delegate: nil)
     }
+
+    deinit {
+        activeUnauthenticatedSession.tearDown()
+    }
 }
  
 class OpenerDelegate: SessionManagerURLHandlerDelegate {


### PR DESCRIPTION
## What's new in this PR?

### Issues

If the user launched the app from scratch after they signed in, tapping an SSO link has no effect.

### Causes

The handling of the link assumed that there was an unauthenticated session, which isn't always the case (for ex, if the user launches the app and never started the login flow).

### Solutions

- Force-create an unauthenticated session when the SSO link is tapped.
- Do not cache the SSO team lookup results (in case the team gets deactivated later).