### PR TITLE
[Fix] Call participant notification

### DIFF
--- a/Source/Calling/AVSCallMember.swift
+++ b/Source/Calling/AVSCallMember.swift
@@ -99,8 +99,4 @@ public struct AVSCallMember: Hashable {
         hasher.combine(clientId)
     }
     
-    public static func == (lhs: AVSCallMember, rhs: AVSCallMember) -> Bool {
-        return lhs.hashValue == rhs.hashValue
-    }
-
 }

--- a/Source/Calling/AVSCallMember.swift
+++ b/Source/Calling/AVSCallMember.swift
@@ -99,4 +99,7 @@ public struct AVSCallMember: Hashable {
         hasher.combine(clientId)
     }
     
+    public static func == (lhs: AVSCallMember, rhs: AVSCallMember) -> Bool {
+        return lhs.hashValue == rhs.hashValue
+    }
 }

--- a/Source/Calling/CallParticipantSnapshot.swift
+++ b/Source/Calling/CallParticipantSnapshot.swift
@@ -54,7 +54,7 @@ class CallParticipantsSnapshot {
     }
 
     // TODO: We should be finding the call member solely by userId and clientId. However the clientId isn't set for
-    // 1:1 calls... yet. To work around this we return the first found user in case the cliendId is nil.
+    // 1:1 calls... yet. To work around this we return the first found user in case the clientId is nil.
     // AVS 5.4 will solve this as we will get the clientId on the established call handler. We need only to
     // update the call member once we know their client id.
     func callParticpantVideoStateChanged(userId: UUID, clientId: String, videoState: VideoState) {
@@ -65,13 +65,15 @@ class CallParticipantsSnapshot {
 
         update(updatedMember: AVSCallMember(userId: userId, clientId: clientId, audioEstablished: callMember.audioEstablished, videoState: videoState))
     }
-    
+
+    // TODO: AVS 5.4 will provide clientId, use it to find the correct call member.
     func callParticpantAudioEstablished(userId: UUID) {
         guard let callMember = members.array.first(where: { $0.remoteId == userId }) else { return }
-        
+
         update(updatedMember: AVSCallMember(userId: userId, clientId: callMember.clientId, audioEstablished: true, videoState: callMember.videoState))
     }
 
+    // TODO: AVS 5.4 will provide clientId, use it to find the correct call member.
     func callParticpantNetworkQualityChanged(userId: UUID, networkQuality: NetworkQuality) {
         guard let callMember = members.array.first(where: { $0.remoteId == userId }) else { return }
 
@@ -84,14 +86,16 @@ class CallParticipantsSnapshot {
         }))
         notifyChange()
     }
-    
+
+    // TODO: This needs to change
     func notifyChange() {
         if let context = callCenter.uiMOC {
             WireCallCenterCallParticipantNotification(conversationId: conversationId, participants: members.map({ ($0.remoteId, $0.callParticipantState) })).post(in: context.notificationContext)
         }
         
     }
-    
+
+    // TODO: AVS 5.4 will provide clientId, use it to find the correct call member.
     public func callParticipantState(forUser userId: UUID) -> CallParticipantState {
         guard let callMember = members.array.first(where: { $0.remoteId == userId }) else { return .unconnected }
         

--- a/Source/Calling/CallParticipantSnapshot.swift
+++ b/Source/Calling/CallParticipantSnapshot.swift
@@ -87,12 +87,12 @@ class CallParticipantsSnapshot {
         notifyChange()
     }
 
-    // TODO: This needs to change
+
     func notifyChange() {
-        if let context = callCenter.uiMOC {
-            WireCallCenterCallParticipantNotification(conversationId: conversationId, participants: members.map({ ($0.remoteId, $0.callParticipantState) })).post(in: context.notificationContext)
-        }
+        guard let context = callCenter.uiMOC else { return }
         
+        let participants = members.map { CallParticipant(member: $0, context: context) }.compactMap(\.self)
+        WireCallCenterCallParticipantNotification(conversationId: conversationId, participants: participants).post(in: context.notificationContext)
     }
 
     // TODO: AVS 5.4 will provide clientId, use it to find the correct call member.

--- a/Source/Calling/CallParticipantSnapshot.swift
+++ b/Source/Calling/CallParticipantSnapshot.swift
@@ -53,10 +53,6 @@ class CallParticipantsSnapshot {
         notifyChange()
     }
 
-    // TODO: We should be finding the call member solely by userId and clientId. However the clientId isn't set for
-    // 1:1 calls... yet. To work around this we return the first found user in case the clientId is nil.
-    // AVS 5.4 will solve this as we will get the clientId on the established call handler. We need only to
-    // update the call member once we know their client id.
     func callParticpantVideoStateChanged(userId: UUID, clientId: String, videoState: VideoState) {
         let participantsByUser = members.array.filter { $0.remoteId == userId }
         let participant = participantsByUser.first { $0.clientId == clientId } ?? participantsByUser.first
@@ -66,14 +62,12 @@ class CallParticipantsSnapshot {
         update(updatedMember: AVSCallMember(userId: userId, clientId: clientId, audioEstablished: callMember.audioEstablished, videoState: videoState))
     }
 
-    // TODO: AVS 5.4 will provide clientId, use it to find the correct call member.
     func callParticpantAudioEstablished(userId: UUID) {
         guard let callMember = members.array.first(where: { $0.remoteId == userId }) else { return }
 
         update(updatedMember: AVSCallMember(userId: userId, clientId: callMember.clientId, audioEstablished: true, videoState: callMember.videoState))
     }
 
-    // TODO: AVS 5.4 will provide clientId, use it to find the correct call member.
     func callParticpantNetworkQualityChanged(userId: UUID, networkQuality: NetworkQuality) {
         guard let callMember = members.array.first(where: { $0.remoteId == userId }) else { return }
 
@@ -95,7 +89,6 @@ class CallParticipantsSnapshot {
         WireCallCenterCallParticipantNotification(conversationId: conversationId, participants: participants).post(in: context.notificationContext)
     }
 
-    // TODO: AVS 5.4 will provide clientId, use it to find the correct call member.
     public func callParticipantState(forUser userId: UUID) -> CallParticipantState {
         guard let callMember = members.array.first(where: { $0.remoteId == userId }) else { return .unconnected }
         

--- a/Source/Calling/CallState.swift
+++ b/Source/Calling/CallState.swift
@@ -22,19 +22,40 @@ import avs
 private let zmLog = ZMSLog(tag: "calling")
 
 /**
- * A participant in in  call.
+ * A participant in the call.
  */
 
-public struct CallParticipant: Equatable {
+public struct CallParticipant: Hashable {
     
     public let user: ZMUser
     public let state: CallParticipantState
-    
+
     public init(user: ZMUser, state: CallParticipantState) {
         self.user = user
         self.state = state
     }
-    
+
+    init?(member: AVSCallMember, context: NSManagedObjectContext) {
+        guard let user = ZMUser(remoteID: member.remoteId, createIfNeeded: false, in: context) else { return nil }
+        self.init(user: user, state: member.callParticipantState)
+    }
+
+    // MARK: - Computed Properties
+
+    private var clientId: String? {
+        switch state {
+        case .connected(_, let clientId): return clientId
+        default: return nil
+        }
+    }
+
+    // MARK: - Hashable
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(user.remoteIdentifier)
+        hasher.combine(clientId)
+    }
+
 }
 
 

--- a/Source/Calling/WireCallCenterV3+Notifications.swift
+++ b/Source/Calling/WireCallCenterV3+Notifications.swift
@@ -319,17 +319,14 @@ extension WireCallCenterV3 {
     /// Add observer of call particpants in a conversation. Returns a token which needs to be retained as long as the observer should be active.
     /// Returns a token which needs to be retained as long as the observer should be active.
     internal class func addCallParticipantObserver(observer: WireCallCenterCallParticipantObserver, for conversation: ZMConversation, context: NSManagedObjectContext) -> Any {
-        let remoteID = conversation.remoteIdentifier!
-        
         return NotificationInContext.addObserver(name: WireCallCenterCallParticipantNotification.notificationName, context: context.notificationContext, queue: .main) { [weak observer] note in
-            guard let note = note.userInfo[WireCallCenterCallParticipantNotification.userInfoKey] as? WireCallCenterCallParticipantNotification,
-                  let observer = observer,
-                  note.conversationId == conversation.remoteIdentifier
-            else { return }
-            
-            if note.conversationId == remoteID {
-                observer.callParticipantsDidChange(conversation: conversation, participants: note.participants)
-            }
+            guard
+                let note = note.userInfo[WireCallCenterCallParticipantNotification.userInfoKey] as? WireCallCenterCallParticipantNotification,
+                let observer = observer,
+                note.conversationId == conversation.remoteIdentifier
+                else { return }
+
+            observer.callParticipantsDidChange(conversation: conversation, participants: note.participants)
         }
     }
     

--- a/Source/Calling/WireCallCenterV3+Notifications.swift
+++ b/Source/Calling/WireCallCenterV3+Notifications.swift
@@ -150,7 +150,7 @@ public protocol WireCallCenterCallParticipantObserver : class {
      - parameter conversation: where the call is ongoing
      - parameter particpants: updated list of call participants
      */
-    func callParticipantsDidChange(conversation: ZMConversation, participants: [(UUID, CallParticipantState)])
+    func callParticipantsDidChange(conversation: ZMConversation, participants: [CallParticipant])
 }
 
 public struct WireCallCenterCallParticipantNotification : SelfPostingNotification {
@@ -158,9 +158,9 @@ public struct WireCallCenterCallParticipantNotification : SelfPostingNotificatio
     static let notificationName = Notification.Name("VoiceChannelParticipantNotification")
     
     let conversationId : UUID
-    let participants: [(UUID, CallParticipantState)]
+    let participants: [CallParticipant]
     
-    init(conversationId: UUID, participants: [(UUID, CallParticipantState)]) {
+    init(conversationId: UUID, participants: [CallParticipant]) {
         self.conversationId = conversationId
         self.participants = participants
     }


### PR DESCRIPTION
## What's new in this PR?

This PR contains changes to address an AVS related crash.

### Issues

Since AVS 5.3, we now allow a user to join a group call with more than one device. This means that a call participant is no longer unique by their user id, we must also take their client id into account. Although we already store the client id, there are several places where we still only refer to the user id. This is due to the fact that when we post a `WireCallCenterCallParticipantNotification`, we were sending on the `UUID` referring to the user's remote identifier.

### Solutions

Pass the entire `CallParticipant` through the notification and make `CallParticipant` hashable over the user id and client id.
