### PR TITLE
[Fix] Remote video render

### DIFF
--- a/Source/Calling/AVSCallMember.swift
+++ b/Source/Calling/AVSCallMember.swift
@@ -100,7 +100,7 @@ public struct AVSCallMember: Hashable {
     }
     
     public static func == (lhs: AVSCallMember, rhs: AVSCallMember) -> Bool {
-        return lhs.remoteId == rhs.remoteId
+        return lhs.hashValue == rhs.hashValue
     }
 
 }

--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -170,8 +170,8 @@ public class AVSWrapper: AVSWrapperType {
     }
 
     private let videoStateChangeHandler: VideoStateChangeHandler = { conversationId, userId, clientId, state, contextRef in
-        AVSWrapper.withCallCenter(contextRef, userId, state) {
-            $0.handleVideoStateChange(userId: $1, newState: $2)
+        AVSWrapper.withCallCenter(contextRef, userId, clientId, state) {
+            $0.handleVideoStateChange(userId: $1, clientId: $2, newState: $3)
         }
     }
 

--- a/Source/Calling/CallParticipantSnapshot.swift
+++ b/Source/Calling/CallParticipantSnapshot.swift
@@ -90,11 +90,7 @@ class CallParticipantsSnapshot {
     
     func update(updatedMember: AVSCallMember) {
         members = OrderedSetState(array: members.array.map({ member in
-            if member.remoteId == updatedMember.remoteId {
-                return updatedMember
-            } else {
-                return member
-            }
+            member == updatedMember ? updatedMember : member
         }))
         notifyChange()
     }

--- a/Source/Calling/CallParticipantSnapshot.swift
+++ b/Source/Calling/CallParticipantSnapshot.swift
@@ -39,20 +39,10 @@ class CallParticipantsSnapshot {
         self.members = type(of: self).removeDuplicateMembers(members)
     }
     
+    // Remove duplicates see: https://wearezeta.atlassian.net/browse/ZIOS-8610
     static func removeDuplicateMembers(_ members: [AVSCallMember]) -> OrderedSetState<AVSCallMember> {
-        // remove duplicates see: https://wearezeta.atlassian.net/browse/ZIOS-8610
-        // When a user joins with two devices, we would have a duplicate entry for this user in the member array returned from AVS
-        // For now, we will keep the one with "the highest state", meaning if one entry has `audioEstablished == false` and the other one `audioEstablished == true`, we keep the one with `audioEstablished == true`
         let callMembers = members.reduce([AVSCallMember]()){ (filtered, member) in
-            var newFiltered = filtered
-            if let idx = newFiltered.firstIndex(of: member) {
-                if !newFiltered[idx].audioEstablished && member.audioEstablished {
-                    newFiltered[idx] = member
-                }
-            } else {
-                newFiltered.append(member)
-            }
-            return newFiltered
+            filtered + (filtered.contains(member) ? [] : [member])
         }
         
         return callMembers.toOrderedSetState()

--- a/Source/Calling/WireCallCenterV3+Events.swift
+++ b/Source/Calling/WireCallCenterV3+Events.swift
@@ -200,10 +200,10 @@ extension WireCallCenterV3 {
     }
 
     /// Handles video state changes.
-    func handleVideoStateChange(userId: UUID, newState: VideoState) {
+    func handleVideoStateChange(userId: UUID, clientId: String,  newState: VideoState) {
         handleEvent("video-state-change") {
             self.nonIdleCalls.forEach {
-                self.callParticipantVideoStateChanged(conversationId: $0.key, userId: userId, videoState: newState)
+                self.callParticipantVideoStateChanged(conversationId: $0.key, userId: userId, clientId: clientId, videoState: newState)
             }
         }
     }

--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -321,8 +321,8 @@ extension WireCallCenterV3 {
     }
 
     /// Call this method when the video state of a participant changes and avs calls the `wcall_video_state_change_h`.
-    func callParticipantVideoStateChanged(conversationId: UUID, userId: UUID, videoState: VideoState) {
-        callSnapshots[conversationId]?.callParticipants.callParticpantVideoStateChanged(userId: userId, videoState: videoState)
+    func callParticipantVideoStateChanged(conversationId: UUID, userId: UUID, clientId: String, videoState: VideoState) {
+        callSnapshots[conversationId]?.callParticipants.callParticpantVideoStateChanged(userId: userId, clientId: clientId, videoState: videoState)
     }
 
     /// Call this method when the client established an audio connection with another user, and avs calls the `wcall_estab_h`.

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -1499,7 +1499,9 @@
 				540029B61918CA8500578793 /* Frameworks */,
 				540029B51918CA8500578793 /* Products */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
 		};
 		540029B51918CA8500578793 /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
## What's new in this PR?

### Issues

The video stream of another participant is black.

### Causes

In the video state handler, the client id is not passed down the chain to the necessary methods. Furthermore, two call members are still considered equal if they have the same user id. The client id was not being taken into account.

### Solutions

- Pass the client id down to the necessary methods.
- Define equality between two `AVSCallMembers` by their hashValue, which is a combination of their `userId` and `clientId`

## Notes

Some logic could be simplified. Although we should still be careful not to include duplicates in the call participant snapshot, the logic was originally in place to handle the case when a user joins the call from two different devices. But now we support multi device participation, so we only need to ensure there a no duplicate members.
