### PR TITLE
Fix: When removing a device, no alert dialog is shown after entered a short invalid password

### DIFF
--- a/Source/Synchronization/Strategies/UserClientRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/UserClientRequestStrategy.swift
@@ -250,7 +250,10 @@ public final class UserClientRequestStrategy: ZMObjectSyncStrategy, ZMObjectStra
                 case "client-not-found":
                     errorCode = .clientToDeleteNotFound
                     break
-                case "invalid-credentials", "missing-auth":
+                case "invalid-credentials",
+                     "missing-auth",
+                     // in case the password not matching password format requirement
+                     "bad-request":
                     errorCode = .invalidCredentials
                     break
                 default:


### PR DESCRIPTION
## What's new in this PR?

### Issues

When removing a device, no alert dialog is shown after entered a short invalid password. The spinner never dismisses. 

### Causes

The back-end gives a different error response other than invalid password error.

### Solutions

Treat `"bad-request"` response as invalid password response