### PR TITLE
Jailbreak detection

### DIFF
--- a/Source/SessionManager/JailbreakDetector.swift
+++ b/Source/SessionManager/JailbreakDetector.swift
@@ -1,0 +1,126 @@
+//
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import UIKit
+import Darwin
+
+public class JailbreakDetector: NSObject {
+    
+    private let fm = FileManager.default
+    
+    @objc public func isJailbroken() -> Bool {
+        return hasJailbrokenFiles ||
+            hasWriteablePaths ||
+            hasSymlinks ||
+            callsFork ||
+            canOpenCydia
+    }
+    
+    private var hasJailbrokenFiles: Bool {
+        let paths: [String] = [
+            "/private/var/stash",
+            "/private/var/lib/apt",
+            "/private/var/tmp/cydia.log",
+            "/private/var/lib/cydia",
+            "/private/var/mobile/Library/SBSettings/Themes",
+            "/Library/MobileSubstrate/MobileSubstrate.dylib",
+            "/Library/MobileSubstrate/DynamicLibraries/Veency.plist",
+            "/Library/MobileSubstrate/DynamicLibraries/LiveClock.plist",
+            "/System/Library/LaunchDaemons/com.ikey.bbot.plist",
+            "/System/Library/LaunchDaemons/com.saurik.Cydia.Startup.plist",
+            "/var/cache/apt",
+            "/var/lib/apt",
+            "/var/lib/cydia",
+            "/var/log/syslog",
+            "/var/tmp/cydia.log",
+            "/bin/bash",
+            "/bin/sh",
+            "/usr/sbin/sshd",
+            "/usr/libexec/ssh-keysign",
+            "/usr/sbin/sshd",
+            "/usr/bin/sshd",
+            "/usr/libexec/sftp-server",
+            "/etc/ssh/sshd_config",
+            "/etc/apt",
+            "/Applications/Cydia.app",
+            "/Applications/RockApp.app",
+            "/Applications/Icy.app",
+            "/Applications/WinterBoard.app",
+            "/Applications/SBSettings.app",
+            "/Applications/MxTube.app",
+            "/Applications/IntelliScreen.app",
+            "/Applications/FakeCarrier.app",
+            "/Applications/blackra1n.app"
+        ]
+        
+        for path in paths {
+            if fm.fileExists(atPath: path) {
+                return true
+            }
+        }
+        
+        return false
+    }
+    
+    private var hasWriteablePaths: Bool {
+        if fm.isWritableFile(atPath: "/") {
+            return true
+        }
+        
+        if fm.isWritableFile(atPath: "/private") {
+            return true
+        }
+        
+        return false
+    }
+    
+    private var hasSymlinks: Bool {
+        let symlinks : [String] = [
+            "/Library/Ringtones",
+            "/Library/Wallpaper",
+            "/usr/arm-apple-darwin9",
+            "/usr/include",
+            "/usr/libexec",
+            "/usr/share",
+            "/Applications"
+        ]
+        
+        for link in symlinks {
+            if fm.fileExists(atPath: link),
+                let attributes = try? fm.attributesOfItem(atPath: link),
+                attributes[.type] as? String == "NSFileTypeSymbolicLink" {
+                return true
+            }
+        }
+        
+        return false
+    }
+    
+    private var callsFork: Bool {
+        let RTLD_DEFAULT = UnsafeMutableRawPointer(bitPattern: -2)
+        let forkPtr = dlsym(RTLD_DEFAULT, "fork")
+        typealias ForkType = @convention(c) () -> Int32
+        let fork = unsafeBitCast(forkPtr, to: ForkType.self)
+        return fork() != -1
+    }
+    
+    private var canOpenCydia: Bool {
+        return UIApplication.shared.canOpenURL(URL(string: "cydia://app")!)
+    }
+    
+}

--- a/Source/SessionManager/JailbreakDetector.swift
+++ b/Source/SessionManager/JailbreakDetector.swift
@@ -19,9 +19,17 @@
 import UIKit
 import Darwin
 
-public class JailbreakDetector: NSObject {
+public protocol JailbreakDetectorProtocol {
+    func isJailbroken() -> Bool
+}
+
+public final class JailbreakDetector: JailbreakDetectorProtocol {
     
     private let fm = FileManager.default
+    
+    public init() {
+        
+    }
     
     @objc public func isJailbroken() -> Bool {
         #if targetEnvironment(simulator)
@@ -127,4 +135,17 @@ public class JailbreakDetector: NSObject {
         return UIApplication.shared.canOpenURL(URL(string: "cydia://app")!)
     }
     
+}
+
+public final class MockJailbreakDetector: JailbreakDetectorProtocol {
+    
+    var jailbroken: Bool = false
+    
+    public init(jailbroken: Bool = false) {
+        self.jailbroken = jailbroken
+    }
+    
+    public func isJailbroken() -> Bool {
+        return jailbroken
+    }
 }

--- a/Source/SessionManager/JailbreakDetector.swift
+++ b/Source/SessionManager/JailbreakDetector.swift
@@ -23,13 +23,9 @@ public protocol JailbreakDetectorProtocol {
     func isJailbroken() -> Bool
 }
 
-public final class JailbreakDetector: JailbreakDetectorProtocol {
+public final class JailbreakDetector: NSObject, JailbreakDetectorProtocol {
     
     private let fm = FileManager.default
-    
-    public init() {
-        
-    }
     
     @objc public func isJailbroken() -> Bool {
         #if targetEnvironment(simulator)

--- a/Source/SessionManager/JailbreakDetector.swift
+++ b/Source/SessionManager/JailbreakDetector.swift
@@ -24,11 +24,15 @@ public class JailbreakDetector: NSObject {
     private let fm = FileManager.default
     
     @objc public func isJailbroken() -> Bool {
+        #if targetEnvironment(simulator)
+        return false
+        #else
         return hasJailbrokenFiles ||
             hasWriteablePaths ||
             hasSymlinks ||
             callsFork ||
             canOpenCydia
+        #endif
     }
     
     private var hasJailbrokenFiles: Bool {

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -44,6 +44,7 @@ public typealias LaunchOptions = [UIApplication.LaunchOptionsKey : Any]
     func sessionManagerWillMigrateAccount(_ account: Account)
     func sessionManagerWillMigrateLegacyAccount()
     func sessionManagerDidBlacklistCurrentVersion()
+    func sessionManagerDidBlacklistJailbrokenDevice()
 }
 
 @objc
@@ -270,6 +271,7 @@ public protocol ForegroundNotificationResponder: class {
     
     let sharedContainerURL: URL
     let dispatchGroup: ZMSDispatchGroup?
+    let jailbreakDetector = JailbreakDetector()
     fileprivate var accountTokens : [UUID : [Any]] = [:]
     fileprivate var memoryWarningObserver: NSObjectProtocol?
     fileprivate var isSelectingAccount : Bool = false
@@ -372,6 +374,10 @@ public protocol ForegroundNotificationResponder: class {
                         self.delegate?.sessionManagerDidBlacklistCurrentVersion()
                     }
             })
+        }
+        
+        if jailbreakDetector.isJailbroken() {
+            self.delegate?.sessionManagerDidBlacklistJailbrokenDevice()
         }
      
         self.memoryWarningObserver = NotificationCenter.default.addObserver(forName: UIApplication.didReceiveMemoryWarningNotification,

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -70,15 +70,31 @@ public class SessionManagerConfiguration: NSObject, NSCopying, Codable {
     /// The default value of this property is `6 hours`
     public var blacklistDownloadInterval: TimeInterval
     
+    /// The `blacklistAccountOnJailbreakDetection` configures if app should lock when the device is jailbroken
+    ///
+    /// The default value of this property is `false`
+    public var blacklistAccountOnJailbreakDetection: Bool
+    
+    /// If set to true then the session manager will delete account data on a jailbroken device.
+    ///
+    /// The default value of this property is `false`
+    public var deleteAccountOnJailbreakDetection: Bool
+    
     public init(deleteAccountOnAuthentictionFailure: Bool = false,
-                blacklistDownloadInterval: TimeInterval = 6 * 60 * 60) {
+                blacklistDownloadInterval: TimeInterval = 6 * 60 * 60,
+                blacklistAccountOnJailbreakDetection: Bool = false,
+                deleteAccountOnJailbreakDetection: Bool = false) {
         self.deleteAccountOnAuthenticationFailure = deleteAccountOnAuthentictionFailure
         self.blacklistDownloadInterval = blacklistDownloadInterval
+        self.blacklistAccountOnJailbreakDetection = blacklistAccountOnJailbreakDetection
+        self.deleteAccountOnJailbreakDetection = deleteAccountOnJailbreakDetection
     }
     
     public func copy(with zone: NSZone? = nil) -> Any {
         let copy = SessionManagerConfiguration(deleteAccountOnAuthentictionFailure: deleteAccountOnAuthenticationFailure,
-                                               blacklistDownloadInterval: blacklistDownloadInterval)
+                                               blacklistDownloadInterval: blacklistDownloadInterval,
+                                               blacklistAccountOnJailbreakDetection: blacklistAccountOnJailbreakDetection,
+                                               deleteAccountOnJailbreakDetection: deleteAccountOnJailbreakDetection)
         
         return copy
     }
@@ -376,7 +392,8 @@ public protocol ForegroundNotificationResponder: class {
             })
         }
         
-        if jailbreakDetector.isJailbroken() {
+        if configuration.blacklistAccountOnJailbreakDetection
+            && jailbreakDetector.isJailbroken() {
             self.delegate?.sessionManagerDidBlacklistJailbrokenDevice()
         }
      

--- a/Tests/Source/Integration/IntegrationTest.swift
+++ b/Tests/Source/Integration/IntegrationTest.swift
@@ -628,6 +628,10 @@ extension IntegrationTest : SessionManagerDelegate {
         // no-op
     }
     
+    public func sessionManagerDidBlacklistJailbrokenDevice() {
+        // no-op
+    }
+    
     public func sessionManagerWillOpenAccount(_ account: Account, userSessionCanBeTornDown: @escaping () -> Void) {
         self.userSession = nil
         userSessionCanBeTornDown()

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -307,6 +307,7 @@
 		7C26879D21F7193800570AA9 /* EventProcessingTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C26879C21F7193800570AA9 /* EventProcessingTracker.swift */; };
 		7C419ED821F8D81D00B95770 /* EventProcessingTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C419ED621F8D7EB00B95770 /* EventProcessingTrackerTests.swift */; };
 		7C5482DA225380160055F1AB /* CallReceivedResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C5482D9225380160055F1AB /* CallReceivedResult.swift */; };
+		7C5B94F622DC6BC500A6F8BB /* JailbreakDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C5B94F522DC6BC500A6F8BB /* JailbreakDetector.swift */; };
 		85D8522CF8DE246DDD5BD12C /* MockEntity.m in Sources */ = {isa = PBXBuildFile; fileRef = 85D85AAE7FA09852AB9B0D6A /* MockEntity.m */; };
 		85D85EAFA1CB6E457D14E3B7 /* MockEntity2.m in Sources */ = {isa = PBXBuildFile; fileRef = 85D85C9E7A2AAAE14D4BC2CC /* MockEntity2.m */; };
 		85D85EEDD5DD19FB747ED4A5 /* MockModelObjectContextFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 85D852DA0CD2C94CADB3B6FE /* MockModelObjectContextFactory.m */; };
@@ -897,6 +898,7 @@
 		7C26879C21F7193800570AA9 /* EventProcessingTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventProcessingTracker.swift; sourceTree = "<group>"; };
 		7C419ED621F8D7EB00B95770 /* EventProcessingTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventProcessingTrackerTests.swift; sourceTree = "<group>"; };
 		7C5482D9225380160055F1AB /* CallReceivedResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallReceivedResult.swift; sourceTree = "<group>"; };
+		7C5B94F522DC6BC500A6F8BB /* JailbreakDetector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JailbreakDetector.swift; sourceTree = "<group>"; };
 		85D8502FFC4412F91D0CC1A4 /* ZMOperationLoop.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMOperationLoop.m; sourceTree = "<group>"; };
 		85D85104C6D06FA902E3253C /* ZMSyncStrategyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMSyncStrategyTests.m; sourceTree = "<group>"; };
 		85D85110893896EBA6E879CE /* MockEntity2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MockEntity2.h; sourceTree = "<group>"; };
@@ -2193,6 +2195,7 @@
 		F19F1D361EFBF60A00275E27 /* SessionManager */ = {
 			isa = PBXGroup;
 			children = (
+				7C5B94F522DC6BC500A6F8BB /* JailbreakDetector.swift */,
 				F159F4151F1E4C4C001B7D80 /* LocalStoreProvider.swift */,
 				BF2AD9FF1F41A3DF000980E8 /* SessionFactories.swift */,
 				F19F1D371EFBF61800275E27 /* SessionManager.swift */,
@@ -2817,6 +2820,7 @@
 				54D175211ADE8B18001AA338 /* ZMUserSession+Registration.m in Sources */,
 				549816291A432BC800A7CE2E /* ZMConnectionTranscoder.m in Sources */,
 				54C8A39C1F7536DB004961DF /* ZMOperationLoop+Notifications.swift in Sources */,
+				7C5B94F622DC6BC500A6F8BB /* JailbreakDetector.swift in Sources */,
 				5EC2C58F2137F5EE00C6CE35 /* CallClosedReason.swift in Sources */,
 				BF2ADA021F41A450000980E8 /* BackendEnvironmentProvider+Cookie.swift in Sources */,
 				5EFE9C15212AB138007932A6 /* UnregisteredUser+Payload.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

Draft PR for jailbreak detection with blacklisting.

- [x] Jailbreak detection: using `JailbreakDetector.swift` by calling the public method `isJailbroken()` (true/false)
- [x] Add support for jailbreak detection inside `SessionManager` and add a delegate method to the `SessionManagerDelegate` in order to interact with UI
- [x] Add to the `SessionManagerConfiguration` object and to the configuration file (https://github.com/wireapp/wire-ios-build-configuration/pull/11/files) the two flags `blacklistAccountOnJailbreakDetection` and 
`deleteAccountOnJailbreakDetection`
- [x] Support on UI side: similar to what we're doing right now with blacklisting and `BlacklistViewController` (reuse with different copy?)
- [x] Avoid iOS Simulator to be recognized as jailbroken device