### PR TITLE
add new enums and protocol methods

### DIFF
--- a/Source/SessionManager/SessionManager+Push.swift
+++ b/Source/SessionManager/SessionManager+Push.swift
@@ -188,13 +188,13 @@ extension SessionManager: PKPushRegistryDelegate {
 
 // MARK: - ShowContentDelegate
 
-
-@objc
 public protocol ShowContentDelegate: class {
     func showConversation(_ conversation: ZMConversation, at message: ZMConversationMessage?)
     func showConversationList()
     func showUserProfile(user: UserType)
+    func showConnectionRequest(userId: UUID)
 }
+
 
 extension SessionManager {
     
@@ -215,6 +215,10 @@ extension SessionManager {
 
     public func showUserProfile(user: UserType) {
         self.showContentDelegate?.showUserProfile(user: user)
+    }
+
+    public func showConnectionRequest(userId: UUID) {
+        self.showContentDelegate?.showConnectionRequest(userId: userId)
     }
 
 }

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -90,6 +90,9 @@ public protocol SessionManagerType : class {
     /// ask UI to open the profile of a user
     func showUserProfile(user: UserType)
 
+    /// ask UI to open the connection request screen
+    func showConnectionRequest(userId: UUID)
+
     /// Needs to be called before we try to register another device because API requires password
     func update(credentials: ZMCredentials) -> Bool
     

--- a/Source/SessionManager/SessionManagerURLHandler.swift
+++ b/Source/SessionManager/SessionManagerURLHandler.swift
@@ -28,6 +28,9 @@ public enum URLAction: Equatable {
 
     case openConversation(id: UUID, conversation: ZMConversation?)
     case openUserProfile(id: UUID, user: ZMUser?)
+
+    // The user id from an unconnected user (The UI has to search for this user id)
+    case connectToUser(id: UUID)
     case warnInvalidDeepLink(error: DeepLinkRequestError)
 
 
@@ -41,12 +44,11 @@ public enum URLAction: Equatable {
 
         switch self {
         case .openUserProfile(let id, _):
-            guard let user = ZMUser.init(remoteID: id, createIfNeeded: false, in: moc) else {
-                self = .warnInvalidDeepLink(error: .invalidUserLink)
-                return
+            if let user = ZMUser.init(remoteID: id, createIfNeeded: false, in: moc) {
+                self = .openUserProfile(id: id, user: user)
+            } else {
+                self = .connectToUser(id: id)
             }
-
-            self = .openUserProfile(id: id, user: user)
         case .openConversation(let id, _):
             guard let conversation = ZMConversation(remoteID: id, createIfNeeded: false, in: moc) else {
                 self = .warnInvalidDeepLink(error: .invalidConversationLink)

--- a/Tests/Source/Calling/CallKitDelegateTests.swift
+++ b/Tests/Source/Calling/CallKitDelegateTests.swift
@@ -45,6 +45,7 @@ class MockSessionManager : NSObject, WireSyncEngine.SessionManagerType {
     var lastRequestToShowConversation: (ZMUserSession, ZMConversation)?
     var lastRequestToShowConversationsList: ZMUserSession?
     var lastRequestToShowUserProfile: UserType?
+    var lastRequestToShowConnectionRequest: UUID?
 
     func showConversation(_ conversation: ZMConversation, at message: ZMConversationMessage?, in session: ZMUserSession) {
         if let message = message {
@@ -61,6 +62,11 @@ class MockSessionManager : NSObject, WireSyncEngine.SessionManagerType {
     func showUserProfile(user: UserType) {
         lastRequestToShowUserProfile = user
     }
+
+    func showConnectionRequest(userId: UUID) {
+        lastRequestToShowConnectionRequest = userId
+    }
+
 
     @objc public var updatePushTokenCalled = false
     func updatePushToken(for session: ZMUserSession) {

--- a/Tests/Source/SessionManager/SessionManagerURLHandlerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerURLHandlerTests.swift
@@ -193,17 +193,18 @@ final class SessionManagerURLHandlerTests: MessagingTest {
         XCTAssertEqual(action, URLAction.openUserProfile(id: uuid, user: nil))
     }
 
-    func testThatItChangesTheActionToWarningWhenTheSessionNotFindTheUserID() {
+    func testThatItChangesTheActionToConnectToUserWhenTheSessionNotFindTheUserID() {
         // given
         let uuidString = "fc43d637-6cc2-4d03-9185-2563c73d6ef2"
         let url = URL(string: "wire://user/\(uuidString)")!
+        let uuid = UUID(uuidString: uuidString)!
 
         // when
         var action = URLAction(url: url)
         action?.setUserSession(userSession: mockUserSession)
 
         // then
-        XCTAssertEqual(action, URLAction.warnInvalidDeepLink(error: .invalidUserLink))
+        XCTAssertEqual(action, URLAction.connectToUser(id: uuid))
     }
 
     func testThatItDiscardsInvalidOpenUserProfileLink() {


### PR DESCRIPTION
## What's new in this PR?


Create a new enum value `.connectToUser(id: UUID)` when the user opens a deep link with a user id of an unconnected user.
Update the protocols for the connection request UI actions.