### PR TITLE
Fetch conversation roles for conversations in other teams

### DIFF
--- a/Source/Synchronization/Transcoders/ZMConversationTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMConversationTranscoder.m
@@ -314,11 +314,16 @@ static NSString *const ConversationTeamManagedKey = @"managed";
         return prefetchedMapping[conversationID];
     }
     
+    ZMUser *selfUser = [ZMUser selfUserInContext:self.managedObjectContext];
+    
     ZMConversation *conversation = [ZMConversation conversationWithRemoteID:conversationID createIfNeeded:NO inContext:self.managedObjectContext];
     if (conversation == nil) {
         conversation = [ZMConversation conversationWithRemoteID:conversationID createIfNeeded:YES inContext:self.managedObjectContext];
+        
         // if we did not have this conversation before, refetch it
-        if (conversation.conversationType == ZMConversationTypeGroup && conversation.teamRemoteIdentifier == nil) {
+        
+        Boolean isNotInMyTeam = conversation.teamRemoteIdentifier == nil || (selfUser.team.remoteIdentifier != conversation.teamRemoteIdentifier);
+        if (conversation.conversationType == ZMConversationTypeGroup && isNotInMyTeam) {
             conversation.needsToDownloadRoles = YES;
         }
 

--- a/Source/Synchronization/Transcoders/ZMConversationTranscoder.swift
+++ b/Source/Synchronization/Transcoders/ZMConversationTranscoder.swift
@@ -104,9 +104,13 @@ extension ZMConversationTranscoder {
 
         conversation.update(transportData: transportData, serverTimeStamp: serverTimeStamp)
 
+        let selfUser = ZMUser.selfUser(in: self.managedObjectContext)
+        let notInMyTeam = conversation.teamRemoteIdentifier == nil ||
+            selfUser.team?.remoteIdentifier != conversation.teamRemoteIdentifier
+        
         if conversationCreated.boolValue,
            conversation.conversationType == .group,
-           conversation.teamRemoteIdentifier == nil {
+           notInMyTeam {
             conversation.needsToDownloadRoles = true
         }
 


### PR DESCRIPTION
## What's new in this PR?

Roles for a conversation should be fetched from a team or the conversation. When we have access to the team metadata (i.e. we are part of the team), we should fetch roles from the team. If not, then from the conversation.

The code was checking if the conversation is in a team, but not if it's our team. If the conversation is in another team, we should fetch the roles from the conversation, as we won't have access to that team.