### PR TITLE
Don't rely on order of .established & .establishedDataChannel

### DIFF
--- a/Source/Calling/CallKitDelegate.swift
+++ b/Source/Calling/CallKitDelegate.swift
@@ -559,7 +559,7 @@ class CallObserver : WireCallCenterCallStateObserver {
         switch callState {
         case .answered(degraded: false):
             onAnswered?()
-        case .establishedDataChannel:
+        case .establishedDataChannel, .established:
             onEstablished?()
         case .terminating(reason: let reason):
             switch reason {

--- a/Tests/Source/Calling/CallKitDelegateTests.swift
+++ b/Tests/Source/Calling/CallKitDelegateTests.swift
@@ -440,31 +440,54 @@ class CallKitDelegateTest: MessagingTest {
     
     // MARK: Performing Actions
     
-    /* Disabled for now, pending furter investigation
     func testThatCallAnswerActionIsFulfilledWhenCallIsEstablished() {
         // given
+        let otherUser = self.otherUser(moc: self.uiMOC)
+        createOneOnOneConversation(user: otherUser)
+        let conversation = otherUser.oneToOneConversation!
         let provider = MockProvider(foo: true)
-        let conversation = self.conversation(type: .oneOnOne)
-        let action = MockCallAnswerAction(call: conversation.remoteIdentifier!)
+        sut.reportIncomingCall(from: otherUser, in: conversation, video: false)
+        let action = MockCallAnswerAction(call: sut.callUUID(for: conversation)!)
+        self.sut.provider(provider, perform: action)
         
         // when
-        self.sut.provider(provider, perform: action)
-        mockWireCallCenterV3.update(callState: .established, conversationId: conversation.remoteIdentifier!)
+        mockWireCallCenterV3.update(callState: .established, conversationId: conversation.remoteIdentifier!, callerId: otherUser.remoteIdentifier, isVideo: false)
         
         // then
         XCTAssertTrue(action.isFulfilled)
     }
     
-    func testThatCallAnswerActionFailWhenCallCantBeJoined() {
+    func testThatCallAnswerActionIsFulfilledWhenDataChannelIsEstablished() {
         // given
+        let otherUser = self.otherUser(moc: self.uiMOC)
+        createOneOnOneConversation(user: otherUser)
+        let conversation = otherUser.oneToOneConversation!
         let provider = MockProvider(foo: true)
-        let conversation = self.conversation(type: .oneOnOne)
-        let action = MockCallAnswerAction(call: conversation.remoteIdentifier!)
+        sut.reportIncomingCall(from: otherUser, in: conversation, video: false)
+        let action = MockCallAnswerAction(call: sut.callUUID(for: conversation)!)
+        self.sut.provider(provider, perform: action)
         
         // when
-        self.sut.provider(provider, perform: action)
-        NotificationCenter.default.post(name: NSNotification.Name.ZMConversationVoiceChannelJoinFailed, object: conversation.remoteIdentifier!)
+        mockWireCallCenterV3.update(callState: .establishedDataChannel, conversationId: conversation.remoteIdentifier!, callerId: otherUser.remoteIdentifier, isVideo: false)
         
+        // then
+        XCTAssertTrue(action.isFulfilled)
+    }
+
+    /* Disabled for now, pending furter investigation
+    func testThatCallAnswerActionFailWhenCallCantBeJoined() {
+        // given
+        let otherUser = self.otherUser(moc: self.uiMOC)
+        let provider = MockProvider(foo: true)
+        let conversation = self.conversation(type: .oneOnOne)
+        
+        sut.reportIncomingCall(from: otherUser, in: conversation, video: false)
+        let action = MockCallAnswerAction(call: sut.callUUID(for: conversation)!)
+        self.sut.provider(provider, perform: action)
+
+        // when
+        mockWireCallCenterV3.update(callState: .terminating(reason: .lostMedia), conversationId: conversation.remoteIdentifier!, callerId: otherUser.remoteIdentifier, isVideo: false)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         // then
         XCTAssertTrue(action.hasFailed)
     }

--- a/Tests/Source/Calling/CallKitDelegateTests.swift
+++ b/Tests/Source/Calling/CallKitDelegateTests.swift
@@ -276,7 +276,7 @@ class CallKitDelegateTest: MessagingTest {
         super.tearDown()
     }
     
-    // Public API - provider configuration
+    // MARK: Provider configuration
     func testThatItReturnsTheProviderConfiguration() {
         // when
         let configuration = WireSyncEngine.CallKitDelegate.providerConfiguration
@@ -323,7 +323,8 @@ class CallKitDelegateTest: MessagingTest {
         XCTAssertTrue(callKitProvider.isInvalidated)
     }
     
-    // Public API - outgoing calls
+    // MARK: Reporting Actions
+    
     func testThatItReportsTheStartCallRequest() {
         // given
         let selfUser = ZMUser.selfUser(in: uiMOC)
@@ -437,7 +438,7 @@ class CallKitDelegateTest: MessagingTest {
         CallKitDelegateTestsMocking.stopMock(call)
     }
     
-    // Actions - answer / start call
+    // MARK: Performing Actions
     
     /* Disabled for now, pending furter investigation
     func testThatCallAnswerActionIsFulfilledWhenCallIsEstablished() {
@@ -533,7 +534,7 @@ class CallKitDelegateTest: MessagingTest {
         XCTAssertTrue(provider.connectedCalls.contains(callUUID))
     }
     
-    // Public API - report end on outgoing call
+    // MARK: Report end on outgoing call
     
     func testThatItReportsTheEndOfCall() {
         // given
@@ -598,7 +599,7 @@ class CallKitDelegateTest: MessagingTest {
         XCTAssertEqual(action.callUUID, callUUID)
     }
     
-    // Public API - activity & intents
+    //  MARK:  Activity & Intents
     
     func userActivityFor(contacts: [INPerson]?, isVideo: Bool = false) -> NSUserActivity {
 
@@ -699,7 +700,7 @@ class CallKitDelegateTest: MessagingTest {
         XCTAssertEqual(self.callKitController.timesRequestTransactionCalled, 0)
     }
     
-    // Observer API V3
+    // MARK: Observing call state
     
     func testThatItReportNewIncomingCall_v3_Incoming() {
         // given


### PR DESCRIPTION
## What's new in this PR?

Support for AVS using vanilla WebRTC. This has changed the semantics of `.establishedDataChannel` and  `.established`:

Previously `.establishedDataChannel` always happened before `.established`, that's no longer true so we now also need to report Callkit calls as connected on `.established`.
