### PR TITLE
Add show user profile method to ShowContentDelegate

### DIFF
--- a/Source/SessionManager/SessionManager+Push.swift
+++ b/Source/SessionManager/SessionManager+Push.swift
@@ -191,17 +191,22 @@ extension SessionManager: PKPushRegistryDelegate {
 
 @objc
 public protocol ShowContentDelegate: class {
-    
     func showConversation(_ conversation: ZMConversation, at message: ZMConversationMessage?)
     func showConversationList()
-    
+    func showUserProfile(user: UserType)
 }
 
 extension SessionManager {
     
-    public func showConversation(_ conversation: ZMConversation, at message: ZMConversationMessage?, in session: ZMUserSession) {
-        activateAccount(for: session) {
-            self.showContentDelegate?.showConversation(conversation, at: message)
+    public func showConversation(_ conversation: ZMConversation,
+                                 at message: ZMConversationMessage? = nil,
+                                 in session: ZMUserSession? = nil) {
+        if let session = session {
+            activateAccount(for: session) {
+                self.showContentDelegate?.showConversation(conversation, at: message)
+            }
+        } else {
+            showContentDelegate?.showConversation(conversation, at: message)
         }
     }
     
@@ -210,5 +215,10 @@ extension SessionManager {
             self.showContentDelegate?.showConversationList()
         }
     }
-    
+
+
+    public func showUserProfile(user: UserType) {
+        self.showContentDelegate?.showUserProfile(user: user)
+    }
+
 }

--- a/Source/SessionManager/SessionManager+Push.swift
+++ b/Source/SessionManager/SessionManager+Push.swift
@@ -200,13 +200,9 @@ extension SessionManager {
     
     public func showConversation(_ conversation: ZMConversation,
                                  at message: ZMConversationMessage? = nil,
-                                 in session: ZMUserSession? = nil) {
-        if let session = session {
-            activateAccount(for: session) {
-                self.showContentDelegate?.showConversation(conversation, at: message)
-            }
-        } else {
-            showContentDelegate?.showConversation(conversation, at: message)
+                                 in session: ZMUserSession) {
+        activateAccount(for: session) {
+            self.showContentDelegate?.showConversation(conversation, at: message)
         }
     }
     

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -77,10 +77,10 @@ public protocol SessionManagerType : class {
     /// - Parameters:
     ///   - conversation: the conversation to switch
     ///   - message: the message to navigate
-    ///   - session: the session of the conversation, provide nil to stay in current session
+    ///   - session: the session of the conversation
     func showConversation(_ conversation: ZMConversation,
                           at message: ZMConversationMessage?,
-                          in session: ZMUserSession?)
+                          in session: ZMUserSession)
     
     /// Switch account and and ask UI to navigate to the conversatio list
     func showConversationList(in session: ZMUserSession)

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -73,10 +73,20 @@ public protocol SessionManagerType : class {
     func configureUserNotifications()
     
     /// Switch account and and ask UI to to navigate to a message in a conversation
-    func showConversation(_ conversation: ZMConversation, at message: ZMConversationMessage?, in session: ZMUserSession)
+    ///
+    /// - Parameters:
+    ///   - conversation: the conversation to switch
+    ///   - message: the message to navigate
+    ///   - session: the session of the conversation, provide nil to stay in current session
+    func showConversation(_ conversation: ZMConversation,
+                          at message: ZMConversationMessage?,
+                          in session: ZMUserSession?)
     
     /// Switch account and and ask UI to navigate to the conversatio list
     func showConversationList(in session: ZMUserSession)
+
+    /// ask UI to open the profile of a user
+    func showUserProfile(user: UserType)
 
     /// Needs to be called before we try to register another device because API requires password
     func update(credentials: ZMCredentials) -> Bool

--- a/Source/SessionManager/SessionManagerURLHandler.swift
+++ b/Source/SessionManager/SessionManagerURLHandler.swift
@@ -208,9 +208,7 @@ public protocol SessionManagerURLHandlerDelegate: class {
     /// - Parameters:
     ///   - action: the action to execute
     ///   - callback: the callback with a bool shouldExecute, it should be called after the action is executed.
-    /// - Returns: return false if the Action is not executed
-    @discardableResult
-    func sessionManagerShouldExecuteURLAction(_ action: URLAction, callback: @escaping (Bool) -> Void) -> Bool
+    func sessionManagerShouldExecuteURLAction(_ action: URLAction, callback: @escaping (Bool) -> Void)
 }
 
 public final class SessionManagerURLHandler: NSObject {
@@ -247,8 +245,7 @@ public final class SessionManagerURLHandler: NSObject {
         return true
     }
 
-    @discardableResult
-    fileprivate func handle(action: URLAction, in userSession: ZMUserSession) -> Bool {
+    fileprivate func handle(action: URLAction, in userSession: ZMUserSession) {
         let callback: (Bool) -> () = { shouldExecute in
             if shouldExecute {
                 action.execute(in: userSession)
@@ -259,11 +256,7 @@ public final class SessionManagerURLHandler: NSObject {
         var mutableAction = action
         mutableAction.setUserSession(userSession: userSession)
 
-        if let result = delegate?.sessionManagerShouldExecuteURLAction(mutableAction, callback: callback) {
-            return result
-        } else {
-            return false
-        }
+        delegate?.sessionManagerShouldExecuteURLAction(mutableAction, callback: callback)
     }
 
     fileprivate func handle(action: URLAction, in unauthenticatedSession: UnauthenticatedSession) {
@@ -276,11 +269,8 @@ public final class SessionManagerURLHandler: NSObject {
     
     public func executePendingAction(userSession: ZMUserSession) {
         if let pendingAction = self.pendingAction {
-
-            ///do not nil pendingAction if handle() return false. The pendingAction will be excuted later.
-            if handle(action: pendingAction, in: userSession) {
-                self.pendingAction = nil
-            }
+            handle(action: pendingAction, in: userSession)
+            self.pendingAction = nil
         }
     }
 }

--- a/Tests/Source/Calling/CallKitDelegateTests.swift
+++ b/Tests/Source/Calling/CallKitDelegateTests.swift
@@ -44,17 +44,22 @@ class MockSessionManager : NSObject, WireSyncEngine.SessionManagerType {
     var lastRequestToShowMessage: (ZMUserSession, ZMConversation, ZMConversationMessage)?
     var lastRequestToShowConversation: (ZMUserSession, ZMConversation)?
     var lastRequestToShowConversationsList: ZMUserSession?
-        
+    var lastRequestToShowUserProfile: UserType?
+
     func showConversation(_ conversation: ZMConversation, at message: ZMConversationMessage?, in session: ZMUserSession) {
-                if let message = message {
-                    lastRequestToShowMessage = (session, conversation, message)
-                } else {
-                    lastRequestToShowConversation = (session, conversation)
-                }
+        if let message = message {
+            lastRequestToShowMessage = (session, conversation, message)
+        } else {
+            lastRequestToShowConversation = (session, conversation)
+        }
     }
     
     func showConversationList(in session: ZMUserSession) {
         lastRequestToShowConversationsList = session
+    }
+
+    func showUserProfile(user: UserType) {
+        lastRequestToShowUserProfile = user
     }
 
     @objc public var updatePushTokenCalled = false

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -1058,8 +1058,6 @@ final class MockSessionManagerURLHandlerDelegate: NSObject, SessionManagerURLHan
 
     func sessionManagerShouldExecuteURLAction(_ action: URLAction, callback: @escaping (Bool) -> Void) {
         callback(action == allowedAction)
-
-        return true
     }
 
 }

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -1056,7 +1056,7 @@ final class MockSessionManagerURLHandlerDelegate: NSObject, SessionManagerURLHan
 
     var allowedAction: URLAction?
 
-    func sessionManagerShouldExecuteURLAction(_ action: URLAction, callback: @escaping (Bool) -> Void) -> Bool {
+    func sessionManagerShouldExecuteURLAction(_ action: URLAction, callback: @escaping (Bool) -> Void) {
         callback(action == allowedAction)
 
         return true

--- a/Tests/Source/SessionManager/SessionManagerURLHandlerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerURLHandlerTests.swift
@@ -36,10 +36,8 @@ final class UserSessionSourceDummy: UserSessionSource {
  
 final class OpenerDelegate: SessionManagerURLHandlerDelegate {
     var calls: [(URLAction, (Bool) -> Void)] = []
-    func sessionManagerShouldExecuteURLAction(_ action: URLAction, callback: @escaping (Bool) -> Void) -> Bool {
+    func sessionManagerShouldExecuteURLAction(_ action: URLAction, callback: @escaping (Bool) -> Void) {
         calls.append((action, callback))
-
-        return true
     }
 }
 


### PR DESCRIPTION
## What's new in this PR?

Add a new `func showUserProfile(user: UserType)` to `ShowContentDelegate`.
~~For `ShowContentDelegate.showConversation` method, change the argument `session` to optional to allow the showConversation in current session.~~
Remove the return of `sessionManagerShouldExecuteURLAction`