### PR TITLE
ZIOS-11250: Add observation mechanism for new unauthenticated sessions

### DIFF
--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -1136,10 +1136,15 @@ class SessionManagerTestDelegate: SessionManagerDelegate {
 class SessionManagerObserverMock: SessionManagerCreatedSessionObserver, SessionManagerDestroyedSessionObserver {
     
     var createdUserSession: [ZMUserSession] = []
+    var createdUnauthenticatedSession: [UnauthenticatedSession] = []
     var destroyedUserSessions: [UUID] = []
     
     func sessionManagerCreated(userSession: ZMUserSession) {
         createdUserSession.append(userSession)
+    }
+
+    func sessionManagerCreated(unauthenticatedSession: UnauthenticatedSession) {
+        createdUnauthenticatedSession.append(unauthenticatedSession)
     }
     
     func sessionManagerDestroyedUserSession(for accountId: UUID) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Sometimes, the session manager recreates user sessions. However, the authentication coordinator in the UI sets up observers on the session to detect events. Thus, we need a mechanism to detect new unauthenticated sessions so that we can recreate these observers.