### PR TITLE
Fix: processReceiptModeUpdate has nil lastServerTimestamp

### DIFF
--- a/Source/Synchronization/Transcoders/ZMConversationTranscoder.swift
+++ b/Source/Synchronization/Transcoders/ZMConversationTranscoder.swift
@@ -222,7 +222,9 @@ extension ZMConversationTranscoder {
     }
     
     @objc (processReceiptModeUpdate:inConversation:lastServerTimestamp:)
-    public func processReceiptModeUpdate(event: ZMUpdateEvent, in conversation: ZMConversation, lastServerTimestamp: Date) {
+    public func processReceiptModeUpdate(event: ZMUpdateEvent,
+                                         in conversation: ZMConversation,
+                                         lastServerTimestamp: Date?) {
         precondition(event.type == .conversationReceiptModeUpdate, "invalid update event type")
         
         guard let payload = event.payload["data"] as? [String : AnyHashable],
@@ -233,6 +235,7 @@ extension ZMConversationTranscoder {
         else { return }
         
         // Discard event if it has already been applied
+        guard let lastServerTimestamp = lastServerTimestamp else { return }
         guard serverTimestamp.compare(lastServerTimestamp) == .orderedDescending else { return }
         
         let newValue = readReceiptMode > 0


### PR DESCRIPTION
## What's new in this PR?

Fix the crash when receipt event has a nil time stamp.