### PR TITLE
Fix: re-authenticate on reboot triggering too often

### DIFF
--- a/Source/SessionManager/SessionManager+Authentication.swift
+++ b/Source/SessionManager/SessionManager+Authentication.swift
@@ -18,7 +18,7 @@
 
 public extension SessionManager {
     
-    private static let previousSystemBootTimeContainer = "PreviousSystemBootTime"
+    static let previousSystemBootTimeContainer = "PreviousSystemBootTime"
     
     static var previousSystemBootTime: Date? {
         get {

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -822,7 +822,7 @@ public protocol ForegroundNotificationResponder: class {
     }
     
     internal func checkDeviceUptimeIfNeeded() {
-        guard configuration.authenticateAfterReboot, isUserSessionActive else { return }
+        guard configuration.authenticateAfterReboot else { return }
         
         let systemBootTime = ProcessInfo.processInfo.systemBootTime
         

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -822,8 +822,11 @@ public protocol ForegroundNotificationResponder: class {
     }
     
     internal func checkDeviceUptimeIfNeeded() {
+        guard configuration.authenticateAfterReboot else { return }
+        
         let systemBootTime = ProcessInfo.processInfo.systemBootTime
-        if configuration.authenticateAfterReboot && systemBootTime > SessionManager.previousSystemBootTime {
+        
+        if let previousSystemBootTime = SessionManager.previousSystemBootTime, abs(systemBootTime.timeIntervalSince(previousSystemBootTime)) > 1.0  {
             log.debug("Logout caused by device reboot at \(systemBootTime)")
             let error = NSError(code: .needsAuthenticationAfterReboot, userInfo: nil)
             self.logoutCurrentSession(deleteCookie: false, error: error)

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -822,14 +822,14 @@ public protocol ForegroundNotificationResponder: class {
     }
     
     internal func checkDeviceUptimeIfNeeded() {
-        guard configuration.authenticateAfterReboot else { return }
+        guard configuration.authenticateAfterReboot, isUserSessionActive else { return }
         
         let systemBootTime = ProcessInfo.processInfo.systemBootTime
         
         if let previousSystemBootTime = SessionManager.previousSystemBootTime, abs(systemBootTime.timeIntervalSince(previousSystemBootTime)) > 1.0  {
             log.debug("Logout caused by device reboot at \(systemBootTime)")
-            let error = NSError(code: .needsAuthenticationAfterReboot, userInfo: nil)
-            self.logoutCurrentSession(deleteCookie: false, error: error)
+            let error = NSError(code: .needsAuthenticationAfterReboot, userInfo: accountManager.selectedAccount?.loginCredentials?.dictionaryRepresentation)
+            self.logoutCurrentSession(deleteCookie: true, error: error)
         }
         
         SessionManager.previousSystemBootTime = systemBootTime


### PR DESCRIPTION
## What's new in this PR?

### Issues

When re-authenticate on reboot is enabled:

- User is logged out every time the app goes into the foreground
- User is logged out if no previous boot time was stored

### Causes

#### User is logged out every time the app goes into the foreground:
This was due the clock can't be guaranteed to be the same on the milliseconds between runs

#### User is logged out if no previous boot time was stored
Value wasn't unwrapped so default comparison behaviour was applied

### Solutions

#### User is logged out every time the app goes into the foreground

Tolerate clock shifts up to 1 seconds (maybe needs to be higher?)

#### User is logged out if no previous boot time was stored

Unwrap the value before performing the comparison.