### PR TITLE
[Fix] App stuck on load screen 

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -467,7 +467,7 @@ public protocol ForegroundNotificationResponder: class {
         }
         
         guard !shouldPerformPostRebootLogout() else {
-            postRebootLogout()
+            performPostRebootLogout()
             return
         }
         
@@ -843,7 +843,7 @@ public protocol ForegroundNotificationResponder: class {
         return true
     }
     
-    func postRebootLogout() {
+    func performPostRebootLogout() {
         let error = NSError(code: .needsAuthenticationAfterReboot, userInfo: accountManager.selectedAccount?.loginCredentials?.dictionaryRepresentation)
         self.logoutCurrentSession(deleteCookie: true, error: error)
         log.debug("Logout caused by device reboot.")

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -843,7 +843,7 @@ public protocol ForegroundNotificationResponder: class {
         return true
     }
     
-    internal func postRebootLogout() {
+    func postRebootLogout() {
         let error = NSError(code: .needsAuthenticationAfterReboot, userInfo: accountManager.selectedAccount?.loginCredentials?.dictionaryRepresentation)
         self.logoutCurrentSession(deleteCookie: true, error: error)
         log.debug("Logout caused by device reboot.")

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -831,7 +831,7 @@ public protocol ForegroundNotificationResponder: class {
         }
     }
     
-    internal func shouldPerformPostRebootLogout() -> Bool {
+    func shouldPerformPostRebootLogout() -> Bool {
         guard configuration.authenticateAfterReboot,
             accountManager.selectedAccount != nil,
             let systemBootTime = ProcessInfo.processInfo.bootTime(),

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -466,7 +466,10 @@ public protocol ForegroundNotificationResponder: class {
             }
         }
         
-        guard !logoutAfterRebootIfNeeded() else { return }
+        guard !shouldPerformPostRebootLogout() else {
+            postRebootLogout()
+            return
+        }
         
         loadSession(for: account) { [weak self] session in
             guard let `self` = self, let session = session else { return }
@@ -828,22 +831,22 @@ public protocol ForegroundNotificationResponder: class {
         }
     }
     
-    @discardableResult
-    internal func logoutAfterRebootIfNeeded() -> Bool {
-        guard configuration.authenticateAfterReboot, let systemBootTime = ProcessInfo.processInfo.bootTime() else {
-            return false
-        }
-        
-        var didLogoutCurrentSession = false
-        
-        if let previousSystemBootTime = SessionManager.previousSystemBootTime, abs(systemBootTime.timeIntervalSince(previousSystemBootTime)) > 1.0  {
-            log.debug("Logout caused by device reboot. Previous boot time: \(previousSystemBootTime). Current boot time: \(systemBootTime)")
-            let error = NSError(code: .needsAuthenticationAfterReboot, userInfo: accountManager.selectedAccount?.loginCredentials?.dictionaryRepresentation)
-            self.logoutCurrentSession(deleteCookie: true, error: error)
-            didLogoutCurrentSession = true
-        }
-        
-        return didLogoutCurrentSession
+    internal func shouldPerformPostRebootLogout() -> Bool {
+        guard configuration.authenticateAfterReboot,
+            accountManager.selectedAccount != nil,
+            let systemBootTime = ProcessInfo.processInfo.bootTime(),
+            let previousSystemBootTime = SessionManager.previousSystemBootTime,
+            abs(systemBootTime.timeIntervalSince(previousSystemBootTime)) > 1.0
+        else { return false }
+
+        log.debug("Will logout due to device reboot. Previous boot time: \(previousSystemBootTime). Current boot time: \(systemBootTime)")
+        return true
+    }
+    
+    internal func postRebootLogout() {
+        let error = NSError(code: .needsAuthenticationAfterReboot, userInfo: accountManager.selectedAccount?.loginCredentials?.dictionaryRepresentation)
+        self.logoutCurrentSession(deleteCookie: true, error: error)
+        log.debug("Logout caused by device reboot.")
     }
     
     internal func updateSystemBootTimeIfNeeded() {

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -313,15 +313,12 @@ final class SessionManagerTests: IntegrationTest {
     }
     
     func testAuthenticationAfterReboot() {
-        
         //GIVEN
         sut = createManager()
-        sut?.configuration.authenticateAfterReboot = true
 
         //WHEN
         sut?.accountManager.addAndSelect(createAccount())
         XCTAssertEqual(sut?.accountManager.accounts.count, 1)
-        SessionManager.previousSystemBootTime = Date(timeIntervalSince1970: 0)
         
         //THEN
         let logoutExpectation = expectation(description: "Authentication after reboot")
@@ -333,15 +330,13 @@ final class SessionManagerTests: IntegrationTest {
         }
         
         performIgnoringZMLogError {
-            self.sut!.logoutAfterRebootIfNeeded()
+            self.sut!.postRebootLogout()
         }
         
         XCTAssertTrue(self.waitForCustomExpectations(withTimeout: 2))
     }
     
-    
-    func testAuthenticationAfterReboot_DoesntLogoutIfNotRebooted() {
-        
+    func testThatShouldPerformPostRebootLogoutReturnsFalseIfNotRebooted() {
         //GIVEN
         sut = createManager()
         sut?.configuration.authenticateAfterReboot = true
@@ -349,19 +344,14 @@ final class SessionManagerTests: IntegrationTest {
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         XCTAssertEqual(sut?.accountManager.accounts.count, 1)
         SessionManager.previousSystemBootTime = ProcessInfo.processInfo.bootTime()
-        
-        // EXPECT
-        delegate.onLogout = { _ in
-            XCTFail("We should not have been logged out")
-        }
-        
-        // WHEN
+
+        //WHEN/THEN
         performIgnoringZMLogError {
-            self.sut!.logoutAfterRebootIfNeeded()
+            XCTAssertFalse(self.sut!.shouldPerformPostRebootLogout())
         }
     }
     
-    func testAuthenticationAfterReboot_DoesntLogoutIfNoPreviousBootTimeExists() {
+    func testThatShouldPerformPostRebootLogoutReturnsFalseIfNoPreviousBootTimeExists() {
         
         //GIVEN
         sut = createManager()
@@ -371,14 +361,9 @@ final class SessionManagerTests: IntegrationTest {
         XCTAssertEqual(sut?.accountManager.accounts.count, 1)
         ZMKeychain.deleteAllKeychainItems(withAccountName: SessionManager.previousSystemBootTimeContainer)
         
-        // EXPECT
-        delegate.onLogout = { _ in
-            XCTFail("We should not have been logged out")
-        }
-        
-        // WHEN
+        //WHEN/THEN
         performIgnoringZMLogError {
-            self.sut!.logoutAfterRebootIfNeeded()
+            XCTAssertFalse(self.sut!.shouldPerformPostRebootLogout())
         }
     }
     

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -330,7 +330,7 @@ final class SessionManagerTests: IntegrationTest {
         }
         
         performIgnoringZMLogError {
-            self.sut!.postRebootLogout()
+            self.sut!.performPostRebootLogout()
         }
         
         XCTAssertTrue(self.waitForCustomExpectations(withTimeout: 2))


### PR DESCRIPTION
## What's new in this PR?

### Issues

GIVEN device was rebooted AND logout on reboot is enabled
AND user is logged out (no `selectedAccount`)
WHEN app launches
THEN app is stuck on load screen

### Causes

if there is no `selectedAccount`, application execution comes to a dead end

### Solutions

continue execution if `selectedAccount` is nil
