### PR TITLE
Don't allow notification fetching from APNS during syncing

### DIFF
--- a/Source/Synchronization/ApplicationStatusDirectory.swift
+++ b/Source/Synchronization/ApplicationStatusDirectory.swift
@@ -38,10 +38,6 @@ public final class ApplicationStatusDirectory : NSObject, ApplicationStatus {
     public let teamInvitationStatus: TeamInvitationStatus
     public let assetDeletionStatus: AssetDeletionStatus
     public let callEventStatus: CallEventStatus
-
-    public var notificationFetchStatus: BackgroundNotificationFetchStatus {
-        return pushNotificationStatus.status
-    }
     
     fileprivate var callInProgressObserverToken : Any? = nil
     
@@ -104,6 +100,15 @@ public final class ApplicationStatusDirectory : NSObject, ApplicationStatus {
             return .synchronizing
         } else {
             return .eventProcessing
+        }
+    }
+    
+    public var notificationFetchStatus: BackgroundNotificationFetchStatus {
+        switch pushNotificationStatus.status {
+        case .done:
+            return .done
+        case .inProgress:
+            return syncStatus.isSyncing ? .done : .inProgress
         }
     }
     

--- a/Source/Synchronization/Strategies/TeamSyncRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/TeamSyncRequestStrategy.swift
@@ -54,7 +54,7 @@ public final class TeamSyncRequestStrategy: AbstractRequestStrategy, ZMContextCh
         self.syncConfiguration = syncConfiguration
         self.syncStatus = syncStatus
         super.init(withManagedObjectContext: managedObjectContext, applicationStatus: applicationStatus)
-        configuration = [.allowsRequestsDuringSync, .allowsRequestsDuringNotificationStreamFetch]
+        configuration = [.allowsRequestsDuringSync]
         memberSync = ZMRemoteIdentifierObjectSync(transcoder: self, managedObjectContext: managedObjectContext)
         
         teamListSync = ZMSimpleListRequestPaginator(

--- a/Source/Synchronization/Transcoders/ZMConnectionTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMConnectionTranscoder.m
@@ -68,8 +68,7 @@ NSUInteger ZMConnectionTranscoderPageSize = 90;
 - (ZMStrategyConfigurationOption)configuration
 {
     return ZMStrategyConfigurationOptionAllowsRequestsDuringSync
-         | ZMStrategyConfigurationOptionAllowsRequestsDuringEventProcessing
-         | ZMStrategyConfigurationOptionAllowsRequestsDuringNotificationStreamFetch;
+         | ZMStrategyConfigurationOptionAllowsRequestsDuringEventProcessing;
 }
 
 

--- a/Source/Synchronization/Transcoders/ZMConversationTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMConversationTranscoder.m
@@ -125,8 +125,7 @@ typedef NS_ENUM(NSUInteger, ZMConversationSource) {
 - (ZMStrategyConfigurationOption)configuration
 {
     return ZMStrategyConfigurationOptionAllowsRequestsDuringSync
-         | ZMStrategyConfigurationOptionAllowsRequestsDuringEventProcessing
-         | ZMStrategyConfigurationOptionAllowsRequestsDuringNotificationStreamFetch;
+         | ZMStrategyConfigurationOptionAllowsRequestsDuringEventProcessing;
 }
 
 - (NSArray<NSString *> *)keysToSync

--- a/Source/Synchronization/Transcoders/ZMLastUpdateEventIDTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMLastUpdateEventIDTranscoder.m
@@ -52,8 +52,7 @@
 
 - (ZMStrategyConfigurationOption)configuration
 {
-    return ZMStrategyConfigurationOptionAllowsRequestsDuringSync
-         | ZMStrategyConfigurationOptionAllowsRequestsDuringNotificationStreamFetch;
+    return ZMStrategyConfigurationOptionAllowsRequestsDuringSync;
 }
 
 - (void)startRequestingLastUpdateEventIDWithoutPersistingIt

--- a/Source/Synchronization/Transcoders/ZMSelfStrategy.m
+++ b/Source/Synchronization/Transcoders/ZMSelfStrategy.m
@@ -93,8 +93,7 @@ NSTimeInterval ZMSelfStrategyPendingValidationRequestInterval = 5;
 
 - (ZMStrategyConfigurationOption)configuration
 {
-    return ZMStrategyConfigurationOptionAllowsRequestsDuringEventProcessing
-         | ZMStrategyConfigurationOptionAllowsRequestsWhileUnauthenticated
+    return ZMStrategyConfigurationOptionAllowsRequestsWhileUnauthenticated
          | ZMStrategyConfigurationOptionAllowsRequestsDuringSync
          | ZMStrategyConfigurationOptionAllowsRequestsDuringEventProcessing;
 }

--- a/Source/Synchronization/Transcoders/ZMUserTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMUserTranscoder.m
@@ -61,8 +61,7 @@ NSUInteger const ZMUserTranscoderNumberOfUUIDsPerRequest = 1600 / 25; // UUID as
 
 - (ZMStrategyConfigurationOption)configuration
 {
-    return ZMStrategyConfigurationOptionAllowsRequestsDuringEventProcessing
-         | ZMStrategyConfigurationOptionAllowsRequestsDuringSync
+    return ZMStrategyConfigurationOptionAllowsRequestsDuringSync
          | ZMStrategyConfigurationOptionAllowsRequestsDuringEventProcessing;
 }
 

--- a/Tests/Source/Synchronization/ZMHotFixTests.m
+++ b/Tests/Source/Synchronization/ZMHotFixTests.m
@@ -128,6 +128,11 @@
     [self.syncMOC setPersistentStoreMetadata:@"0.1" forKey:@"lastSavedVersion"];
 }
 
+- (void)updateLastSavedVersion:(NSString *)lastSavedVersion
+{
+    [self.syncMOC setPersistentStoreMetadata:lastSavedVersion forKey:@"lastSavedVersion"];
+}
+
 - (void)testThatItOnlyCallsMethodsForVersionsNewerThanTheLastSavedVersion
 {
     [self.syncMOC performGroupedBlockAndWait:^{
@@ -221,7 +226,7 @@
     [self.syncMOC performGroupedBlockAndWait:^{
 
         // given
-        [self saveNewVersion];
+        [self updateLastSavedVersion:@"40.3"];
 
         // when
         self.sut = [[ZMHotFix alloc] initWithSyncMOC:self.syncMOC];
@@ -261,8 +266,8 @@
 
     [self.syncMOC performGroupedBlockAndWait:^{
         // given
-        [self saveNewVersion];
-
+        [self updateLastSavedVersion:@"40.22"];
+        
         [[NSFileManager defaultManager] createDirectoryAtURL:imageURL withIntermediateDirectories:YES attributes:nil error:nil];
         [[NSFileManager defaultManager] createDirectoryAtURL:conversationUrl withIntermediateDirectories:YES attributes:nil error:nil];
 
@@ -291,7 +296,7 @@
 
     [self.syncMOC performGroupedBlockAndWait:^{
         // given
-        [self saveNewVersion];
+        [self updateLastSavedVersion:@"41.41"];
         userClient = [self createSelfClient];
 
         [ZMKeychain setData:verificationKey forAccount:@"APSVerificationKey"];
@@ -343,7 +348,7 @@
 
     [self.syncMOC performGroupedBlockAndWait:^{
         // given
-        [self saveNewVersion];
+        [self updateLastSavedVersion:@"41.41"];
         userClient = [self createSelfClient];
         XCTAssertFalse(userClient.needsToUploadSignalingKeys);
         XCTAssertFalse([userClient hasLocalModificationsForKey:@"needsToUploadSignalingKeys"]);
@@ -393,7 +398,7 @@
 
     [self.syncMOC performGroupedBlockAndWait:^{
         // given
-        [self saveNewVersion];
+        [self updateLastSavedVersion:@"41.10"];
         ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
         conversation.conversationType = ZMConversationTypeOneOnOne;
         conversation.remoteIdentifier = NSUUID.createUUID;
@@ -523,7 +528,7 @@
     NSURL *directoryNotBeDeleted = [cachesDirectory URLByAppendingPathComponent:@"dontDeleteMe" isDirectory:YES];
 
     [self.syncMOC performGroupedBlockAndWait:^{
-        [self saveNewVersion];
+        [self updateLastSavedVersion:@"60.0.0"];
         // Create expected PINCache folders
         for (NSString *cache in PINCaches) {
             NSURL *cacheURL = [cachesDirectory URLByAppendingPathComponent:cache isDirectory:YES];
@@ -574,7 +579,7 @@
 
     [self.syncMOC performGroupedBlockAndWait:^{
         // given
-        [self saveNewVersion];
+        [self updateLastSavedVersion:@"62.41"];
         connectedUser = [ZMUser insertNewObjectInManagedObjectContext:self.syncMOC];
         connectedUser.connection = [ZMConnection insertNewObjectInManagedObjectContext:self.syncMOC];
         connectedUser.connection.status = ZMConnectionStatusAccepted;
@@ -626,7 +631,7 @@
 
     [self.syncMOC performGroupedBlockAndWait:^{
         // given
-        [self saveNewVersion];
+        [self updateLastSavedVersion:@"75.0.0"];
         connectedUser = [ZMUser insertNewObjectInManagedObjectContext:self.syncMOC];
         connectedUser.connection = [ZMConnection insertNewObjectInManagedObjectContext:self.syncMOC];
         connectedUser.connection.status = ZMConnectionStatusAccepted;


### PR DESCRIPTION
## What's new in this PR?

### Issues

It's been observed that the notification stream is fetched unnecessarily during the initial sync. Since this fetch doesn't include the `since` query parameter it will contain "old" events which are a wasted effort to consume.

### Causes

When logging in into an account the user creates a new client, which will cause the backend to send a push notice prompting us to update the `PushNotificationStatus`. This in turn causes the the `ZMMissingUpdateEventsTranscoder` to create a request to fetch notification stream, which will not include the `since` parameter because it is only be persisted after the sync is finished. Doing a `/notifications` request without the `since` parameter will return all events the backend still has stored.

### Solutions

Don't allow fetching the APNS notifications while we are syncing. 

NOTE: the fact that we were previously allowing this forced many strategies to include `.allowsRequestsDuringNotificationStreamFetch` in their configuration otherwise they would get stuck when the scenario described above happens.