### PR TITLE
Feature: Go to a specific user profile when clicking on a link outside/inside the app

### DIFF
--- a/Source/DeepLink/DeepLinkError.swift
+++ b/Source/DeepLink/DeepLinkError.swift
@@ -1,0 +1,28 @@
+//
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/**
+ * Errors that can occur when requesting a user profile or conversation from a link.
+ */
+
+public enum DeepLinkRequestError: Error, Equatable {
+    /// The Deep link provided by the user was invalid.
+    case invalidLink
+}

--- a/Source/DeepLink/DeepLinkError.swift
+++ b/Source/DeepLink/DeepLinkError.swift
@@ -23,7 +23,7 @@ import Foundation
  */
 
 public enum DeepLinkRequestError: Error, Equatable {
-    /// The Deep link provided by the user was invalid.
-    case invalidLink
+    case invalidUserLink
+    case invalidConversationLink
     case notLoggedIn
 }

--- a/Source/DeepLink/DeepLinkError.swift
+++ b/Source/DeepLink/DeepLinkError.swift
@@ -25,4 +25,5 @@ import Foundation
 public enum DeepLinkRequestError: Error, Equatable {
     /// The Deep link provided by the user was invalid.
     case invalidLink
+    case notLoggedIn
 }

--- a/Source/DeepLink/URL+DeepLink.swift
+++ b/Source/DeepLink/URL+DeepLink.swift
@@ -1,0 +1,26 @@
+//
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension URL {
+    enum DeepLink {
+        static let user = "user"
+        static let conversation = "conversation"
+    }
+}

--- a/Source/SessionManager/SessionManagerURLHandler.swift
+++ b/Source/SessionManager/SessionManagerURLHandler.swift
@@ -181,6 +181,13 @@ extension URLAction {
 }
 
 public protocol SessionManagerURLHandlerDelegate: class {
+
+    /// sessionManager executes a URLAction
+    ///
+    /// - Parameters:
+    ///   - action: the action to execute
+    ///   - callback: the callback with a bool shouldExecute, it should be called after the action is executed.
+    /// - Returns: return false if the Action is not executed
     func sessionManagerShouldExecuteURLAction(_ action: URLAction, callback: @escaping (Bool) -> Void) -> Bool
 }
 

--- a/Source/SessionManager/SessionManagerURLHandler.swift
+++ b/Source/SessionManager/SessionManagerURLHandler.swift
@@ -18,6 +18,20 @@
 
 import Foundation
 
+public struct User: Equatable {
+    public static func == (lhs: User, rhs: User) -> Bool {
+        return lhs.id == rhs.id
+    }
+
+    private let id: UUID
+    var user: UserType?
+
+    init(id: UUID) {
+        self.id = id
+        user = nil
+    }
+}
+
 public enum URLAction: Equatable {
     case connectBot(serviceUser: ServiceUserData)
     case companyLoginSuccess(userInfo: UserInfo)
@@ -27,7 +41,7 @@ public enum URLAction: Equatable {
     case warnInvalidCompanyLogin(error: ConmpanyLoginRequestError)
 
     case openConversation(id: UUID)
-    case openUserProfile(id: UUID)
+    case openUserProfile(user: User)
     case warnInvalidDeepLink(error: DeepLinkRequestError)
 
     var causesLogout: Bool {
@@ -65,7 +79,7 @@ extension URLAction {
         case URL.DeepLink.user:
             if let lastComponent = url.pathComponents.last,
                 let uuid = UUID(uuidString: lastComponent) {
-                self = .openUserProfile(id: uuid)
+                self = .openUserProfile(user: User(id: uuid))
             } else {
                 self = .warnInvalidDeepLink(error: .invalidLink)
             }

--- a/Source/SessionManager/SessionManagerURLHandler.swift
+++ b/Source/SessionManager/SessionManagerURLHandler.swift
@@ -209,6 +209,7 @@ public protocol SessionManagerURLHandlerDelegate: class {
     ///   - action: the action to execute
     ///   - callback: the callback with a bool shouldExecute, it should be called after the action is executed.
     /// - Returns: return false if the Action is not executed
+    @discardableResult
     func sessionManagerShouldExecuteURLAction(_ action: URLAction, callback: @escaping (Bool) -> Void) -> Bool
 }
 
@@ -266,7 +267,7 @@ public final class SessionManagerURLHandler: NSObject {
     }
 
     fileprivate func handle(action: URLAction, in unauthenticatedSession: UnauthenticatedSession) {
-        let _ = delegate?.sessionManagerShouldExecuteURLAction(action) { shouldExecute in
+        delegate?.sessionManagerShouldExecuteURLAction(action) { shouldExecute in
             if shouldExecute {
                 action.execute(in: unauthenticatedSession)
             }

--- a/Source/SessionManager/SessionManagerURLHandler.swift
+++ b/Source/SessionManager/SessionManagerURLHandler.swift
@@ -23,12 +23,10 @@ public struct DeepLinkUser: Equatable {
         return lhs.id == rhs.id
     }
 
-    var userSession: ZMUserSession? {
-        didSet {
-            if let moc = userSession?.managedObjectContext,
-                let user = ZMUser.init(remoteID: id, createIfNeeded: false, in: moc) {
-                self.user = user
-            }
+    mutating func setUserSession(userSession: ZMUserSession) {
+        if let moc = userSession.managedObjectContext,
+            let user = ZMUser.init(remoteID: id, createIfNeeded: false, in: moc) {
+            self.user = user
         }
     }
 
@@ -56,7 +54,7 @@ public enum URLAction: Equatable {
     mutating func setUserSession(userSession: ZMUserSession) {
         switch self {
         case .openUserProfile(var deepLinkUser):
-            deepLinkUser.userSession = userSession
+            deepLinkUser.setUserSession(userSession: userSession)
             self = .openUserProfile(deepLinkUser: deepLinkUser)
         default:
             break
@@ -288,7 +286,8 @@ public final class SessionManagerURLHandler: NSObject {
     public func executePendingAction(userSession: ZMUserSession) {
         if let pendingAction = self.pendingAction {
 
-            if self.handle(action: pendingAction, in: userSession) { ///TODO: not nil pendingAction if return false
+            ///do not nil pendingAction if handle() return false. The pendingAction will be excuted later.
+            if handle(action: pendingAction, in: userSession) {
                 self.pendingAction = nil
             }
         }

--- a/Source/SessionManager/SessionManagerURLHandler.swift
+++ b/Source/SessionManager/SessionManagerURLHandler.swift
@@ -18,8 +18,8 @@
 
 import Foundation
 
-public struct User: Equatable {
-    public static func == (lhs: User, rhs: User) -> Bool {
+public struct DeepLinkUser: Equatable {
+    public static func == (lhs: DeepLinkUser, rhs: DeepLinkUser) -> Bool {
         return lhs.id == rhs.id
     }
 
@@ -32,13 +32,12 @@ public struct User: Equatable {
         }
     }
 
-    let id: UUID
+    private let id: UUID
 
     private(set) public var user: UserType?
 
     init(id: UUID) {
         self.id = id
-//        userSession = nil
     }
 }
 
@@ -51,14 +50,14 @@ public enum URLAction: Equatable {
     case warnInvalidCompanyLogin(error: ConmpanyLoginRequestError)
 
     case openConversation(id: UUID)
-    case openUserProfile(user: User)
+    case openUserProfile(deepLinkUser: DeepLinkUser)
     case warnInvalidDeepLink(error: DeepLinkRequestError)
 
     mutating func setUserSession(userSession: ZMUserSession) {
         switch self {
-        case .openUserProfile(var user):
-            user.userSession = userSession
-            self = .openUserProfile(user: user)
+        case .openUserProfile(var deepLinkUser):
+            deepLinkUser.userSession = userSession
+            self = .openUserProfile(deepLinkUser: deepLinkUser)
         default:
             break
         }
@@ -99,7 +98,7 @@ extension URLAction {
         case URL.DeepLink.user:
             if let lastComponent = url.pathComponents.last,
                 let uuid = UUID(uuidString: lastComponent) {
-                self = .openUserProfile(user: User(id: uuid))
+                self = .openUserProfile(deepLinkUser: DeepLinkUser(id: uuid))
             } else {
                 self = .warnInvalidDeepLink(error: .invalidLink)
             }

--- a/Source/SessionManager/SessionManagerURLHandler.swift
+++ b/Source/SessionManager/SessionManagerURLHandler.swift
@@ -164,12 +164,6 @@ extension URLAction {
         switch self {
         case .connectBot(let serviceUserData):
             session.startConversation(with: serviceUserData, completion: nil)
-//        case .openConversation(let id):
-//            ///TODO: open the conversation
-//            break
-//        case .openUserProfile(let id):
-//            ///TODO: open the user profile
-//            break
         default:
             fatalError("This action cannot be executed with an authenticated session.")
         }
@@ -213,23 +207,18 @@ public final class SessionManagerURLHandler: NSObject {
         }
 
         if action.opensDeepLink {
-            guard let userSession = userSessionSource?.activeUserSession else {
+            guard let _ = userSessionSource?.activeUserSession else {
                 pendingAction = action
                 return true
             }
-            return true
-
-//            handle(action: action, in: userSession)
         } else if action.requiresAuthentication {
 
             guard let userSession = userSessionSource?.activeUserSession else {
                 pendingAction = action
                 return true
             }
-            return true
 
-//            handle(action: action, in: userSession)
-
+            handle(action: action, in: userSession)
         } else {
             guard let unauthenticatedSession = userSessionSource?.activeUnauthenticatedSession else {
                 return false
@@ -244,17 +233,7 @@ public final class SessionManagerURLHandler: NSObject {
     fileprivate func handle(action: URLAction, in userSession: ZMUserSession) {
         delegate?.sessionManagerShouldExecuteURLAction(action) { shouldExecute in
             if shouldExecute {
-                switch action {
-                /// These actions are not related to SE
-                case .openConversation(id: _):
-                    ///TODO: open a conversation is possible
-                    break
-                case .openUserProfile(id: _):
-                    ///TODO:
-                    break
-                default:
-                    action.execute(in: userSession)
-                }
+                action.execute(in: userSession)                
             }
         }
     }

--- a/Source/SessionManager/SessionManagerURLHandler.swift
+++ b/Source/SessionManager/SessionManagerURLHandler.swift
@@ -268,10 +268,10 @@ public final class SessionManagerURLHandler: NSObject {
         }
 
         ///update openUserProfile's associated value with session
-        var muteableAction = action
-        muteableAction.setUserSession(userSession: userSession)
+        var mutableAction = action
+        mutableAction.setUserSession(userSession: userSession)
 
-        if let result = delegate?.sessionManagerShouldExecuteURLAction(muteableAction, callback: callback) {
+        if let result = delegate?.sessionManagerShouldExecuteURLAction(mutableAction, callback: callback) {
             return result
         } else {
             return false

--- a/Source/SessionManager/SessionManagerURLHandler.swift
+++ b/Source/SessionManager/SessionManagerURLHandler.swift
@@ -164,7 +164,12 @@ extension URLAction {
         switch self {
         case .connectBot(let serviceUserData):
             session.startConversation(with: serviceUserData, completion: nil)
-
+//        case .openConversation(let id):
+//            ///TODO: open the conversation
+//            break
+//        case .openUserProfile(let id):
+//            ///TODO: open the user profile
+//            break
         default:
             fatalError("This action cannot be executed with an authenticated session.")
         }
@@ -212,16 +217,18 @@ public final class SessionManagerURLHandler: NSObject {
                 pendingAction = action
                 return true
             }
+            return true
 
-            handle(action: action, in: userSession)
+//            handle(action: action, in: userSession)
         } else if action.requiresAuthentication {
 
             guard let userSession = userSessionSource?.activeUserSession else {
                 pendingAction = action
                 return true
             }
+            return true
 
-            handle(action: action, in: userSession)
+//            handle(action: action, in: userSession)
 
         } else {
             guard let unauthenticatedSession = userSessionSource?.activeUnauthenticatedSession else {
@@ -237,7 +244,17 @@ public final class SessionManagerURLHandler: NSObject {
     fileprivate func handle(action: URLAction, in userSession: ZMUserSession) {
         delegate?.sessionManagerShouldExecuteURLAction(action) { shouldExecute in
             if shouldExecute {
-                action.execute(in: userSession)
+                switch action {
+                /// These actions are not related to SE
+                case .openConversation(id: _):
+                    ///TODO: open a conversation is possible
+                    break
+                case .openUserProfile(id: _):
+                    ///TODO:
+                    break
+                default:
+                    action.execute(in: userSession)
+                }
             }
         }
     }

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -1052,12 +1052,14 @@ extension SessionManagerTests {
     }
 }
 
-class MockSessionManagerURLHandlerDelegate: NSObject, SessionManagerURLHandlerDelegate  {
+final class MockSessionManagerURLHandlerDelegate: NSObject, SessionManagerURLHandlerDelegate  {
 
     var allowedAction: URLAction?
 
-    func sessionManagerShouldExecuteURLAction(_ action: URLAction, callback: @escaping (Bool) -> Void) {
+    func sessionManagerShouldExecuteURLAction(_ action: URLAction, callback: @escaping (Bool) -> Void) -> Bool {
         callback(action == allowedAction)
+
+        return true
     }
 
 }

--- a/Tests/Source/SessionManager/SessionManagerURLHandlerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerURLHandlerTests.swift
@@ -177,7 +177,7 @@ final class SessionManagerURLHandlerTests: MessagingTest {
         let action = URLAction(url: url)
 
         // then
-        XCTAssertEqual(action, URLAction.openUserProfile(id: uuid))
+        XCTAssertEqual(action, URLAction.openUserProfile(deepLinkUser: DeepLinkUser(id: uuid)))
     }
 
     func testThatItDiscardsInvalidOpenUserProfileLink() {

--- a/Tests/Source/SessionManager/SessionManagerURLHandlerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerURLHandlerTests.swift
@@ -163,7 +163,7 @@ final class SessionManagerURLHandlerTests: MessagingTest {
         let action = URLAction(url: url)
 
         // then
-        XCTAssertEqual(action, URLAction.openConversation(id: uuid))
+        XCTAssertEqual(action, URLAction.openConversation(id: uuid, conversation: nil))
     }
 
     func testThatItParsesOpenUserProfileLink() {
@@ -177,7 +177,7 @@ final class SessionManagerURLHandlerTests: MessagingTest {
         let action = URLAction(url: url)
 
         // then
-        XCTAssertEqual(action, URLAction.openUserProfile(deepLinkUser: DeepLinkUser(id: uuid)))
+        XCTAssertEqual(action, URLAction.openConversation(id: uuid, conversation: nil))
     }
 
     func testThatItDiscardsInvalidOpenUserProfileLink() {
@@ -188,7 +188,7 @@ final class SessionManagerURLHandlerTests: MessagingTest {
         let action = URLAction(url: url)
 
         // then
-        XCTAssertEqual(action, URLAction.warnInvalidDeepLink(error: .invalidLink))
+        XCTAssertEqual(action, URLAction.warnInvalidDeepLink(error: .invalidUserLink))
     }
 
     func testThatItDiscardsInvalidOpenConversationLink() {
@@ -199,6 +199,6 @@ final class SessionManagerURLHandlerTests: MessagingTest {
         let action = URLAction(url: url)
 
         // then
-        XCTAssertEqual(action, URLAction.warnInvalidDeepLink(error: .invalidLink))
+        XCTAssertEqual(action, URLAction.warnInvalidDeepLink(error: .invalidConversationLink))
     }
 }

--- a/Tests/Source/SessionManager/SessionManagerURLHandlerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerURLHandlerTests.swift
@@ -177,7 +177,7 @@ final class SessionManagerURLHandlerTests: MessagingTest {
         let action = URLAction(url: url)
 
         // then
-        XCTAssertEqual(action, URLAction.openConversation(id: uuid, conversation: nil))
+        XCTAssertEqual(action, URLAction.openUserProfile(id: uuid, user: nil))
     }
 
     func testThatItDiscardsInvalidOpenUserProfileLink() {

--- a/Tests/Source/SessionManager/SessionManagerURLHandlerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerURLHandlerTests.swift
@@ -36,8 +36,10 @@ final class UserSessionSourceDummy: UserSessionSource {
  
 final class OpenerDelegate: SessionManagerURLHandlerDelegate {
     var calls: [(URLAction, (Bool) -> Void)] = []
-    func sessionManagerShouldExecuteURLAction(_ action: URLAction, callback: @escaping (Bool) -> Void) {
+    func sessionManagerShouldExecuteURLAction(_ action: URLAction, callback: @escaping (Bool) -> Void) -> Bool {
         calls.append((action, callback))
+
+        return true
     }
 }
 

--- a/Tests/Source/SessionManager/SessionManagerURLHandlerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerURLHandlerTests.swift
@@ -21,7 +21,7 @@ import Foundation
 import XCTest
 @testable import WireSyncEngine
 
-class UserSessionSourceDummy: UserSessionSource {
+final class UserSessionSourceDummy: UserSessionSource {
     var activeUserSession: ZMUserSession? = nil
     var activeUnauthenticatedSession: UnauthenticatedSession
 
@@ -34,7 +34,7 @@ class UserSessionSourceDummy: UserSessionSource {
     }
 }
  
-class OpenerDelegate: SessionManagerURLHandlerDelegate {
+final class OpenerDelegate: SessionManagerURLHandlerDelegate {
     var calls: [(URLAction, (Bool) -> Void)] = []
     func sessionManagerShouldExecuteURLAction(_ action: URLAction, callback: @escaping (Bool) -> Void) {
         calls.append((action, callback))
@@ -147,5 +147,56 @@ final class SessionManagerURLHandlerTests: MessagingTest {
 
         // then
         XCTAssertEqual(action, .warnInvalidCompanyLogin(error: .invalidLink))
+    }
+
+    // MARK: - Deep link
+
+    func testThatItParsesOpenConversationLink() {
+        // given
+        let uuidString = "fc43d637-6cc2-4d03-9185-2563c73d6ef2"
+        let url = URL(string: "wire://conversation/\(uuidString)")!
+        let uuid = UUID(uuidString: uuidString)!
+
+        // when
+        let action = URLAction(url: url)
+
+        // then
+        XCTAssertEqual(action, URLAction.openConversation(id: uuid))
+    }
+
+    func testThatItParsesOpenUserProfileLink() {
+        // given
+        let uuidString = "fc43d637-6cc2-4d03-9185-2563c73d6ef2"
+        let url = URL(string: "wire://user/\(uuidString)")!
+        let uuid = UUID(uuidString: uuidString)!
+
+
+        // when
+        let action = URLAction(url: url)
+
+        // then
+        XCTAssertEqual(action, URLAction.openUserProfile(id: uuid))
+    }
+
+    func testThatItDiscardsInvalidOpenUserProfileLink() {
+        // given
+        let url = URL(string: "wire://user/blahBlah)")!
+
+        // when
+        let action = URLAction(url: url)
+
+        // then
+        XCTAssertEqual(action, URLAction.warnInvalidDeepLink(error: .invalidLink))
+    }
+
+    func testThatItDiscardsInvalidOpenConversationLink() {
+        // given
+        let url = URL(string: "wire://conversation/foobar)")!
+
+        // when
+        let action = URLAction(url: url)
+
+        // then
+        XCTAssertEqual(action, URLAction.warnInvalidDeepLink(error: .invalidLink))
     }
 }

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -397,6 +397,8 @@
 		EFC8281C1FB343B600E27E21 /* RegistationCredentialVerificationStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFC8281B1FB343B600E27E21 /* RegistationCredentialVerificationStrategy.swift */; };
 		EFC8281E1FB34F9600E27E21 /* EmailVerificationStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFC8281D1FB34F9600E27E21 /* EmailVerificationStrategyTests.swift */; };
 		EFC828221FB356CE00E27E21 /* RegistrationStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFC828211FB356CE00E27E21 /* RegistrationStatusTests.swift */; };
+		EFF9403E2240FE5D004F3115 /* URL+DeepLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF9403D2240FE5D004F3115 /* URL+DeepLink.swift */; };
+		EFF940402240FF12004F3115 /* DeepLinkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF9403F2240FF12004F3115 /* DeepLinkError.swift */; };
 		F11E35D62040172200D4D5DB /* ZMHotFixTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11E35D52040172200D4D5DB /* ZMHotFixTests.swift */; };
 		F130BF282062C05600DBE261 /* SessionManager+Backup.swift in Sources */ = {isa = PBXBuildFile; fileRef = F130BF272062C05600DBE261 /* SessionManager+Backup.swift */; };
 		F132C105203F02C700C58933 /* ZMConversationTranscoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 54294A1F19472D4E007BE3CE /* ZMConversationTranscoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1008,6 +1010,8 @@
 		EFC8281B1FB343B600E27E21 /* RegistationCredentialVerificationStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistationCredentialVerificationStrategy.swift; sourceTree = "<group>"; };
 		EFC8281D1FB34F9600E27E21 /* EmailVerificationStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailVerificationStrategyTests.swift; sourceTree = "<group>"; };
 		EFC828211FB356CE00E27E21 /* RegistrationStatusTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegistrationStatusTests.swift; sourceTree = "<group>"; };
+		EFF9403D2240FE5D004F3115 /* URL+DeepLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+DeepLink.swift"; sourceTree = "<group>"; };
+		EFF9403F2240FF12004F3115 /* DeepLinkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkError.swift; sourceTree = "<group>"; };
 		F11E35D52040172200D4D5DB /* ZMHotFixTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMHotFixTests.swift; sourceTree = "<group>"; };
 		F130BF272062C05600DBE261 /* SessionManager+Backup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionManager+Backup.swift"; sourceTree = "<group>"; };
 		F132C113203F20AB00C58933 /* ZMHotFixDirectoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMHotFixDirectoryTests.swift; sourceTree = "<group>"; };
@@ -1455,6 +1459,7 @@
 		5423B98C191A49CD0044347D /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				EFF9403C2240FE12004F3115 /* DeepLink */,
 				54B2A0821DAE71F100BB40B1 /* Analytics */,
 				0928E38F1BA2CFF60057232E /* E2EE */,
 				A9EADFFF19DBF20A00FD386C /* Utility */,
@@ -2105,6 +2110,15 @@
 				D52257222062637500562561 /* DeletableAssetIdentifierProvider.swift */,
 			);
 			path = "Asset Deletion";
+			sourceTree = "<group>";
+		};
+		EFF9403C2240FE12004F3115 /* DeepLink */ = {
+			isa = PBXGroup;
+			children = (
+				EFF9403D2240FE5D004F3115 /* URL+DeepLink.swift */,
+				EFF9403F2240FF12004F3115 /* DeepLinkError.swift */,
+			);
+			path = DeepLink;
 			sourceTree = "<group>";
 		};
 		F159F4121F1E310C001B7D80 /* SessionManager */ = {
@@ -2774,6 +2788,7 @@
 				F16C8BE82044129700677D31 /* ZMConversationTranscoder.swift in Sources */,
 				1626344920D7DB81000D4063 /* PushNotificationCategory.swift in Sources */,
 				F98EDCD71D82B913001E65CB /* LocalNotificationContentType.swift in Sources */,
+				EFF940402240FF12004F3115 /* DeepLinkError.swift in Sources */,
 				F90EC5A31E7BF1AC00A6779E /* AVSWrapper.swift in Sources */,
 				5E8BB8992147CD3F00EEA64B /* AVSBridging.swift in Sources */,
 				16F5F16C1E4092C00062F0AE /* NSManagedObjectContext+CTCallCenter.swift in Sources */,
@@ -2904,6 +2919,7 @@
 				16962EE220286A4C0069D88D /* LocalNotificationType+Localization.swift in Sources */,
 				EEEA75FD1F8A6142006D1070 /* ZMLocalNotification.swift in Sources */,
 				F9ABE8511EFD568B00D83214 /* TeamRequestFactory.swift in Sources */,
+				EFF9403E2240FE5D004F3115 /* URL+DeepLink.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## What's new in this PR?

Supporting the URL scheme type for opening a user profile or a conversation.

Modify `sessionManagerShouldExecuteURLAction` of protocol `SessionManagerURLHandlerDelegate` to return a flag that the `URLAction` is executed successfully or not.