### PR TITLE
[Refactor] UserType in Legal Hold Classes

### DIFF
--- a/Source/UserSession/ZMUserSession+LegalHold.swift
+++ b/Source/UserSession/ZMUserSession+LegalHold.swift
@@ -20,9 +20,9 @@ import Foundation
 import WireDataModel
 import WireTransport
 
-public enum LegalHoldActivationError: Error {
-    case userNotInTeam(UserType)
-    case invalidUser(UserType)
+public enum LegalHoldActivationError: Error, Equatable {
+    case selfUserNotInTeam
+    case invalidSelfUser
     case invalidResponse(Int, String?)
     case invalidPassword
     case couldNotEstablishSession
@@ -58,11 +58,11 @@ extension ZMUserSession {
 
             // 1) Check the state
             guard let teamID = selfUser.team?.remoteIdentifier else {
-                return complete(error: .userNotInTeam(selfUser))
+                return complete(error: .selfUserNotInTeam)
             }
 
             guard let userID = selfUser.remoteIdentifier else {
-                return complete(error: .invalidUser(selfUser))
+                return complete(error: .invalidSelfUser)
             }
 
             // 2) Create the potential LH client

--- a/Source/UserSession/ZMUserSession+LegalHold.swift
+++ b/Source/UserSession/ZMUserSession+LegalHold.swift
@@ -20,9 +20,9 @@ import Foundation
 import WireDataModel
 import WireTransport
 
-public enum LegalHoldActivationError: Error, Equatable {
-    case userNotInTeam(ZMUser)
-    case invalidUser(ZMUser)
+public enum LegalHoldActivationError: Error {
+    case userNotInTeam(UserType)
+    case invalidUser(UserType)
     case invalidResponse(Int, String?)
     case invalidPassword
     case couldNotEstablishSession

--- a/Tests/Source/Integration/ZMUserSessionLegalHoldTests.swift
+++ b/Tests/Source/Integration/ZMUserSessionLegalHoldTests.swift
@@ -103,8 +103,7 @@ class ZMUserSessionLegalHoldTests: IntegrationTest {
         let completionExpectation = expectation(description: "The request completes.")
 
         userSession?.accept(legalHoldRequest: legalHoldRequest, password: "I tRieD 3 tImeS!") { error in
-            XCTAssertEqual(error?.index, LegalHoldActivationError.invalidPassword.index)
-            
+            XCTAssertEqual(error, .invalidPassword)
             completionExpectation.fulfill()
         }
 
@@ -116,24 +115,4 @@ class ZMUserSessionLegalHoldTests: IntegrationTest {
         XCTAssertEqual(realSelfUser.legalHoldStatus, .pending(legalHoldRequest))
     }
 
-}
-
-// The property was created with the purpose of using it in tests.
-// We can't make LegalHoldActivationError equatable, because we'd also need to make UserType equatable.
-// But UserType is marked with @objc and Equatable is a Swift only protocol.
-extension LegalHoldActivationError {
-     var index: Int {
-        switch self {
-        case .userNotInTeam:
-            return 0
-        case .invalidUser:
-            return 1
-        case .invalidResponse:
-            return 2
-        case .invalidPassword:
-            return 3
-        default:
-            return 4
-        }
-    }
 }

--- a/Tests/Source/Integration/ZMUserSessionLegalHoldTests.swift
+++ b/Tests/Source/Integration/ZMUserSessionLegalHoldTests.swift
@@ -103,7 +103,8 @@ class ZMUserSessionLegalHoldTests: IntegrationTest {
         let completionExpectation = expectation(description: "The request completes.")
 
         userSession?.accept(legalHoldRequest: legalHoldRequest, password: "I tRieD 3 tImeS!") { error in
-            XCTAssertEqual(error, .invalidPassword)
+            XCTAssertEqual(error?.index, LegalHoldActivationError.invalidPassword.index)
+            
             completionExpectation.fulfill()
         }
 
@@ -115,4 +116,24 @@ class ZMUserSessionLegalHoldTests: IntegrationTest {
         XCTAssertEqual(realSelfUser.legalHoldStatus, .pending(legalHoldRequest))
     }
 
+}
+
+// The property was created with the purpose of using it in tests.
+// We can't make LegalHoldActivationError equatable, because we'd also need to make UserType equatable.
+// But UserType is marked with @objc and Equatable is a Swift only protocol.
+extension LegalHoldActivationError {
+     var index: Int {
+        switch self {
+        case .userNotInTeam:
+            return 0
+        case .invalidUser:
+            return 1
+        case .invalidResponse:
+            return 2
+        case .invalidPassword:
+            return 3
+        default:
+            return 4
+        }
+    }
 }


### PR DESCRIPTION
## What's new in this PR?

This PR is part of an ongoing effort to all public references that leak concrete user objects. See the architecture issues for more info: wireapp/ios-architecture#89

Public exposure of ZMUser has been removed from the following cluster of files:

LegalHold.swift