### PR TITLE
Fix: logout not working for SSO users

### DIFF
--- a/Source/UserSession/ZMUserSession+Authentication.swift
+++ b/Source/UserSession/ZMUserSession+Authentication.swift
@@ -23,7 +23,14 @@ extension ZMUserSession {
     public func logout(credentials: ZMEmailCredentials, _ completion: @escaping (VoidResult) -> Void) {
         guard let selfClientIdentifier = ZMUser.selfUser(inUserSession: self).selfClient()?.remoteIdentifier else { return }
         
-        let request = ZMTransportRequest(path: "/clients/\(selfClientIdentifier)", method: .methodDELETE, payload: ["password": credentials.password] as ZMTransportData)
+        let payload: [String: Any]
+        if let password = credentials.password, !password.isEmpty {
+            payload = ["password": password]
+        } else {
+            payload = [:]
+        }
+        
+        let request = ZMTransportRequest(path: "/clients/\(selfClientIdentifier)", method: .methodDELETE, payload: payload as ZMTransportData)
         
         request.add(ZMCompletionHandler(on: managedObjectContext, block: {[weak self] (response) in
             guard let strongSelf = self else { return }

--- a/Tests/Source/UserSession/ZMUserSessionTests+Authentication.swift
+++ b/Tests/Source/UserSession/ZMUserSessionTests+Authentication.swift
@@ -37,6 +37,23 @@ class ZMUserSessionTests_Authentication: ZMUserSessionTestsBase {
         XCTAssertEqual(payload?["password"] as? String, credentials.password)
     }
     
+    func testThatItEnqueuesRequestToDeleteTheSelfClientWithoutPassword() {
+        // given
+        let selfClient = createSelfClient()
+        let credentials = ZMEmailCredentials(email: "john.doe@domain.com", password: "")
+        
+        // when
+        sut.logout(credentials: credentials, {_ in })
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        // then
+        let request = lastEnqueuedRequest!
+        let payload = request.payload as? [String: Any]
+        XCTAssertEqual(request.method, ZMTransportRequestMethod.methodDELETE)
+        XCTAssertEqual(request.path, "/clients/\(selfClient.remoteIdentifier!)")
+        XCTAssertEqual(payload?.keys.count, 0)
+    }
+    
     func testThatItPostsNotification_WhenLogoutRequestSucceeds() {
         // given
         let recorder = PostLoginAuthenticationNotificationRecorder(managedObjectContext: uiMOC)


### PR DESCRIPTION
## What's new in this PR?

### Issues

SSO users would get an error when trying to logout

### Causes

SSO user's don't have a password but still included the `password` field in the DELETE request which the backend didn't accept.

### Solutions

Don't include an empty password in the DELETE request.