### PR TITLE
Fix: typing indicator still visible when user is removed from conversation

### DIFF
--- a/Source/Synchronization/Strategies/TypingStrategy.swift
+++ b/Source/Synchronization/Strategies/TypingStrategy.swift
@@ -232,8 +232,10 @@ extension TypingStrategy : ZMEventConsumer {
             
             if let message = ZMGenericMessage(from: event),
                 message.hasText() || message.hasEdited() || (message.hasEphemeral() && message.ephemeral.hasText())  {
-                processMessageAddEvent(for: user, in: conversation)
+                typing.setIs(false, for: user, in: conversation)
             }
+        } else if event.type == .conversationMemberLeave {
+            typing.setIs(false, for: user, in: conversation)
         }
     }
     
@@ -244,11 +246,6 @@ extension TypingStrategy : ZMEventConsumer {
             typing.setIs(startedTyping, for: user, in: conversation)
         }
     }
-    
-    func processMessageAddEvent(for user: ZMUser, in conversation: ZMConversation) {
-        typing.setIs(false, for: user, in: conversation)
-    }
-    
 }
 
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

If a user that is currently typing gets removed from conversation the typing indicator stays visible.

### Causes

We would only expire the indicator after 60s of inactivity, but ignore the fact that user already left the conversation.

### Solutions

Listen for `member-leave` event and reset the typing status.
