### PR TITLE
[Refactor] Hide Concrete Users in Calling Classes

### DIFF
--- a/Source/Calling/CallKitDelegate.swift
+++ b/Source/Calling/CallKitDelegate.swift
@@ -479,7 +479,7 @@ extension CallKitDelegate : WireCallCenterCallStateObserver, WireCallCenterMisse
         }
     }
     
-    public func callCenterMissedCall(conversation: ZMConversation, caller: ZMUser, timestamp: Date, video: Bool) {
+    public func callCenterMissedCall(conversation: ZMConversation, caller: UserType, timestamp: Date, video: Bool) {
         // Since we missed the call we will not have an assigned callUUID and can just create a random one
         provider.reportCall(with: UUID(), endedAt: timestamp, reason: .unanswered)
     }

--- a/Source/Calling/CallKitDelegate.swift
+++ b/Source/Calling/CallKitDelegate.swift
@@ -462,11 +462,10 @@ extension CallKitDelegate : CXProviderDelegate {
 
 extension CallKitDelegate : WireCallCenterCallStateObserver, WireCallCenterMissedCallObserver {
     
-    public func callCenterDidChange(callState: CallState, conversation: ZMConversation, caller: ZMUser, timestamp: Date?, previousCallState: CallState?) {
-        
+    public func callCenterDidChange(callState: CallState, conversation: ZMConversation, caller: UserType, timestamp: Date?, previousCallState: CallState?) {
         switch callState {
         case .incoming(video: let video, shouldRing: let shouldRing, degraded: _):
-            if shouldRing {
+            if shouldRing, let caller = caller as? ZMUser {
                 if conversation.mutedMessageTypesIncludingAvailability == .none {
                     reportIncomingCall(from: caller, in: conversation, video: video)
                 }
@@ -568,7 +567,7 @@ class CallObserver : WireCallCenterCallStateObserver {
         token = WireCallCenterV3.addCallStateObserver(observer: self, for: conversation, context: conversation.managedObjectContext!)
     }
     
-    public func callCenterDidChange(callState: CallState, conversation: ZMConversation, caller: ZMUser, timestamp: Date?, previousCallState: CallState?) {
+    public func callCenterDidChange(callState: CallState, conversation: ZMConversation, caller: UserType, timestamp: Date?, previousCallState: CallState?) {
         switch callState {
         case .answered(degraded: false):
             onAnswered?()

--- a/Source/Calling/SystemMessageCallObserver.swift
+++ b/Source/Calling/SystemMessageCallObserver.swift
@@ -26,7 +26,7 @@ final class CallSystemMessageGenerator: NSObject {
     var startDateByConversation = [ZMConversation: Date]()
     var connectDateByConversation = [ZMConversation: Date]()
 
-    public func appendSystemMessageIfNeeded(callState: CallState, conversation: ZMConversation, caller: ZMUser, timestamp: Date?, previousCallState: CallState?) -> ZMSystemMessage?{
+    func appendSystemMessageIfNeeded(callState: CallState, conversation: ZMConversation, caller: ZMUser, timestamp: Date?, previousCallState: CallState?) -> ZMSystemMessage? {
         var systemMessage : ZMSystemMessage? = nil
 
         switch callState {

--- a/Source/Calling/VoiceChannel.swift
+++ b/Source/Calling/VoiceChannel.swift
@@ -54,7 +54,7 @@ public protocol CallProperties : NSObjectProtocol {
     /// Voice channel is sending audio using a contant bit rate
     var isConstantBitRateAudioActive: Bool { get }
     var isVideoCall: Bool { get }
-    var initiator: ZMUser? { get }
+    var initiator: UserType? { get }
     var videoState: VideoState { get set }
     var networkQuality: NetworkQuality { get }
     var muted: Bool { get set }

--- a/Source/Calling/VoiceChannelV3.swift
+++ b/Source/Calling/VoiceChannelV3.swift
@@ -79,7 +79,7 @@ public class VoiceChannelV3 : NSObject, VoiceChannel {
         return callCenter.networkQuality(conversationId: remoteIdentifier)
     }
     
-    public var initiator : ZMUser? {
+    public var initiator: UserType? {
         guard let context = conversation?.managedObjectContext,
               let convId = conversation?.remoteIdentifier,
               let userId = self.callCenter?.initiatorForCall(conversationId: convId)

--- a/Source/Calling/WireCallCenterV3+Notifications.swift
+++ b/Source/Calling/WireCallCenterV3+Notifications.swift
@@ -97,7 +97,7 @@ public protocol WireCallCenterCallStateObserver : class {
      - parameter caller: user which initiated the call
      - parameter timestamp: when the call state change occured
      */
-    func callCenterDidChange(callState: CallState, conversation: ZMConversation, caller: ZMUser, timestamp: Date?, previousCallState: CallState?)
+    func callCenterDidChange(callState: CallState, conversation: ZMConversation, caller: UserType, timestamp: Date?, previousCallState: CallState?)
 }
 
 public struct WireCallCenterCallStateNotification : SelfPostingNotification {

--- a/Source/Calling/WireCallCenterV3+Notifications.swift
+++ b/Source/Calling/WireCallCenterV3+Notifications.swift
@@ -18,23 +18,6 @@
 
 import Foundation
 
-@objc
-public enum ReceivedVideoState : UInt {
-    /// Sender is not sending video
-    case stopped
-    /// Sender is sending video
-    case started
-    /// Sender is sending video but currently has a bad connection
-    case badConnection
-}
-
-@objc
-public protocol ReceivedVideoObserver : class {
-    
-    @objc(callCenterDidChangeReceivedVideoState:user:)
-    func callCenterDidChange(receivedVideoState: ReceivedVideoState, user: ZMUser)
-    
-}
 
 protocol SelfPostingNotification {
     static var notificationName : Notification.Name { get }

--- a/Source/Calling/WireCallCenterV3+Notifications.swift
+++ b/Source/Calling/WireCallCenterV3+Notifications.swift
@@ -114,7 +114,7 @@ public struct WireCallCenterCallStateNotification : SelfPostingNotification {
 // MARK:- Missed call observer
 
 public protocol WireCallCenterMissedCallObserver : class {
-    func callCenterMissedCall(conversation: ZMConversation, caller: ZMUser, timestamp: Date, video: Bool)
+    func callCenterMissedCall(conversation: ZMConversation, caller: UserType, timestamp: Date, video: Bool)
 }
 
 public struct WireCallCenterMissedCallNotification : SelfPostingNotification {

--- a/Source/Calling/WireCallCenterV3+Notifications.swift
+++ b/Source/Calling/WireCallCenterV3+Notifications.swift
@@ -154,7 +154,7 @@ public struct WireCallCenterCallParticipantNotification : SelfPostingNotificatio
 
 @objc
 public protocol VoiceGainObserver : class {
-    func voiceGainDidChange(forParticipant participant: ZMUser, volume: Float)
+    func voiceGainDidChange(forParticipant participant: UserType, volume: Float)
 }
 
 @objcMembers

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -1103,9 +1103,9 @@ extension SessionManager: ZMConversationListObserver {
 
 extension SessionManager : WireCallCenterCallStateObserver {
     
-    public func callCenterDidChange(callState: CallState, conversation: ZMConversation, caller: ZMUser, timestamp: Date?, previousCallState: CallState?) {
+    public func callCenterDidChange(callState: CallState, conversation: ZMConversation, caller: UserType, timestamp: Date?, previousCallState: CallState?) {
         guard let moc = conversation.managedObjectContext else { return }
-    
+
         switch callState {
         case .answered, .outgoing:
             for (_, session) in backgroundUserSessions where session.managedObjectContext == moc && activeUserSession != session {

--- a/Source/UserSession/CallStateObserver.swift
+++ b/Source/UserSession/CallStateObserver.swift
@@ -60,9 +60,8 @@ public final class CallStateObserver : NSObject {
 
 extension CallStateObserver : WireCallCenterCallStateObserver, WireCallCenterMissedCallObserver  {
     
-    public func callCenterDidChange(callState: CallState, conversation: ZMConversation, caller: ZMUser, timestamp: Date?, previousCallState: CallState?) {
-        
-        let callerId = caller.remoteIdentifier
+    public func callCenterDidChange(callState: CallState, conversation: ZMConversation, caller: UserType, timestamp: Date?, previousCallState: CallState?) {
+        let callerId = (caller as? ZMUser)?.remoteIdentifier
         let conversationId = conversation.remoteIdentifier
         
         syncManagedObjectContext.performGroupedBlock {

--- a/Source/UserSession/CallStateObserver.swift
+++ b/Source/UserSession/CallStateObserver.swift
@@ -139,8 +139,8 @@ extension CallStateObserver : WireCallCenterCallStateObserver, WireCallCenterMis
         }
     }
     
-    public func callCenterMissedCall(conversation: ZMConversation, caller: ZMUser, timestamp: Date, video: Bool) {
-        let callerId = caller.remoteIdentifier
+    public func callCenterMissedCall(conversation: ZMConversation, caller: UserType, timestamp: Date, video: Bool) {
+        let callerId = (caller as? ZMUser)?.remoteIdentifier
         let conversationId = conversation.remoteIdentifier
         
         syncManagedObjectContext.performGroupedBlock {


### PR DESCRIPTION
## What's new in this PR?

This PR is part of an ongoing effort to remove all concrete user objects from the UI project. See the architecture issues for more info: https://github.com/wireapp/ios-architecture/issues/89.

All public references `ZMUser` have been hidden in the following files:

- `VoiceChannel.swift`
- `VoiceChannelV3.swift`
- `CallKitDelegate.swift`
- `SystemMessageCallObserver.swift`
- `CallStateObserver.swift`
- `WireCallCenterV3+Notifications.swift`