### PR TITLE
Fix: When the user/convsersation ID is not found in a user session, change URLAction to warning

### DIFF
--- a/Source/SessionManager/SessionManagerURLHandler.swift
+++ b/Source/SessionManager/SessionManagerURLHandler.swift
@@ -229,26 +229,30 @@ public final class SessionManagerURLHandler: NSObject {
         self.userSessionSource = userSessionSource
     }
     
-    @objc
-    public func openURL(_ url: URL, options: [UIApplication.OpenURLOptionsKey: AnyObject]) {
+    @objc @discardableResult
+    public func openURL(_ url: URL, options: [UIApplication.OpenURLOptionsKey: AnyObject]) -> Bool {
         guard let action = URLAction(url: url) else {
-            return
+            return false
         }
 
         if action.requiresAuthentication {
+
             guard let userSession = userSessionSource?.activeUserSession else {
                 pendingAction = action
-                return
+                return true
             }
 
             handle(action: action, in: userSession)
+
         } else {
             guard let unauthenticatedSession = userSessionSource?.activeUnauthenticatedSession else {
-                return
+                return false
             }
 
             handle(action: action, in: unauthenticatedSession)
         }
+
+        return true
     }
 
     fileprivate func handle(action: URLAction, in userSession: ZMUserSession) {

--- a/Tests/Source/SessionManager/SessionManagerURLHandlerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerURLHandlerTests.swift
@@ -178,6 +178,20 @@ final class SessionManagerURLHandlerTests: MessagingTest {
         XCTAssertEqual(action, URLAction.openUserProfile(id: uuid, user: nil))
     }
 
+    ///TODO: test for invalid session
+    func testThatItChangesTheActionToWarningWhenTheSessionNotFindTheUserID() {
+        // given
+        let uuidString = "fc43d637-6cc2-4d03-9185-2563c73d6ef2"
+        let url = URL(string: "wire://user/\(uuidString)")!
+
+        // when
+        var action = URLAction(url: url)
+        action?.setUserSession(userSession: mockUserSession)
+
+        // then
+        XCTAssertEqual(action, URLAction.warnInvalidDeepLink(error: .invalidUserLink))
+    }
+
     func testThatItDiscardsInvalidOpenUserProfileLink() {
         // given
         let url = URL(string: "wire://user/blahBlah)")!

--- a/Tests/Source/SessionManager/SessionManagerURLHandlerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerURLHandlerTests.swift
@@ -164,6 +164,20 @@ final class SessionManagerURLHandlerTests: MessagingTest {
         XCTAssertEqual(action, URLAction.openConversation(id: uuid, conversation: nil))
     }
 
+    func testThatItChangesTheActionToWarningWhenTheSessionNotFindTheConverationID() {
+        // given
+        let uuidString = "fc43d637-6cc2-4d03-9185-2563c73d6ef2"
+        let url = URL(string: "wire://conversation/\(uuidString)")!
+
+        // when
+        var action = URLAction(url: url)
+        action?.setUserSession(userSession: mockUserSession)
+
+        // then
+        XCTAssertEqual(action, URLAction.warnInvalidDeepLink(error: .invalidConversationLink))
+    }
+
+
     func testThatItParsesOpenUserProfileLink() {
         // given
         let uuidString = "fc43d637-6cc2-4d03-9185-2563c73d6ef2"
@@ -178,7 +192,6 @@ final class SessionManagerURLHandlerTests: MessagingTest {
         XCTAssertEqual(action, URLAction.openUserProfile(id: uuid, user: nil))
     }
 
-    ///TODO: test for invalid session
     func testThatItChangesTheActionToWarningWhenTheSessionNotFindTheUserID() {
         // given
         let uuidString = "fc43d637-6cc2-4d03-9185-2563c73d6ef2"


### PR DESCRIPTION
## What's new in this PR?

Change the URLAction to .warnInvalidDeepLink when the user/convsersation ID is not found in a user session.