### PR TITLE
Fix: app crash when calling EventProcessingTracker.debugDescription

### DIFF
--- a/Source/Synchronization/EventProcessingTracker.swift
+++ b/Source/Synchronization/EventProcessingTracker.swift
@@ -114,8 +114,11 @@ import WireDataModel
     }
     
     override public var debugDescription: String {
-        let description = "\(persistedAttributes(for: eventName))"
+        let description = isolationQueue.sync {
+            "\(persistedAttributes(for: eventName))"
+        }
         dispatchEvent()
+        
         return description
     }
 }

--- a/Source/Synchronization/EventProcessingTracker.swift
+++ b/Source/Synchronization/EventProcessingTracker.swift
@@ -117,7 +117,6 @@ import WireDataModel
         let description = isolationQueue.sync {
             "\(persistedAttributes(for: eventName))"
         }
-        dispatchEvent()
         
         return description
     }

--- a/Tests/Source/Synchronization/EventProcessingTrackerTests.swift
+++ b/Tests/Source/Synchronization/EventProcessingTrackerTests.swift
@@ -32,7 +32,18 @@ final class EventProcessingTrackerTests: XCTestCase {
         sut = nil
         super.tearDown()
     }
-    
+
+    func testThatItIncrementCounters_savesPerformed_debugDescription() {
+        //given
+        XCTAssertEqual(sut.debugDescription, "Optional([:])")
+
+        //when
+        sut.registerSavePerformed()
+
+        //then
+        XCTAssertEqual(sut.debugDescription, "Optional([\"event_savesPerformed\": 1])")
+    }
+
     func testThatItIncrementCounters_savesPerformed() {
         //when
         sut.registerSavePerformed()


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crashes when calling `EventProcessingTracker.debugDescription`

### Causes

Getting `eventAttributes` from the queue other than `isolationQueue` may cause an access violation. 

### Solutions

Get `persistedAttributes` from `isolationQueue`.