### PR TITLE
Remove the need for mocking the user session with OCMock (Part 1)

### DIFF
--- a/Source/UserSession/Search/SearchResult+AddressBook.swift
+++ b/Source/UserSession/Search/SearchResult+AddressBook.swift
@@ -26,7 +26,7 @@ extension SearchResult {
     
     /// Creates a new search result with the same results and additional
     /// results obtained by searching through the address book with the same query
-    public func extendWithContactsFromAddressBook(_ query: String, userSession: ZMUserSession) -> SearchResult {
+    public func extendWithContactsFromAddressBook(_ query: String, contextProvider: ZMManagedObjectContextProvider) -> SearchResult {
         /*
          When I have a search result obtained (either with a local search or from the BE) by matching on Wire
          users display names or handle, I also want to check if I have any address book contact in my local
@@ -45,17 +45,17 @@ extension SearchResult {
         // the result as Wire user results, not an non-Wire address book results
         
         let (additionalUsersFromAddressBook, addressBookContactsWithoutUser) = contactsThatAreAlsoUsers(contacts: allMatchingAddressBookContacts,
-                                                                                                        managedObjectContext: userSession.managedObjectContext)
-        let searchUsersFromAddressBook = addressBookContactsWithoutUser.compactMap {  ZMSearchUser(contextProvider: userSession, contact: $0) }
+                                                                                                        managedObjectContext: contextProvider.managedObjectContext)
+        let searchUsersFromAddressBook = addressBookContactsWithoutUser.compactMap {  ZMSearchUser(contextProvider: contextProvider, contact: $0) }
         
         // of those users, which one are connected and which one are not?
         let additionalConnectedUsers = additionalUsersFromAddressBook
             .filter { $0.connection != nil }
-            .compactMap { ZMSearchUser(contextProvider: userSession, user: $0) }
+            .compactMap { ZMSearchUser(contextProvider: contextProvider, user: $0) }
         let additionalNonConnectedUsers = additionalUsersFromAddressBook
             .filter { $0.connection == nil }
-            .compactMap { ZMSearchUser(contextProvider: userSession, user: $0) }
-        let connectedUsers = contacts.compactMap { ZMSearchUser(contextProvider: userSession, user: $0) }
+            .compactMap { ZMSearchUser(contextProvider: contextProvider, user: $0) }
+        let connectedUsers = contacts.compactMap { ZMSearchUser(contextProvider: contextProvider, user: $0) }
         
         return SearchResult(contacts: contacts,
                             teamMembers: teamMembers,

--- a/Source/UserSession/Search/SearchResult.swift
+++ b/Source/UserSession/Search/SearchResult.swift
@@ -29,7 +29,7 @@ public struct SearchResult {
 
 extension SearchResult {
     
-    public init?(payload: [AnyHashable : Any], query: String, userSession: ZMUserSession) {
+    public init?(payload: [AnyHashable : Any], query: String, contextProvider: ZMManagedObjectContextProvider) {
         guard let documents = payload["documents"] as? [[String : Any]] else {
             return nil
         }
@@ -44,7 +44,7 @@ extension SearchResult {
             return !isHandleQuery || name?.hasPrefix("@") ?? true || handle?.contains(queryWithoutAtSymbol) ?? false
         }
         
-        let searchUsers = ZMSearchUser.searchUsers(from: filteredDocuments, contextProvider: userSession)
+        let searchUsers = ZMSearchUser.searchUsers(from: filteredDocuments, contextProvider: contextProvider)
         
         contacts = []
         teamMembers = []
@@ -54,12 +54,12 @@ extension SearchResult {
         services = []
     }
     
-    public init?(servicesPayload servicesFullPayload: [AnyHashable : Any], query: String, userSession: ZMUserSession) {
+    public init?(servicesPayload servicesFullPayload: [AnyHashable : Any], query: String, contextProvider: ZMManagedObjectContextProvider) {
         guard let servicesPayload = servicesFullPayload["services"] as? [[String : Any]] else {
             return nil
         }
         
-        let searchUsersServices = ZMSearchUser.searchUsers(from: servicesPayload, contextProvider: userSession)
+        let searchUsersServices = ZMSearchUser.searchUsers(from: servicesPayload, contextProvider: contextProvider)
         
         contacts = []
         teamMembers = []
@@ -69,9 +69,9 @@ extension SearchResult {
         services = searchUsersServices
     }
     
-    public init?(userLookupPayload: [AnyHashable : Any], userSession: ZMUserSession) {
+    public init?(userLookupPayload: [AnyHashable : Any], contextProvider: ZMManagedObjectContextProvider) {
         guard let userLookupPayload = userLookupPayload as? [String : Any],
-              let searchUser = ZMSearchUser.searchUser(from: userLookupPayload, contextProvider: userSession),
+              let searchUser = ZMSearchUser.searchUser(from: userLookupPayload, contextProvider: contextProvider),
               searchUser.user == nil ||
               searchUser.user?.isTeamMember == false else {
             return nil

--- a/Tests/Source/DatabaseTest.swift
+++ b/Tests/Source/DatabaseTest.swift
@@ -1,0 +1,101 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension ManagedObjectContextDirectory: ZMManagedObjectContextProvider {
+    
+    public var managedObjectContext: NSManagedObjectContext! {
+        return uiContext
+    }
+    
+    public var syncManagedObjectContext: NSManagedObjectContext! {
+        return syncContext
+    }
+    
+}
+
+class DatabaseTest: ZMTBaseTest {
+    
+    let accountId = UUID()
+    var contextDirectory: ManagedObjectContextDirectory?
+    
+    var useInMemoryDatabase: Bool {
+        return true
+    }
+    
+    var uiMOC: NSManagedObjectContext {
+        return self.contextDirectory!.uiContext
+    }
+    
+    var syncMOC: NSManagedObjectContext {
+        return self.contextDirectory!.syncContext
+    }
+    
+    var searchMOC: NSManagedObjectContext {
+        return self.contextDirectory!.searchContext
+    }
+    
+    var sharedContainerURL: URL? {
+        let bundleIdentifier = Bundle.main.bundleIdentifier
+        let groupIdentifier = "group." + bundleIdentifier!
+        return FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: groupIdentifier)
+    }
+    
+    private func cleanUp() {
+        try? FileManager.default.contentsOfDirectory(at: sharedContainerURL!, includingPropertiesForKeys: nil, options: .skipsHiddenFiles).forEach {
+            try? FileManager.default.removeItem(at: $0)
+        }
+        
+        StorageStack.reset()
+    }
+    
+    private func createDatabase() {
+        StorageStack.reset()
+        
+        let expectation = self.expectation(description: "Created context")
+        StorageStack.shared.createStorageAsInMemory = useInMemoryDatabase
+        StorageStack.shared.createManagedObjectContextDirectory(accountIdentifier: accountId, applicationContainer: sharedContainerURL!, dispatchGroup: self.dispatchGroup) {
+            self.contextDirectory = $0
+            expectation.fulfill()
+        }
+        XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
+    }
+    
+    override func setUp() {
+        super.setUp()
+        
+        createDatabase()
+    }
+    
+    override func tearDown() {
+        cleanUp()
+        contextDirectory = nil
+        
+        super.tearDown()
+    }
+    
+    func performPretendingUIMocIsSyncMoc(_ block: () -> Void) {
+        uiMOC.resetContextType()
+        uiMOC.markAsSyncContext()
+        block()
+        uiMOC.resetContextType()
+        uiMOC.markAsUIContext()
+    }
+    
+}

--- a/Tests/Source/DiskDatabaseTest.swift
+++ b/Tests/Source/DiskDatabaseTest.swift
@@ -22,65 +22,20 @@ import XCTest
 import WireTesting
 import WireDataModel
 
-public class DiskDatabaseTest: ZMTBaseTest {
-    var sharedContainerURL : URL!
-    var accountId : UUID!
-    var moc: NSManagedObjectContext {
-        return contextDirectory.uiContext
-    }
-    var contextDirectory: ManagedObjectContextDirectory!
+class DiskDatabaseTest: DatabaseTest {
     
-    var storeURL : URL {
-        return StorageStack.accountFolder(
-            accountIdentifier: accountId,
-            applicationContainer: sharedContainerURL
-            ).appendingPersistentStoreLocation()
+    override var useInMemoryDatabase: Bool {
+        return false
     }
     
     public override func setUp() {
         super.setUp()
-
-        accountId = .create()
-        let bundleIdentifier = Bundle.main.bundleIdentifier
-        let groupIdentifier = "group." + bundleIdentifier!
-        sharedContainerURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: groupIdentifier)
-        cleanUp()
-        createDatabase()
-
-        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 1))
-        XCTAssert(FileManager.default.fileExists(atPath: storeURL.path))
-    }
-    
-    public override func tearDown() {
-        cleanUp()
-        contextDirectory = nil
-        sharedContainerURL = nil
-        accountId = nil
-        super.tearDown()
-    }
-    
-    private func createDatabase() {
-        StorageStack.reset()
-        StorageStack.shared.createStorageAsInMemory = false
-
-        let expectation = self.expectation(description: "Created context")
-        StorageStack.shared.createManagedObjectContextDirectory(accountIdentifier: accountId, applicationContainer: storeURL, dispatchGroup: self.dispatchGroup) {
-            self.contextDirectory = $0
-            expectation.fulfill()
-        }
-        XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
-        self.moc.performGroupedBlockAndWait {
-            let selfUser = ZMUser.selfUser(in: self.moc)
+        
+        self.syncMOC.performGroupedBlockAndWait {
+            let selfUser = ZMUser.selfUser(in: self.syncMOC)
             selfUser.remoteIdentifier = self.accountId
         }
     }
     
-    private func cleanUp() {
-        try? FileManager.default.contentsOfDirectory(at: sharedContainerURL, includingPropertiesForKeys: nil, options: .skipsHiddenFiles).forEach {
-            try? FileManager.default.removeItem(at: $0)
-        }
-
-        StorageStack.reset()
-    }
 }
 

--- a/Tests/Source/UserSession/SearchDirectoryTests.swift
+++ b/Tests/Source/UserSession/SearchDirectoryTests.swift
@@ -20,14 +20,15 @@ import Foundation
 
 @testable import WireSyncEngine
 
-class SearchDirectoryTests : MessagingTest {
+class SearchDirectoryTests : DatabaseTest {
 
     func testThatItEmptiesTheSearchUserCacheOnTeardown() {
         // given
         uiMOC.zm_searchUserCache = NSCache()
+        let mockTransport = MockTransportSession(dispatchGroup: dispatchGroup)
         let uuid = UUID.create()
-        let sut = SearchDirectory(userSession: mockUserSession)
-        _ = ZMSearchUser(contextProvider: mockUserSession, name: "John Doe", handle: "john", accentColor: .brightOrange, remoteIdentifier: uuid)
+        let sut = SearchDirectory(searchContext: searchMOC, contextProvider: contextDirectory!, transportSession: mockTransport)
+        _ = ZMSearchUser(contextProvider: contextDirectory!, name: "John Doe", handle: "john", accentColor: .brightOrange, remoteIdentifier: uuid)
         XCTAssertNotNil(uiMOC.zm_searchUserCache?.object(forKey: uuid as NSUUID))
     
         // when

--- a/Tests/Source/UserSession/SearchResultTests.swift
+++ b/Tests/Source/UserSession/SearchResultTests.swift
@@ -20,7 +20,7 @@ import Foundation
 
 @testable import WireSyncEngine
 
-class SearchResultTests : MessagingTest {
+class SearchResultTests : DatabaseTest {
     
     func testThatItFiltersConnectedUsers() {
         // given
@@ -45,7 +45,7 @@ class SearchResultTests : MessagingTest {
             ]]
         
         // when
-        let result = SearchResult(payload: payload, query: "", userSession: mockUserSession)
+        let result = SearchResult(payload: payload, query: "", contextProvider: contextDirectory!)
         
         // then
         XCTAssertEqual(result?.directory.count, 1)
@@ -78,7 +78,7 @@ class SearchResultTests : MessagingTest {
             ]]
         
         // when
-        let result = SearchResult(payload: payload, query: "", userSession: mockUserSession)
+        let result = SearchResult(payload: payload, query: "", contextProvider: contextDirectory!)
         
         // then
         XCTAssertEqual(result?.directory.count, 1)
@@ -99,7 +99,7 @@ class SearchResultTests : MessagingTest {
             ]]
         
         // when
-        let result = SearchResult(payload: payload, query: name, userSession: mockUserSession)
+        let result = SearchResult(payload: payload, query: name, contextProvider: contextDirectory!)
         
         // then
         XCTAssertEqual(result?.directory.count, 2)
@@ -121,7 +121,7 @@ class SearchResultTests : MessagingTest {
             ]]
         
         // when
-        let result = SearchResult(payload: payload, query: "@\(name)", userSession: mockUserSession)!
+        let result = SearchResult(payload: payload, query: "@\(name)", contextProvider: contextDirectory!)!
         
         // then
         XCTAssertEqual(result.directory.count, 1)

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		1662B0F923D9CE8F00B8C7C5 /* UnauthenticatedSessionTests+DomainLookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1662B0F823D9CE8F00B8C7C5 /* UnauthenticatedSessionTests+DomainLookup.swift */; };
 		166A8BF31E015F3B00F5EEEA /* WireCallCenterV3Factory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166A8BF21E015F3B00F5EEEA /* WireCallCenterV3Factory.swift */; };
 		166A8BF91E02C7D500F5EEEA /* ZMHotFix+PendingChanges.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166A8BF81E02C7D500F5EEEA /* ZMHotFix+PendingChanges.swift */; };
+		166B2B6E23EB2CD3003E8581 /* DatabaseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166B2B6D23EB2CD3003E8581 /* DatabaseTest.swift */; };
 		166D18A4230EBFFA001288CD /* MediaManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166D18A3230EBFFA001288CD /* MediaManager.swift */; };
 		166D18A6230EC418001288CD /* MockMediaManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166D18A5230EC418001288CD /* MockMediaManager.swift */; };
 		166D191D231569DD001288CD /* SessionManagerTests+MessageRetention.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166D191C231569DD001288CD /* SessionManagerTests+MessageRetention.swift */; };
@@ -559,6 +560,27 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		166B2B6523EB11C8003E8581 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 166B2B5F23EB11C8003E8581 /* WireDataModel.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = F9C9A4FC1CAD5DF10039E10C;
+			remoteInfo = WireDataModel;
+		};
+		166B2B6723EB11C8003E8581 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 166B2B5F23EB11C8003E8581 /* WireDataModel.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = F9C9A5061CAD5DF10039E10C;
+			remoteInfo = WireDataModelTests;
+		};
+		166B2B6923EB11C8003E8581 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 166B2B5F23EB11C8003E8581 /* WireDataModel.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = F9C9A7F31CAED9510039E10C;
+			remoteInfo = WireDataModelTestHost;
+		};
 		3E1860D0191A649D000FE027 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 540029AB1918CA8500578793 /* Project object */;
@@ -686,6 +708,8 @@
 		1662B0F823D9CE8F00B8C7C5 /* UnauthenticatedSessionTests+DomainLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UnauthenticatedSessionTests+DomainLookup.swift"; sourceTree = "<group>"; };
 		166A8BF21E015F3B00F5EEEA /* WireCallCenterV3Factory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WireCallCenterV3Factory.swift; sourceTree = "<group>"; };
 		166A8BF81E02C7D500F5EEEA /* ZMHotFix+PendingChanges.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMHotFix+PendingChanges.swift"; sourceTree = "<group>"; };
+		166B2B5F23EB11C8003E8581 /* WireDataModel.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = WireDataModel.xcodeproj; path = "../wire-ios-data-model/WireDataModel.xcodeproj"; sourceTree = "<group>"; };
+		166B2B6D23EB2CD3003E8581 /* DatabaseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseTest.swift; sourceTree = "<group>"; };
 		166D18A3230EBFFA001288CD /* MediaManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaManager.swift; sourceTree = "<group>"; };
 		166D18A5230EC418001288CD /* MockMediaManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMediaManager.swift; sourceTree = "<group>"; };
 		166D191C231569DD001288CD /* SessionManagerTests+MessageRetention.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionManagerTests+MessageRetention.swift"; sourceTree = "<group>"; };
@@ -1347,6 +1371,16 @@
 			path = E2EE;
 			sourceTree = "<group>";
 		};
+		166B2B6023EB11C8003E8581 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				166B2B6623EB11C8003E8581 /* WireDataModel.framework */,
+				166B2B6823EB11C8003E8581 /* WireDataModelTests.xctest */,
+				166B2B6A23EB11C8003E8581 /* WireDataModelTestHost.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		3E18605A191A4EF8000FE027 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -1504,6 +1538,7 @@
 		540029AA1918CA8500578793 = {
 			isa = PBXGroup;
 			children = (
+				166B2B5F23EB11C8003E8581 /* WireDataModel.xcodeproj */,
 				09284B6A1B8272C300EEE10E /* WireSyncEngine Test Host.entitlements */,
 				09CC4AB71B7CB8B700201C63 /* Cartfile */,
 				F93C4C6F1E1E8B77007E9CEE /* Cartfile.resolved */,
@@ -1610,6 +1645,7 @@
 				5E2C354C21A806A80034F1EE /* MockBackgroundActivityManager.swift */,
 				54BD32D01A5ACCF9008EB1B0 /* Test-Bridging-Header.h */,
 				16A5FE20215B584200AEEBBD /* MockLinkPreviewDetector.swift */,
+				166B2B6D23EB2CD3003E8581 /* DatabaseTest.swift */,
 				87AEA67B1EFBD27700C94BF3 /* DiskDatabaseTest.swift */,
 				5E8EE1FD20FDCD1300DB1F9B /* MockPasteboard.swift */,
 				5E0EB1F82100A46F00B5DC2B /* MockCompanyLoginRequesterDelegate.swift */,
@@ -2542,6 +2578,12 @@
 			mainGroup = 540029AA1918CA8500578793;
 			productRefGroup = 540029B51918CA8500578793 /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 166B2B6023EB11C8003E8581 /* Products */;
+					ProjectRef = 166B2B5F23EB11C8003E8581 /* WireDataModel.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				549815921A43232400A7CE2E /* WireSyncEngine-ios */,
@@ -2550,6 +2592,30 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		166B2B6623EB11C8003E8581 /* WireDataModel.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = WireDataModel.framework;
+			remoteRef = 166B2B6523EB11C8003E8581 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		166B2B6823EB11C8003E8581 /* WireDataModelTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = WireDataModelTests.xctest;
+			remoteRef = 166B2B6723EB11C8003E8581 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		166B2B6A23EB11C8003E8581 /* WireDataModelTestHost.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = WireDataModelTestHost.app;
+			remoteRef = 166B2B6923EB11C8003E8581 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		3E186086191A56F6000FE027 /* Resources */ = {
@@ -2803,6 +2869,7 @@
 				F94F6B331E54B9C000D46A29 /* CallingRequestStrategyTests.swift in Sources */,
 				168E96DD220C6EB700FC92FA /* UserTests+AccountDeletion.swift in Sources */,
 				545643D61C62C1A800A2129C /* ConversationTestsBase.m in Sources */,
+				166B2B6E23EB2CD3003E8581 /* DatabaseTest.swift in Sources */,
 				16904A84207E078C00C92806 /* ConversationTests+Participants.swift in Sources */,
 				5E8BB8A52149130800EEA64B /* AVSBridgingTests.swift in Sources */,
 				54E4DD0F1DE4A9C500FEF192 /* UserHandleTests.swift in Sources */,

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -560,27 +560,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		166B2B6523EB11C8003E8581 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 166B2B5F23EB11C8003E8581 /* WireDataModel.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = F9C9A4FC1CAD5DF10039E10C;
-			remoteInfo = WireDataModel;
-		};
-		166B2B6723EB11C8003E8581 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 166B2B5F23EB11C8003E8581 /* WireDataModel.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = F9C9A5061CAD5DF10039E10C;
-			remoteInfo = WireDataModelTests;
-		};
-		166B2B6923EB11C8003E8581 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 166B2B5F23EB11C8003E8581 /* WireDataModel.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = F9C9A7F31CAED9510039E10C;
-			remoteInfo = WireDataModelTestHost;
-		};
 		3E1860D0191A649D000FE027 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 540029AB1918CA8500578793 /* Project object */;
@@ -708,7 +687,6 @@
 		1662B0F823D9CE8F00B8C7C5 /* UnauthenticatedSessionTests+DomainLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UnauthenticatedSessionTests+DomainLookup.swift"; sourceTree = "<group>"; };
 		166A8BF21E015F3B00F5EEEA /* WireCallCenterV3Factory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WireCallCenterV3Factory.swift; sourceTree = "<group>"; };
 		166A8BF81E02C7D500F5EEEA /* ZMHotFix+PendingChanges.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMHotFix+PendingChanges.swift"; sourceTree = "<group>"; };
-		166B2B5F23EB11C8003E8581 /* WireDataModel.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = WireDataModel.xcodeproj; path = "../wire-ios-data-model/WireDataModel.xcodeproj"; sourceTree = "<group>"; };
 		166B2B6D23EB2CD3003E8581 /* DatabaseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseTest.swift; sourceTree = "<group>"; };
 		166D18A3230EBFFA001288CD /* MediaManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaManager.swift; sourceTree = "<group>"; };
 		166D18A5230EC418001288CD /* MockMediaManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMediaManager.swift; sourceTree = "<group>"; };
@@ -1371,16 +1349,6 @@
 			path = E2EE;
 			sourceTree = "<group>";
 		};
-		166B2B6023EB11C8003E8581 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				166B2B6623EB11C8003E8581 /* WireDataModel.framework */,
-				166B2B6823EB11C8003E8581 /* WireDataModelTests.xctest */,
-				166B2B6A23EB11C8003E8581 /* WireDataModelTestHost.app */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		3E18605A191A4EF8000FE027 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -1538,7 +1506,6 @@
 		540029AA1918CA8500578793 = {
 			isa = PBXGroup;
 			children = (
-				166B2B5F23EB11C8003E8581 /* WireDataModel.xcodeproj */,
 				09284B6A1B8272C300EEE10E /* WireSyncEngine Test Host.entitlements */,
 				09CC4AB71B7CB8B700201C63 /* Cartfile */,
 				F93C4C6F1E1E8B77007E9CEE /* Cartfile.resolved */,
@@ -2578,12 +2545,6 @@
 			mainGroup = 540029AA1918CA8500578793;
 			productRefGroup = 540029B51918CA8500578793 /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = 166B2B6023EB11C8003E8581 /* Products */;
-					ProjectRef = 166B2B5F23EB11C8003E8581 /* WireDataModel.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				549815921A43232400A7CE2E /* WireSyncEngine-ios */,
@@ -2592,30 +2553,6 @@
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		166B2B6623EB11C8003E8581 /* WireDataModel.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = WireDataModel.framework;
-			remoteRef = 166B2B6523EB11C8003E8581 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		166B2B6823EB11C8003E8581 /* WireDataModelTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = WireDataModelTests.xctest;
-			remoteRef = 166B2B6723EB11C8003E8581 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		166B2B6A23EB11C8003E8581 /* WireDataModelTestHost.app */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.application;
-			path = WireDataModelTestHost.app;
-			remoteRef = 166B2B6923EB11C8003E8581 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		3E186086191A56F6000FE027 /* Resources */ = {


### PR DESCRIPTION
## What's new in this PR?

In order to convert the `ZMUserSession` to Swift we need to remove any usage of OCMock where it mocks the user session.

---

 Refactor search classes and tests to inject the `ZMManagedObjectContextProvider` and `TransportSessionType` instead of the `ZMUserSession`.