### PR TITLE
Notification fetching follow up

### DIFF
--- a/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
@@ -99,7 +99,7 @@ previouslyReceivedEventIDsCollection:(id<PreviouslyReceivedEventIDsCollection>)e
 
 - (BOOL)isFetchingStreamForAPNS
 {
-    return self.pushNotificationStatus.status == BackgroundNotificationFetchStatusInProgress;
+    return self.applicationStatus.notificationFetchStatus == BackgroundNotificationFetchStatusInProgress;
 }
 
 - (BOOL)isFetchingStreamInBackground


### PR DESCRIPTION
## What's new in this PR?

Follow up on https://github.com/wireapp/wire-ios-sync-engine/pull/986

### Issues

We were still performing `/notifications` requests during sync

### Causes

`isFetchingStreamForAPNS` was not using the `notificationFetchStatus` logic.

### Solutions

Query the application status for the `notificationFetchStatus`