### PR TITLE
Add method for logging out from a user session

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -980,11 +980,19 @@ extension SessionManager: PostLoginAuthenticationObserver {
         log.debug("Client registration was successful")
     }
     
+    public func userDidLogout(accountId: UUID) {
+        log.debug("\(accountId): User logged out")
+        
+        if let account = accountManager.account(with: accountId) {
+            delete(account: account, reason: .userInitiated)
+        }
+    }
+    
     public func accountDeleted(accountId: UUID) {
         log.debug("\(accountId): Account was deleted")
         
         if let account = accountManager.account(with: accountId) {
-            delete(account: account)
+            delete(account: account, reason: .sessionExpired)
         }
     }
     

--- a/Source/UserSession/PostLoginAuthenticationNotification.swift
+++ b/Source/UserSession/PostLoginAuthenticationNotification.swift
@@ -48,11 +48,15 @@ extension NSManagedObjectContext: GenericAsyncQueue {
     /// Invoked when a client is successfully registered
     @objc optional func clientRegistrationDidSucceed(accountId : UUID)
     
-    /// Invoken when there was an error registering the client
+    /// Invoked when there was an error registering the client
     @objc optional func clientRegistrationDidFail(_ error: NSError, accountId : UUID)
     
     /// Account was successfully deleted
     @objc optional func accountDeleted(accountId : UUID)
+    
+    /// Invoked when the user successfully logged out
+    @objc optional func userDidLogout(accountId: UUID)
+    
 }
 
 /// Authentication events that could happen after login
@@ -69,6 +73,9 @@ enum PostLoginAuthenticationEvent {
     
     /// Account was successfully deleted on the backend
     case accountDeleted
+    
+    /// User did logout
+    case userDidLogout
 }
 
 @objcMembers public class PostLoginAuthenticationNotification : NSObject {
@@ -117,6 +124,8 @@ enum PostLoginAuthenticationEvent {
                         observer.clientRegistrationDidSucceed?(accountId: accountId)
                     case .accountDeleted:
                         observer.accountDeleted?(accountId: accountId)
+                    case .userDidLogout:
+                        observer.userDidLogout?(accountId: accountId)
                     }
                 }
             }
@@ -148,5 +157,10 @@ enum PostLoginAuthenticationEvent {
     @objc(notifyAccountDeletedInContext:)
     static func notifyAccountDeleted(context: NSManagedObjectContext) {
         self.notify(event: .accountDeleted, context: context)
+    }
+    
+    @objc(notifyUserDidLogoutInContext:)
+    static func notifyUserDidLogout(context: NSManagedObjectContext) {
+        self.notify(event: .userDidLogout, context: context)
     }
 }

--- a/Source/UserSession/ZMUserSession+Authentication.swift
+++ b/Source/UserSession/ZMUserSession+Authentication.swift
@@ -1,0 +1,74 @@
+//
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension ZMUserSession {
+    
+    public func logout(credentials: ZMEmailCredentials, _ completion: @escaping (VoidResult) -> Void) {
+        guard let selfClientIdentifier = ZMUser.selfUser(inUserSession: self).selfClient()?.remoteIdentifier else { return }
+        
+        let request = ZMTransportRequest(path: "/clients/\(selfClientIdentifier)", method: .methodDELETE, payload: ["password": credentials.password] as ZMTransportData)
+        
+        request.add(ZMCompletionHandler(on: managedObjectContext, block: {[weak self] (response) in
+            guard let strongSelf = self else { return }
+            
+            if response.httpStatus == 200 {
+                PostLoginAuthenticationNotification.notifyUserDidLogout(context: strongSelf.managedObjectContext)
+                completion(.success)
+            } else {
+                completion(.failure(strongSelf.errorFromFailedDeleteResponse(response)))
+            }
+        }))
+        
+        transportSession.enqueueOneTime(request)
+    }
+    
+    func errorFromFailedDeleteResponse(_ response: ZMTransportResponse!) -> NSError {
+        
+        var errorCode: ZMUserSessionErrorCode
+        switch response.result {
+        case .permanentError:
+                switch response.payload?.asDictionary()?["label"] as? String {
+                case "client-not-found":
+                    errorCode = .clientDeletedRemotely
+                    break
+                case "invalid-credentials",
+                     "missing-auth",
+                     "bad-request": // in case the password not matching password format requirement
+                    errorCode = .invalidCredentials
+                    break
+                default:
+                    errorCode = .unknownError
+                    break
+                }
+        case .temporaryError, .tryAgainLater, .expired:
+            errorCode = .networkError
+        default:
+            errorCode = .unknownError
+        }
+        
+        var userInfo: [String: Any]? = nil
+        if let transportSessionError = response.transportSessionError {
+            userInfo = [NSUnderlyingErrorKey: transportSessionError]
+        }
+        
+        return NSError(code: errorCode, userInfo: userInfo)
+    }   
+    
+}

--- a/Tests/Source/E2EE/UserClientRequestStrategyTests.swift
+++ b/Tests/Source/E2EE/UserClientRequestStrategyTests.swift
@@ -71,6 +71,10 @@ class PostLoginAuthenticationObserverToken : NSObject, PostLoginAuthenticationOb
         handler(.accountDeleted, accountId)
     }
     
+    func userDidLogout(accountId: UUID) {
+        handler(.userDidLogout, accountId)
+    }
+    
 }
 
 @objc
@@ -79,6 +83,7 @@ public enum PostLoginAuthenticationEventObjC : Int {
     case clientRegistrationDidSucceed
     case clientRegistrationDidFail
     case accountDeleted
+    case userDidLogout
 }
 
 public typealias PostLoginAuthenticationObjCHandler = (_ event : PostLoginAuthenticationEventObjC, _ accountId: UUID, _ error: NSError?) -> Void
@@ -112,6 +117,8 @@ public class PostLoginAuthenticationObserverObjCToken : NSObject {
                 handler(.authenticationInvalidated, accountId, error)
             case .accountDeleted:
                 handler(.accountDeleted, accountId, nil)
+            case .userDidLogout:
+                handler(.userDidLogout, accountId, nil)
             }
         })
     }

--- a/Tests/Source/UserSession/ZMUserSessionTests+Authentication.swift
+++ b/Tests/Source/UserSession/ZMUserSessionTests+Authentication.swift
@@ -1,0 +1,113 @@
+////
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+class ZMUserSessionTests_Authentication: ZMUserSessionTestsBase {
+    
+    func testThatItEnqueuesRequestToDeleteTheSelfClient() {
+        // given
+        let selfClient = createSelfClient()
+        let credentials = ZMEmailCredentials(email: "john.doe@domain.com", password: "123456")
+        
+        // when
+        sut.logout(credentials: credentials, {_ in })
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        // then
+        let request = lastEnqueuedRequest!
+        let payload = request.payload as? [String: Any]
+        XCTAssertEqual(request.method, ZMTransportRequestMethod.methodDELETE)
+        XCTAssertEqual(request.path, "/clients/\(selfClient.remoteIdentifier!)")
+        XCTAssertEqual(payload?["password"] as? String, credentials.password)
+    }
+    
+    func testThatItPostsNotification_WhenLogoutRequestSucceeds() {
+        // given
+        let recorder = PostLoginAuthenticationNotificationRecorder(managedObjectContext: uiMOC)
+        let credentials = ZMEmailCredentials(email: "john.doe@domain.com", password: "123456")
+        _ = createSelfClient()
+        
+        // when
+        sut.logout(credentials: credentials, {_ in })
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        lastEnqueuedRequest?.complete(with: ZMTransportResponse(payload: nil, httpStatus: 200, transportSessionError: nil))
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        // then
+        XCTAssertEqual(recorder.notifications.count, 1)
+        let event = recorder.notifications.last
+        XCTAssertEqual(event?.event, .userDidLogout)
+        XCTAssertEqual(event?.accountId, ZMUser.selfUser(in: uiMOC).remoteIdentifier)
+    }
+    
+    func testThatItCallsTheCompletionHandler_WhenLogoutRequestSucceeds() {
+        // given
+        let credentials = ZMEmailCredentials(email: "john.doe@domain.com", password: "123456")
+        _ = createSelfClient()
+        
+        // expect
+        let completionHandlerCalled = expectation(description: "Completion handler called")
+        
+        // when
+        sut.logout(credentials: credentials, {result in
+            switch result {
+            case .success:
+                completionHandlerCalled.fulfill()
+            case .failure(_):
+                XCTFail()
+            }
+        })
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        lastEnqueuedRequest?.complete(with: ZMTransportResponse(payload: nil, httpStatus: 200, transportSessionError: nil))
+        XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
+    }
+        
+    func testThatItCallsTheCompletionHandlerWithCorrectErrorCode_WhenLogoutRequestFails() {
+        checkThatItCallsTheCompletionHandler(with: .clientDeletedRemotely, for: ZMTransportResponse(payload: ["label": "client-not-found"] as ZMTransportData, httpStatus: 404, transportSessionError: nil))
+        checkThatItCallsTheCompletionHandler(with: .invalidCredentials, for: ZMTransportResponse(payload: ["label": "invalid-credentials"] as ZMTransportData, httpStatus: 403, transportSessionError: nil))
+        checkThatItCallsTheCompletionHandler(with: .invalidCredentials, for: ZMTransportResponse(payload: ["label": "missing-auth"]  as ZMTransportData, httpStatus: 403, transportSessionError: nil))
+        checkThatItCallsTheCompletionHandler(with: .invalidCredentials, for: ZMTransportResponse(payload: ["label": "bad-request"]  as ZMTransportData, httpStatus: 403, transportSessionError: nil))
+    }
+    
+    func checkThatItCallsTheCompletionHandler(with errorCode: ZMUserSessionErrorCode, for response: ZMTransportResponse) {
+        // given
+        let credentials = ZMEmailCredentials(email: "john.doe@domain.com", password: "123456")
+        _ = createSelfClient()
+        
+        // expect
+        let completionHandlerCalled = expectation(description: "Completion handler called")
+        
+        // when
+        sut.logout(credentials: credentials, {result in
+            switch result {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                if errorCode == (error as NSError).userSessionErrorCode {
+                    completionHandlerCalled.fulfill()
+                }
+                
+            }
+        })
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        lastEnqueuedRequest?.complete(with: response)
+        XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
+    }
+    
+}

--- a/Tests/Source/UserSession/ZMUserSessionTestsBase.h
+++ b/Tests/Source/UserSession/ZMUserSessionTestsBase.h
@@ -64,6 +64,7 @@
 
 @property (nonatomic) MockSessionManager *mockSessionManager;
 @property (nonatomic) id transportSession;
+@property (nonatomic) ZMTransportRequest *lastEnqueuedRequest;
 @property (nonatomic) ZMPersistentCookieStorage *cookieStorage;
 @property (nonatomic) NSData *validCookie;
 @property (nonatomic, copy) ZMCompletionHandlerBlock authFailHandler;

--- a/Tests/Source/UserSession/ZMUserSessionTestsBase.m
+++ b/Tests/Source/UserSession/ZMUserSessionTestsBase.m
@@ -85,6 +85,11 @@
         return YES;
     }]];
     [[self.transportSession stub] setNetworkStateDelegate:OCMOCK_ANY];
+    [[self.transportSession stub] enqueueOneTimeRequest:[OCMArg checkWithBlock:^BOOL(ZMTransportRequest *obj) {
+        self.lastEnqueuedRequest = obj;
+        return YES;
+    }]];
+    
     
     self.mockSessionManager = [[MockSessionManager alloc] init];
     self.mediaManager = [[MockMediaManager alloc] init];

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -126,6 +126,8 @@
 		16DCAD691B0F9447008C1DD9 /* NSURL+LaunchOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 16DCAD651B0F9447008C1DD9 /* NSURL+LaunchOptions.m */; };
 		16DCAD6F1B147706008C1DD9 /* NSURL+LaunchOptionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 16DCAD6D1B1476FE008C1DD9 /* NSURL+LaunchOptionsTests.m */; };
 		16DCB91C213449620002E910 /* ZMOperationLoop+PushChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16DCB91B213449620002E910 /* ZMOperationLoop+PushChannel.swift */; };
+		16E0FB87232F8933000E3235 /* ZMUserSession+Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E0FB86232F8933000E3235 /* ZMUserSession+Authentication.swift */; };
+		16E0FBB623311A19000E3235 /* ZMUserSessionTests+Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E0FBB4233119FE000E3235 /* ZMUserSessionTests+Authentication.swift */; };
 		16F5F16C1E4092C00062F0AE /* NSManagedObjectContext+CTCallCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16F5F16B1E4092C00062F0AE /* NSManagedObjectContext+CTCallCenter.swift */; };
 		16F6BB0C1ED5824B009EA803 /* ZMUserSession+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 16F6BB0B1ED58242009EA803 /* ZMUserSession+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		16F6BB381EDEA659009EA803 /* SearchResult+AddressBook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16F6BB371EDEA659009EA803 /* SearchResult+AddressBook.swift */; };
@@ -536,6 +538,20 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		16E0FBBC23313952000E3235 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 16E0FBB723313952000E3235 /* WireMockTransport.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 54C902331B7532DD007162A8;
+			remoteInfo = WireMockTransport;
+		};
+		16E0FBBE23313952000E3235 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 16E0FBB723313952000E3235 /* WireMockTransport.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 54C9023E1B7532DD007162A8;
+			remoteInfo = WireMockTransportTests;
+		};
 		3E1860D0191A649D000FE027 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 540029AB1918CA8500578793 /* Project object */;
@@ -699,6 +715,9 @@
 		16DCAD651B0F9447008C1DD9 /* NSURL+LaunchOptions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURL+LaunchOptions.m"; sourceTree = "<group>"; };
 		16DCAD6D1B1476FE008C1DD9 /* NSURL+LaunchOptionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURL+LaunchOptionsTests.m"; sourceTree = "<group>"; };
 		16DCB91B213449620002E910 /* ZMOperationLoop+PushChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMOperationLoop+PushChannel.swift"; sourceTree = "<group>"; };
+		16E0FB86232F8933000E3235 /* ZMUserSession+Authentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSession+Authentication.swift"; sourceTree = "<group>"; };
+		16E0FBB4233119FE000E3235 /* ZMUserSessionTests+Authentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSessionTests+Authentication.swift"; sourceTree = "<group>"; };
+		16E0FBB723313952000E3235 /* WireMockTransport.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = WireMockTransport.xcodeproj; path = "../wire-ios-mocktransport/WireMockTransport.xcodeproj"; sourceTree = "<group>"; };
 		16F5F16B1E4092C00062F0AE /* NSManagedObjectContext+CTCallCenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+CTCallCenter.swift"; sourceTree = "<group>"; };
 		16F6BB0B1ED58242009EA803 /* ZMUserSession+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ZMUserSession+Private.h"; sourceTree = "<group>"; };
 		16F6BB371EDEA659009EA803 /* SearchResult+AddressBook.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SearchResult+AddressBook.swift"; sourceTree = "<group>"; };
@@ -1304,6 +1323,15 @@
 			path = E2EE;
 			sourceTree = "<group>";
 		};
+		16E0FBB823313952000E3235 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				16E0FBBD23313952000E3235 /* WireMockTransport.framework */,
+				16E0FBBF23313952000E3235 /* WireMockTransportTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		3E18605A191A4EF8000FE027 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -1464,6 +1492,7 @@
 		540029AA1918CA8500578793 = {
 			isa = PBXGroup;
 			children = (
+				16E0FBB723313952000E3235 /* WireMockTransport.xcodeproj */,
 				09284B6A1B8272C300EEE10E /* WireSyncEngine Test Host.entitlements */,
 				09CC4AB71B7CB8B700201C63 /* Cartfile */,
 				F93C4C6F1E1E8B77007E9CEE /* Cartfile.resolved */,
@@ -1610,6 +1639,7 @@
 				F92CA9641F153622007D8570 /* ZMUserSessionTests+FileRelocation.swift */,
 				F1AE5F6E21F73388009CDBBC /* ZMUserSessionTests+Timers.swift */,
 				168474252252579A004DE9EC /* ZMUserSessionTests+Syncing.swift */,
+				16E0FBB4233119FE000E3235 /* ZMUserSessionTests+Authentication.swift */,
 				0920C4D81B305FF500C55728 /* UserSessionGiphyRequestStateTests.swift */,
 				541228431AEE422C00D9ED1C /* ZMAuthenticationStatusTests.m */,
 				7CE017142317D07E00144905 /* ZMAuthenticationStatusTests.swift */,
@@ -1740,6 +1770,7 @@
 				164EAF9B1F4455FA00B628C4 /* ZMUserSession+Actions.swift */,
 				3E4F728219EC0D76002FE184 /* ZMUserSession+Background.m */,
 				54D175251ADE9EC9001AA338 /* ZMUserSession+Authentication.m */,
+				16E0FB86232F8933000E3235 /* ZMUserSession+Authentication.swift */,
 				09B730891B301F0200A5CCC9 /* ZMUserSession+Proxy.m */,
 				54034F371BB1A6D900F4ED62 /* ZMUserSession+Logs.swift */,
 				8751DA051F66BFA6000D308B /* ZMUserSession+Push.swift */,
@@ -2481,6 +2512,12 @@
 			mainGroup = 540029AA1918CA8500578793;
 			productRefGroup = 540029B51918CA8500578793 /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 16E0FBB823313952000E3235 /* Products */;
+					ProjectRef = 16E0FBB723313952000E3235 /* WireMockTransport.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				549815921A43232400A7CE2E /* WireSyncEngine-ios */,
@@ -2489,6 +2526,23 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		16E0FBBD23313952000E3235 /* WireMockTransport.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = WireMockTransport.framework;
+			remoteRef = 16E0FBBC23313952000E3235 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		16E0FBBF23313952000E3235 /* WireMockTransportTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = WireMockTransportTests.xctest;
+			remoteRef = 16E0FBBE23313952000E3235 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		3E186086191A56F6000FE027 /* Resources */ = {
@@ -2550,7 +2604,7 @@
 				"$(SRCROOT)/Carthage/Build/iOS/WireSystem.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/WireTesting.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/WireTransport.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/WireMockTransport.framework",
+				"$(BUILT_PRODUCTS_DIR)/WireMockTransport.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/WireProtos.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/ProtocolBuffers.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/WireCryptobox.framework",
@@ -2600,6 +2654,7 @@
 				87D003FF1BB5810D00472E06 /* APSSignalingKeyStoreTests.swift in Sources */,
 				542DFEE61DDCA452000F5B95 /* UserProfileUpdateStatusTests.swift in Sources */,
 				F95FFBD11EB8A478004031CB /* CallSystemMessageGeneratorTests.swift in Sources */,
+				16E0FBB623311A19000E3235 /* ZMUserSessionTests+Authentication.swift in Sources */,
 				D55272EC2062733F00F542BE /* AssetDeletionRequestStrategyTests.swift in Sources */,
 				5502C6EC22B7D4E2000684B7 /* ZMUserSessionLegalHoldTests.swift in Sources */,
 				545434AB19AB6ADA003892D9 /* ZMMissingUpdateEventsTranscoderTests.m in Sources */,
@@ -2956,6 +3011,7 @@
 				F1C51FE91FB4A9C7009C2269 /* RegistrationStrategy.swift in Sources */,
 				549816301A432BC800A7CE2E /* ZMSelfStrategy.m in Sources */,
 				5E8EE1F720FDC6B900DB1F9B /* CompanyLoginRequestDetector.swift in Sources */,
+				16E0FB87232F8933000E3235 /* ZMUserSession+Authentication.swift in Sources */,
 				F19F1D381EFBF61800275E27 /* SessionManager.swift in Sources */,
 				D522571E2062552800562561 /* AssetDeletionRequestStrategy.swift in Sources */,
 				1658C2371F503CF800889F22 /* FlowManager.swift in Sources */,

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -538,20 +538,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		16E0FBBC23313952000E3235 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 16E0FBB723313952000E3235 /* WireMockTransport.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 54C902331B7532DD007162A8;
-			remoteInfo = WireMockTransport;
-		};
-		16E0FBBE23313952000E3235 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 16E0FBB723313952000E3235 /* WireMockTransport.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 54C9023E1B7532DD007162A8;
-			remoteInfo = WireMockTransportTests;
-		};
 		3E1860D0191A649D000FE027 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 540029AB1918CA8500578793 /* Project object */;
@@ -717,7 +703,6 @@
 		16DCB91B213449620002E910 /* ZMOperationLoop+PushChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMOperationLoop+PushChannel.swift"; sourceTree = "<group>"; };
 		16E0FB86232F8933000E3235 /* ZMUserSession+Authentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSession+Authentication.swift"; sourceTree = "<group>"; };
 		16E0FBB4233119FE000E3235 /* ZMUserSessionTests+Authentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSessionTests+Authentication.swift"; sourceTree = "<group>"; };
-		16E0FBB723313952000E3235 /* WireMockTransport.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = WireMockTransport.xcodeproj; path = "../wire-ios-mocktransport/WireMockTransport.xcodeproj"; sourceTree = "<group>"; };
 		16F5F16B1E4092C00062F0AE /* NSManagedObjectContext+CTCallCenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+CTCallCenter.swift"; sourceTree = "<group>"; };
 		16F6BB0B1ED58242009EA803 /* ZMUserSession+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ZMUserSession+Private.h"; sourceTree = "<group>"; };
 		16F6BB371EDEA659009EA803 /* SearchResult+AddressBook.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SearchResult+AddressBook.swift"; sourceTree = "<group>"; };
@@ -1323,15 +1308,6 @@
 			path = E2EE;
 			sourceTree = "<group>";
 		};
-		16E0FBB823313952000E3235 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				16E0FBBD23313952000E3235 /* WireMockTransport.framework */,
-				16E0FBBF23313952000E3235 /* WireMockTransportTests.xctest */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		3E18605A191A4EF8000FE027 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -1492,7 +1468,6 @@
 		540029AA1918CA8500578793 = {
 			isa = PBXGroup;
 			children = (
-				16E0FBB723313952000E3235 /* WireMockTransport.xcodeproj */,
 				09284B6A1B8272C300EEE10E /* WireSyncEngine Test Host.entitlements */,
 				09CC4AB71B7CB8B700201C63 /* Cartfile */,
 				F93C4C6F1E1E8B77007E9CEE /* Cartfile.resolved */,
@@ -2512,12 +2487,6 @@
 			mainGroup = 540029AA1918CA8500578793;
 			productRefGroup = 540029B51918CA8500578793 /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = 16E0FBB823313952000E3235 /* Products */;
-					ProjectRef = 16E0FBB723313952000E3235 /* WireMockTransport.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				549815921A43232400A7CE2E /* WireSyncEngine-ios */,
@@ -2526,23 +2495,6 @@
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		16E0FBBD23313952000E3235 /* WireMockTransport.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = WireMockTransport.framework;
-			remoteRef = 16E0FBBC23313952000E3235 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		16E0FBBF23313952000E3235 /* WireMockTransportTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = WireMockTransportTests.xctest;
-			remoteRef = 16E0FBBE23313952000E3235 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		3E186086191A56F6000FE027 /* Resources */ = {
@@ -2604,7 +2556,7 @@
 				"$(SRCROOT)/Carthage/Build/iOS/WireSystem.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/WireTesting.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/WireTransport.framework",
-				"$(BUILT_PRODUCTS_DIR)/WireMockTransport.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/WireMockTransport.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/WireProtos.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/ProtocolBuffers.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/WireCryptobox.framework",


### PR DESCRIPTION
## What's new in this PR?

Add `logout(credentials:, completion:)` to the `ZMUserSession` which logs a user out  by deleting the self client. Deleting a client invalidates any cookie associated with the client.