### PR TITLE
[Feature] wipe after failed unlock

### DIFF
--- a/Source/Public/NSError+ZMUserSession.h
+++ b/Source/Public/NSError+ZMUserSession.h
@@ -26,7 +26,9 @@ typedef NS_ENUM(NSUInteger, ZMAccountDeletedReason) {
     /// The user account was deleted because a jailbreak was detected
     ZMAccountDeletedReasonJailbreakDetected,
     /// The user account was deleted because the session expired
-    ZMAccountDeletedReasonSessionExpired
+    ZMAccountDeletedReasonSessionExpired,
+    /// The user account was deleted because the limit of failed password attempts was reached
+    ZMAccountDeletedReasonFailedPasswordLimitReached
 };
 
 typedef NS_ENUM(NSUInteger, ZMUserSessionErrorCode) {

--- a/Source/SessionManager/SessionManagerConfiguration.swift
+++ b/Source/SessionManager/SessionManagerConfiguration.swift
@@ -55,18 +55,26 @@ public class SessionManagerConfiguration: NSObject, NSCopying, Codable {
     /// The default value of this property is `false`
     public var authenticateAfterReboot: Bool
     
+    /// The `failedPasswordThresholdBeforeWipe` configures the limit of failed password attempts before
+    /// which the session manager will delete account data.
+    ///
+    /// The default value of this property is `nil`, i.e. threshold is ignored
+    public var failedPasswordThresholdBeforeWipe: Int?
+    
     public init(wipeOnCookieInvalid: Bool = false,
                 blacklistDownloadInterval: TimeInterval = 6 * 60 * 60,
                 blockOnJailbreakOrRoot: Bool = false,
                 wipeOnJailbreakOrRoot: Bool = false,
                 messageRetentionInterval: TimeInterval? = nil,
-                authenticateAfterReboot: Bool = false) {
+                authenticateAfterReboot: Bool = false,
+                failedPasswordThresholdBeforeWipe: Int? = nil) {
         self.wipeOnCookieInvalid = wipeOnCookieInvalid
         self.blacklistDownloadInterval = blacklistDownloadInterval
         self.blockOnJailbreakOrRoot = blockOnJailbreakOrRoot
         self.wipeOnJailbreakOrRoot = wipeOnJailbreakOrRoot
         self.messageRetentionInterval = messageRetentionInterval
         self.authenticateAfterReboot = authenticateAfterReboot
+        self.failedPasswordThresholdBeforeWipe = failedPasswordThresholdBeforeWipe
     }
     
     public func copy(with zone: NSZone? = nil) -> Any {
@@ -75,7 +83,8 @@ public class SessionManagerConfiguration: NSObject, NSCopying, Codable {
                                                blockOnJailbreakOrRoot: blockOnJailbreakOrRoot,
                                                wipeOnJailbreakOrRoot: wipeOnJailbreakOrRoot,
                                                messageRetentionInterval: messageRetentionInterval,
-                                               authenticateAfterReboot: authenticateAfterReboot)
+                                               authenticateAfterReboot: authenticateAfterReboot,
+                                               failedPasswordThresholdBeforeWipe: failedPasswordThresholdBeforeWipe)
         
         return copy
     }

--- a/Source/UserSession/ZMUserSession+VerifyPassword.swift
+++ b/Source/UserSession/ZMUserSession+VerifyPassword.swift
@@ -24,6 +24,31 @@ public protocol UserSessionVerifyPasswordInterface {
 
 extension ZMUserSession: UserSessionVerifyPasswordInterface {
     public func verify(password: String, completion: @escaping (VerifyPasswordResult?) -> Void) {
-        VerifyPasswordRequestStrategy.triggerPasswordVerification(with: password, completion: completion, context: self.syncManagedObjectContext)
+        VerifyPasswordRequestStrategy.triggerPasswordVerification(
+            with: password,
+            completion: { [weak self] result in
+                guard let `self` = self else { return }
+                completion(result)
+                if case .denied? = result {
+                    self.failedPasswordCount += 1
+                    self.sessionManager.passwordVerificationDidFail(with: self.failedPasswordCount)
+                } else if case .validated? = result {
+                    self.failedPasswordCount = 0
+                }
+            },
+            context: self.syncManagedObjectContext)
+        
+    }
+    
+    var failedPasswordCount: Int {
+        get {
+            let count = self.managedObjectContext.persistentStoreMetadata(forKey: "failedPasswordCount") as? Int
+            return count ?? 0
+        } set {
+            self.managedObjectContext.setPersistentStoreMetadata(newValue, key: "failedPasswordCount")
+            self.managedObjectContext.saveOrRollback()
+        }
     }
 }
+
+

--- a/Source/UserSession/ZMUserSession+VerifyPassword.swift
+++ b/Source/UserSession/ZMUserSession+VerifyPassword.swift
@@ -23,6 +23,8 @@ public protocol UserSessionVerifyPasswordInterface {
 }
 
 extension ZMUserSession: UserSessionVerifyPasswordInterface {
+    static let failedPasswordCountKey: String = "failedPasswordCount"
+    
     public func verify(password: String, completion: @escaping (VerifyPasswordResult?) -> Void) {
         VerifyPasswordRequestStrategy.triggerPasswordVerification(
             with: password,
@@ -37,15 +39,14 @@ extension ZMUserSession: UserSessionVerifyPasswordInterface {
                 }
             },
             context: self.syncManagedObjectContext)
-        
     }
     
-    var failedPasswordCount: Int {
+    private var failedPasswordCount: Int {
         get {
-            let count = self.managedObjectContext.persistentStoreMetadata(forKey: "failedPasswordCount") as? Int
+            let count = self.managedObjectContext.persistentStoreMetadata(forKey: ZMUserSession.failedPasswordCountKey) as? Int
             return count ?? 0
         } set {
-            self.managedObjectContext.setPersistentStoreMetadata(newValue, key: "failedPasswordCount")
+            self.managedObjectContext.setPersistentStoreMetadata(newValue, key: ZMUserSession.failedPasswordCountKey)
             self.managedObjectContext.saveOrRollback()
         }
     }

--- a/Tests/Source/Calling/CallKitDelegateTests.swift
+++ b/Tests/Source/Calling/CallKitDelegateTests.swift
@@ -89,7 +89,9 @@ class MockSessionManager : NSObject, WireSyncEngine.SessionManagerType {
         return false
     }
     
-    
+    func passwordVerificationDidFail(with failCount: Int) {
+        // no-op
+    }
 }
 
 class MockCallKitProvider: CXProvider {


### PR DESCRIPTION
## What's new in this PR?

Delete the selected account after `n` failed password attempts (only affects appLock)