### PR TITLE
Fix logout not working on non active account

### DIFF
--- a/Source/UnauthenticatedSession/UnauthenticatedSession.swift
+++ b/Source/UnauthenticatedSession/UnauthenticatedSession.swift
@@ -40,6 +40,8 @@ private let log = ZMSLog(tag: "UnauthenticatedSession")
 @objcMembers
 public class UnauthenticatedSession: NSObject {
     
+    /// **accountId** will be set if the unauthenticated session is associated with an existing account
+    public internal(set) var accountId: UUID?
     public let groupQueue: DispatchGroupQueue
     private(set) public var authenticationStatus: ZMAuthenticationStatus!
     public let registrationStatus: RegistrationStatus 


### PR DESCRIPTION
## What's new in this PR?

### Issues

If you get logged out when switching accounts, pressing the log out button doesn't work.

### Causes

We attempt to log out the selected account, according to the account manager, when you press the log out button but that's actually the account you were switching from since the switch never completed.

### Solutions

Expose which account an unauthenticated session is associated with so that the UI can pick the correct account to log out from.