### PR TITLE
Fix: allow joining other call when you already have an active call

### DIFF
--- a/Source/Calling/CallKitDelegate.swift
+++ b/Source/Calling/CallKitDelegate.swift
@@ -249,7 +249,7 @@ extension CallKitDelegate {
         }
     }
     
-    func requestEndCall(in conversation: ZMConversation) {
+    func requestEndCall(in conversation: ZMConversation, completion: (()->())? = nil) {
         guard let callUUID = callUUID(for: conversation) else { return }
         
         let action = CXEndCallAction(call: callUUID)
@@ -262,6 +262,7 @@ extension CallKitDelegate {
                 self?.log("Cannot end call: \(error)")
                 conversation.voiceChannel?.leave()
             }
+            completion?()
         }
     }
     

--- a/Source/Calling/VoiceChannel.swift
+++ b/Source/Calling/VoiceChannel.swift
@@ -67,7 +67,7 @@ public protocol CallActions : NSObjectProtocol {
     
     func mute(_ muted: Bool, userSession: ZMUserSession)
     func join(video: Bool, userSession: ZMUserSession) -> Bool
-    func leave(userSession: ZMUserSession)
+    func leave(userSession: ZMUserSession, completion: (() -> ())?)
     func continueByDecreasingConversationSecurity(userSession: ZMUserSession)
     func leaveAndDecreaseConversationSecurity(userSession: ZMUserSession)
 }

--- a/Source/Calling/VoiceChannelV3.swift
+++ b/Source/Calling/VoiceChannelV3.swift
@@ -154,7 +154,7 @@ extension VoiceChannelV3 : CallActions {
                 userSession.callingStrategy.dropPendingCallMessages(for: syncConversation)
             }
         }
-        leave(userSession: userSession)
+        leave(userSession: userSession, completion: nil)
     }
     
     public func join(video: Bool, userSession: ZMUserSession) -> Bool {
@@ -166,11 +166,12 @@ extension VoiceChannelV3 : CallActions {
         }
     }
     
-    public func leave(userSession: ZMUserSession) {
+    public func leave(userSession: ZMUserSession, completion: (() -> ())?) {
         if userSession.callNotificationStyle == .callKit, #available(iOS 10.0, *) {
-            userSession.callKitDelegate?.requestEndCall(in: conversation!)
+            userSession.callKitDelegate?.requestEndCall(in: conversation!, completion: completion)
         } else {
-            return leave()
+            leave()
+            completion?()
         }
     }
     

--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -259,9 +259,10 @@ extension WireCallCenterV3 {
     /// Returns conversations with active calls.
     public func activeCallConversations(in userSession: ZMUserSession) -> [ZMConversation] {
         let conversations = nonIdleCalls.compactMap { (key: UUID, value: CallState) -> ZMConversation? in
-            if value == CallState.established {
+            switch value {
+            case .establishedDataChannel, .established, .answered, .outgoing:
                 return ZMConversation(remoteID: key, createIfNeeded: false, in: userSession.managedObjectContext)
-            } else {
+            default:
                 return nil
             }
         }

--- a/Source/UserSession/ZMUserSession+Actions.swift
+++ b/Source/UserSession/ZMUserSession+Actions.swift
@@ -83,7 +83,7 @@ import Foundation
         let conversation = userInfo.conversation(in: managedObjectContext)
         
         managedObjectContext.perform { 
-            conversation?.voiceChannel?.leave(userSession: self)
+            conversation?.voiceChannel?.leave(userSession: self, completion: nil)
             BackgroundActivityFactory.shared.endBackgroundActivity(activity)
             completionHandler()
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

There are situations when you would want to join another call while there is an ongoing call already. It was not working and after ending the current call you would not be able to join another call.

### Causes

There is a race condition because ending call is asynchronous. We would immediately try to start a call  after finishing the previous one, but this needs to happen in a completion handler.

### Solutions

Add a completion handler to the end call method. Also relaxed a bit what is considered an active call - added all states where CallKit would be involved.
