### PR TITLE
[Fix] Don't report incoming calls from yourself as "missed"

### DIFF
--- a/Source/Calling/SystemMessageCallObserver.swift
+++ b/Source/Calling/SystemMessageCallObserver.swift
@@ -53,10 +53,10 @@ final class CallSystemMessageGenerator: NSObject {
             systemMessage =  conversation.appendPerformedCallMessage(with: duration, caller: caller)
         }
         else {
-            if let startDate = startDateByConversation[conversation] {
-                log.info("Appending performed call message: \(startDate), \(caller.displayName), \"\(conversation.displayName)\"")
+            if caller.isSelfUser {
+                log.info("Appending performed call message: \(caller.displayName), \"\(conversation.displayName)\"")
                 systemMessage =  conversation.appendPerformedCallMessage(with: 0, caller: caller)
-            } else if reason == .canceled || reason == .timeout || reason == .normal {
+            } else if reason.isOne(of: .canceled, .timeout, .normal) {
                 log.info("Appending missed call message: \(caller.displayName), \"\(conversation.displayName)\"")
                 
                 var isRelevant = true

--- a/Tests/Source/Calling/CallSystemMessageGeneratorTests.swift
+++ b/Tests/Source/Calling/CallSystemMessageGeneratorTests.swift
@@ -60,7 +60,7 @@ class CallSystemMessageGeneratorTests : MessagingTest {
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
     }
     
-    func testThatItAppendsPerformedCallSystemMessage_OutgoingCall_V3(){
+    func testThatItAppendsPerformedCallSystemMessage_AnsweredOutgoingCall(){
         // given
         let messageCount = conversation.allMessages.count
         
@@ -82,7 +82,7 @@ class CallSystemMessageGeneratorTests : MessagingTest {
         }
     }
     
-    func testThatItAppendsPerformedCallSystemMessage_IncomingCall_V3(){
+    func testThatItAppendsPerformedCallSystemMessage_AnsweredIncomingCall(){
         // given
         let messageCount = conversation.allMessages.count
         
@@ -104,7 +104,27 @@ class CallSystemMessageGeneratorTests : MessagingTest {
         }
     }
     
-    func testThatItAppendsMissedCallSystemMessage_UnansweredIncomingCall_V3(){
+    func testThatItAppendsPerformedCallSystemMessage_UnansweredIncomingCallFromSelfuser(){
+        // given
+        let messageCount = conversation.allMessages.count
+        
+        // when
+        let msg1 = sut.appendSystemMessageIfNeeded(callState: .incoming(video: false, shouldRing: true, degraded: false), conversation: conversation, caller: selfUser, timestamp: nil, previousCallState: nil)
+        let msg2 = sut.appendSystemMessageIfNeeded(callState: .terminating(reason: .canceled), conversation: conversation, caller: selfUser, timestamp: nil, previousCallState: nil)
+        
+        // then
+        XCTAssertEqual(conversation.allMessages.count, messageCount+1)
+        XCTAssertNil(msg1)
+        if let message = conversation.lastMessage as? ZMSystemMessage {
+            XCTAssertEqual(message, msg2)
+            XCTAssertEqual(message.systemMessageType, .performedCall)
+            XCTAssertTrue(message.users.contains(selfUser))
+        } else {
+            XCTFail("No system message inserted")
+        }
+    }
+    
+    func testThatItAppendsMissedCallSystemMessage_UnansweredIncomingCall(){
         // given
         let messageCount = conversation.allMessages.count
         


### PR DESCRIPTION
## What's new in this PR?

### Issues

If you have two devices A & B and you make an outgoing call from device A, it would get reported as a missed call on device B. In addition to the missed call system message this would also trigger a push notification.

### Solutions

It doesn't make sense to miss a call from yourself so we should instead report this as a "performed call".