### PR TITLE
[Fix] wrong system boot time

### DIFF
--- a/Source/SessionManager/ProcessInfo+SystemBootTime.swift
+++ b/Source/SessionManager/ProcessInfo+SystemBootTime.swift
@@ -16,8 +16,14 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-public extension ProcessInfo {
-    var systemBootTime: Date {
-        return Date() - systemUptime
+public extension ProcessInfo {    
+    func bootTime() -> Date? {
+        var tv = timeval()
+        var tvSize = MemoryLayout<timeval>.size
+        let err = sysctlbyname("kern.boottime", &tv, &tvSize, nil, 0);
+        guard err == 0, tvSize == MemoryLayout<timeval>.size else {
+            return nil
+        }
+        return Date(timeIntervalSince1970: Double(tv.tv_sec) + Double(tv.tv_usec) / 1_000_000.0)
     }
 }

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -830,9 +830,10 @@ public protocol ForegroundNotificationResponder: class {
     
     @discardableResult
     internal func logoutAfterRebootIfNeeded() -> Bool {
-        guard configuration.authenticateAfterReboot else { return false }
+        guard configuration.authenticateAfterReboot, let systemBootTime = ProcessInfo.processInfo.bootTime() else {
+            return false
+        }
         
-        let systemBootTime = ProcessInfo.processInfo.systemBootTime
         var didLogoutCurrentSession = false
         
         if let previousSystemBootTime = SessionManager.previousSystemBootTime, abs(systemBootTime.timeIntervalSince(previousSystemBootTime)) > 1.0  {
@@ -846,9 +847,10 @@ public protocol ForegroundNotificationResponder: class {
     }
     
     internal func updateSystemBootTimeIfNeeded() {
-        guard configuration.authenticateAfterReboot else { return }
+        guard configuration.authenticateAfterReboot, let bootTime = ProcessInfo.processInfo.bootTime() else {
+            return
+        }
         
-        let bootTime = ProcessInfo.processInfo.systemBootTime
         SessionManager.previousSystemBootTime = bootTime
         log.debug("Updated system boot time: \(bootTime)")
     }

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -348,7 +348,7 @@ final class SessionManagerTests: IntegrationTest {
         sut?.accountManager.addAndSelect(createAccount())
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         XCTAssertEqual(sut?.accountManager.accounts.count, 1)
-        SessionManager.previousSystemBootTime = ProcessInfo.processInfo.systemBootTime
+        SessionManager.previousSystemBootTime = ProcessInfo.processInfo.bootTime()
         
         // EXPECT
         delegate.onLogout = { _ in


### PR DESCRIPTION
## What's new in this PR?

### Issues

`systemUptime` isn't updated when iOS system is asleep, which leads to calculating incorrect boot time.

### Solutions

Calculate boot time more accurately using the kernel boot time
