### PR TITLE
Fix issues with authenticate on reboot

### DIFF
--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -333,7 +333,7 @@ class SessionManagerTests: IntegrationTest {
         }
         
         performIgnoringZMLogError {
-            self.sut!.checkDeviceUptimeIfNeeded()
+            self.sut!.logoutAfterRebootIfNeeded()
         }
         
         XCTAssertTrue(self.waitForCustomExpectations(withTimeout: 2))
@@ -357,7 +357,7 @@ class SessionManagerTests: IntegrationTest {
         
         // WHEN
         performIgnoringZMLogError {
-            self.sut!.checkDeviceUptimeIfNeeded()
+            self.sut!.logoutAfterRebootIfNeeded()
         }
     }
     
@@ -378,7 +378,7 @@ class SessionManagerTests: IntegrationTest {
         
         // WHEN
         performIgnoringZMLogError {
-            self.sut!.checkDeviceUptimeIfNeeded()
+            self.sut!.logoutAfterRebootIfNeeded()
         }
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

1. Cookie wasn't deleted when logged the user out
2. SessionManager would attempt to start the user session again after logging the user out
3. On second relaunch of the app data would be deleted

### Causes

1. `ZMUserSession ` doesn't exist when we logout the user on launch
2. SessionManager tries to launch the `ZMUserSession` in `SessionManager.start()`
3.  If cookie is deleted in combination with `wipeOnCookieInvalid = true` we get this behaviour. 

### Solutions

1. Delete the cookie directly without going through the `ZMUserSession`
2. Move the logout on reboot into the SessionManager.start() code path
3. Don't update the systemBootTime until after we've re-authenticated.