### PR TITLE
Add option for deleting account data when authentication is invalidated

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -57,17 +57,17 @@ public protocol UserSessionSource: class {
 /// change the default behaviour.
 
 @objcMembers
-public class SessionManagerConfiguration: NSObject, NSCopying {
+public class SessionManagerConfiguration: NSObject, NSCopying, Codable {
     
     /// If set to true then the session manager will delete account data instead of just asking the user to re-authenticate when the cookie or client gets invalidated.
     ///
     /// The default value of this property is `false`.
-    var deleteAccountOnAuthenticationFailure: Bool
+    public var deleteAccountOnAuthenticationFailure: Bool
     
     /// The `blacklistDownloadInterval` configures at which rate we update the client blacklist
     ///
     /// The default value of this property is `6 hours`
-    var blacklistDownloadInterval: TimeInterval
+    public var blacklistDownloadInterval: TimeInterval
     
     public init(deleteAccountOnAuthentictionFailure: Bool = false,
                 blacklistDownloadInterval: TimeInterval = 6 * 60 * 60) {
@@ -84,6 +84,14 @@ public class SessionManagerConfiguration: NSObject, NSCopying {
     
     public static var defaultConfiguration: SessionManagerConfiguration {
         return SessionManagerConfiguration()
+    }
+    
+    public static func load(from URL: URL) -> SessionManagerConfiguration? {
+        guard let data = try? Data(contentsOf: URL) else { return nil }
+        
+        let decoder = JSONDecoder()
+        
+        return  try? decoder.decode(SessionManagerConfiguration.self, from: data)
     }
 }
 

--- a/Tests/Source/Integration/IntegrationTest.h
+++ b/Tests/Source/Integration/IntegrationTest.h
@@ -34,11 +34,14 @@
 @class SearchDirectory;
 @class PushRegistryMock;
 @class UserNotificationCenterMock;
+@class SessionManagerConfiguration;
+@class MockEnvironment;
 
 @interface IntegrationTest : ZMTBaseTest
 
 @property (nonatomic, null_unspecified) NSUUID *currentUserIdentifier;
 @property (nonatomic, nullable) SessionManager *sessionManager;
+@property (nonatomic, null_unspecified) MockEnvironment *mockEnvironment;
 @property (nonatomic, null_unspecified) MockTransportSession *mockTransportSession;
 @property (nonatomic, readonly, nullable) ZMTransportSession *transportSession;
 @property (nonatomic, nullable) AVSMediaManager *mediaManager;
@@ -50,6 +53,7 @@
 @property (nonatomic, readonly) BOOL useRealKeychain;
 @property (nonatomic, nullable) SearchDirectory *sharedSearchDirectory;
 @property (nonatomic, nullable) UserNotificationCenterMock *notificationCenter;
+@property (nonatomic, readonly, nonnull) SessionManagerConfiguration *sessionManagerConfiguration;
 
 @property (nonatomic, null_unspecified) MockUser *selfUser;
 @property (nonatomic, null_unspecified) MockConversation *selfConversation;

--- a/Tests/Source/Integration/IntegrationTest.m
+++ b/Tests/Source/Integration/IntegrationTest.m
@@ -40,6 +40,7 @@
     [BackgroundActivityFactory.sharedFactory resume];
 
     self.mockMediaManager = [OCMockObject niceMockForClass:AVSMediaManager.class];
+    self.mockEnvironment = [[MockEnvironment alloc] init];
  
     self.currentUserIdentifier = [NSUUID createUUID];
     [self _setUp];
@@ -52,11 +53,17 @@
     [self.mockMediaManager stopMocking];
     self.mockMediaManager = nil;
     self.currentUserIdentifier = nil;
+    self.mockEnvironment = nil;
     
     WaitForAllGroupsToBeEmpty(0.5);
     [NSFileManager.defaultManager removeItemAtURL:[MockUserClient mockEncryptionSessionDirectory] error:nil];
     
     [super tearDown];
+}
+
+
+- (SessionManagerConfiguration *)sessionManagerConfiguration {
+    return [SessionManagerConfiguration defaultConfiguration];
 }
 
 - (BOOL)useInMemoryStore

--- a/Tests/Source/Integration/IntegrationTest.swift
+++ b/Tests/Source/Integration/IntegrationTest.swift
@@ -119,7 +119,7 @@ extension IntegrationTest {
         application = ApplicationMock()
         notificationCenter = UserNotificationCenterMock()
         mockTransportSession = MockTransportSession(dispatchGroup: self.dispatchGroup)
-        mockTransportSession.cookieStorage = ZMPersistentCookieStorage(forServerName: "ztest.example.com", userIdentifier: currentUserIdentifier)
+        mockTransportSession.cookieStorage = ZMPersistentCookieStorage(forServerName: mockEnvironment.backendURL.host!, userIdentifier: currentUserIdentifier)
         WireCallCenterV3Factory.wireCallCenterClass = WireCallCenterV3IntegrationMock.self
         mockTransportSession.cookieStorage.deleteKeychainItems()
                 
@@ -223,15 +223,14 @@ extension IntegrationTest {
     func createSessionManager() {
         guard let mediaManager = mediaManager, let application = application, let transportSession = transportSession else { return XCTFail() }
         StorageStack.shared.createStorageAsInMemory = useInMemoryStore
-        let environment = MockEnvironment()
         let reachability = TestReachability()
-        let unauthenticatedSessionFactory = MockUnauthenticatedSessionFactory(transportSession: transportSession as! UnauthenticatedTransportSessionProtocol, environment: environment, reachability: reachability)
+        let unauthenticatedSessionFactory = MockUnauthenticatedSessionFactory(transportSession: transportSession as! UnauthenticatedTransportSessionProtocol, environment: mockEnvironment, reachability: reachability)
         let authenticatedSessionFactory = MockAuthenticatedSessionFactory(
             application: application,
             mediaManager: mediaManager,
             flowManager: FlowManagerMock(),
             transportSession: transportSession,
-            environment: environment,
+            environment: mockEnvironment,
             reachability: reachability
         )
 
@@ -244,7 +243,8 @@ extension IntegrationTest {
             application: application,
             pushRegistry: pushRegistry,
             dispatchGroup: self.dispatchGroup,
-            environment: environment
+            environment: mockEnvironment,
+            configuration: sessionManagerConfiguration
         )
         
         sessionManager?.start(launchOptions: [:])


### PR DESCRIPTION
## What's new in this PR?

Add an option for deleting account data when users's authentication is invalidated

### Solutions

I'm introducing `SessionManagerConfiguration` which holds configurable options of the `SessionManager`. This will allow us to add new options in the future without having to change the signature of the `SessionManager` init method.

In this PR I'm adding `deleteAccountOnAuthenticationFailure` which controls if the account data is deleted in addition to the cookie when a user session authentication gets invalidated.

## Notes

While adding tests for the new authentication behaviour I noticed that the integration tests where using two separate cookie storages: `ztest.example.com` and `example.com`.  I fixed this by always creating the cookie storage from the `MockEnvironment`.