### PR TITLE
Fix: incorrectly deleting folders when processing the event stream

### DIFF
--- a/Source/Synchronization/Strategies/LabelDownstreamRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/LabelDownstreamRequestStrategy.swift
@@ -107,6 +107,7 @@ public class LabelDownstreamRequestStrategy: AbstractRequestStrategy {
         
         let deletedLabels = managedObjectContext.fetchOrAssert(request: fetchRequest)
         deletedLabels.forEach { managedObjectContext.delete($0) } // TODO jacob consider doing a batch delete
+        managedObjectContext.saveOrRollback()
     }
     
 }

--- a/Tests/Source/Synchronization/Strategies/LabelDownstreamRequestStrategyTests.swift
+++ b/Tests/Source/Synchronization/Strategies/LabelDownstreamRequestStrategyTests.swift
@@ -294,7 +294,7 @@ class LabelDownstreamRequestStrategyTests: MessagingTest {
         
         // THEN
         syncMOC.performGroupedBlockAndWait {
-            XCTAssertTrue(label2.isDeleted)
+            XCTAssertTrue(label2.isZombieObject)
         }
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

Folders you just created would go missing if you put the app into background / foreground

### Causes

When we create folders we don't this will end up as events in the notification stream. If the put the app into background / foreground this will trigger us to process notification steam which will includes these events if nothing else happened in between.

create folder A
create folder B
create folder C

current state: [A, B, C]

process folder events:
event1 [A]
event2 [A, B]
event3 [A, B, C]

When processing event 1 we will delete folder B and C since they are not included in the update. This should be a problem since they will get added back in event 2 & 3. But this didn't happen because when we process event 2 & 3 we will fetch the existing folder B & C and update them instead because they haven't actually been deleted yet.

### Solutions

Perform a save on the context after deleting folders to make the change immediately