### PR TITLE
Forwarding only successful responses to AVS

### DIFF
--- a/Source/Synchronization/Strategies/CallingRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/CallingRequestStrategy.swift
@@ -184,9 +184,9 @@ extension CallingRequestStrategy : WireCallCenterTransport {
             let genericMessage = ZMGenericMessage.message(content: ZMCalling.calling(message: dataString))
             
             self.genericMessageStrategy.schedule(message: genericMessage, inConversation: conversation) { (response) in
-                
-                completionHandler(response.httpStatus)
-                
+                if response.httpStatus == 201 {
+                    completionHandler(response.httpStatus)
+                }
             }
         }
     }

--- a/Source/Synchronization/Strategies/CallingRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/CallingRequestStrategy.swift
@@ -74,13 +74,15 @@ extension CallingRequestStrategy : ZMSingleRequestTranscoder {
     public func didReceive(_ response: ZMTransportResponse, forSingleRequest sync: ZMSingleRequestSync) {
         
         zmLog.debug("Received response for \(self): \(response)")
-        var payloadAsString : String? = nil
-        if let payload = response.payload, let data = try? JSONSerialization.data(withJSONObject: payload, options: []) {
-            payloadAsString = String(data: data, encoding: .utf8)
+        if response.httpStatus == 200 {
+            var payloadAsString : String? = nil
+            if let payload = response.payload, let data = try? JSONSerialization.data(withJSONObject: payload, options: []) {
+                payloadAsString = String(data: data, encoding: .utf8)
+            }
+            zmLog.debug("Callback: \(String(describing: self.callConfigCompletion))")
+            self.callConfigCompletion?(payloadAsString, response.httpStatus)
+            self.callConfigCompletion = nil
         }
-        zmLog.debug("Callback: \(String(describing: self.callConfigCompletion))")
-        self.callConfigCompletion?(payloadAsString, response.httpStatus)
-        self.callConfigCompletion = nil
     }
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

When requesting call config we can receive responses that are of no interest for AVS - e.g. clients missing (status code 412). There is no need to forward those, only successful ones are useful.

### Solutions

Filter all responses and forward only those with status code 200.

