### PR TITLE
Don't attempt to download the blacklist in the tests

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -318,20 +318,22 @@ public protocol ForegroundNotificationResponder: class {
             environment: environment
         )
         
-        self.blacklistVerificator = ZMBlacklistVerificator(checkInterval: blacklistDownloadInterval,
-                                                           version: appVersion,
-                                                           environment: environment,
-                                                           working: nil,
-                                                           application: application,
-                                                           blacklistCallback:
-            { [weak self] (blacklisted) in
-                guard let `self` = self, !self.isAppVersionBlacklisted else { return }
-                
-                if blacklisted {
-                    self.isAppVersionBlacklisted = true
-                    self.delegate?.sessionManagerDidBlacklistCurrentVersion()
-                }
-        })
+        if blacklistDownloadInterval > 0 {
+            self.blacklistVerificator = ZMBlacklistVerificator(checkInterval: blacklistDownloadInterval,
+                                                               version: appVersion,
+                                                               environment: environment,
+                                                               working: nil,
+                                                               application: application,
+                                                               blacklistCallback:
+                { [weak self] (blacklisted) in
+                    guard let `self` = self, !self.isAppVersionBlacklisted else { return }
+                    
+                    if blacklisted {
+                        self.isAppVersionBlacklisted = true
+                        self.delegate?.sessionManagerDidBlacklistCurrentVersion()
+                    }
+            })
+        }
      
         self.memoryWarningObserver = NotificationCenter.default.addObserver(forName: UIApplication.didReceiveMemoryWarningNotification,
                                                                             object: nil,

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -137,7 +137,7 @@ class SessionManagerTests: IntegrationTest {
                               delegate: nil,
                               application: application,
                               environment: sessionManager!.environment,
-                              blacklistDownloadInterval : 60) { sessionManager in
+                              blacklistDownloadInterval : -1) { sessionManager in
                                 
                                 let environment = MockEnvironment()
                                 let reachability = TestReachability()
@@ -199,7 +199,7 @@ class SessionManagerTests: IntegrationTest {
                               delegate: nil,
                               application: application,
                               environment: sessionManager!.environment,
-                              blacklistDownloadInterval : 60) { sessionManager in
+                              blacklistDownloadInterval : -1) { sessionManager in
                                 
                                 let environment = MockEnvironment()
                                 let reachability = TestReachability()
@@ -261,7 +261,7 @@ class SessionManagerTests: IntegrationTest {
                               delegate: nil,
                               application: application,
                               environment: sessionManager!.environment,
-                              blacklistDownloadInterval : 60) { sessionManager in
+                              blacklistDownloadInterval : -1) { sessionManager in
                                 
                                 let environment = MockEnvironment()
                                 let reachability = TestReachability()
@@ -610,7 +610,7 @@ class SessionManagerTests_MultiUserSession: IntegrationTest {
                               delegate: nil,
                               application: application,
                               environment: sessionManager!.environment,
-                              blacklistDownloadInterval : 60) { sessionManager in
+                              blacklistDownloadInterval : -1) { sessionManager in
                                 
                                 let environment = MockEnvironment()
                                 let reachability = TestReachability()
@@ -665,7 +665,7 @@ class SessionManagerTests_MultiUserSession: IntegrationTest {
                        delegate: nil,
                        application: application,
                        environment: sessionManager!.environment,
-                       blacklistDownloadInterval : 60) { sessionManager in
+                       blacklistDownloadInterval : -1) { sessionManager in
                         
                         let environment = MockEnvironment()
                         let reachability = TestReachability()


### PR DESCRIPTION
## What's new in this PR?

### Issues

Tests are unstable because downloading the blacklist fails

### Causes

We are attempting download the production blacklist in the tests which is not guaranteed to always be stable.

### Solutions

Disable the the blacklist downloading if `blacklistDownloadInterval` is `< 0` and pass `-1` in the tests.

## Notes

One could imagine mocking the blacklist in the tests but that requires quite some re-factoring.