### PR TITLE
Re-fetch team users after email field was introduced

### DIFF
--- a/Source/Synchronization/ZMHotFixDirectory.m
+++ b/Source/Synchronization/ZMHotFixDirectory.m
@@ -175,6 +175,13 @@ static NSString* ZMLogTag ZM_UNUSED = @"HotFix";
                      patchCode:^(NSManagedObjectContext *context) {
                          [ZMHotFixDirectory refetchTeamMembers:context];
                      }],
+                    
+                    // We need to refetch the team members after email field was introduced
+                    [ZMHotFixPatch
+                     patchWithVersion:@"249.1.2"
+                     patchCode:^(NSManagedObjectContext *context) {
+                         [ZMHotFixDirectory refetchTeamMembers:context];
+                     }],
                     ];
     });
     return patches;


### PR DESCRIPTION
## What's new in this PR?

Since backend introduced the `email` for team users we need to re-fetch all users in the team.
