### PR TITLE
[Refactor] UserType in Notification Classes

### DIFF
--- a/Source/Notifications/Push notifications/Helpers/NotificationUserInfo.swift
+++ b/Source/Notifications/Push notifications/Helpers/NotificationUserInfo.swift
@@ -195,7 +195,7 @@ extension NotificationUserInfo {
      * - returns: The sender of the event, if found.
      */
 
-    public func sender(in managedObjectContext: NSManagedObjectContext) -> ZMUser? {
+    public func sender(in managedObjectContext: NSManagedObjectContext) -> UserType? {
         guard let senderID = senderID else {
             return nil
         }
@@ -209,7 +209,8 @@ extension NotificationUserInfo {
 
 extension NotificationUserInfo {
 
-    public func setupUserInfo(for conversation: ZMConversation, sender: ZMUser) {
+    public func setupUserInfo(for conversation: ZMConversation, sender: UserType) {
+        guard let sender = sender as? ZMUser else { return }
         addSelfUserInfo(using: conversation)
         self.conversationID = conversation.remoteIdentifier
         self.senderID = sender.remoteIdentifier

--- a/Source/Notifications/Push notifications/Helpers/NotificationUserInfo.swift
+++ b/Source/Notifications/Push notifications/Helpers/NotificationUserInfo.swift
@@ -195,7 +195,7 @@ extension NotificationUserInfo {
      * - returns: The sender of the event, if found.
      */
 
-    public func sender(in managedObjectContext: NSManagedObjectContext) -> ZMUser? {
+    func sender(in managedObjectContext: NSManagedObjectContext) -> ZMUser? {
         guard let senderID = senderID else {
             return nil
         }

--- a/Source/Notifications/Push notifications/Helpers/NotificationUserInfo.swift
+++ b/Source/Notifications/Push notifications/Helpers/NotificationUserInfo.swift
@@ -164,7 +164,7 @@ extension NotificationUserInfo {
      * - returns: The conversation, if found.
      */
 
-    public func conversation(in managedObjectContext: NSManagedObjectContext) -> ZMConversation? {
+    func conversation(in managedObjectContext: NSManagedObjectContext) -> ZMConversation? {
         guard let remoteID = conversationID else {
             return nil
         }
@@ -180,7 +180,7 @@ extension NotificationUserInfo {
      * - returns: The message, if found.
      */
 
-    public func message(in conversation: ZMConversation, managedObjectContext: NSManagedObjectContext) -> ZMMessage? {
+    func message(in conversation: ZMConversation, managedObjectContext: NSManagedObjectContext) -> ZMMessage? {
         guard let nonce = messageNonce else {
             return nil
         }
@@ -209,13 +209,13 @@ extension NotificationUserInfo {
 
 extension NotificationUserInfo {
 
-    public func setupUserInfo(for conversation: ZMConversation, sender: ZMUser) {
+    func setupUserInfo(for conversation: ZMConversation, sender: ZMUser) {
         addSelfUserInfo(using: conversation)
         self.conversationID = conversation.remoteIdentifier
         self.senderID = sender.remoteIdentifier
     }
 
-    public func setupUserInfo(for conversation: ZMConversation, event: ZMUpdateEvent) {
+    func setupUserInfo(for conversation: ZMConversation, event: ZMUpdateEvent) {
         addSelfUserInfo(using: conversation)
         self.conversationID = conversation.remoteIdentifier
         self.senderID = event.senderUUID()
@@ -223,7 +223,7 @@ extension NotificationUserInfo {
         self.eventTime = event.timeStamp()
     }
 
-    public func setupUserInfo(for message: ZMMessage) {
+    func setupUserInfo(for message: ZMMessage) {
         addSelfUserInfo(using: message)
         self.conversationID = message.conversation?.remoteIdentifier
         self.senderID = message.sender?.remoteIdentifier

--- a/Source/Notifications/Push notifications/Helpers/NotificationUserInfo.swift
+++ b/Source/Notifications/Push notifications/Helpers/NotificationUserInfo.swift
@@ -195,7 +195,7 @@ extension NotificationUserInfo {
      * - returns: The sender of the event, if found.
      */
 
-    public func sender(in managedObjectContext: NSManagedObjectContext) -> UserType? {
+    public func sender(in managedObjectContext: NSManagedObjectContext) -> ZMUser? {
         guard let senderID = senderID else {
             return nil
         }
@@ -209,8 +209,7 @@ extension NotificationUserInfo {
 
 extension NotificationUserInfo {
 
-    public func setupUserInfo(for conversation: ZMConversation, sender: UserType) {
-        guard let sender = sender as? ZMUser else { return }
+    public func setupUserInfo(for conversation: ZMConversation, sender: ZMUser) {
         addSelfUserInfo(using: conversation)
         self.conversationID = conversation.remoteIdentifier
         self.senderID = sender.remoteIdentifier

--- a/Source/Notifications/Push notifications/Helpers/ZMLocalNotificationSet.swift
+++ b/Source/Notifications/Push notifications/Helpers/ZMLocalNotificationSet.swift
@@ -25,7 +25,7 @@ import WireTransport
     func enqueueDelayedSave()
 }
 
-@objc public final class ZMLocalNotificationSet : NSObject  {
+@objc final class ZMLocalNotificationSet : NSObject  {
     
     let archivingKey : String
     let keyValueStore : ZMSynchonizableKeyValueStore
@@ -125,7 +125,7 @@ import WireTransport
 
 
 // Event Notifications
-public extension ZMLocalNotificationSet {
+extension ZMLocalNotificationSet {
 
     func cancelNotificationForIncomingCall(_ conversation: ZMConversation) {
         let toRemove = notifications.filter {

--- a/Source/Notifications/Push notifications/Helpers/ZMLocalNotificationSet.swift
+++ b/Source/Notifications/Push notifications/Helpers/ZMLocalNotificationSet.swift
@@ -21,7 +21,7 @@ import UIKit
 import WireTransport
 
 
-@objc protocol ZMSynchonizableKeyValueStore : KeyValueStore {
+@objc public protocol ZMSynchonizableKeyValueStore : KeyValueStore {
     func enqueueDelayedSave()
 }
 

--- a/Source/Notifications/Push notifications/Helpers/ZMLocalNotificationSet.swift
+++ b/Source/Notifications/Push notifications/Helpers/ZMLocalNotificationSet.swift
@@ -21,7 +21,7 @@ import UIKit
 import WireTransport
 
 
-@objc public protocol ZMSynchonizableKeyValueStore : KeyValueStore {
+@objc protocol ZMSynchonizableKeyValueStore : KeyValueStore {
     func enqueueDelayedSave()
 }
 
@@ -31,17 +31,17 @@ import WireTransport
     let keyValueStore : ZMSynchonizableKeyValueStore
     var notificationCenter: UserNotificationCenter = UNUserNotificationCenter.current()
     
-    public fileprivate(set) var notifications = Set<ZMLocalNotification>() {
+    fileprivate(set) var notifications = Set<ZMLocalNotification>() {
         didSet { updateArchive() }
     }
 
-    public private(set) var oldNotifications = [NotificationUserInfo]()
+    private(set) var oldNotifications = [NotificationUserInfo]()
 
     private var allNotifications: [NotificationUserInfo] {
         return notifications.compactMap { $0.userInfo } + oldNotifications
     }
     
-    public init(archivingKey: String, keyValueStore: ZMSynchonizableKeyValueStore) {
+    init(archivingKey: String, keyValueStore: ZMSynchonizableKeyValueStore) {
         self.archivingKey = archivingKey
         self.keyValueStore = keyValueStore
         super.init()
@@ -64,21 +64,21 @@ import WireTransport
         keyValueStore.enqueueDelayedSave() // we need to save otherwise changes might not be stored
     }
     
-    @discardableResult public func remove(_ notification: ZMLocalNotification) -> ZMLocalNotification? {
+    @discardableResult func remove(_ notification: ZMLocalNotification) -> ZMLocalNotification? {
         return notifications.remove(notification)
     }
     
-    public func addObject(_ notification: ZMLocalNotification) {
+    func addObject(_ notification: ZMLocalNotification) {
         notifications.insert(notification)
     }
     
-    public func replaceObject(_ toReplace: ZMLocalNotification, newObject: ZMLocalNotification) {
+    func replaceObject(_ toReplace: ZMLocalNotification, newObject: ZMLocalNotification) {
         notifications.remove(toReplace)
         notifications.insert(newObject)
     }
     
     /// Cancels all notifications
-    public func cancelAllNotifications() {
+    func cancelAllNotifications() {
         let ids = allNotifications.compactMap { $0.requestID?.uuidString }
         notificationCenter.removeAllNotifications(withIdentifiers: ids)
         notifications = Set()
@@ -86,13 +86,13 @@ import WireTransport
     }
     
     /// This cancels all notifications of a specific conversation
-    public func cancelNotifications(_ conversation: ZMConversation) {
+    func cancelNotifications(_ conversation: ZMConversation) {
         cancelOldNotifications(conversation)
         cancelCurrentNotifications(conversation)
     }
     
     /// Cancel all notifications created in this run
-    internal func cancelCurrentNotifications(_ conversation: ZMConversation) {
+    func cancelCurrentNotifications(_ conversation: ZMConversation) {
         guard notifications.count > 0 else { return }
         let toRemove = notifications.filter { $0.conversationID == conversation.remoteIdentifier }
         notificationCenter.removeAllNotifications(withIdentifiers: toRemove.map { $0.id.uuidString })
@@ -100,7 +100,7 @@ import WireTransport
     }
     
     /// Cancels all notifications created in previous runs
-    internal func cancelOldNotifications(_ conversation: ZMConversation) {
+    func cancelOldNotifications(_ conversation: ZMConversation) {
         guard oldNotifications.count > 0 else { return }
         
         oldNotifications = oldNotifications.filter { userInfo in
@@ -115,7 +115,7 @@ import WireTransport
     }
     
     /// Cancal all notifications with the given message nonce
-    internal func cancelCurrentNotifications(messageNonce: UUID) {
+    func cancelCurrentNotifications(messageNonce: UUID) {
         guard notifications.count > 0 else { return }
         let toRemove = notifications.filter { $0.messageNonce == messageNonce }
         notificationCenter.removeAllNotifications(withIdentifiers: toRemove.map { $0.id.uuidString })

--- a/Source/Notifications/Push notifications/LocalNotificationDispatcher+Calling.swift
+++ b/Source/Notifications/Push notifications/LocalNotificationDispatcher+Calling.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-public extension LocalNotificationDispatcher {
+extension LocalNotificationDispatcher {
     
     func process(callState: CallState, in conversation: ZMConversation, caller: ZMUser) {
         // missed call notification are handled separately

--- a/Source/Notifications/Push notifications/LocalNotificationDispatcher+Calling.swift
+++ b/Source/Notifications/Push notifications/LocalNotificationDispatcher+Calling.swift
@@ -20,25 +20,26 @@ import Foundation
 
 public extension LocalNotificationDispatcher {
     
-    func process(callState: CallState, in conversation: ZMConversation, caller: ZMUser) {
-        // missed call notification are handled separately
-        // but if call was answered elsewhere then proceed
+    func process(callState: CallState, in conversation: ZMConversation, caller: UserType) {
+        // Missed call notification are handled separately but if call was answered elsewhere then proceed.
         switch callState {
-        case .terminating(reason: let reason):
+        case .terminating(let reason):
             switch reason {
             case .anweredElsewhere, .rejectedElsewhere: break
             default: return
             }
         default: break
         }
-        
+
+        guard let caller = caller as? ZMUser else { return }
         let note = ZMLocalNotification(callState: callState, conversation: conversation, caller: caller)
         callingNotifications.cancelNotifications(conversation)
         note.apply(scheduleLocalNotification)
         note.apply(callingNotifications.addObject)
     }
     
-    func processMissedCall(in conversation: ZMConversation, caller: ZMUser) {
+    func processMissedCall(in conversation: ZMConversation, caller: UserType) {
+        guard let caller = caller as? ZMUser else { return }
         let note = ZMLocalNotification(callState: .terminating(reason: .canceled), conversation: conversation, caller: caller)
         callingNotifications.cancelNotifications(conversation)
         note.apply(scheduleLocalNotification)

--- a/Source/Notifications/Push notifications/LocalNotificationDispatcher+Calling.swift
+++ b/Source/Notifications/Push notifications/LocalNotificationDispatcher+Calling.swift
@@ -20,26 +20,25 @@ import Foundation
 
 public extension LocalNotificationDispatcher {
     
-    func process(callState: CallState, in conversation: ZMConversation, caller: UserType) {
-        // Missed call notification are handled separately but if call was answered elsewhere then proceed.
+    func process(callState: CallState, in conversation: ZMConversation, caller: ZMUser) {
+        // missed call notification are handled separately
+        // but if call was answered elsewhere then proceed
         switch callState {
-        case .terminating(let reason):
+        case .terminating(reason: let reason):
             switch reason {
             case .anweredElsewhere, .rejectedElsewhere: break
             default: return
             }
         default: break
         }
-
-        guard let caller = caller as? ZMUser else { return }
+        
         let note = ZMLocalNotification(callState: callState, conversation: conversation, caller: caller)
         callingNotifications.cancelNotifications(conversation)
         note.apply(scheduleLocalNotification)
         note.apply(callingNotifications.addObject)
     }
     
-    func processMissedCall(in conversation: ZMConversation, caller: UserType) {
-        guard let caller = caller as? ZMUser else { return }
+    func processMissedCall(in conversation: ZMConversation, caller: ZMUser) {
         let note = ZMLocalNotification(callState: .terminating(reason: .canceled), conversation: conversation, caller: caller)
         callingNotifications.cancelNotifications(conversation)
         note.apply(scheduleLocalNotification)

--- a/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification.swift
+++ b/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification.swift
@@ -52,7 +52,7 @@ protocol NotificationBuilder {
 /// various notification types (message, calling, etc.) and includes
 /// information regarding the conversation, sender, and team name.
 ///
-open class ZMLocalNotification: NSObject {
+class ZMLocalNotification: NSObject {
     
     /// The unique identifier for this notification. Use it to later update
     /// or remove pending or scheduled notification requests.

--- a/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification.swift
+++ b/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification.swift
@@ -145,7 +145,7 @@ extension ZMLocalNotification {
         return userInfo?.conversation(in: moc)
     }
     
-    public func sender(in moc: NSManagedObjectContext) -> ZMUser? {
+    public func sender(in moc: NSManagedObjectContext) -> UserType? {
         return userInfo?.sender(in: moc)
     }
 }

--- a/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification.swift
+++ b/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification.swift
@@ -27,7 +27,7 @@ import WireDataModel
 /// Defines the various types of local notifications, some of which
 /// have associated subtypes.
 ///
-public enum LocalNotificationType {
+enum LocalNotificationType {
     case event(LocalNotificationEventType)
     case calling(CallState)
     case message(LocalNotificationContentType)
@@ -56,14 +56,14 @@ class ZMLocalNotification: NSObject {
     
     /// The unique identifier for this notification. Use it to later update
     /// or remove pending or scheduled notification requests.
-    public let id: UUID
+    let id: UUID
     
-    public let type: LocalNotificationType
-    public var title: String?
-    public var body: String
-    public var category: String
-    public var sound: NotificationSound
-    public var userInfo: NotificationUserInfo?
+    let type: LocalNotificationType
+    var title: String?
+    var body: String
+    var category: String
+    var sound: NotificationSound
+    var userInfo: NotificationUserInfo?
 
     init?(conversation: ZMConversation?, builder: NotificationBuilder) {
         guard builder.shouldCreateNotification() else { return nil }
@@ -80,7 +80,7 @@ class ZMLocalNotification: NSObject {
     }
 
     /// Returns a configured concrete `UNNotificationContent` object.
-    public lazy var content: UNNotificationContent = {
+    lazy var content: UNNotificationContent = {
         let content = UNMutableNotificationContent()
         content.body = self.body
         content.categoryIdentifier = self.category
@@ -106,7 +106,7 @@ class ZMLocalNotification: NSObject {
     }()
     
     /// Returns a configured concrete `UNNotificationRequest`.
-    public lazy var request: UNNotificationRequest = {
+    lazy var request: UNNotificationRequest = {
         return UNNotificationRequest(identifier: id.uuidString, content: content, trigger: nil)
     }()
 
@@ -116,13 +116,13 @@ class ZMLocalNotification: NSObject {
 
 extension ZMLocalNotification {
 
-    public var selfUserID: UUID? { return userInfo?.selfUserID }
-    public var senderID: UUID? { return userInfo?.senderID }
-    public var messageNonce: UUID? { return userInfo?.messageNonce }
-    public var conversationID: UUID? { return userInfo?.conversationID }
+    var selfUserID: UUID? { return userInfo?.selfUserID }
+    var senderID: UUID? { return userInfo?.senderID }
+    var messageNonce: UUID? { return userInfo?.messageNonce }
+    var conversationID: UUID? { return userInfo?.conversationID }
 
     /// Returns true if it is a calling notification, else false.
-    public var isCallingNotification: Bool {
+    var isCallingNotification: Bool {
         switch type {
         case .calling: return true
         default: return false
@@ -130,7 +130,7 @@ extension ZMLocalNotification {
     }
     
     /// Returns true if it is a ephemeral notification, else false.
-    public var isEphemeral: Bool {
+    var isEphemeral: Bool {
         guard case .message(.ephemeral) = type else { return false }
         return true
     }
@@ -141,11 +141,11 @@ extension ZMLocalNotification {
 
 extension ZMLocalNotification {
 
-    public func conversation(in moc: NSManagedObjectContext) -> ZMConversation? {
+    func conversation(in moc: NSManagedObjectContext) -> ZMConversation? {
         return userInfo?.conversation(in: moc)
     }
     
-    public func sender(in moc: NSManagedObjectContext) -> ZMUser? {
+    func sender(in moc: NSManagedObjectContext) -> ZMUser? {
         return userInfo?.sender(in: moc)
     }
 }

--- a/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification.swift
+++ b/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification.swift
@@ -16,13 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import UIKit
-import UserNotifications
-import WireSystem
-import WireUtilities
-import WireTransport
-import WireDataModel
-
 
 /// Defines the various types of local notifications, some of which
 /// have associated subtypes.

--- a/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification.swift
+++ b/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification.swift
@@ -145,7 +145,7 @@ extension ZMLocalNotification {
         return userInfo?.conversation(in: moc)
     }
     
-    public func sender(in moc: NSManagedObjectContext) -> UserType? {
+    public func sender(in moc: NSManagedObjectContext) -> ZMUser? {
         return userInfo?.sender(in: moc)
     }
 }

--- a/Source/Notifications/Push notifications/Notification Types/LocalNotificationType+Localization.swift
+++ b/Source/Notifications/Push notifications/Notification Types/LocalNotificationType+Localization.swift
@@ -204,7 +204,7 @@ extension LocalNotificationType {
         return nil
     }
     
-    public func alertTitleText(team: Team?) -> String? {
+    func alertTitleText(team: Team?) -> String? {
         guard case .availabilityBehaviourChangeAlert(let availability) = self, availability.isOne(of: .away, .busy) else { return nil }
         
         let teamName = team?.name
@@ -214,7 +214,7 @@ extension LocalNotificationType {
         return .localizedStringWithFormat(localizationKey.pushFormatString, arguments: [teamName].compactMap({ $0 }))
     }
     
-    public func alertMessageBodyText() -> String {
+    func alertMessageBodyText() -> String {
         guard case .availabilityBehaviourChangeAlert(let availability) = self, availability.isOne(of: .away, .busy) else { return "" }
         
         let availabilityKey = availability == .away ? "away" : "busy"
@@ -222,7 +222,7 @@ extension LocalNotificationType {
         return .localizedStringWithFormat(localizationKey.pushFormatString)
     }
     
-    public func messageBodyText(senderName: String?) -> String {
+    func messageBodyText(senderName: String?) -> String {
         if case LocalNotificationType.event(let eventType) = self {
             return messageBodyText(eventType: eventType, senderName: senderName)
         } else {

--- a/Source/Notifications/Push notifications/Notification Types/LocalNotificationType+Localization.swift
+++ b/Source/Notifications/Push notifications/Notification Types/LocalNotificationType+Localization.swift
@@ -145,7 +145,7 @@ extension LocalNotificationType {
         }
     }
     
-    fileprivate func senderKey(_ sender: UserType?, _ conversation: ZMConversation?) -> String? {
+    fileprivate func senderKey(_ sender : ZMUser?, _ conversation : ZMConversation?) -> String? {
         guard let sender = sender else { return NoUserNameKey }
         
         if case .failedMessage = self {
@@ -177,7 +177,7 @@ extension LocalNotificationType {
         return .localizedStringWithFormat(localizationKey.pushFormatString, arguments: arguments)
     }
     
-    public func titleText(selfUser: UserType, conversation: ZMConversation? = nil) -> String? {
+    public func titleText(selfUser: ZMUser, conversation : ZMConversation? = nil) -> String? {
         
         if case .message(let contentType) = self {
             switch contentType {
@@ -190,7 +190,7 @@ extension LocalNotificationType {
             }
         }
         
-        let teamName = selfUser.teamName
+        let teamName = selfUser.team?.name
         let conversationName = conversation?.meaningfulDisplayName
         
         if let conversationName = conversationName, let teamName = teamName {
@@ -230,7 +230,7 @@ extension LocalNotificationType {
         }
     }
     
-    public func messageBodyText(sender: UserType?, conversation: ZMConversation?) -> String {
+    public func messageBodyText(sender: ZMUser?, conversation: ZMConversation?) -> String {
         
         if case LocalNotificationType.event(let eventType) = self {
             return messageBodyText(eventType: eventType, senderName: sender?.name)

--- a/Source/Notifications/Push notifications/Notification Types/LocalNotificationType+Localization.swift
+++ b/Source/Notifications/Push notifications/Notification Types/LocalNotificationType+Localization.swift
@@ -177,7 +177,7 @@ extension LocalNotificationType {
         return .localizedStringWithFormat(localizationKey.pushFormatString, arguments: arguments)
     }
     
-    public func titleText(selfUser: ZMUser, conversation : ZMConversation? = nil) -> String? {
+    func titleText(selfUser: ZMUser, conversation : ZMConversation? = nil) -> String? {
         
         if case .message(let contentType) = self {
             switch contentType {
@@ -230,7 +230,7 @@ extension LocalNotificationType {
         }
     }
     
-    public func messageBodyText(sender: ZMUser?, conversation: ZMConversation?) -> String {
+    func messageBodyText(sender: ZMUser?, conversation: ZMConversation?) -> String {
         
         if case LocalNotificationType.event(let eventType) = self {
             return messageBodyText(eventType: eventType, senderName: sender?.name)

--- a/Source/Notifications/Push notifications/Notification Types/LocalNotificationType+Localization.swift
+++ b/Source/Notifications/Push notifications/Notification Types/LocalNotificationType+Localization.swift
@@ -145,7 +145,7 @@ extension LocalNotificationType {
         }
     }
     
-    fileprivate func senderKey(_ sender : ZMUser?, _ conversation : ZMConversation?) -> String? {
+    fileprivate func senderKey(_ sender: UserType?, _ conversation: ZMConversation?) -> String? {
         guard let sender = sender else { return NoUserNameKey }
         
         if case .failedMessage = self {
@@ -177,7 +177,7 @@ extension LocalNotificationType {
         return .localizedStringWithFormat(localizationKey.pushFormatString, arguments: arguments)
     }
     
-    public func titleText(selfUser: ZMUser, conversation : ZMConversation? = nil) -> String? {
+    public func titleText(selfUser: UserType, conversation: ZMConversation? = nil) -> String? {
         
         if case .message(let contentType) = self {
             switch contentType {
@@ -190,7 +190,7 @@ extension LocalNotificationType {
             }
         }
         
-        let teamName = selfUser.team?.name
+        let teamName = selfUser.teamName
         let conversationName = conversation?.meaningfulDisplayName
         
         if let conversationName = conversationName, let teamName = teamName {
@@ -230,7 +230,7 @@ extension LocalNotificationType {
         }
     }
     
-    public func messageBodyText(sender: ZMUser?, conversation: ZMConversation?) -> String {
+    public func messageBodyText(sender: UserType?, conversation: ZMConversation?) -> String {
         
         if case LocalNotificationType.event(let eventType) = self {
             return messageBodyText(eventType: eventType, senderName: sender?.name)

--- a/Tests/Source/Notifications/PushNotifications/LocalNotificationDispatcherTests.swift
+++ b/Tests/Source/Notifications/PushNotifications/LocalNotificationDispatcherTests.swift
@@ -21,6 +21,8 @@
 import XCTest
 
 class LocalNotificationDispatcherTests: MessagingTest {
+
+    typealias ZMLocalNotification = WireSyncEngine.ZMLocalNotification
     
     var sut: LocalNotificationDispatcher!
     var conversation1: ZMConversation!

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationForTests_CallState.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationForTests_CallState.swift
@@ -20,6 +20,8 @@ import Foundation
 @testable import WireSyncEngine
 
 class ZMLocalNotificationTests_CallState : MessagingTest {
+
+    typealias ZMLocalNotification = WireSyncEngine.ZMLocalNotification
     
     var sender : ZMUser!
     var conversation : ZMConversation!

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationSetTests.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationSetTests.swift
@@ -42,6 +42,9 @@ public final class MockKVStore : NSObject, ZMSynchonizableKeyValueStore {
 
 class ZMLocalNotificationSetTests : MessagingTest {
 
+    typealias ZMLocalNotification = WireSyncEngine.ZMLocalNotification
+    typealias ZMLocalNotificationSet = WireSyncEngine.ZMLocalNotificationSet
+
     var sut : ZMLocalNotificationSet!
     var notificationCenter: UserNotificationCenterMock!
     var keyValueStore : MockKVStore!

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests.swift
@@ -20,6 +20,8 @@ import XCTest
 @testable import WireSyncEngine
 
 class ZMLocalNotificationTests: MessagingTest {
+
+    typealias ZMLocalNotification = WireSyncEngine.ZMLocalNotification
     
     var sender: ZMUser!
     var selfUser: ZMUser!

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_ExpiredMessage.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_ExpiredMessage.swift
@@ -20,6 +20,8 @@ import XCTest
 @testable import WireSyncEngine
 
 class ZMLocalNotificationTests_ExpiredMessage: MessagingTest {
+
+    typealias ZMLocalNotification = WireSyncEngine.ZMLocalNotification
     
     var userWithNoName: ZMUser!
     var userWithName: ZMUser!


### PR DESCRIPTION
## What's new in this PR?

This PR is part of an ongoing effort to all public references that leak concrete user objects. See the architecture issues for more info: https://github.com/wireapp/ios-architecture/issues/89

Public exposure of `ZMUser` has been removed from the following cluster of files:

- `NotificationUserInfo.swift`
- `ZMLocalNotification.swift`
- `LocalNotificationType+Localization.swift`
- `LocalNotificationDispatcher+Calling.swift`

## Note

I came across a lot of unnecessary public access modifiers, so I've removed those too to harden the SE boundary.
