### PR TITLE
[Fix] Stop processing the team.conversation-delete event

### DIFF
--- a/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification+Events.swift
+++ b/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification+Events.swift
@@ -31,7 +31,7 @@ extension ZMLocalNotification {
         case .conversationCreate:
             builder = ConversationCreateEventNotificationBuilder(event: event, conversation: conversation, managedObjectContext: moc)
             
-        case .conversationDelete, .teamConversationDelete:
+        case .conversationDelete:
             builder = ConversationDeleteEventNotificationBuilder(event: event, conversation: conversation, managedObjectContext: moc)
             
         case .userConnection:

--- a/Source/Synchronization/Strategies/TeamDownloadRequestStrategy+Events.swift
+++ b/Source/Synchronization/Strategies/TeamDownloadRequestStrategy+Events.swift
@@ -54,7 +54,6 @@ extension TeamDownloadRequestStrategy: ZMEventConsumer {
         case .teamMemberJoin: processAddedMember(with: event)
         case .teamMemberLeave: processRemovedMember(with: event)
         case .teamMemberUpdate: processUpdatedMember(with: event)
-        case .teamConversationDelete: processDeletedTeamConversation(with: event)
         default: break
         }
     }
@@ -113,14 +112,6 @@ extension TeamDownloadRequestStrategy: ZMEventConsumer {
         member.needsToBeUpdatedFromBackend = true
     }
     
-    private func processDeletedTeamConversation(with event: ZMUpdateEvent) {
-        guard let data = event.dataPayload else { return }
-        guard let conversationId = (data[TeamEventPayloadKey.conversation.rawValue] as? String).flatMap(UUID.init) else {return }
-        guard let conversation = ZMConversation(remoteID: conversationId, createIfNeeded: false, in: managedObjectContext) else { return }
-        
-        managedObjectContext.delete(conversation)
-    }
-
     private func deleteTeamAndConversations(_ team: Team) {
         team.conversations.forEach(managedObjectContext.delete)
         managedObjectContext.delete(team)

--- a/Source/Synchronization/Transcoders/ZMConversationTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMConversationTranscoder.m
@@ -358,7 +358,7 @@ static NSString *const ConversationTeamManagedKey = @"managed";
 
 - (void)deleteConversationFromEvent:(ZMUpdateEvent *)event
 {
-    NSUUID *conversationId = [event.payload optionalUuidForKey:@"conversation"];
+    NSUUID *conversationId = event.conversationUUID;
     
     if (conversationId == nil) {
         ZMLogError(@"Missing conversation payload in ZMupdateEventConversatinDelete");

--- a/Tests/Source/Synchronization/Strategies/TeamDownloadRequestStrategy+EventsTests.swift
+++ b/Tests/Source/Synchronization/Strategies/TeamDownloadRequestStrategy+EventsTests.swift
@@ -675,31 +675,6 @@ class TeamDownloadRequestStrategy_EventsTests: MessagingTest {
         }
     }
 
-    // MARK: - Team Conversation-Delete 
-
-    func testThatItDeletesTeamConversation() {
-        // given
-        let conversationId = UUID.create()
-        let payload: [String: Any] = [
-            "type": "team.conversation-delete",
-            "time": Date().transportString(),
-            "data": ["conv": conversationId.transportString()]
-        ]
-
-        syncMOC.performGroupedBlockAndWait {
-            let conversation = ZMConversation.insertNewObject(in: self.syncMOC)
-            conversation.remoteIdentifier = conversationId
-            conversation.conversationType = .group
-            XCTAssertNotNil(ZMConversation.fetch(withRemoteIdentifier: conversationId, in: self.syncMOC))
-        }
-
-        // when
-        processEvent(fromPayload: payload)
-        
-        // then
-        XCTAssertNil(ZMConversation(remoteID: conversationId, createIfNeeded: false, in: uiMOC))
-    }
-
     // MARK: - Helper
 
     private func processEvent(fromPayload eventPayload: [String: Any], file: StaticString = #file, line: UInt = #line) {


### PR DESCRIPTION
## What's new in this PR?

Stop processing the `team.conversation-delete event` since it has been replaced by the `conversation.delete` event in all cases.