### PR TITLE
Fix call participants not appearing in group calls

### DIFF
--- a/Source/Calling/AVSCallMember.swift
+++ b/Source/Calling/AVSCallMember.swift
@@ -25,7 +25,7 @@ public struct AVSParticipantsChange: Codable {
         let userid: UUID
         let clientid: String
         let aestab: Int32
-        let vrrecv: Int32
+        let vrecv: Int32
     }
     let convid: UUID
     let members: [Member]
@@ -35,7 +35,7 @@ extension AVSCallMember {
     init(member: AVSParticipantsChange.Member) {
         remoteId = member.userid
         audioEstablished = (member.aestab == 1)
-        videoState = VideoState(rawValue: member.vrrecv) ?? .stopped
+        videoState = VideoState(rawValue: member.vrecv) ?? .stopped
         networkQuality = .normal
     }
 }

--- a/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -849,7 +849,7 @@ extension WireCallCenterV3Tests {
     }
 
     func callBackMemberHandler(conversationId: UUID, userId: UUID, audioEstablished: Bool) {
-        let member = AVSParticipantsChange.Member(userid: userId, clientid: "123", aestab: audioEstablished ? 1 : 0, vrrecv: 0)
+        let member = AVSParticipantsChange.Member(userid: userId, clientid: "123", aestab: audioEstablished ? 1 : 0, vrecv: 0)
         let change = AVSParticipantsChange(convid: conversationId, members: [member])
         
         let encoded = try! JSONEncoder().encode(change)


### PR DESCRIPTION
## What's new in this PR?

### Issues

Call participants don't appear in group calls

### Causes

Since AVS 5.1 the call participants are received as JSON which fails to decode.

### Solutions

Fix call participant JSON decoding by correcting typo: `vrrecv` -> `vrecv`