### PR TITLE
Fix: app crash when call ZMUserSession.conversationDirectory

### DIFF
--- a/Source/UserSession/UserProfileImageUpdateStatus.swift
+++ b/Source/UserSession/UserProfileImageUpdateStatus.swift
@@ -262,8 +262,9 @@ extension UserProfileImageUpdateStatus: ZMAssetsPreprocessorDelegate {
     public func completedDownsampleOperation(_ operation: ZMImageDownsampleOperationProtocol, imageOwner: ZMImageOwner) {
         syncMOC.performGroupedBlock {
             ProfileImageSize.allSizes.forEach {
-                if operation.format == $0.imageFormat {
-                    self.setState(state: .upload(image: operation.downsampleImageData), for: $0)
+                if operation.format == $0.imageFormat,
+                   let downsampleImageData = operation.downsampleImageData {
+                    self.setState(state: .upload(image: downsampleImageData), for: $0)
                 }
             }
         }

--- a/Source/UserSession/ZMUserSession+ConversationDirectory.swift
+++ b/Source/UserSession/ZMUserSession+ConversationDirectory.swift
@@ -19,9 +19,9 @@
 import Foundation
 
 extension ZMUserSession {
-    
-    public var conversationDirectory: ConversationDirectoryType {
-        return managedObjectContext.conversationListDirectory()
+
+    public var conversationDirectory: ConversationDirectoryType? {
+        return managedObjectContext?.conversationListDirectory()
     }
     
 }


### PR DESCRIPTION
## What's new in this PR?

Fix the issue that when accessing `ZMUserSession.conversationDirectory`, `managedObjectContext` would be nil if current `ZMUserSession` is deleted.

## Dependencies

Needs releases with:

- [x] https://github.com/wireapp/wire-ios-data-model/pull/805