### PR TITLE
Reduce unnecessary saving during the initial sync

### DIFF
--- a/Source/Synchronization/Transcoders/ZMConversationTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMConversationTranscoder.m
@@ -265,8 +265,6 @@ typedef NS_ENUM(NSUInteger, ZMConversationSource) {
              // Slow synced conversations should be considered read from the start
             conversation.lastReadServerTimeStamp = conversation.lastModifiedDate;
         }
-        
-        [self.managedObjectContext enqueueDelayedSave];
     }
     return conversation;
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

The initial sync on a large account takes a long time to finish.

### Causes

The profiling report for a large account shows that a significant amount of time is spent in core data's save method, which is triggered when inserting a conversation.

### Solutions

Remove a delayed save after inserting a new conversation. This save should not be necessary since we enqueue a save after the request response has been processed.