### PR TITLE
Fix initial sync-is-completed state handling

### DIFF
--- a/Source/UserSession/NotificationInContext+UserSession.swift
+++ b/Source/UserSession/NotificationInContext+UserSession.swift
@@ -31,7 +31,7 @@ extension ZMUserSession : NotificationContext { } // Mark ZMUserSession as valid
 
 extension ZMUserSession {
     
-    @objc static func notifyInitialSyncCompleted(context: NSManagedObjectContext) {
+    @objc public static func notifyInitialSyncCompleted(context: NSManagedObjectContext) {
         NotificationInContext(name: initialSyncCompletionNotificationName, context: context.notificationContext).post()
     }
     

--- a/Source/UserSession/SyncStatus.swift
+++ b/Source/UserSession/SyncStatus.swift
@@ -94,6 +94,10 @@ extension Notification.Name {
         return pushChannelEstablishedDate != nil
     }
     
+    public var isSlowSyncing : Bool {
+        return !currentSyncPhase.isOne(of: [.fetchingMissedEvents, .done])
+    }
+    
     public var isSyncing : Bool {
         return currentSyncPhase.isSyncing
     }
@@ -159,7 +163,6 @@ extension SyncStatus {
             
             zmLog.debug("sync complete")
             syncStateDelegate.didFinishQuickSync()
-            ZMUserSession.notifyInitialSyncCompleted(context: managedObjectContext)
         }
         RequestAvailableNotification.notifyNewRequestsAvailable(self)
     }

--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -196,6 +196,7 @@ ZM_EMPTY_ASSERTING_INIT()
             self.transportSession.pushChannel.clientID = self.selfUserClient.remoteIdentifier;
             self.transportSession.networkStateDelegate = self;
             self.mediaManager = mediaManager;
+            self.hasCompletedInitialSync = !self.applicationStatusDirectory.syncStatus.isSlowSyncing;
         }];
 
         _application = application;
@@ -536,6 +537,7 @@ ZM_EMPTY_ASSERTING_INIT()
         ZM_STRONG(self);
         self.hasCompletedInitialSync = YES;
         self.notificationDispatcher.isDisabled = NO;
+        [ZMUserSession notifyInitialSyncCompletedWithContext:self.managedObjectContext];
     }];
 }
 

--- a/Tests/Source/UserSession/SyncStatusTests.swift
+++ b/Tests/Source/UserSession/SyncStatusTests.swift
@@ -20,22 +20,6 @@
 import XCTest
 @testable import WireSyncEngine
 
-class InitialSyncObserver : NSObject, ZMInitialSyncCompletionObserver {
-    
-    var didNotify : Bool = false
-    var initialSyncToken : Any?
-    
-    init(context: NSManagedObjectContext) {
-        super.init()
-        initialSyncToken = ZMUserSession.addInitialSyncCompletionObserver(self, context: context)
-    }
-    
-    func initialSyncCompleted() {
-        didNotify = true
-    }
-}
-
-
 class SyncStatusTests : MessagingTest {
 
     var sut : SyncStatus!
@@ -263,22 +247,6 @@ class SyncStatusTests : MessagingTest {
 
     }
     
-    func testThatItNotifiesObserverThatSyncCompleted(){
-        // given
-        uiMOC.zm_lastNotificationID = UUID.timeBasedUUID() as UUID
-        sut = SyncStatus(managedObjectContext: uiMOC, syncStateDelegate: mockSyncDelegate)
-        
-        let observer = InitialSyncObserver(context: uiMOC)
-        XCTAssertFalse(observer.didNotify)
-
-        // when
-        sut.finishCurrentSyncPhase(phase: .fetchingMissedEvents)
-        XCTAssert(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
-        // then
-        XCTAssertTrue(observer.didNotify)
-    }
-
 }
 
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

The certain elements of the UI (group settings) would be disabled when they shouldn't.

### Causes

The UI elements were waiting for the initial sync to complete which now never happens since we've split up the syncing into slow sync and quick sync.

### Solutions

Set `hasCompletedInitialSync` to `YES` when initialising the `ZMUserSession` if there's no need to perform a slow sync.