### PR TITLE
Fix missing CallKit Wire button icon

### DIFF
--- a/Source/Calling/CallKitDelegate.swift
+++ b/Source/Calling/CallKitDelegate.swift
@@ -90,7 +90,7 @@ public class CallKitDelegate : NSObject {
         configuration.supportedHandleTypes = [.generic]
         configuration.ringtoneSound = NotificationSound.call.name
         
-        if let image = UIImage(named: "logo") {
+        if let image = UIImage(named: "wire-logo-letter") {
             configuration.iconTemplateImageData = image.pngData()
         }
         


### PR DESCRIPTION
## What's new in this PR?

### Issues

CallKit button for opening the Wire app was missing its icon.

### Causes

`logo` image doesn't exist anymore

### Solutions

Wire logo has been re-added as `wire-logo-letter`