### PR TITLE
Introduce MediaManagerType for easier mocking of the AVSMediaManager

### DIFF
--- a/Source/Calling/CallKitDelegate.swift
+++ b/Source/Calling/CallKitDelegate.swift
@@ -39,13 +39,13 @@ public class CallKitDelegate : NSObject {
     fileprivate let provider : CXProvider
     fileprivate let callController : CXCallController
     fileprivate unowned let sessionManager : SessionManagerType
-    fileprivate weak var mediaManager: AVSMediaManager?
+    fileprivate weak var mediaManager: MediaManagerType?
     fileprivate var callStateObserverToken : Any?
     fileprivate var missedCallObserverToken : Any?
     fileprivate var connectedCallConversation : ZMConversation?
     fileprivate var calls : [UUID : CallKitCall]
     
-    public convenience init(sessionManager: SessionManagerType, mediaManager: AVSMediaManager?) {
+    public convenience init(sessionManager: SessionManagerType, mediaManager: MediaManagerType?) {
         self.init(provider: CXProvider(configuration: CallKitDelegate.providerConfiguration),
                   callController: CXCallController(queue: DispatchQueue.main),
                   sessionManager: sessionManager,
@@ -55,7 +55,7 @@ public class CallKitDelegate : NSObject {
     public init(provider : CXProvider,
          callController: CXCallController,
          sessionManager: SessionManagerType,
-         mediaManager: AVSMediaManager?) {
+         mediaManager: MediaManagerType?) {
         
         self.provider = provider
         self.callController = callController

--- a/Source/Calling/FlowManager.swift
+++ b/Source/Calling/FlowManager.swift
@@ -29,10 +29,10 @@ public protocol FlowManagerType {
 public class FlowManager : NSObject, FlowManagerType {
     public static let AVSFlowManagerCreatedNotification = Notification.Name("AVSFlowManagerCreatedNotification")
     
-    fileprivate var mediaManager : AVSMediaManager?
+    fileprivate var mediaManager : MediaManagerType?
     fileprivate var avsFlowManager : AVSFlowManager?
 
-    init(mediaManager: AVSMediaManager) {
+    init(mediaManager: MediaManagerType) {
         super.init()
 
         self.mediaManager = mediaManager

--- a/Source/Calling/MediaManager.swift
+++ b/Source/Calling/MediaManager.swift
@@ -1,0 +1,31 @@
+//
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import avs
+
+public protocol MediaManagerType: class {
+ 
+    func setUiStartsAudio(_ enabled: Bool)
+    func startAudio()
+    func setupAudioDevice()
+    func resetAudioDevice()
+    
+}
+
+extension AVSMediaManager: MediaManagerType { }

--- a/Source/Public/ZMUserSession.h
+++ b/Source/Public/ZMUserSession.h
@@ -32,10 +32,10 @@
 @class ZMProxyRequest;
 @class CallKitDelegate;
 @class CallingRequestStrategy;
-@class AVSMediaManager;
 @class WireCallCenterV3;
 @class SessionManager;
 
+@protocol MediaManagerType;
 @protocol UserProfile;
 @protocol AnalyticsType;
 @protocol ZMNetworkAvailabilityObserver;
@@ -67,7 +67,7 @@ extern NSString * const ZMUserSessionResetPushTokensNotificationName;
  @param appVersion: The application version (build number)
  @param storeProvider: An object conforming to the @c LocalStoreProviderProtocol that provides information about local store locations etc.
 */
-- (instancetype)initWithMediaManager:(AVSMediaManager *)mediaManager
+- (instancetype)initWithMediaManager:(id<MediaManagerType>)mediaManager
                          flowManager:(id<FlowManagerType>)flowManager
                            analytics:(id<AnalyticsType>)analytics
                     transportSession:(ZMTransportSession *)transportSession

--- a/Source/SessionManager/SessionFactories.swift
+++ b/Source/SessionManager/SessionFactories.swift
@@ -23,7 +23,7 @@ import avs
 open class AuthenticatedSessionFactory {
 
     let appVersion: String
-    let mediaManager: AVSMediaManager
+    let mediaManager: MediaManagerType
     let flowManager : FlowManagerType
     var analytics: AnalyticsType?
     let application : ZMApplication
@@ -33,7 +33,7 @@ open class AuthenticatedSessionFactory {
     public init(
         appVersion: String,
         application: ZMApplication,
-        mediaManager: AVSMediaManager,
+        mediaManager: MediaManagerType,
         flowManager: FlowManagerType,
         environment: BackendEnvironmentProvider,
         reachability: ReachabilityProvider & TearDownCapable,

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -310,7 +310,7 @@ public protocol ForegroundNotificationResponder: class {
     ///
     public static func create(
         appVersion: String,
-        mediaManager: AVSMediaManager,
+        mediaManager: MediaManagerType,
         analytics: AnalyticsType?,
         delegate: SessionManagerDelegate?,
         application: ZMApplication,
@@ -340,7 +340,7 @@ public protocol ForegroundNotificationResponder: class {
     
     private convenience init(
         appVersion: String,
-        mediaManager: AVSMediaManager,
+        mediaManager: MediaManagerType,
         analytics: AnalyticsType?,
         delegate: SessionManagerDelegate?,
         application: ZMApplication,

--- a/Source/Synchronization/ZMOperationLoop.h
+++ b/Source/Synchronization/ZMOperationLoop.h
@@ -19,7 +19,6 @@
 
 @class ZMTransportSession;
 @class LocalNotificationDispatcher;
-@class AVSMediaManager;
 
 @protocol ZMSyncStateDelegate;
 @protocol ZMApplication;

--- a/Source/Synchronization/ZMSyncStrategy.h
+++ b/Source/Synchronization/ZMSyncStrategy.h
@@ -36,7 +36,6 @@
 @class BackgroundAPNSPingBackStatus;
 @class ZMAccountStatus;
 @class ApplicationStatusDirectory;
-@class AVSMediaManager;
 @class CallingRequestStrategy;
 @class EventDecoder;
 

--- a/Source/UserSession/ZMUserSession+Internal.h
+++ b/Source/UserSession/ZMUserSession+Internal.h
@@ -34,10 +34,9 @@
 @class ZMPushRegistrant;
 @class UserProfileUpdateStatus;
 @class ClientUpdateStatus;
-@class AVSFlowManager;
 @class CallKitDelegate;
-@class AVSMediaManager;
 
+@protocol MediaManagerType; 
 @protocol FlowManagerType;
 
 
@@ -78,7 +77,7 @@
 + (NSString *)databaseIdentifier;
 
 - (instancetype)initWithTransportSession:(ZMTransportSession *)session
-                            mediaManager:(AVSMediaManager *)mediaManager
+                            mediaManager:(id<MediaManagerType>)mediaManager
                              flowManager:(id<FlowManagerType>)flowManager
                                analytics:(id<AnalyticsType>)analytics
                            operationLoop:(ZMOperationLoop *)operationLoop

--- a/Source/UserSession/ZMUserSession+Private.h
+++ b/Source/UserSession/ZMUserSession+Private.h
@@ -27,7 +27,8 @@
 @class AccountStatus;
 @class ApplicationStatusDirectory;
 @class UserExpirationObserver;
-@class AVSMediaManager;
+
+@protocol MediaManagerType;
 
 #import "ZMUserSession.h"
 
@@ -56,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable) ManagedObjectContextChangeObserver *messageReplyObserver;
 @property (nonatomic, nullable) ManagedObjectContextChangeObserver *likeMesssageObserver;
 @property (nonatomic, nonnull)  UserExpirationObserver *userExpirationObserver;
-@property (nonatomic, readonly) AVSMediaManager *mediaManager;
+@property (nonatomic, readonly) id<MediaManagerType> mediaManager;
 
 - (void)tearDown;
 

--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -69,7 +69,7 @@ static NSString * const AppstoreURL = @"https://itunes.apple.com/us/app/zeta-cli
 /// map from NSUUID to ZMCommonContactsSearchCachedEntry
 @property (nonatomic) NSCache *commonContactsCache;
 
-@property (nonatomic) AVSMediaManager* mediaManager;
+@property (nonatomic) id<MediaManagerType> mediaManager;
 @property (nonatomic) id<FlowManagerType> flowManager;
 @end
 
@@ -88,7 +88,7 @@ ZM_EMPTY_ASSERTING_INIT()
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (instancetype)initWithMediaManager:(AVSMediaManager *)mediaManager
+- (instancetype)initWithMediaManager:(id<MediaManagerType>)mediaManager
                         flowManager:(id<FlowManagerType>)flowManager
                            analytics:(id<AnalyticsType>)analytics
                     transportSession:(ZMTransportSession *)transportSession
@@ -127,7 +127,7 @@ ZM_EMPTY_ASSERTING_INIT()
 }
 
 - (instancetype)initWithTransportSession:(ZMTransportSession *)session
-                            mediaManager:(AVSMediaManager *)mediaManager
+                            mediaManager:(id<MediaManagerType>)mediaManager
                              flowManager:(id<FlowManagerType>)flowManager
                                analytics:(id<AnalyticsType>)analytics
                            operationLoop:(ZMOperationLoop *)operationLoop

--- a/Tests/Source/Calling/FlowManagerTests.swift
+++ b/Tests/Source/Calling/FlowManagerTests.swift
@@ -31,7 +31,7 @@ class FlowManagerTests : MessagingTest {
         }
 
         // WHEN
-        _ = FlowManager(mediaManager: AVSMediaManager.default())
+        _ = FlowManager(mediaManager: MockMediaManager())
 
         // THEN
         XCTAssertTrue(self.waitForCustomExpectations(withTimeout: 0.5))

--- a/Tests/Source/Calling/MockMediaManager.swift
+++ b/Tests/Source/Calling/MockMediaManager.swift
@@ -1,0 +1,43 @@
+//
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+@objc
+class MockMediaManager: NSObject, MediaManagerType {
+    
+    func setUiStartsAudio(_ enabled: Bool) {
+        // no-op
+    }
+    
+    var didStartAudio: Bool = false
+    func startAudio() {
+        didStartAudio = true
+    }
+    
+    var didSetupAudioDevice = false
+    func setupAudioDevice() {
+        didSetupAudioDevice = true
+    }
+    
+    var didResetAudioDevice = false
+    func resetAudioDevice() {
+        didResetAudioDevice = true
+    }
+    
+}

--- a/Tests/Source/Integration/IntegrationTest.h
+++ b/Tests/Source/Integration/IntegrationTest.h
@@ -25,7 +25,6 @@
 @class MockTransportSession;
 @class ApplicationMock;
 @class ZMUserSession;
-@class AVSMediaManager;
 @class UnauthenticatedSession;
 @class MockUser;
 @class MockTeam;
@@ -37,6 +36,7 @@
 @class SessionManagerConfiguration;
 @class MockJailbreakDetector;
 @class MockEnvironment;
+@class MockMediaManager;
 
 @interface IntegrationTest : ZMTBaseTest
 
@@ -45,7 +45,7 @@
 @property (nonatomic, null_unspecified) MockEnvironment *mockEnvironment;
 @property (nonatomic, null_unspecified) MockTransportSession *mockTransportSession;
 @property (nonatomic, readonly, nullable) ZMTransportSession *transportSession;
-@property (nonatomic, nullable) AVSMediaManager *mediaManager;
+@property (nonatomic, null_unspecified) MockMediaManager *mockMediaManager;
 @property (nonatomic, nullable) ApplicationMock *application;
 @property (nonatomic, nullable) ZMUserSession *userSession;
 @property (nonatomic, null_unspecified) PushRegistryMock *pushRegistry;

--- a/Tests/Source/Integration/IntegrationTest.m
+++ b/Tests/Source/Integration/IntegrationTest.m
@@ -25,13 +25,6 @@
 #import "WireSyncEngine_iOS_Tests-Swift.h"
 #import <WireSyncEngine/WireSyncEngine.h>
 
-@interface IntegrationTest ()
-
-@property (nonatomic, nullable) id mockMediaManager;
-
-@end
-
-
 @implementation IntegrationTest
 
 - (void)setUp {
@@ -39,7 +32,7 @@
     BackgroundActivityFactory.sharedFactory.activityManager = UIApplication.sharedApplication;
     [BackgroundActivityFactory.sharedFactory resume];
 
-    self.mockMediaManager = [OCMockObject niceMockForClass:AVSMediaManager.class];
+    self.mockMediaManager = [[MockMediaManager alloc] init];
     self.mockEnvironment = [[MockEnvironment alloc] init];
  
     self.currentUserIdentifier = [NSUUID createUUID];
@@ -50,7 +43,6 @@
     [self _tearDown];
     BackgroundActivityFactory.sharedFactory.activityManager = nil;
     
-    [self.mockMediaManager stopMocking];
     self.mockMediaManager = nil;
     self.currentUserIdentifier = nil;
     self.mockEnvironment = nil;
@@ -79,11 +71,6 @@
 - (ZMTransportSession *)transportSession
 {
     return (ZMTransportSession *)self.mockTransportSession;
-}
-
-- (AVSMediaManager *)mediaManager
-{
-    return self.mockMediaManager;
 }
 
 @end

--- a/Tests/Source/Integration/IntegrationTest.swift
+++ b/Tests/Source/Integration/IntegrationTest.swift
@@ -60,7 +60,7 @@ final class MockAuthenticatedSessionFactory: AuthenticatedSessionFactory {
 
     let transportSession: ZMTransportSession
 
-    init(application: ZMApplication, mediaManager: AVSMediaManager, flowManager: FlowManagerType, transportSession: ZMTransportSession, environment: BackendEnvironmentProvider, reachability: ReachabilityProvider & TearDownCapable) {
+    init(application: ZMApplication, mediaManager: MediaManagerType, flowManager: FlowManagerType, transportSession: ZMTransportSession, environment: BackendEnvironmentProvider, reachability: ReachabilityProvider & TearDownCapable) {
         self.transportSession = transportSession
         super.init(
             appVersion: "0.0.0",
@@ -225,13 +225,13 @@ extension IntegrationTest {
     
     @objc
     func createSessionManager() {
-        guard let mediaManager = mediaManager, let application = application, let transportSession = transportSession else { return XCTFail() }
+        guard let application = application, let transportSession = transportSession else { return XCTFail() }
         StorageStack.shared.createStorageAsInMemory = useInMemoryStore
         let reachability = TestReachability()
         let unauthenticatedSessionFactory = MockUnauthenticatedSessionFactory(transportSession: transportSession as! UnauthenticatedTransportSessionProtocol, environment: mockEnvironment, reachability: reachability)
         let authenticatedSessionFactory = MockAuthenticatedSessionFactory(
             application: application,
-            mediaManager: mediaManager,
+            mediaManager: mockMediaManager,
             flowManager: FlowManagerMock(),
             transportSession: transportSession,
             environment: mockEnvironment,

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -33,13 +33,13 @@ class SessionManagerTests: IntegrationTest {
     }
     
     func createManager() -> SessionManager? {
-        guard let mediaManager = mediaManager, let application = application, let transportSession = transportSession else { return nil }
+        guard let application = application, let transportSession = transportSession else { return nil }
         let environment = MockEnvironment()
         let reachability = TestReachability()
         let unauthenticatedSessionFactory = MockUnauthenticatedSessionFactory(transportSession: transportSession as! UnauthenticatedTransportSessionProtocol, environment: environment, reachability: reachability)
         let authenticatedSessionFactory = MockAuthenticatedSessionFactory(
             application: application,
-            mediaManager: mediaManager,
+            mediaManager: mockMediaManager,
             flowManager: FlowManagerMock(),
             transportSession: transportSession,
             environment: environment,
@@ -126,7 +126,7 @@ class SessionManagerTests: IntegrationTest {
         let account = self.createAccount()
         sessionManager!.environment.cookieStorage(for: account).authenticationCookieData = NSData.secureRandomData(ofLength: 16)
         
-        guard let mediaManager = mediaManager, let application = application else { return XCTFail() }
+        guard let application = application else { return XCTFail() }
         
         let sessionManagerExpectation = self.expectation(description: "Session manager and session is loaded")
 
@@ -135,7 +135,7 @@ class SessionManagerTests: IntegrationTest {
         var createToken: Any? = nil
         var destroyToken: Any? = nil
         SessionManager.create(appVersion: "0.0.0",
-                              mediaManager: mediaManager,
+                              mediaManager: MockMediaManager(),
                               analytics: nil,
                               delegate: nil,
                               application: application,
@@ -146,7 +146,7 @@ class SessionManagerTests: IntegrationTest {
                                 let reachability = TestReachability()
                                 let authenticatedSessionFactory = MockAuthenticatedSessionFactory(
                                     application: application,
-                                    mediaManager: mediaManager,
+                                    mediaManager: MockMediaManager(),
                                     flowManager: FlowManagerMock(),
                                     transportSession: self.transportSession!,
                                     environment: environment,
@@ -213,7 +213,7 @@ class SessionManagerTests: IntegrationTest {
         let account2 = self.createAccount(with: UUID.create())
         sessionManager!.environment.cookieStorage(for: account2).authenticationCookieData = NSData.secureRandomData(ofLength: 16)
         
-        guard let mediaManager = mediaManager, let application = application else { return XCTFail() }
+        guard let application = application else { return XCTFail() }
         
         let sessionManagerExpectation = self.expectation(description: "Session manager and sessions are loaded")
         
@@ -222,7 +222,7 @@ class SessionManagerTests: IntegrationTest {
         
         var destroyToken: Any? = nil
         SessionManager.create(appVersion: "0.0.0",
-                              mediaManager: mediaManager,
+                              mediaManager: MockMediaManager(),
                               analytics: nil,
                               delegate: nil,
                               application: application,
@@ -233,7 +233,7 @@ class SessionManagerTests: IntegrationTest {
                                 let reachability = TestReachability()
                                 let authenticatedSessionFactory = MockAuthenticatedSessionFactory(
                                     application: application,
-                                    mediaManager: mediaManager,
+                                    mediaManager: MockMediaManager(),
                                     flowManager: FlowManagerMock(),
                                     transportSession: self.transportSession!,
                                     environment: environment,
@@ -273,14 +273,14 @@ class SessionManagerTests: IntegrationTest {
     func testThatJailbrokenDeviceCallsDelegateMethod() {
         
         //GIVEN
-        guard let mediaManager = mediaManager, let application = application else { return XCTFail() }
+        guard let application = application else { return XCTFail() }
         let sessionManagerExpectation = self.expectation(description: "Session manager has detected a jailbroken device")
         let jailbreakDetector = MockJailbreakDetector(jailbroken: true)
         let configuration = SessionManagerConfiguration(blockOnJailbreakOrRoot: true)
         
         //WHEN
         SessionManager.create(appVersion: "0.0.0",
-                              mediaManager: mediaManager,
+                              mediaManager: mockMediaManager,
                               analytics: nil,
                               delegate: self.delegate,
                               application: application,
@@ -767,14 +767,14 @@ class SessionManagerTests_MultiUserSession: IntegrationTest {
         let account = self.createAccount()
         sessionManager!.environment.cookieStorage(for: account).authenticationCookieData = NSData.secureRandomData(ofLength: 16)
         
-        guard let mediaManager = mediaManager, let application = application else { return XCTFail() }
+        guard let application = application else { return XCTFail() }
         
         let sessionManagerExpectation = self.expectation(description: "Session manager and session is loaded")
         
         // WHEN
         var realSessionManager: SessionManager! = nil
         SessionManager.create(appVersion: "0.0.0",
-                              mediaManager: mediaManager,
+                              mediaManager: MockMediaManager(),
                               analytics: nil,
                               delegate: nil,
                               application: application,
@@ -785,7 +785,7 @@ class SessionManagerTests_MultiUserSession: IntegrationTest {
                                 let reachability = TestReachability()
                                 let authenticatedSessionFactory = MockAuthenticatedSessionFactory(
                                     application: application,
-                                    mediaManager: mediaManager,
+                                    mediaManager: MockMediaManager(),
                                     flowManager: FlowManagerMock(),
                                     transportSession: self.transportSession!,
                                     environment: environment,
@@ -822,14 +822,14 @@ class SessionManagerTests_MultiUserSession: IntegrationTest {
         let account = self.createAccount()
         sessionManager!.environment.cookieStorage(for: account).authenticationCookieData = NSData.secureRandomData(ofLength: 16)
         
-        guard let mediaManager = mediaManager, let application = application else { return XCTFail() }
+        guard let application = application else { return XCTFail() }
         
         let sessionManagerExpectation = self.expectation(description: "Session manager and session is loaded")
 
         // WHEN
         var realSessionManager: SessionManager! = nil
         SessionManager.create(appVersion: "0.0.0",
-                       mediaManager: mediaManager,
+                       mediaManager: MockMediaManager(),
                        analytics: nil,
                        delegate: nil,
                        application: application,
@@ -840,7 +840,7 @@ class SessionManagerTests_MultiUserSession: IntegrationTest {
                         let reachability = TestReachability()
                         let authenticatedSessionFactory = MockAuthenticatedSessionFactory(
                             application: application,
-                            mediaManager: mediaManager,
+                            mediaManager: MockMediaManager(),
                             flowManager: FlowManagerMock(),
                             transportSession: self.transportSession!,
                             environment: environment,

--- a/Tests/Source/UserSession/ZMUserSessionTestsBase.m
+++ b/Tests/Source/UserSession/ZMUserSessionTestsBase.m
@@ -171,7 +171,6 @@
     [self.requestAvailableNotification stopMocking];
     self.requestAvailableNotification = nil;
     
-    [self.mediaManager stopMocking];
     self.mediaManager = nil;
     
     self.flowManagerMock = nil;

--- a/Tests/Source/UserSession/ZMUserSessionTestsBase.m
+++ b/Tests/Source/UserSession/ZMUserSessionTestsBase.m
@@ -87,7 +87,7 @@
     [[self.transportSession stub] setNetworkStateDelegate:OCMOCK_ANY];
     
     self.mockSessionManager = [[MockSessionManager alloc] init];
-    self.mediaManager = [OCMockObject niceMockForClass:AVSMediaManager.class];
+    self.mediaManager = [[MockMediaManager alloc] init];
     self.flowManagerMock = [[FlowManagerMock alloc] init];
     self.requestAvailableNotification = [OCMockObject mockForClass:ZMRequestAvailableNotification.class];
     

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -83,6 +83,8 @@
 		166264932166517A00300F45 /* CallEventStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166264922166517A00300F45 /* CallEventStatusTests.swift */; };
 		166A8BF31E015F3B00F5EEEA /* WireCallCenterV3Factory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166A8BF21E015F3B00F5EEEA /* WireCallCenterV3Factory.swift */; };
 		166A8BF91E02C7D500F5EEEA /* ZMHotFix+PendingChanges.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166A8BF81E02C7D500F5EEEA /* ZMHotFix+PendingChanges.swift */; };
+		166D18A4230EBFFA001288CD /* MediaManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166D18A3230EBFFA001288CD /* MediaManager.swift */; };
+		166D18A6230EC418001288CD /* MockMediaManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166D18A5230EC418001288CD /* MockMediaManager.swift */; };
 		1671F9FF1E2FAF50009F3150 /* ZMLocalNotificationForTests_CallState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1671F9FE1E2FAF50009F3150 /* ZMLocalNotificationForTests_CallState.swift */; };
 		1675532C21B16D1E009C9FEA /* ConversationTests+ReceiptMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1675532B21B16D1E009C9FEA /* ConversationTests+ReceiptMode.swift */; };
 		1679D1CD1EF97387007B0DF5 /* ZMUserSessionTestsBase+Calling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1679D1CB1EF9730C007B0DF5 /* ZMUserSessionTestsBase+Calling.swift */; };
@@ -405,9 +407,9 @@
 		EEEA75FB1F8A6142006D1070 /* ZMLocalNotification+Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEEA75F61F8A6140006D1070 /* ZMLocalNotification+Events.swift */; };
 		EEEA75FC1F8A6142006D1070 /* ZMLocalNotification+Calling.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEEA75F71F8A6141006D1070 /* ZMLocalNotification+Calling.swift */; };
 		EEEA75FD1F8A6142006D1070 /* ZMLocalNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEEA75F81F8A6141006D1070 /* ZMLocalNotification.swift */; };
+		EF169DDF22E85BA100B74D4A /* ZMConversationSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF169DDE22E85BA100B74D4A /* ZMConversationSource.swift */; };
 		EF2CB12722D5E58B00350B0A /* TeamImageAssetUpdateStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2CB12622D5E58B00350B0A /* TeamImageAssetUpdateStrategy.swift */; };
 		EF2CB12A22D5E5BF00350B0A /* TeamImageAssetUpdateStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2CB12822D5E5BB00350B0A /* TeamImageAssetUpdateStrategyTests.swift */; };
-		EF169DDF22E85BA100B74D4A /* ZMConversationSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF169DDE22E85BA100B74D4A /* ZMConversationSource.swift */; };
 		EFC8281C1FB343B600E27E21 /* RegistationCredentialVerificationStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFC8281B1FB343B600E27E21 /* RegistationCredentialVerificationStrategy.swift */; };
 		EFC8281E1FB34F9600E27E21 /* EmailVerificationStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFC8281D1FB34F9600E27E21 /* EmailVerificationStrategyTests.swift */; };
 		EFC828221FB356CE00E27E21 /* RegistrationStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFC828211FB356CE00E27E21 /* RegistrationStatusTests.swift */; };
@@ -653,6 +655,8 @@
 		166264922166517A00300F45 /* CallEventStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallEventStatusTests.swift; sourceTree = "<group>"; };
 		166A8BF21E015F3B00F5EEEA /* WireCallCenterV3Factory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WireCallCenterV3Factory.swift; sourceTree = "<group>"; };
 		166A8BF81E02C7D500F5EEEA /* ZMHotFix+PendingChanges.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMHotFix+PendingChanges.swift"; sourceTree = "<group>"; };
+		166D18A3230EBFFA001288CD /* MediaManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaManager.swift; sourceTree = "<group>"; };
+		166D18A5230EC418001288CD /* MockMediaManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMediaManager.swift; sourceTree = "<group>"; };
 		1671F9FE1E2FAF50009F3150 /* ZMLocalNotificationForTests_CallState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMLocalNotificationForTests_CallState.swift; sourceTree = "<group>"; };
 		1675532B21B16D1E009C9FEA /* ConversationTests+ReceiptMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationTests+ReceiptMode.swift"; sourceTree = "<group>"; };
 		1679D1CB1EF9730C007B0DF5 /* ZMUserSessionTestsBase+Calling.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMUserSessionTestsBase+Calling.swift"; sourceTree = "<group>"; };
@@ -1036,9 +1040,9 @@
 		EEEA75F61F8A6140006D1070 /* ZMLocalNotification+Events.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMLocalNotification+Events.swift"; sourceTree = "<group>"; };
 		EEEA75F71F8A6141006D1070 /* ZMLocalNotification+Calling.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMLocalNotification+Calling.swift"; sourceTree = "<group>"; };
 		EEEA75F81F8A6141006D1070 /* ZMLocalNotification.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMLocalNotification.swift; sourceTree = "<group>"; };
+		EF169DDE22E85BA100B74D4A /* ZMConversationSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMConversationSource.swift; sourceTree = "<group>"; };
 		EF2CB12622D5E58B00350B0A /* TeamImageAssetUpdateStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamImageAssetUpdateStrategy.swift; sourceTree = "<group>"; };
 		EF2CB12822D5E5BB00350B0A /* TeamImageAssetUpdateStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamImageAssetUpdateStrategyTests.swift; sourceTree = "<group>"; };
-		EF169DDE22E85BA100B74D4A /* ZMConversationSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMConversationSource.swift; sourceTree = "<group>"; };
 		EF797FE71FB5E8DB00F7FF21 /* RegistrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationTests.swift; sourceTree = "<group>"; };
 		EFC8281B1FB343B600E27E21 /* RegistationCredentialVerificationStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistationCredentialVerificationStrategy.swift; sourceTree = "<group>"; };
 		EFC8281D1FB34F9600E27E21 /* EmailVerificationStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailVerificationStrategyTests.swift; sourceTree = "<group>"; };
@@ -1404,6 +1408,7 @@
 				165D3A3C1E1D60520052E654 /* ZMConversation+VoiceChannel.swift */,
 				16A764601F3E0B0B00564F21 /* CallKitDelegate.swift */,
 				1658C2361F503CF800889F22 /* FlowManager.swift */,
+				166D18A3230EBFFA001288CD /* MediaManager.swift */,
 				BF735CF91E70003D003BC61F /* SystemMessageCallObserver.swift */,
 				165911521DEF38EC007FA847 /* CallStateObserver.swift */,
 				5E8BB89B2147CE1600EEA64B /* AVSCallMember.swift */,
@@ -1440,6 +1445,7 @@
 				F9F846331ED307F10087C1A4 /* CallParticipantsSnapshotTests.swift */,
 				87B30C5B1FA756220054DFB1 /* FlowManagerTests.swift */,
 				5E8BB8A3214912D100EEA64B /* AVSBridgingTests.swift */,
+				166D18A5230EC418001288CD /* MockMediaManager.swift */,
 			);
 			path = Calling;
 			sourceTree = "<group>";
@@ -2749,6 +2755,7 @@
 				16D448F51F1D00C40037285C /* SlowSyncTests+Teams.swift in Sources */,
 				F9ABE8571EFD56BF00D83214 /* TeamDownloadRequestStrategy+EventsTests.swift in Sources */,
 				85D85EAFA1CB6E457D14E3B7 /* MockEntity2.m in Sources */,
+				166D18A6230EC418001288CD /* MockMediaManager.swift in Sources */,
 				09914E531BD6613D00C10BF8 /* ZMDecodedAPSMessageTest.m in Sources */,
 				F9F9F5621D75D62100AE6499 /* RequestStrategyTestBase.swift in Sources */,
 				7C419ED821F8D81D00B95770 /* EventProcessingTrackerTests.swift in Sources */,
@@ -2877,6 +2884,7 @@
 				54D175271ADE9EC9001AA338 /* ZMUserSession+Authentication.m in Sources */,
 				549816351A432BC800A7CE2E /* ZMLoginTranscoder.m in Sources */,
 				5E8BB89C2147CE1600EEA64B /* AVSCallMember.swift in Sources */,
+				166D18A4230EBFFA001288CD /* MediaManager.swift in Sources */,
 				874F142D1C16FD9700C15118 /* Device.swift in Sources */,
 				CEF2DE7F1DB778F300451642 /* RequestLoopAnalyticsTracker.swift in Sources */,
 				F19E55A422B3A740005C792D /* PKPushPayload+SafeLogging.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

Introduce MediaManagerType for easier mocking of the AVSMediaManager

This is done in a effort to remove all usage of OCMock in the integration tests so that we can move them completely to Swift.