### PR TITLE
Fix: catch exception when calling enumerateContacts

### DIFF
--- a/Source/Registration/ContactAddressBook.swift
+++ b/Source/Registration/ContactAddressBook.swift
@@ -58,12 +58,16 @@ extension ContactAddressBook : AddressBookAccessor {
     
     /// Enumerates the contacts, invoking the block for each contact.
     /// If the block returns false, it will stop enumerating them.
-    internal func enumerateRawContacts(block: @escaping (ContactRecord) -> (Bool)) {
+    func enumerateRawContacts(block: @escaping (ContactRecord) -> (Bool)) {
         let request = CNContactFetchRequest(keysToFetch: ContactAddressBook.keysToFetch)
         request.sortOrder = .userDefault
-        try! store.enumerateContacts(with: request) { (contact, stop) in
-            let shouldContinue = block(contact)
-            stop.initialize(to: ObjCBool(!shouldContinue))
+        do {
+            try store.enumerateContacts(with: request) { (contact, stop) in
+                let shouldContinue = block(contact)
+                stop.initialize(to: ObjCBool(!shouldContinue))
+            }
+        } catch {
+            fatal(error.localizedDescription)
         }
     }
 


### PR DESCRIPTION
## What's new in this PR?

Catch the exception throw by `enumerateContacts` to study the cause of the crash.