### PR TITLE
Forward call event to notification dispatcher if the conversation is muted

### DIFF
--- a/Source/UserSession/CallStateObserver.swift
+++ b/Source/UserSession/CallStateObserver.swift
@@ -85,8 +85,8 @@ extension CallStateObserver : WireCallCenterCallStateObserver, WireCallCenterMis
             // This will unarchive the conversation when there is an incoming call
             self.updateConversation(conversation, with: callState, timestamp: timestamp)
             
-            // CallKit depends on a fetched conversation
-            let skipCallKit = conversation.needsToBeUpdatedFromBackend
+            // CallKit depends on a fetched conversation & and is not used for muted conversations
+            let skipCallKit = conversation.needsToBeUpdatedFromBackend || conversation.mutedMessageTypesIncludingAvailability != .none
             let notificationStyle = self.userSession?.callNotificationStyle ?? .callKit
             
             if notificationStyle == .pushNotifications || skipCallKit {

--- a/Tests/Source/Calling/CallStateObserverTests.swift
+++ b/Tests/Source/Calling/CallStateObserverTests.swift
@@ -195,6 +195,19 @@ class CallStateObserverTests : MessagingTest {
         XCTAssertEqual(notificationCenter.scheduledRequests.count, 1)
     }
     
+    func testThatIncomingCallsInMutedConversationAreForwardedToTheNotificationDispatcher_whenCallStyleIsCallkit() {
+        // given
+        mockCallNotificationStyle = .callKit
+        conversationUI.mutedMessageTypes = .regular
+        
+        // when
+        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: true, degraded: false), conversation: conversationUI, caller: senderUI, timestamp: nil, previousCallState: nil)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        // then
+        XCTAssertEqual(notificationCenter.scheduledRequests.count, 1)
+    }
+    
     func testIncomingCallsInUnfetchedConversationAreForwaredToTheNotificationDispatcher_whenCallStyleIsPushNotification() {
         // given
         mockCallNotificationStyle = .pushNotifications


### PR DESCRIPTION
## What's new in this PR?

### Issues

If CallKit is enabled you don't receive any notifications for muted conversations.

### Causes

We don't forward call events to the notification dispatcher if we have CallKit enabled.

### Solutions

We should make an exception and forward call events if the conversation is muted.