### PR TITLE
[Fix] Fails to start calls from outside the app with CallKit

### DIFF
--- a/Source/Calling/CallKitDelegate.swift
+++ b/Source/Calling/CallKitDelegate.swift
@@ -133,7 +133,7 @@ extension CallKitDelegate {
         
         guard contacts.count == 1,
               let contact = contacts.first,
-              let customIdentifier = contact.customIdentifier,
+              let customIdentifier = contact.personHandle?.value,
               let (accountId, conversationId) = callIdentifiers(from: customIdentifier),
               let account = sessionManager.accountManager.account(with: accountId)
         else {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Calls started from outside the app (Phone app / CallKit interface) would only open the app but no calls would be made.

### Causes

Given that CallKit is enabled

Each new call (joined or started) is given a handle (`CXHandle`). 
It is simply a way to identify the call. 

When a user starts a Wire call via the Phone app, or through CallKit's interface,
The AppDelegate's `application(_:continue:restorationHandler:)` method is called.

An instance of `NSUserActivity` is passed as parameter and contains the contact (`INPerson`) that the user selected.
This `INPerson` instance has an `INPersonHandle` property that corresponds to the call's handle (`CXHandle`)

Using the handle, we're able to start a call to the intended conversation.

However, the wrong property of the `INPerson` instance was used.

### Solutions

use `INPerson.personHandle?.value` instead of `INPerson.customIdentifier`
