### PR TITLE
Fix/zios 11316 cannot open a non connected user profile with deep link

### DIFF
--- a/Source/SessionManager/SessionManagerURLHandler.swift
+++ b/Source/SessionManager/SessionManagerURLHandler.swift
@@ -44,7 +44,6 @@ public enum URLAction: Equatable {
 
         switch self {
         case .openUserProfile(let id, _):
-
             if let user = ZMUser.init(remoteID: id, createIfNeeded: false, in: moc) {
                 self = .openUserProfile(id: id, user: user)
             } else {
@@ -52,7 +51,6 @@ public enum URLAction: Equatable {
                 self = .connectToUser(id: id, searchTask: task)
             }
 
-            return
         case .openConversation(let id, _):
             guard let conversation = ZMConversation(remoteID: id, createIfNeeded: false, in: moc) else {
                 self = .warnInvalidDeepLink(error: .invalidConversationLink)

--- a/Source/SessionManager/SessionManagerURLHandler.swift
+++ b/Source/SessionManager/SessionManagerURLHandler.swift
@@ -29,7 +29,7 @@ public enum URLAction: Equatable {
     case openConversation(id: UUID, conversation: ZMConversation?)
     case openUserProfile(id: UUID, user: ZMUser?)
 
-    case connectToUser(id: UUID)///TODO: a task?
+    case connectToUser(id: UUID, searchTask: SearchTask)
     case warnInvalidDeepLink(error: DeepLinkRequestError)
 
 
@@ -44,12 +44,15 @@ public enum URLAction: Equatable {
 
         switch self {
         case .openUserProfile(let id, _):
-            guard let user = ZMUser.init(remoteID: id, createIfNeeded: false, in: moc) else {
-                self = .warnInvalidDeepLink(error: .invalidUserLink)
-                return
+
+            if let user = ZMUser.init(remoteID: id, createIfNeeded: false, in: moc) {
+                self = .openUserProfile(id: id, user: user)
+            } else {
+                let task = searchDirectory.lookup(userId: id)
+                self = .connectToUser(id: id, searchTask: task)
             }
 
-            self = .openUserProfile(id: id, user: user)
+            return
         case .openConversation(let id, _):
             guard let conversation = ZMConversation(remoteID: id, createIfNeeded: false, in: moc) else {
                 self = .warnInvalidDeepLink(error: .invalidConversationLink)

--- a/Source/UserSession/Search/SearchTask.swift
+++ b/Source/UserSession/Search/SearchTask.swift
@@ -19,7 +19,7 @@
 import Foundation
 import WireUtilities
 
-public class SearchTask {
+final public class SearchTask {
     
     public enum Task {
         case search(searchRequest: SearchRequest)
@@ -91,6 +91,17 @@ public class SearchTask {
         performRemoteSearchForTeamUser()
         performRemoteSearchForServices()
         performUserLookup()
+    }
+}
+
+extension SearchTask: Equatable {
+    public static func == (lhs: SearchTask, rhs: SearchTask) -> Bool {
+        return lhs.session == rhs.session &&
+            lhs.userLookupTaskIdentifier == rhs.userLookupTaskIdentifier &&
+            lhs.directoryTaskIdentifier == rhs.directoryTaskIdentifier &&
+            lhs.handleTaskIdentifier == rhs.handleTaskIdentifier &&
+            lhs.servicesTaskIdentifier == rhs.servicesTaskIdentifier &&
+            lhs.context == rhs.context
     }
 }
 


### PR DESCRIPTION
## What's new in this PR?

Create a new enum value `.connectToUser(id: UUID, searchTask: SearchTask)` when the user opens a deep link with a user id of an unconnected user.