### PR TITLE
Hotfix path: refetch the self user properties after update

### DIFF
--- a/Source/Synchronization/ZMHotFixDirectory+Swift.swift
+++ b/Source/Synchronization/ZMHotFixDirectory+Swift.swift
@@ -143,6 +143,13 @@ import Foundation
 
         context.enqueueDelayedSave()
     }
+
+    /// Refreshes the self user.
+    public static func refetchSelfUser(_ context: NSManagedObjectContext) {
+        let selfUser = ZMUser.selfUser(in: context)
+        selfUser.needsToBeUpdatedFromBackend = true
+        context.enqueueDelayedSave()
+    }
     
     /// Marks all connected users (including self) to be refetched.
     /// Unconnected users are refreshed with a call to `refreshData` when information is displayed.

--- a/Source/Synchronization/ZMHotFixDirectory.m
+++ b/Source/Synchronization/ZMHotFixDirectory.m
@@ -161,6 +161,13 @@ static NSString* ZMLogTag ZM_UNUSED = @"HotFix";
                      patchCode:^(NSManagedObjectContext *context) {
                          [ZMHotFixDirectory markAllNewConversationSystemMessagesAsRead:context];
                      }],
+
+                    /// We need to refetch the managedBy flag of the user after the backend release.
+                    [ZMHotFixPatch
+                     patchWithVersion:@"235.0.1"
+                     patchCode:^(NSManagedObjectContext *context) {
+                         [ZMHotFixDirectory refetchUserProperties:context];
+                     }],
                     ];
     });
     return patches;

--- a/Source/Synchronization/ZMHotFixDirectory.m
+++ b/Source/Synchronization/ZMHotFixDirectory.m
@@ -166,7 +166,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"HotFix";
                     [ZMHotFixPatch
                      patchWithVersion:@"235.0.1"
                      patchCode:^(NSManagedObjectContext *context) {
-                         [ZMHotFixDirectory refetchUserProperties:context];
+                         [ZMHotFixDirectory refetchSelfUser:context];
                      }],
                     ];
     });

--- a/Tests/Source/Synchronization/ZMHotFixTests.m
+++ b/Tests/Source/Synchronization/ZMHotFixTests.m
@@ -717,7 +717,6 @@
         // then
         XCTAssertTrue(connectedUser.needsToBeUpdatedFromBackend);
         XCTAssertTrue(unconnectedUser.needsToBeUpdatedFromBackend);
-        XCTAssertFalse(selfUser.needsToBeUpdatedFromBackend);
     }];
 }
 

--- a/Tests/Source/Synchronization/ZMHotFixTests.swift
+++ b/Tests/Source/Synchronization/ZMHotFixTests.swift
@@ -98,4 +98,34 @@ class ZMHotFixTests_Integration: MessagingTest {
         }
     }
 
+    func testThatItUpdatesManagedByPropertyFromUser_From_235_0_0() {
+        syncMOC.performGroupedBlock {
+            // GIVEN
+            self.syncMOC.setPersistentStoreMetadata("235.0.0", key: "lastSavedVersion")
+            self.syncMOC.setPersistentStoreMetadata(NSNumber(booleanLiteral: true), key: "HasHistory")
+
+            let selfUser = ZMUser.selfUser(in: self.syncMOC)
+            selfUser.needsToBeUpdatedFromBackend = false
+            self.syncMOC.saveOrRollback()
+
+            XCTAssertFalse(selfUser.needsToBeUpdatedFromBackend)
+
+
+            // WHEN
+            let sut = ZMHotFix(syncMOC: self.syncMOC)
+            self.performIgnoringZMLogError {
+                sut!.applyPatches(forCurrentVersion: "235.0.0")
+            }
+        }
+        XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        syncMOC.performGroupedBlock {
+            self.syncMOC.saveOrRollback()
+        }
+        syncMOC.performGroupedBlock {
+            let selfUser = ZMUser.selfUser(in: self.syncMOC)
+            XCTAssertTrue(selfUser.needsToBeUpdatedFromBackend)
+        }
+    }
+
 }

--- a/Tests/Source/Synchronization/ZMHotFixTests.swift
+++ b/Tests/Source/Synchronization/ZMHotFixTests.swift
@@ -114,14 +114,11 @@ class ZMHotFixTests_Integration: MessagingTest {
             // WHEN
             let sut = ZMHotFix(syncMOC: self.syncMOC)
             self.performIgnoringZMLogError {
-                sut!.applyPatches(forCurrentVersion: "235.0.0")
+                sut!.applyPatches(forCurrentVersion: "235.0.1")
             }
         }
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
-        syncMOC.performGroupedBlock {
-            self.syncMOC.saveOrRollback()
-        }
         syncMOC.performGroupedBlock {
             let selfUser = ZMUser.selfUser(in: self.syncMOC)
             XCTAssertTrue(selfUser.needsToBeUpdatedFromBackend)


### PR DESCRIPTION
## What's new in this PR?

### Issues

When upgrading from 3.26 to 3.27, some users did not have the `managed_by` flag set in their self profile. It caused an issue with identifying their level of permissions to edit their profile picture and name.

### Solutions

Add a hotfix patch to refetch the self user properties when updating the app.