### PR TITLE
Lookup user by UUID

### DIFF
--- a/Source/SessionManager/SessionManager+Push.swift
+++ b/Source/SessionManager/SessionManager+Push.swift
@@ -188,13 +188,13 @@ extension SessionManager: PKPushRegistryDelegate {
 
 // MARK: - ShowContentDelegate
 
-
-@objc
 public protocol ShowContentDelegate: class {
     func showConversation(_ conversation: ZMConversation, at message: ZMConversationMessage?)
     func showConversationList()
     func showUserProfile(user: UserType)
+    func showConnectionRequest(userId: UUID)
 }
+
 
 extension SessionManager {
     
@@ -215,6 +215,10 @@ extension SessionManager {
 
     public func showUserProfile(user: UserType) {
         self.showContentDelegate?.showUserProfile(user: user)
+    }
+
+    public func showConnectionRequest(userId: UUID) {
+        self.showContentDelegate?.showConnectionRequest(userId: userId)
     }
 
 }

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -90,6 +90,9 @@ public protocol SessionManagerType : class {
     /// ask UI to open the profile of a user
     func showUserProfile(user: UserType)
 
+    /// ask UI to open the connection request screen
+    func showConnectionRequest(userId: UUID)
+
     /// Needs to be called before we try to register another device because API requires password
     func update(credentials: ZMCredentials) -> Bool
     

--- a/Source/SessionManager/SessionManagerURLHandler.swift
+++ b/Source/SessionManager/SessionManagerURLHandler.swift
@@ -28,6 +28,9 @@ public enum URLAction: Equatable {
 
     case openConversation(id: UUID, conversation: ZMConversation?)
     case openUserProfile(id: UUID, user: ZMUser?)
+
+    // The user id from an unconnected user (The UI has to search for this user id)
+    case connectToUser(id: UUID)
     case warnInvalidDeepLink(error: DeepLinkRequestError)
 
 
@@ -41,12 +44,11 @@ public enum URLAction: Equatable {
 
         switch self {
         case .openUserProfile(let id, _):
-            guard let user = ZMUser.init(remoteID: id, createIfNeeded: false, in: moc) else {
-                self = .warnInvalidDeepLink(error: .invalidUserLink)
-                return
+            if let user = ZMUser.init(remoteID: id, createIfNeeded: false, in: moc) {
+                self = .openUserProfile(id: id, user: user)
+            } else {
+                self = .connectToUser(id: id)
             }
-
-            self = .openUserProfile(id: id, user: user)
         case .openConversation(let id, _):
             guard let conversation = ZMConversation(remoteID: id, createIfNeeded: false, in: moc) else {
                 self = .warnInvalidDeepLink(error: .invalidConversationLink)

--- a/Source/UserSession/Search/SearchDirectory.swift
+++ b/Source/UserSession/Search/SearchDirectory.swift
@@ -48,7 +48,7 @@ import Foundation
     }
     
     /// Lookup a user by user Id and returns a search user in the directory results. If the user doesn't exists
-    /// or isn't available in public directory a empty directory result is returned.
+    /// an empty directory result is returned.
     ///
     /// Returns a SearchTask which should be retained until the results arrive.
     public func lookup(userId: UUID) -> SearchTask {

--- a/Source/UserSession/Search/SearchDirectory.swift
+++ b/Source/UserSession/Search/SearchDirectory.swift
@@ -38,7 +38,20 @@ import Foundation
     ///
     /// Returns a SearchTask which should be retained until the results arrive.
     public func perform(_ request: SearchRequest) -> SearchTask {
-        let task = SearchTask(request: request, context: searchContext, session: userSession)
+        let task = SearchTask(task: .search(searchRequest: request), context: searchContext, session: userSession)
+        
+        task.onResult { [weak self] (result, _) in
+            self?.observeSearchUsers(result)
+        }
+        
+        return task
+    }
+    
+    /// Lookup user by user Id
+    ///
+    /// Returns a SearchTask which should be retained until the results arrive.
+    public func lookup(userId: UUID) -> SearchTask {
+        let task = SearchTask(task: .lookup(userId: userId), context: searchContext, session: userSession)
         
         task.onResult { [weak self] (result, _) in
             self?.observeSearchUsers(result)

--- a/Source/UserSession/Search/SearchDirectory.swift
+++ b/Source/UserSession/Search/SearchDirectory.swift
@@ -47,7 +47,8 @@ import Foundation
         return task
     }
     
-    /// Lookup user by user Id
+    /// Lookup a user by user Id and returns a search user in the directory results. If the user doesn't exists
+    /// or isn't available in public directory a empty directory result is returned.
     ///
     /// Returns a SearchTask which should be retained until the results arrive.
     public func lookup(userId: UUID) -> SearchTask {

--- a/Source/UserSession/Search/SearchResult.swift
+++ b/Source/UserSession/Search/SearchResult.swift
@@ -69,6 +69,20 @@ extension SearchResult {
         services = searchUsersServices
     }
     
+    public init?(userLookupPayload: [AnyHashable : Any], userSession: ZMUserSession) {
+        guard let userLookupPayload = userLookupPayload as? [String : Any],
+              let searchUser = ZMSearchUser.searchUser(from: userLookupPayload, contextProvider: userSession) else {
+            return nil
+        }
+        
+        contacts = []
+        teamMembers = []
+        addressBook = []
+        directory = [searchUser]
+        conversations = []
+        services = []
+    }
+    
     func copy(on context: NSManagedObjectContext) -> SearchResult {
         
         let copiedContacts = contacts.compactMap { context.object(with: $0.objectID) as? ZMUser }

--- a/Source/UserSession/Search/SearchTask.swift
+++ b/Source/UserSession/Search/SearchTask.swift
@@ -21,11 +21,17 @@ import WireUtilities
 
 public class SearchTask {
     
+    public enum Task {
+        case search(searchRequest: SearchRequest)
+        case lookup(userId: UUID)
+    }
+    
     public typealias ResultHandler = (_ result: SearchResult, _ isCompleted: Bool) -> Void
  
     fileprivate let session: ZMUserSession
     fileprivate let context: NSManagedObjectContext
-    fileprivate let request: SearchRequest
+    fileprivate let task: Task
+    fileprivate var userLookupTaskIdentifier: ZMTaskIdentifier?
     fileprivate var directoryTaskIdentifier: ZMTaskIdentifier?
     fileprivate var handleTaskIdentifier: ZMTaskIdentifier?
     fileprivate var servicesTaskIdentifier: ZMTaskIdentifier?
@@ -46,8 +52,8 @@ public class SearchTask {
         }
     }
     
-    public init(request: SearchRequest, context: NSManagedObjectContext, session: ZMUserSession) {
-        self.request = request
+    public init(task: Task, context: NSManagedObjectContext, session: ZMUserSession) {
+        self.task = task
         self.session = session
         self.context = context
     }
@@ -61,6 +67,7 @@ public class SearchTask {
     public func cancel() {
         resultHandlers.removeAll()
         
+        userLookupTaskIdentifier.flatMap(session.transportSession.cancelTask)
         directoryTaskIdentifier.flatMap(session.transportSession.cancelTask)
         servicesTaskIdentifier.flatMap(session.transportSession.cancelTask)
         handleTaskIdentifier.flatMap(session.transportSession.cancelTask)
@@ -75,31 +82,34 @@ public class SearchTask {
         performRemoteSearch()
         performRemoteSearchForTeamUser()
         performRemoteSearchForServices()
+        performUserLookup()
     }
 }
 
 extension SearchTask {
     
     func performLocalSearch() {
+        guard case .search(let request) = task else { return }
+        
         tasksRemaining += 1
         
         context.performGroupedBlock {
             
             var team : Team? = nil
-            if let teamObjectID = self.request.team?.objectID {
+            if let teamObjectID = request.team?.objectID {
                 team = (try? self.context.existingObject(with: teamObjectID)) as? Team
             }
             
-            let connectedUsers = self.request.searchOptions.contains(.contacts) ? self.connectedUsers(matchingQuery: self.request.normalizedQuery) : []
-            let teamMembers = self.request.searchOptions.contains(.teamMembers) ? self.teamMembers(matchingQuery: self.request.normalizedQuery, team: team) : []
-            let conversations = self.request.searchOptions.contains(.conversations) ? self.conversations(matchingQuery: self.request.query) : []
+            let connectedUsers = request.searchOptions.contains(.contacts) ? self.connectedUsers(matchingQuery: request.normalizedQuery) : []
+            let teamMembers = request.searchOptions.contains(.teamMembers) ? self.teamMembers(matchingQuery: request.normalizedQuery, team: team, searchOptions: request.searchOptions) : []
+            let conversations = request.searchOptions.contains(.conversations) ? self.conversations(matchingQuery: request.query) : []
             let result = SearchResult(contacts: connectedUsers, teamMembers: teamMembers, addressBook: [], directory: [], conversations: conversations, services: [])
             
             self.session.managedObjectContext.performGroupedBlock {
                 self.result = self.result.union(withLocalResult: result.copy(on: self.session.managedObjectContext))
                 
-                if self.request.searchOptions.contains(.addressBook) {
-                    self.result = self.result.extendWithContactsFromAddressBook(self.request.normalizedQuery, userSession: self.session)
+                if request.searchOptions.contains(.addressBook) {
+                    self.result = self.result.extendWithContactsFromAddressBook(request.normalizedQuery, userSession: self.session)
                 }
                 
                 self.tasksRemaining -= 1
@@ -107,10 +117,10 @@ extension SearchTask {
         }
     }
     
-    func teamMembers(matchingQuery query : String, team: Team?) -> [Member] {
+    func teamMembers(matchingQuery query : String, team: Team?, searchOptions: SearchOptions) -> [Member] {
         var result =  team?.members(matchingQuery: query) ?? []
         
-        if request.searchOptions.contains(.excludeNonActiveTeamMembers) {
+        if searchOptions.contains(.excludeNonActiveTeamMembers) {
             let activeConversations = ZMUser.selfUser(in: context).activeConversations
             let activeContacts = Set(activeConversations.flatMap({ $0.activeParticipants }))
             let selfUser = ZMUser.selfUser(in: context)
@@ -124,7 +134,7 @@ extension SearchTask {
             })
         }
         
-        if request.searchOptions.contains(.excludeNonActivePartners) {
+        if searchOptions.contains(.excludeNonActivePartners) {
             let query = query.strippingLeadingAtSign()
             let selfUser = ZMUser.selfUser(in: context)
             let activeConversations = ZMUser.selfUser(in: context).activeConversations
@@ -177,13 +187,54 @@ extension SearchTask {
 
 extension SearchTask {
     
-    func performRemoteSearch() {
-        guard request.searchOptions.contains(.directory) else { return }
+    func performUserLookup() {
+        guard case .lookup(let userId) = task else { return }
         
         tasksRemaining += 1
         
         context.performGroupedBlock {
-            let request = type(of: self).searchRequestInDirectory(withQuery: self.request.query)
+            let request  = type(of: self).searchRequestForUser(withUUID: userId)
+            
+            request.add(ZMCompletionHandler(on: self.session.managedObjectContext, block: { [weak self] (response) in
+                defer {
+                    self?.tasksRemaining -= 1
+                }
+                
+                guard
+                    let session = self?.session,
+                    let payload = response.payload?.asDictionary(),
+                    let result = SearchResult(userLookupPayload: payload, userSession: session)
+                    else {
+                        return
+                }
+                
+                if let updatedResult = self?.result.union(withDirectoryResult: result) {
+                    self?.result = updatedResult
+                }
+            }))
+            
+            request.add(ZMTaskCreatedHandler(on: self.context, block: { [weak self] (taskIdentifier) in
+                self?.userLookupTaskIdentifier = taskIdentifier
+            }))
+        }
+        
+    }
+    
+    static func searchRequestForUser(withUUID uuid : UUID) -> ZMTransportRequest {
+        return ZMTransportRequest(getFromPath: "/users/\(uuid.transportString())")
+    }
+    
+}
+
+extension SearchTask {
+    
+    func performRemoteSearch() {
+        guard case .search(let searchRequest) = task, searchRequest.searchOptions.contains(.directory) else { return }
+        
+        tasksRemaining += 1
+        
+        context.performGroupedBlock {
+            let request = type(of: self).searchRequestInDirectory(withQuery: searchRequest.query)
             
             request.add(ZMCompletionHandler(on: self.session.managedObjectContext, block: { [weak self] (response) in
                 
@@ -193,9 +244,8 @@ extension SearchTask {
                 
                 guard
                     let session = self?.session,
-                    let query = self?.request.query,
                     let payload = response.payload?.asDictionary(),
-                    let result = SearchResult(payload: payload, query: query, userSession: session)
+                    let result = SearchResult(payload: payload, query: searchRequest.query, userSession: session)
                 else {
                     return
                 }
@@ -232,12 +282,12 @@ extension SearchTask {
 extension SearchTask {
     
     func performRemoteSearchForTeamUser() {
-        guard request.searchOptions.contains(.directory) else { return }
+        guard case .search(let searchRequest) = task, searchRequest.searchOptions.contains(.directory) else { return }
         
         tasksRemaining += 1
         
         context.performGroupedBlock {
-            let request = type(of: self).searchRequestInDirectory(withHandle: self.request.query)
+            let request = type(of: self).searchRequestInDirectory(withHandle: searchRequest.query)
             
             request.add(ZMCompletionHandler(on: self.session.managedObjectContext, block: { [weak self] (response) in
                 
@@ -247,7 +297,6 @@ extension SearchTask {
                 
                 guard
                     let session = self?.session,
-                    let query = self?.request.query,
                     let payload = response.payload?.asArray(),
                     let userPayload = (payload.first as? ZMTransportData)?.asDictionary()
                     else {
@@ -264,7 +313,7 @@ extension SearchTask {
                 
                 let document = ["handle": handle, "name": name, "id": id]
                 let documentPayload = ["documents": [document]]
-                guard let result = SearchResult(payload: documentPayload, query: query, userSession: session) else {
+                guard let result = SearchResult(payload: documentPayload, query: searchRequest.query, userSession: session) else {
                     return
                 }
                 
@@ -314,7 +363,7 @@ extension SearchTask {
 extension SearchTask {
     
     func performRemoteSearchForServices() {
-        guard request.searchOptions.contains(.services) else { return }
+        guard case .search(let searchRequest) = task, searchRequest.searchOptions.contains(.services) else { return }
         
         tasksRemaining += 1
 
@@ -322,7 +371,7 @@ extension SearchTask {
             let selfUser = ZMUser.selfUser(in: self.context)
             guard let teamIdentifier = selfUser.team?.remoteIdentifier else { return }
 
-            let request = type(of: self).servicesSearchRequest(teamIdentifier: teamIdentifier, query: self.request.query)
+            let request = type(of: self).servicesSearchRequest(teamIdentifier: teamIdentifier, query: searchRequest.query)
             
             request.add(ZMCompletionHandler(on: self.session.managedObjectContext, block: { [weak self] (response) in
                 
@@ -332,9 +381,8 @@ extension SearchTask {
                 
                 guard
                     let session = self?.session,
-                    let query = self?.request.query,
                     let payload = response.payload?.asDictionary(),
-                    let result = SearchResult(servicesPayload: payload, query: query, userSession: session)
+                    let result = SearchResult(servicesPayload: payload, query: searchRequest.query, userSession: session)
                     else {
                         return
                 }

--- a/Source/UserSession/Search/SearchTask.swift
+++ b/Source/UserSession/Search/SearchTask.swift
@@ -52,6 +52,14 @@ public class SearchTask {
         }
     }
     
+    convenience init(request: SearchRequest, context: NSManagedObjectContext, session: ZMUserSession) {
+        self.init(task: .search(searchRequest: request), context: context, session: session)
+    }
+    
+    convenience init(lookupUserId userId: UUID, context: NSManagedObjectContext, session: ZMUserSession) {
+        self.init(task: .lookup(userId: userId), context: context, session: session)
+    }
+    
     public init(task: Task, context: NSManagedObjectContext, session: ZMUserSession) {
         self.task = task
         self.session = session
@@ -216,6 +224,8 @@ extension SearchTask {
             request.add(ZMTaskCreatedHandler(on: self.context, block: { [weak self] (taskIdentifier) in
                 self?.userLookupTaskIdentifier = taskIdentifier
             }))
+            
+            self.session.transportSession.enqueueOneTime(request)
         }
         
     }

--- a/Tests/Source/Calling/CallKitDelegateTests.swift
+++ b/Tests/Source/Calling/CallKitDelegateTests.swift
@@ -45,6 +45,7 @@ class MockSessionManager : NSObject, WireSyncEngine.SessionManagerType {
     var lastRequestToShowConversation: (ZMUserSession, ZMConversation)?
     var lastRequestToShowConversationsList: ZMUserSession?
     var lastRequestToShowUserProfile: UserType?
+    var lastRequestToShowConnectionRequest: UUID?
 
     func showConversation(_ conversation: ZMConversation, at message: ZMConversationMessage?, in session: ZMUserSession) {
         if let message = message {
@@ -61,6 +62,11 @@ class MockSessionManager : NSObject, WireSyncEngine.SessionManagerType {
     func showUserProfile(user: UserType) {
         lastRequestToShowUserProfile = user
     }
+
+    func showConnectionRequest(userId: UUID) {
+        lastRequestToShowConnectionRequest = userId
+    }
+
 
     @objc public var updatePushTokenCalled = false
     func updatePushToken(for session: ZMUserSession) {

--- a/Tests/Source/SessionManager/SessionManagerURLHandlerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerURLHandlerTests.swift
@@ -193,17 +193,18 @@ final class SessionManagerURLHandlerTests: MessagingTest {
         XCTAssertEqual(action, URLAction.openUserProfile(id: uuid, user: nil))
     }
 
-    func testThatItChangesTheActionToWarningWhenTheSessionNotFindTheUserID() {
+    func testThatItChangesTheActionToConnectToUserWhenTheSessionNotFindTheUserID() {
         // given
         let uuidString = "fc43d637-6cc2-4d03-9185-2563c73d6ef2"
         let url = URL(string: "wire://user/\(uuidString)")!
+        let uuid = UUID(uuidString: uuidString)!
 
         // when
         var action = URLAction(url: url)
         action?.setUserSession(userSession: mockUserSession)
 
         // then
-        XCTAssertEqual(action, URLAction.warnInvalidDeepLink(error: .invalidUserLink))
+        XCTAssertEqual(action, URLAction.connectToUser(id: uuid))
     }
 
     func testThatItDiscardsInvalidOpenUserProfileLink() {


### PR DESCRIPTION
## What's new in this PR?

Add `lookup(userId: UUID) -> SearchTask` to the `SearchDirectory`. This method fetches a user by UUID and returns the results in the form of a `SearchUser`.