### PR TITLE
[Fix] Save context after updating roles

### DIFF
--- a/Source/Data Model/Conversation+Role.swift
+++ b/Source/Data Model/Conversation+Role.swift
@@ -63,6 +63,7 @@ struct ConversationRoleRequestFactory {
             switch response.httpStatus {
             case 200..<300:
                 conversation.addParticipantAndUpdateConversationState(user: participant, role: role)
+                conversation.managedObjectContext?.saveOrRollback()
                 completion?(.success)
             default:
                 completion?(.failure(RequestError.unknown))


### PR DESCRIPTION
## What's new in this PR?

### Issues

Conversation change notifications were not being fired when we update the participant roles. This led to UI states being out of sync with the local database.

### Causes

The CoreData context was not being saved after modifying the participant roles.

### Solutions

Invoke a save.