### PR TITLE
Not showing notification actions when content is hidden

### DIFF
--- a/Source/Notifications/Push notifications/Notification Types/LocalNotificationType+Configuration.swift
+++ b/Source/Notifications/Push notifications/Notification Types/LocalNotificationType+Configuration.swift
@@ -61,6 +61,8 @@ extension LocalNotificationType {
             switch contentType {
             case .audio, .video, .fileUpload, .image, .text, .location:
                 category = PushNotificationCategory.conversationWithLike.addMuteIfNeeded(hasTeam: hasTeam)
+            case .hidden:
+                category = .alert
             default:
                 category = PushNotificationCategory.conversation.addMuteIfNeeded(hasTeam: hasTeam)
             }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When user disables message contents preview in notifications we still allow replying from notification action.

### Causes

We were falling back to a default action list for messages (reply) instead of handling it correctly.

### Solutions

Add a case when content is hidden.

