### PR TITLE
Add hotfix for re-downloading team members

### DIFF
--- a/Source/Synchronization/ZMHotFixDirectory+Swift.swift
+++ b/Source/Synchronization/ZMHotFixDirectory+Swift.swift
@@ -191,6 +191,10 @@ import Foundation
         context.enqueueDelayedSave()
     }
     
+    public static func refetchTeamMembers(_ context: NSManagedObjectContext) {
+        ZMUser.selfUser(in: context).team?.needsToRedownloadMembers = true
+    }
+    
     /// Marks all conversations to be refetched.
     public static func refetchAllConversations(_ context: NSManagedObjectContext) {
         refetchConversations(matching: NSPredicate(value: true), in: context)

--- a/Source/Synchronization/ZMHotFixDirectory.m
+++ b/Source/Synchronization/ZMHotFixDirectory.m
@@ -168,6 +168,13 @@ static NSString* ZMLogTag ZM_UNUSED = @"HotFix";
                      patchCode:^(NSManagedObjectContext *context) {
                          [ZMHotFixDirectory refetchSelfUser:context];
                      }],
+                    
+                    /// We need to refetch the team members after createdBy and createdAt fields were introduced
+                    [ZMHotFixPatch
+                     patchWithVersion:@"238.0.1"
+                     patchCode:^(NSManagedObjectContext *context) {
+                         [ZMHotFixDirectory refetchTeamMembers:context];
+                     }],
                     ];
     });
     return patches;


### PR DESCRIPTION
## What's new in this PR?

We need to re-download the team members after the `createdBy` and `createdAt` fields were introduced.