### PR TITLE
[Fix] legal hold not being updated in conversations after restoring from backup

### DIFF
--- a/Source/Synchronization/Strategies/UserClientRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/UserClientRequestStrategy.swift
@@ -335,7 +335,7 @@ public final class UserClientRequestStrategy: ZMObjectSyncStrategy, ZMObjectStra
                 return
             }
             // not there? delete
-            moc.delete($0)
+            $0.deleteClientAndEndSession()
         }
         
         moc.saveOrRollback()


### PR DESCRIPTION
## What's new in this PR?

### Issues

The legal hold status is not updated in conversations after restoring from backup in the following scenario:

1. User A is put under legal hold
2. Legal hold indicator gets active in conversation C1
3. User A makes a backup
4. User A is removed from legal hold
5. User A restores the backup

Conversation C1 would still indicate that it's under legal hold even though we know it's not since user A was the only participant under legal hold.

### Causes

When restoring a backup we re-fetch the list of clients belonging to the self user and delete any no longer existing clients. This would delete the legal hold client but not trigger a re-calculation of the legal hold status in the conversations where the self user is a participant.

### Solutions

Delete any no longer existing clients using the `deleteClientAndEndSession()` method which does trigger a re-calculation of the legal hold status.