### PR TITLE
Make sure there is an active background task

### DIFF
--- a/Source/Synchronization/ZMOperationLoop.m
+++ b/Source/Synchronization/ZMOperationLoop.m
@@ -243,7 +243,6 @@ static char* const ZMLogTag ZM_UNUSED = "OperationLoop";
             return nil;
         }
         ZMTransportRequest *request = [self.syncStrategy nextRequest];
-        BackgroundActivity *activity = request ? [BackgroundActivityFactory.sharedFactory startBackgroundActivityWithName:[NSString stringWithFormat:@"Generated: %@ %@", request.methodAsString, request.path]] : nil;
         [request addCompletionHandler:[ZMCompletionHandler handlerOnGroupQueue:self.syncMOC block:^(ZMTransportResponse *response) {
             ZM_STRONG(self);
             
@@ -251,13 +250,6 @@ static char* const ZMLogTag ZM_UNUSED = "OperationLoop";
             
             // Check if there is something to do now and when the save completes
             [ZMRequestAvailableNotification notifyNewRequestsAvailable:self];
-            
-            [self.syncStrategy.syncMOC.dispatchGroup notifyOnQueue:dispatch_get_global_queue(0, 0) block:^{
-                [ZMRequestAvailableNotification notifyNewRequestsAvailable:self];
-                if (activity) {
-                    [BackgroundActivityFactory.sharedFactory endBackgroundActivity:activity];
-                }
-            }];
         }]];
         
         return request;

--- a/Tests/Source/Synchronization/ZMOperationLoopTests.m
+++ b/Tests/Source/Synchronization/ZMOperationLoopTests.m
@@ -279,7 +279,6 @@
     [[[self.transportSession expect] andReturn:resultYES] attemptToEnqueueSyncRequestWithGenerator:[OCMArg checkWithBlock:checkGenerator]];
     [[[self.transportSession expect] andReturn:resultNO] attemptToEnqueueSyncRequestWithGenerator:OCMOCK_ANY];
     [[[self.transportSession expect] andReturn:resultNO] attemptToEnqueueSyncRequestWithGenerator:OCMOCK_ANY];
-    [[[self.transportSession expect] andReturn:resultNO] attemptToEnqueueSyncRequestWithGenerator:OCMOCK_ANY];
     [ZMRequestAvailableNotification notifyNewRequestsAvailable:self]; // this will enqueue `request`
     WaitForAllGroupsToBeEmpty(0.5);
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

Looking at real-live logs after #968 we have noticed that sometimes the background task introduced there is not ended which causes the app to stay in background longer.

### Causes

There is this curious extra notification that we try to do when dispatch group on sync MOC is empty. It seems in some cases this never gets run. This needs further debugging, but since the dispatch group is only useful in tests it's quite low priority.

### Solutions

Remove extra notification and code to wait until group is empty. There is also no need for the extra background task because we should have either delayed save or next request happening at that point already.

