### PR TITLE
[Feature] new request strategy to verify password

### DIFF
--- a/Source/Synchronization/Strategies/VerifyPasswordRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/VerifyPasswordRequestStrategy.swift
@@ -48,7 +48,6 @@ public final class VerifyPasswordRequestStrategy: AbstractRequestStrategy {
         _ = NotificationInContext.addObserver(
             name: .verifyPassword,
             context: moc.notificationContext,
-            queue: .main,
             using: { [weak self] notification in
                 self?.preparePasswordVerification(notification)
             })

--- a/Source/Synchronization/Strategies/VerifyPasswordRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/VerifyPasswordRequestStrategy.swift
@@ -1,0 +1,111 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+private let passwordEndpoint = "/self/password"
+private let passwordKey = "passwordKey"
+
+private extension NSNotification.Name {
+    static let verifyPassword = NSNotification.Name(rawValue: "VerifyPasswordNotification")
+    static let passwordVerified = NSNotification.Name(rawValue: "PasswordVerifiedNotification")
+}
+
+public enum VerifyPasswordResult {
+    case validated
+    case denied
+    case timeout
+    case unknown
+}
+
+public final class VerifyPasswordRequestStrategy: AbstractRequestStrategy {
+    
+    /// Request sync
+    private var requestSync: ZMSingleRequestSync!
+    private var password: String?
+    private let moc: NSManagedObjectContext
+
+    @objc public override init(withManagedObjectContext moc: NSManagedObjectContext, applicationStatus: ApplicationStatus) {
+        self.moc = moc
+        super.init(withManagedObjectContext: moc, applicationStatus: applicationStatus)
+        self.requestSync = ZMSingleRequestSync(singleRequestTranscoder: self, groupQueue: moc)
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(preparePasswordVerification(_:)), name: .verifyPassword, object: moc)
+    }
+    
+    @objc private func preparePasswordVerification(_ notification: Notification) {
+        self.password = notification.userInfo?[passwordKey] as? String
+        self.requestSync.readyForNextRequestIfNotBusy()
+        RequestAvailableNotification.notifyNewRequestsAvailable(self)
+    }
+    
+    public override func nextRequestIfAllowed() -> ZMTransportRequest? {
+        guard password != nil else {
+            return nil
+        }
+        return self.requestSync.nextRequest()
+    }
+    
+    public static func triggerPasswordVerification(with password: String, context moc: NSManagedObjectContext) {
+        NotificationCenter.default.post(name: .verifyPassword, object: moc, userInfo: [passwordKey: password])
+    }
+    
+    public static func addPasswordVerifiedObserver(_ observer: Any, selector: Selector, context moc: NSManagedObjectContext) {
+        NotificationCenter.default.addObserver(observer, selector: selector, name: .passwordVerified, object: moc)
+    }
+    
+    public static func notifyPasswordVerified(with result: VerifyPasswordResult, context moc: NSManagedObjectContext) {
+        NotificationCenter.default.post(name: .passwordVerified, object: moc, userInfo: [VerifyPasswordRequestStrategy.verificationResultKey: result])
+    }
+    
+    public static let verificationResultKey = "verificationResultKey"
+}
+
+// MARK: - Request generation logic
+extension VerifyPasswordRequestStrategy: ZMSingleRequestTranscoder {
+    
+    public func request(for sync: ZMSingleRequestSync) -> ZMTransportRequest? {
+        guard sync == self.requestSync, let password = self.password else {
+            return nil
+        }
+        
+        let payload : [String: Any] = [
+            "new_password": password,
+            "old_password": password
+        ]
+        let request = ZMTransportRequest(path: passwordEndpoint, method: .methodPUT, payload: payload as ZMTransportData?, shouldCompress: true)
+        return request
+    }
+    
+    public func didReceive(_ response: ZMTransportResponse, forSingleRequest sync: ZMSingleRequestSync) {
+        password = nil
+        let result: VerifyPasswordResult
+        switch response.httpStatus {
+        case 403: // Invalid credentials
+            result = .denied
+        case 409: //
+            result = .validated
+        case 408:
+            result = .timeout
+        default:
+            result = .unknown
+        }
+        VerifyPasswordRequestStrategy.notifyPasswordVerified(with: result, context: moc)
+        self.requestSync.resetCompletionState()
+    }
+}

--- a/Source/Synchronization/Strategies/VerifyPasswordRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/VerifyPasswordRequestStrategy.swift
@@ -39,13 +39,14 @@ public final class VerifyPasswordRequestStrategy: AbstractRequestStrategy {
     private var requestSync: ZMSingleRequestSync!
     private var password: String?
     private let moc: NSManagedObjectContext
+    private var observerToken: Any?
 
     @objc public override init(withManagedObjectContext moc: NSManagedObjectContext, applicationStatus: ApplicationStatus) {
         self.moc = moc
         super.init(withManagedObjectContext: moc, applicationStatus: applicationStatus)
         self.requestSync = ZMSingleRequestSync(singleRequestTranscoder: self, groupQueue: moc)
         
-        _ = NotificationInContext.addObserver(
+        observerToken = NotificationInContext.addObserver(
             name: .verifyPassword,
             context: moc.notificationContext,
             using: { [weak self] notification in

--- a/Source/Synchronization/ZMSyncStrategy.m
+++ b/Source/Synchronization/ZMSyncStrategy.m
@@ -186,7 +186,7 @@ ZM_EMPTY_ASSERTING_INIT()
                                    [[TeamImageAssetUpdateStrategy alloc] initWithManagedObjectContext:self.syncMOC applicationStatus:applicationStatusDirectory],
                                    [[LabelDownstreamRequestStrategy alloc] initWithManagedObjectContext:self.syncMOC applicationStatus:applicationStatusDirectory syncStatus:applicationStatusDirectory.syncStatus],
                                    [[LabelUpstreamRequestStrategy alloc] initWithManagedObjectContext:self.syncMOC applicationStatus:applicationStatusDirectory],
-                                   [[ConversationRoleDownstreamRequestStrategy alloc] initWithManagedObjectContext:self.syncMOC applicationStatus:applicationStatusDirectory]
+                                   [[ConversationRoleDownstreamRequestStrategy alloc] initWithManagedObjectContext:self.syncMOC applicationStatus:applicationStatusDirectory],
                                    [[VerifyPasswordRequestStrategy alloc] initWithManagedObjectContext:self.syncMOC applicationStatus:applicationStatusDirectory]
                                    ];
 

--- a/Source/Synchronization/ZMSyncStrategy.m
+++ b/Source/Synchronization/ZMSyncStrategy.m
@@ -1,20 +1,20 @@
-// 
+//
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
+//
 
 
 @import UIKit;
@@ -123,13 +123,13 @@ ZM_EMPTY_ASSERTING_INIT()
         self.uiMOC = storeProvider.contextDirectory.uiContext;
         self.hotFix = [[ZMHotFix alloc] initWithSyncMOC:self.syncMOC];
         self.eventProcessingTracker = [[EventProcessingTracker alloc] init];
-        
+
         self.eventMOC = [NSManagedObjectContext createEventContextWithSharedContainerURL:storeProvider.applicationContainer userIdentifier:storeProvider.userIdentifier];
         [self.eventMOC addGroup:self.syncMOC.dispatchGroup];
         self.applicationStatusDirectory = applicationStatusDirectory;
-        
+
         [self createTranscodersWithLocalNotificationsDispatcher:localNotificationsDispatcher flowManager:flowManager applicationStatusDirectory:applicationStatusDirectory];
-        
+
         self.eventsBuffer = [[ZMUpdateEventsBuffer alloc] initWithUpdateEventConsumer:self];
         self.userClientRequestStrategy = [[UserClientRequestStrategy alloc] initWithClientRegistrationStatus:applicationStatusDirectory.clientRegistrationStatus
                                                                                           clientUpdateStatus:applicationStatusDirectory.clientUpdateStatus
@@ -137,7 +137,7 @@ ZM_EMPTY_ASSERTING_INIT()
                                                                                                userKeysStore:self.syncMOC.zm_cryptKeyStore];
         self.missingClientsRequestStrategy = [[MissingClientsRequestStrategy alloc] initWithManagedObjectContext:self.syncMOC applicationStatus:applicationStatusDirectory];
         self.fetchingClientRequestStrategy = [[FetchingClientRequestStrategy alloc] initWithManagedObjectContext:self.syncMOC applicationStatus:applicationStatusDirectory];
-        
+
         self.requestStrategies = @[
                                    self.userClientRequestStrategy,
                                    self.missingClientsRequestStrategy,
@@ -187,8 +187,9 @@ ZM_EMPTY_ASSERTING_INIT()
                                    [[LabelDownstreamRequestStrategy alloc] initWithManagedObjectContext:self.syncMOC applicationStatus:applicationStatusDirectory syncStatus:applicationStatusDirectory.syncStatus],
                                    [[LabelUpstreamRequestStrategy alloc] initWithManagedObjectContext:self.syncMOC applicationStatus:applicationStatusDirectory],
                                    [[ConversationRoleDownstreamRequestStrategy alloc] initWithManagedObjectContext:self.syncMOC applicationStatus:applicationStatusDirectory]
+                                   [[VerifyPasswordRequestStrategy alloc] initWithManagedObjectContext:self.syncMOC applicationStatus:applicationStatusDirectory]
                                    ];
-        
+
         self.changeTrackerBootStrap = [[ZMChangeTrackerBootstrap alloc] initWithManagedObjectContext:self.syncMOC changeTrackers:self.allChangeTrackers];
 
         ZM_ALLOW_MISSING_SELECTOR([[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(managedObjectContextDidSave:) name:NSManagedObjectContextDidSaveNotification object:self.syncMOC]);
@@ -346,7 +347,7 @@ ZM_EMPTY_ASSERTING_INIT()
         }];
         _allChangeTrackers = [_allChangeTrackers arrayByAddingObject:self.conversationStatusSync];
     }
-    
+
     return _allChangeTrackers;
 }
 
@@ -354,16 +355,16 @@ ZM_EMPTY_ASSERTING_INIT()
 {
     if (_eventConsumers == nil) {
         NSMutableArray<id<ZMEventConsumer>> *eventConsumers = [NSMutableArray array];
-        
+
         for (id<ZMObjectStrategy> objectStrategy in self.requestStrategies) {
             if ([objectStrategy conformsToProtocol:@protocol(ZMEventConsumer)]) {
                 [eventConsumers addObject:objectStrategy];
             }
         }
-        
+
         _eventConsumers = eventConsumers;
     }
-    
+
     return _eventConsumers;
 }
 
@@ -373,11 +374,11 @@ ZM_EMPTY_ASSERTING_INIT()
         self.didFetchObjects = YES;
         [self.changeTrackerBootStrap fetchObjectsForChangeTrackers];
     }
-    
+
     if(self.tornDown) {
         return nil;
     }
-    
+
     return [self.requestStrategies firstNonNilReturnedFromSelector:@selector(nextRequest)];
 }
 

--- a/Source/UserSession/ZMUserSession+VerifyPassword.swift
+++ b/Source/UserSession/ZMUserSession+VerifyPassword.swift
@@ -1,0 +1,28 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension ZMUserSession {
+    public func verify(password: String, completion: @escaping (VerifyPasswordResult?) -> Void) {
+        enqueueChanges { [weak self] in
+            guard let `self` = self else { return }
+            VerifyPasswordRequestStrategy.triggerPasswordVerification(with: password, completion: completion, context: self.syncManagedObjectContext)
+        }
+    }
+}

--- a/Source/UserSession/ZMUserSession+VerifyPassword.swift
+++ b/Source/UserSession/ZMUserSession+VerifyPassword.swift
@@ -20,9 +20,6 @@ import Foundation
 
 extension ZMUserSession {
     public func verify(password: String, completion: @escaping (VerifyPasswordResult?) -> Void) {
-        enqueueChanges { [weak self] in
-            guard let `self` = self else { return }
-            VerifyPasswordRequestStrategy.triggerPasswordVerification(with: password, completion: completion, context: self.syncManagedObjectContext)
-        }
+        VerifyPasswordRequestStrategy.triggerPasswordVerification(with: password, completion: completion, context: self.syncManagedObjectContext)
     }
 }

--- a/Source/UserSession/ZMUserSession+VerifyPassword.swift
+++ b/Source/UserSession/ZMUserSession+VerifyPassword.swift
@@ -18,7 +18,11 @@
 
 import Foundation
 
-extension ZMUserSession {
+public protocol UserSessionVerifyPasswordInterface {
+    func verify(password: String, completion: @escaping (VerifyPasswordResult?) -> Void)
+}
+
+extension ZMUserSession: UserSessionVerifyPasswordInterface {
     public func verify(password: String, completion: @escaping (VerifyPasswordResult?) -> Void) {
         VerifyPasswordRequestStrategy.triggerPasswordVerification(with: password, completion: completion, context: self.syncManagedObjectContext)
     }

--- a/Tests/Source/Synchronization/Strategies/VerifyPasswordRequestStrategyTests.swift
+++ b/Tests/Source/Synchronization/Strategies/VerifyPasswordRequestStrategyTests.swift
@@ -112,6 +112,8 @@ class VerifyPasswordRequestStrategyTests: MessagingTest {
     func testThatNotificationObserverDoesntReactWhenObjectDontMatch() {
         //given
         let moc = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
+        moc.persistentStoreCoordinator = NSPersistentStoreCoordinator()
+        
         //when
         VerifyPasswordRequestStrategy.triggerPasswordVerification(with: "", completion: {_ in}, context: moc)
         //then

--- a/Tests/Source/Synchronization/Strategies/VerifyPasswordRequestStrategyTests.swift
+++ b/Tests/Source/Synchronization/Strategies/VerifyPasswordRequestStrategyTests.swift
@@ -1,0 +1,154 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import WireSyncEngine
+
+class VerifyPasswordRequestStrategyTests: MessagingTest {
+    var sut: VerifyPasswordRequestStrategy!
+    var mockApplicationStatus: MockApplicationStatus!
+    var verifyPasswordResult: VerifyPasswordResult?
+    var didCallNewRequestAvailable: Bool!
+    var sync: ZMSingleRequestSync!
+    
+    override func setUp() {
+        super.setUp()
+        verifyPasswordResult = nil
+        sync = ZMSingleRequestSync()
+        mockApplicationStatus = MockApplicationStatus()
+        sut = VerifyPasswordRequestStrategy(withManagedObjectContext: syncMOC, applicationStatus: mockApplicationStatus)
+        VerifyPasswordRequestStrategy.addPasswordVerifiedObserver(self, selector: #selector(passwordVerified(notification:)), context: syncMOC)
+        RequestAvailableNotification.addObserver(self)
+        didCallNewRequestAvailable = false
+    }
+    
+    override func tearDown() {
+        NotificationCenter.default.removeObserver(self)
+        sut = nil
+        mockApplicationStatus = nil
+        verifyPasswordResult = nil
+        sync = nil
+        super.tearDown()
+    }
+    
+    func testThatItGeneratesCorrectRequestIfPasswordIsSet() {
+        //given
+        let password = "password"
+        VerifyPasswordRequestStrategy.triggerPasswordVerification(with: password, context: syncMOC)
+        
+        //when
+        let request = sut.nextRequestIfAllowed()
+        
+        //then
+        XCTAssertNotNil(request)
+        let payload = request?.payload?.asDictionary()
+        XCTAssertEqual(payload?["new_password"] as? String, password)
+        XCTAssertEqual(payload?["old_password"] as? String, password)
+        XCTAssertEqual(request?.path, "/self/password")
+        XCTAssertEqual(request?.method, ZMTransportRequestMethod.methodPUT)
+    }
+    
+    func testThatItOnlyGeneratesRequestWhenNeeded() {
+        //given
+        var request: ZMTransportRequest?
+        //when
+        request = sut.nextRequestIfAllowed()
+        //then
+        XCTAssertNil(request)
+
+        //given
+        VerifyPasswordRequestStrategy.triggerPasswordVerification(with: "password", context: syncMOC)
+        //when
+        request = sut.nextRequestIfAllowed()
+        //then
+        XCTAssertNotNil(request)
+        
+        //given
+        let response = ZMTransportResponse(payload: nil, httpStatus: 200, transportSessionError: nil)
+        sut.didReceive(response, forSingleRequest: sync)
+        //when
+        request = sut.nextRequestIfAllowed()
+        //then
+        XCTAssertNil(request)
+    }
+    
+    func testThat403ResponseIsProcessedAsDenied() {
+        testThat(statusCode: 403, isProcessedAs: .denied)
+    }
+    
+    func testThat408ResponseIsProcessedAsTimeout() {
+        testThat(statusCode: 408, isProcessedAs: .timeout)
+    }
+    
+    func testThat409ResponseIsProcessedAsValidated() {
+        testThat(statusCode: 409, isProcessedAs: .validated)
+    }
+    
+    func testThatBogusStatusCodeIsProcessedAsUnknown() {
+        testThat(statusCode: 999, isProcessedAs: .unknown)
+    }
+    
+    func testThatNotificationObserversReactWhenObjectMatch() {
+        //when
+        VerifyPasswordRequestStrategy.notifyPasswordVerified(with: .validated, context: syncMOC)
+        //then
+        XCTAssertEqual(verifyPasswordResult, VerifyPasswordResult.validated)
+        
+        //when
+        VerifyPasswordRequestStrategy.triggerPasswordVerification(with: "", context: syncMOC)
+        //then
+        XCTAssertTrue(didCallNewRequestAvailable)
+    }
+    
+    func testThatNotificationObserversDontReactWhenObjectDontMatch() {
+        //given
+        let moc = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
+        //when
+        VerifyPasswordRequestStrategy.notifyPasswordVerified(with: .validated, context: moc)
+        //then
+        XCTAssertNil(verifyPasswordResult)
+        
+        //when
+        VerifyPasswordRequestStrategy.triggerPasswordVerification(with: "", context: moc)
+        //then
+        XCTAssertFalse(didCallNewRequestAvailable)
+    }
+}
+
+extension VerifyPasswordRequestStrategyTests {
+    func testThat(statusCode: Int, isProcessedAs result: VerifyPasswordResult) {
+        //given
+        VerifyPasswordRequestStrategy.triggerPasswordVerification(with: "password", context: syncMOC)
+        let response = ZMTransportResponse(payload: nil, httpStatus: statusCode, transportSessionError: nil)
+        //when
+        sut.didReceive(response, forSingleRequest: sync)
+        //then
+        XCTAssertNotNil(verifyPasswordResult)
+        XCTAssertEqual(verifyPasswordResult, result)
+    }
+    
+    @objc func passwordVerified(notification: Notification) {
+        verifyPasswordResult = notification.userInfo?[VerifyPasswordRequestStrategy.verificationResultKey] as? VerifyPasswordResult
+    }
+}
+
+extension VerifyPasswordRequestStrategyTests: RequestAvailableObserver {
+    func newRequestsAvailable() {
+        didCallNewRequestAvailable = true
+    }
+}

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -317,6 +317,8 @@
 		5EDF03EC2245563C00C04007 /* LinkPreviewAssetUploadRequestStrategy+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EDF03EB2245563C00C04007 /* LinkPreviewAssetUploadRequestStrategy+Helper.swift */; };
 		5EFE9C15212AB138007932A6 /* UnregisteredUser+Payload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EFE9C14212AB138007932A6 /* UnregisteredUser+Payload.swift */; };
 		5EFE9C17212AB945007932A6 /* RegistrationPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EFE9C16212AB945007932A6 /* RegistrationPhase.swift */; };
+		636B716223ABE85D00B624D6 /* VerifyPasswordRequestStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636B716123ABE85D00B624D6 /* VerifyPasswordRequestStrategyTests.swift */; };
+		6387932F23A2403300FD23CF /* VerifyPasswordRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6387932E23A2403300FD23CF /* VerifyPasswordRequestStrategy.swift */; };
 		7C1F4BF5203C4F67000537A8 /* Analytics+Push.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C1F4BF4203C4F67000537A8 /* Analytics+Push.swift */; };
 		7C26879D21F7193800570AA9 /* EventProcessingTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C26879C21F7193800570AA9 /* EventProcessingTracker.swift */; };
 		7C419ED821F8D81D00B95770 /* EventProcessingTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C419ED621F8D7EB00B95770 /* EventProcessingTrackerTests.swift */; };
@@ -936,6 +938,8 @@
 		5EDF03EB2245563C00C04007 /* LinkPreviewAssetUploadRequestStrategy+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LinkPreviewAssetUploadRequestStrategy+Helper.swift"; sourceTree = "<group>"; };
 		5EFE9C14212AB138007932A6 /* UnregisteredUser+Payload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UnregisteredUser+Payload.swift"; sourceTree = "<group>"; };
 		5EFE9C16212AB945007932A6 /* RegistrationPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationPhase.swift; sourceTree = "<group>"; };
+		636B716123ABE85D00B624D6 /* VerifyPasswordRequestStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifyPasswordRequestStrategyTests.swift; sourceTree = "<group>"; };
+		6387932E23A2403300FD23CF /* VerifyPasswordRequestStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifyPasswordRequestStrategy.swift; sourceTree = "<group>"; };
 		7C1F4BF4203C4F67000537A8 /* Analytics+Push.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Analytics+Push.swift"; sourceTree = "<group>"; };
 		7C26879C21F7193800570AA9 /* EventProcessingTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventProcessingTracker.swift; sourceTree = "<group>"; };
 		7C419ED621F8D7EB00B95770 /* EventProcessingTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventProcessingTrackerTests.swift; sourceTree = "<group>"; };
@@ -1719,6 +1723,7 @@
 				0920833F1BA95EE100F82B29 /* UserClientRequestFactory.swift */,
 				8798607A1C3D48A400218A3E /* DeleteAccountRequestStrategy.swift */,
 				549AEA3A1D6340BC003C0BEC /* AddressBookUploadRequestStrategy.swift */,
+				6387932E23A2403300FD23CF /* VerifyPasswordRequestStrategy.swift */,
 				16DABFAD1DCF98D3001973E3 /* CallingRequestStrategy.swift */,
 				547E5B591DDB67390038D936 /* UserProfileUpdateRequestStrategy.swift */,
 				F19F4F3B1E604AA700F4D8FF /* UserImageAssetUpdateStrategy.swift */,
@@ -1762,6 +1767,7 @@
 				1672A652234784B500380537 /* LabelDownstreamRequestStrategyTests.swift */,
 				16D0A118234B999600A83F87 /* LabelUpstreamRequestStrategyTests.swift */,
 				A938BDC923A7966700D4C208 /* ConversationRoleDownstreamRequestStrategyTests.swift */,
+				636B716123ABE85D00B624D6 /* VerifyPasswordRequestStrategyTests.swift */,
 			);
 			path = Strategies;
 			sourceTree = "<group>";
@@ -2826,6 +2832,7 @@
 				F132C114203F20AB00C58933 /* ZMHotFixDirectoryTests.swift in Sources */,
 				5463C897193F3C74006799DE /* ZMTimingTests.m in Sources */,
 				1660AA0F1ECE0C870056D403 /* SearchResultTests.swift in Sources */,
+				636B716223ABE85D00B624D6 /* VerifyPasswordRequestStrategyTests.swift in Sources */,
 				54A3ACC31A261603008AF8DF /* BackgroundTests.m in Sources */,
 				BF889DC61D0ADE110031F3E6 /* AnalyticsTests.swift in Sources */,
 				54877C9619922C0B0097FB58 /* UserProfileTests.m in Sources */,
@@ -3045,6 +3052,7 @@
 				54973A361DD48CAB007F8702 /* NSManagedObject+EncryptionContext.swift in Sources */,
 				F9ABDF411CECBD8A008461B2 /* AccountStatus.swift in Sources */,
 				165D3A3D1E1D60520052E654 /* ZMConversation+VoiceChannel.swift in Sources */,
+				6387932F23A2403300FD23CF /* VerifyPasswordRequestStrategy.swift in Sources */,
 				165D3A221E1D43870052E654 /* VoiceChannel.swift in Sources */,
 				5EDF03EC2245563C00C04007 /* LinkPreviewAssetUploadRequestStrategy+Helper.swift in Sources */,
 				54991D581DEDCF2B007E282F /* AddressBook.swift in Sources */,

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -318,6 +318,7 @@
 		5EFE9C15212AB138007932A6 /* UnregisteredUser+Payload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EFE9C14212AB138007932A6 /* UnregisteredUser+Payload.swift */; };
 		5EFE9C17212AB945007932A6 /* RegistrationPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EFE9C16212AB945007932A6 /* RegistrationPhase.swift */; };
 		636B716223ABE85D00B624D6 /* VerifyPasswordRequestStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636B716123ABE85D00B624D6 /* VerifyPasswordRequestStrategyTests.swift */; };
+		636B716823BF46EB00B624D6 /* ZMUserSession+VerifyPassword.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636B716723BF46EA00B624D6 /* ZMUserSession+VerifyPassword.swift */; };
 		6387932F23A2403300FD23CF /* VerifyPasswordRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6387932E23A2403300FD23CF /* VerifyPasswordRequestStrategy.swift */; };
 		7C1F4BF5203C4F67000537A8 /* Analytics+Push.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C1F4BF4203C4F67000537A8 /* Analytics+Push.swift */; };
 		7C26879D21F7193800570AA9 /* EventProcessingTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C26879C21F7193800570AA9 /* EventProcessingTracker.swift */; };
@@ -939,6 +940,7 @@
 		5EFE9C14212AB138007932A6 /* UnregisteredUser+Payload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UnregisteredUser+Payload.swift"; sourceTree = "<group>"; };
 		5EFE9C16212AB945007932A6 /* RegistrationPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationPhase.swift; sourceTree = "<group>"; };
 		636B716123ABE85D00B624D6 /* VerifyPasswordRequestStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifyPasswordRequestStrategyTests.swift; sourceTree = "<group>"; };
+		636B716723BF46EA00B624D6 /* ZMUserSession+VerifyPassword.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSession+VerifyPassword.swift"; sourceTree = "<group>"; };
 		6387932E23A2403300FD23CF /* VerifyPasswordRequestStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifyPasswordRequestStrategy.swift; sourceTree = "<group>"; };
 		7C1F4BF4203C4F67000537A8 /* Analytics+Push.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Analytics+Push.swift"; sourceTree = "<group>"; };
 		7C26879C21F7193800570AA9 /* EventProcessingTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventProcessingTracker.swift; sourceTree = "<group>"; };
@@ -1793,6 +1795,7 @@
 				F9AB00211F0CDAF00037B437 /* FileRelocator.swift */,
 				BF36DDF01E8BACD400D61310 /* ZMUserSession+OperationLoop.h */,
 				54BAF1BC19212EBA008042FB /* ZMUserSession.m */,
+				636B716723BF46EA00B624D6 /* ZMUserSession+VerifyPassword.swift */,
 				549AEA3C1D6365C1003C0BEC /* ZMUserSession+AddressBook.swift */,
 				16E0FBE2233296A9000E3235 /* ZMUserSession+ConversationDirectory.swift */,
 				164EAF9B1F4455FA00B628C4 /* ZMUserSession+Actions.swift */,
@@ -2958,6 +2961,7 @@
 				5478A1411DEC4048006F7268 /* UserProfile.swift in Sources */,
 				5E8BB89E2147E9DF00EEA64B /* AVSWrapper+Handlers.swift in Sources */,
 				F16C8BE82044129700677D31 /* ZMConversationTranscoder.swift in Sources */,
+				636B716823BF46EB00B624D6 /* ZMUserSession+VerifyPassword.swift in Sources */,
 				1626344920D7DB81000D4063 /* PushNotificationCategory.swift in Sources */,
 				F98EDCD71D82B913001E65CB /* LocalNotificationContentType.swift in Sources */,
 				F19E55A222B3A3FA005C792D /* UNNotificationResponse+SafeLogging.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

Addition of a new request strategy to verify the account password.
Since there isn't an endpoint to verify the password, It will use the `update password` endpoint (done similarly on Android).
