### PR TITLE
Log error instead of fatal

### DIFF
--- a/Source/Registration/ContactAddressBook.swift
+++ b/Source/Registration/ContactAddressBook.swift
@@ -19,8 +19,10 @@
 import Foundation
 import Contacts
 
+private let zmLog = ZMSLog(tag: "ContactAddressBook")
+
 /// iOS Contacts-based address book
-class ContactAddressBook : AddressBook {
+final class ContactAddressBook : AddressBook {
     
     let store = CNContactStore()
 }
@@ -67,12 +69,12 @@ extension ContactAddressBook : AddressBookAccessor {
                 stop.initialize(to: ObjCBool(!shouldContinue))
             }
         } catch {
-            fatal(error.localizedDescription)
+            zmLog.error(error.localizedDescription)
         }
     }
 
     /// Number of contacts in the address book
-    internal var numberOfContacts: UInt {
+    var numberOfContacts: UInt {
         return 0
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crash after adding a catch in  https://github.com/wireapp/wire-ios-sync-engine/pull/1103

### Causes

Calling `fatal` always crashes

### Solutions

In this case, we should not crash the app when `enumerateContacts` throws. Logging the error instead.