### PR TITLE
ZIOS-11190: Fix dismissing SSO flow if the user is already logged in

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -404,6 +404,13 @@ public protocol ForegroundNotificationResponder: class {
     }
 
     private func selectInitialAccount(_ account: Account?, launchOptions: LaunchOptions) {
+        if let url = launchOptions[UIApplication.LaunchOptionsKey.url] as? URL {
+            if URLAction(url: url)?.causesLogout == true {
+                // Do not log in if the launch URL action causes a logout
+                return
+            }
+        }
+        
         loadSession(for: account) { [weak self] session in
             guard let `self` = self, let session = session else { return }
             self.updateCurrentAccount(in: session.managedObjectContext)

--- a/Source/SessionManager/SessionManagerURLHandler.swift
+++ b/Source/SessionManager/SessionManagerURLHandler.swift
@@ -25,6 +25,13 @@ public enum URLAction: Equatable {
 
     case startCompanyLogin(code: UUID)
     case warnInvalidCompanyLogin(error: ConmpanyLoginRequestError)
+    
+    var causesLogout: Bool {
+        switch self {
+        case .startCompanyLogin: return true
+        default: return false
+        }
+    }
 
     var requiresAuthentication: Bool {
         switch self {


### PR DESCRIPTION
## What's new in this PR?

### Issues

When launching the app from scratch with an SSO link, the flow would appear briefly and disappear after a few seconds if there is already an account logged in.

### Causes

When the app launches, we try to select the first available account. This causes a race condition with the URL handling:

- we launch the app and start asynchronously loading the resources on disk
- we handle the URL synchronously and tell the app state controller to go unauthenticated and the SSO flow starts
- the asynchronous loading finishes and tells the app state controller to go authenticated
- the SSO flow is dismissed and the conversation list is displayed

### Solutions

Do not select the initial account if the URL action at launch causes a logout action.