### PR TITLE
[Refactor] UserType in Conversation Classes

### DIFF
--- a/Source/Data Model/Conversation+Participants.swift
+++ b/Source/Data Model/Conversation+Participants.swift
@@ -51,14 +51,15 @@ import Foundation
 
 extension ZMConversation {
     
-    public func addParticipants(_ participants: Set<ZMUser>, userSession: ZMUserSession, completion: @escaping (VoidResult) -> Void) {
+    public func addParticipants(_ participants: [UserType], userSession: ZMUserSession, completion: @escaping (VoidResult) -> Void) {
         
+        let users = participants.compactMap { $0 as? ZMUser }
         guard conversationType == .group,
-              !participants.isEmpty,
-              !participants.contains(ZMUser.selfUser(inUserSession: userSession))
+              !users.isEmpty,
+              !users.contains(ZMUser.selfUser(inUserSession: userSession))
         else { return completion(.failure(ConversationAddParticipantsError.invalidOperation)) }
         
-        let request = ConversationParticipantRequestFactory.requestForAddingParticipants(participants, conversation: self)
+        let request = ConversationParticipantRequestFactory.requestForAddingParticipants(Set(users), conversation: self)
         
         request.add(ZMCompletionHandler(on: managedObjectContext!) { response in
             if response.httpStatus == 200 {
@@ -83,12 +84,15 @@ extension ZMConversation {
         userSession.transportSession.enqueueOneTime(request)
     }
     
-    public func removeParticipant(_ participant: ZMUser, userSession: ZMUserSession, completion: @escaping (VoidResult) -> Void) {
+    public func removeParticipant(_ participant: UserType, userSession: ZMUserSession, completion: @escaping (VoidResult) -> Void) {
         
-        guard conversationType == .group, let conversationId = remoteIdentifier  else { return completion(.failure(ConversationRemoveParticipantError.invalidOperation)) }
+        guard conversationType == .group,
+            let conversationId = remoteIdentifier,
+            let user = participant as? ZMUser
+        else { return completion(.failure(ConversationRemoveParticipantError.invalidOperation)) }
         
         let isRemovingSelfUser = participant.isSelfUser
-        let request = ConversationParticipantRequestFactory.requestForRemovingParticipant(participant, conversation: self)
+        let request = ConversationParticipantRequestFactory.requestForRemovingParticipant(user, conversation: self)
         
         request.add(ZMCompletionHandler(on: managedObjectContext!) { response in
             if response.httpStatus == 200 {
@@ -142,6 +146,5 @@ internal struct ConversationParticipantRequestFactory {
         
         return ZMTransportRequest(path: path, method: .methodPOST, payload: payload as ZMTransportData)
     }
-    
     
 }

--- a/Source/Data Model/Conversation+Participants.swift
+++ b/Source/Data Model/Conversation+Participants.swift
@@ -53,8 +53,8 @@ extension ZMConversation {
     
     public func addParticipants(_ participants: [UserType], userSession: ZMUserSession, completion: @escaping (VoidResult) -> Void) {
         
-        let users = participants.compactMap { $0 as? ZMUser }
-        guard conversationType == .group,
+        guard let users = participants as? [ZMUser],
+              conversationType == .group,
               !users.isEmpty,
               !users.contains(ZMUser.selfUser(inUserSession: userSession))
         else { return completion(.failure(ConversationAddParticipantsError.invalidOperation)) }

--- a/Source/Data Model/Conversation+Role.swift
+++ b/Source/Data Model/Conversation+Role.swift
@@ -18,6 +18,10 @@
 
 import Foundation
 
+private enum RequestError: Int, Error {
+    case unknown = 0
+}
+
 extension ZMConversation {
 
     private typealias Factory = ConversationRoleRequestFactory
@@ -28,6 +32,7 @@ extension ZMConversation {
                            completion: @escaping (VoidResult) -> Void) {
 
         guard let user = participant as? ZMUser else {
+            completion(.failure(RequestError.unknown))
             return
         }
         let maybeRequest = Factory.requestForUpdatingParticipantRole(newRole,
@@ -41,10 +46,6 @@ extension ZMConversation {
 }
 
 struct ConversationRoleRequestFactory {
-
-    enum RequestError: Int, Error {
-        case unknown = 0
-    }
 
     static func requestForUpdatingParticipantRole(_ role: Role,
                                                   for participant: ZMUser,

--- a/Source/Data Model/Conversation+Role.swift
+++ b/Source/Data Model/Conversation+Role.swift
@@ -22,13 +22,16 @@ extension ZMConversation {
 
     private typealias Factory = ConversationRoleRequestFactory
 
-    public func updateRole(of participant: ZMUser,
+    public func updateRole(of participant: UserType,
                            to newRole: Role,
                            session: ZMUserSession,
                            completion: @escaping (VoidResult) -> Void) {
 
+        guard let user = participant as? ZMUser else {
+            return
+        }
         let maybeRequest = Factory.requestForUpdatingParticipantRole(newRole,
-                                                                     for: participant,
+                                                                     for: user,
                                                                      in: self,
                                                                      completion: completion)
         if let request = maybeRequest {

--- a/Tests/Source/Data Model/Conversation+ParticipantsTests.swift
+++ b/Tests/Source/Data Model/Conversation+ParticipantsTests.swift
@@ -72,7 +72,7 @@ class Conversation_ParticipantsTests: MessagingTest {
         let receivedSuccess = expectation(description: "received success")
         
         // when
-        conversation.addParticipants(Set(arrayLiteral: user), userSession: mockUserSession) { result in
+        conversation.addParticipants([user], userSession: mockUserSession) { result in
             switch result {
             case .success:
                 receivedSuccess.fulfill()
@@ -103,7 +103,7 @@ class Conversation_ParticipantsTests: MessagingTest {
         let receivedError = expectation(description: "received error")
         
         // when
-        conversation.addParticipants(Set(arrayLiteral: selfUser), userSession: mockUserSession) { result in
+        conversation.addParticipants([selfUser], userSession: mockUserSession) { result in
             switch result {
             case .failure(let error):
                 if case ConversationAddParticipantsError.invalidOperation = error {
@@ -130,7 +130,7 @@ class Conversation_ParticipantsTests: MessagingTest {
             let receivedError = expectation(description: "received error")
             
             // when
-            conversation.addParticipants(Set(arrayLiteral: user), userSession: mockUserSession) { result in
+            conversation.addParticipants([user], userSession: mockUserSession) { result in
                 switch result {
                 case .failure(let error):
                     if case ConversationAddParticipantsError.invalidOperation = error {
@@ -163,7 +163,7 @@ class Conversation_ParticipantsTests: MessagingTest {
         let receivedError = expectation(description: "received error")
         
         // when
-        conversation.addParticipants(Set(arrayLiteral: user), userSession: mockUserSession) { result in
+        conversation.addParticipants([user], userSession: mockUserSession) { result in
             switch result {
             case .failure(let error):
                 if case ConversationAddParticipantsError.invalidOperation = error {
@@ -198,7 +198,7 @@ class Conversation_ParticipantsTests: MessagingTest {
         let receivedError = expectation(description: "received error")
         
         // when
-        conversation.addParticipants(Set(arrayLiteral: user), userSession: mockUserSession) { result in
+        conversation.addParticipants([user], userSession: mockUserSession) { result in
             switch result {
             case .failure(let error):
                 if case ConversationAddParticipantsError.conversationNotFound = error {

--- a/Tests/Source/Integration/ConversationTests+LegalHold.swift
+++ b/Tests/Source/Integration/ConversationTests+LegalHold.swift
@@ -89,7 +89,7 @@ class ConversationTests_LegalHold: ConversationTestsBase {
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // when
-        groupConversation?.addParticipants(Set(arrayLiteral: legalHoldUser), userSession: userSession!, completion: { _ in })
+        groupConversation?.addParticipants([legalHoldUser], userSession: userSession!, completion: { _ in })
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then
@@ -111,7 +111,7 @@ class ConversationTests_LegalHold: ConversationTestsBase {
         legalHoldUser.fetchUserClients()
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
-        groupConversation?.addParticipants(Set(arrayLiteral: legalHoldUser), userSession: userSession!, completion: { _ in })
+        groupConversation?.addParticipants([legalHoldUser], userSession: userSession!, completion: { _ in })
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         XCTAssertEqual(groupConversation?.legalHoldStatus, .pendingApproval)
         

--- a/Tests/Source/Integration/ConversationTests+Participants.swift
+++ b/Tests/Source/Integration/ConversationTests+Participants.swift
@@ -32,7 +32,7 @@ class ConversationTests_Participants: ConversationTestsBase {
         observer?.clearNotifications()
         
         // when
-        conversation.addParticipants(Set(arrayLiteral: connectedUser), userSession: userSession!, completion: { (_) in })
+        conversation.addParticipants([connectedUser], userSession: userSession!, completion: { (_) in })
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then - Participants changes and messages changes (System message for the added user)
@@ -70,7 +70,7 @@ class ConversationTests_Participants: ConversationTestsBase {
         XCTAssertFalse(conversation.localParticipants.contains(connectedUser))
         
         // when
-        conversation.addParticipants(Set(arrayLiteral: connectedUser), userSession: userSession!, completion: { (_) in })
+        conversation.addParticipants([connectedUser], userSession: userSession!, completion: { (_) in })
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then


### PR DESCRIPTION
## What's new in this PR?

This PR is part of an ongoing effort to all public references that leak concrete user objects. See the architecture issues for more info: wireapp/ios-architecture#89

Public exposure of ZMUser has been removed from the following cluster of files:

- Conversation+Participants.swift
- Conversation+Role.swift