### PR TITLE
[Fix] No video received in one to one call

### DIFF
--- a/Tests/Source/Calling/CallParticipantsSnapshotTests.swift
+++ b/Tests/Source/Calling/CallParticipantsSnapshotTests.swift
@@ -173,4 +173,22 @@ class CallParticipantsSnapshotTests : MessagingTest {
         let expectation = [callMember1, updatedCallMember2]
         XCTAssertEqual(sut.members.array, expectation)
     }
+
+    func testThatItUpdatesTheCallMemberWithAClientId() {
+        // given
+        let userId = UUID()
+        let clientId = "clientId"
+
+        let callMember = AVSCallMember(userId: userId, clientId: nil, videoState: .stopped)
+
+        let sut = WireSyncEngine.CallParticipantsSnapshot(conversationId: UUID(),
+                                                          members: [callMember],
+                                                          callCenter: mockWireCallCenterV3)
+        // when
+        sut.callParticpantVideoStateChanged(userId: userId, clientId: clientId, videoState: .started)
+
+        // then
+        let expectation = [AVSCallMember(userId: userId, clientId: clientId, videoState: .started)]
+        XCTAssertEqual(sut.members.array, expectation)
+    }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When the other participant in a one to one call has video enabled, their video is not visible in the call.

### Causes

In group calls, whenever a participant joins the call we get their client id via the participants changed callback. However this is not the case in one to one calls. As a result, when the other participant enables video, the video state changed callback is invoked (with the client id), and we try to update our internal list of participants (in this case just one). There was a logic error when trying to find the participant instance to update (with the client id and the video state), where we were already expecting the client id to be set. As a result, we didn't update the participant, because we were trying to match the user id and client id.

### Solutions

Refactor the logic used in the video state changed handler that searches for the call member with the client id  (then falling back to only the user id), and use it when looking for the member to update in the `update(updatedMember:)` method.

## Notes

This is a tentative workaround until AVS 5.4 is ready, where we will get the client id in the call established callback.