### PR TITLE
[Refactor]  Remove the need for mocking the user session with OCMock (Part 3)

### DIFF
--- a/Source/Data Model/ZMUser+Consent.swift
+++ b/Source/Data Model/ZMUser+Consent.swift
@@ -33,7 +33,7 @@ extension ZMUser {
     
     public func fetchMarketingConsent(in userSession: ZMUserSession,
                                       completion: @escaping CompletionFetch) {
-        fetchConsent(for: .marketing, in: userSession, completion: completion)
+        fetchConsent(for: .marketing, on: userSession.transportSession, completion: completion)
     }
     
     static func parse(consentPayload: ZMTransportData) -> [ConsentType: Bool] {
@@ -59,7 +59,7 @@ extension ZMUser {
     }
     
     func fetchConsent(for consentType: ConsentType,
-                      in userSession: ZMUserSession,
+                      on transportSession: TransportSessionType,
                       completion: @escaping CompletionFetch) {
         
         
@@ -81,19 +81,19 @@ extension ZMUser {
             completion(.success(status))
         })
         
-        userSession.transportSession.enqueueOneTime(request)
+        transportSession.enqueueOneTime(request)
     }
     
     public typealias CompletionSet   = (VoidResult) -> Void
     public func setMarketingConsent(to value: Bool,
                                     in userSession: ZMUserSession,
                                     completion: @escaping CompletionSet) {
-        setConsent(to: value, for: .marketing, in: userSession, completion: completion)
+        setConsent(to: value, for: .marketing, on: userSession.transportSession, completion: completion)
     }
     
     func setConsent(to value: Bool,
                     for consentType: ConsentType,
-                    in userSession: ZMUserSession,
+                    on transportSession: TransportSessionType,
                     completion: @escaping CompletionSet) {
         let request = ConsentRequestFactory.setConsentRequest(for: consentType, value: value)
         
@@ -110,7 +110,7 @@ extension ZMUser {
             completion(.success)
         })
         
-        userSession.transportSession.enqueueOneTime(request)
+        transportSession.enqueueOneTime(request)
     }
 }
 

--- a/Source/UserSession/CallStateObserver.swift
+++ b/Source/UserSession/CallStateObserver.swift
@@ -26,30 +26,35 @@ public final class CallStateObserver : NSObject {
     @objc static public let CallInProgressNotification = Notification.Name(rawValue: "ZMCallInProgressNotification")
     @objc static public let CallInProgressKey = "callInProgress"
     
-    fileprivate weak var userSession: ZMUserSession?
+    fileprivate weak var notificationStyleProvider: CallNotificationStyleProvider?
     fileprivate let localNotificationDispatcher : LocalNotificationDispatcher
-    fileprivate let syncManagedObjectContext : NSManagedObjectContext
+    fileprivate let uiContext : NSManagedObjectContext
+    fileprivate let syncContext : NSManagedObjectContext
     fileprivate var callStateToken : Any? = nil
     fileprivate var missedCalltoken : Any? = nil
     fileprivate let systemMessageGenerator = CallSystemMessageGenerator()
     
-    @objc public init(localNotificationDispatcher : LocalNotificationDispatcher, userSession: ZMUserSession) {
-        self.userSession = userSession
+    @objc public init(localNotificationDispatcher: LocalNotificationDispatcher,
+                      contextProvider: ZMManagedObjectContextProvider,
+                      callNotificationStyleProvider: CallNotificationStyleProvider) {
+        
+        self.uiContext = contextProvider.managedObjectContext
+        self.syncContext = contextProvider.syncManagedObjectContext
+        self.notificationStyleProvider = callNotificationStyleProvider
         self.localNotificationDispatcher = localNotificationDispatcher
-        self.syncManagedObjectContext = userSession.syncManagedObjectContext
         
         super.init()
         
-        self.callStateToken = WireCallCenterV3.addCallStateObserver(observer: self, context: userSession.managedObjectContext)
-        self.missedCalltoken = WireCallCenterV3.addMissedCallObserver(observer: self, context: userSession.managedObjectContext)
+        self.callStateToken = WireCallCenterV3.addCallStateObserver(observer: self, context: uiContext)
+        self.missedCalltoken = WireCallCenterV3.addMissedCallObserver(observer: self, context: uiContext)
     }
     
     fileprivate var callInProgress : Bool = false {
         didSet {
             if callInProgress != oldValue {
-                syncManagedObjectContext.performGroupedBlock {
+                syncContext.performGroupedBlock {
                     NotificationInContext(name: CallStateObserver.CallInProgressNotification,
-                                          context: self.syncManagedObjectContext.notificationContext,
+                                          context: self.syncContext.notificationContext,
                                           userInfo: [ CallStateObserver.CallInProgressKey : self.callInProgress ]).post()
                 }
             }
@@ -64,19 +69,18 @@ extension CallStateObserver : WireCallCenterCallStateObserver, WireCallCenterMis
         let callerId = (caller as? ZMUser)?.remoteIdentifier
         let conversationId = conversation.remoteIdentifier
         
-        syncManagedObjectContext.performGroupedBlock {
+        syncContext.performGroupedBlock {
             guard
                 let callerId = callerId,
                 let conversationId = conversationId,
-                let conversation = ZMConversation(remoteID: conversationId, createIfNeeded: false, in: self.syncManagedObjectContext),
-                let caller = ZMUser(remoteID: callerId, createIfNeeded: false, in: self.syncManagedObjectContext)
+                let conversation = ZMConversation(remoteID: conversationId, createIfNeeded: false, in: self.syncContext),
+                let caller = ZMUser(remoteID: callerId, createIfNeeded: false, in: self.syncContext)
             else {
                 return
             }
             
-            let uiManagedObjectContext = self.syncManagedObjectContext.zm_userInterface
-            uiManagedObjectContext?.performGroupedBlock {
-                if let activeCallCount = uiManagedObjectContext?.zm_callCenter?.activeCalls.count {
+            self.uiContext.performGroupedBlock {
+                if let activeCallCount = self.uiContext.zm_callCenter?.activeCalls.count {
                     self.callInProgress = activeCallCount > 0
                 }
             }
@@ -86,7 +90,7 @@ extension CallStateObserver : WireCallCenterCallStateObserver, WireCallCenterMis
             
             // CallKit depends on a fetched conversation & and is not used for muted conversations
             let skipCallKit = conversation.needsToBeUpdatedFromBackend || conversation.mutedMessageTypesIncludingAvailability != .none
-            let notificationStyle = self.userSession?.callNotificationStyle ?? .callKit
+            let notificationStyle = self.notificationStyleProvider?.callNotificationStyle ?? .callKit
             
             if notificationStyle == .pushNotifications || skipCallKit {
                 self.localNotificationDispatcher.process(callState: callState, in: conversation, caller: caller)
@@ -107,16 +111,15 @@ extension CallStateObserver : WireCallCenterCallStateObserver, WireCallCenterMis
                     break
                 }
                 
-                self.syncManagedObjectContext.enqueueDelayedSave()
+                self.syncContext.enqueueDelayedSave()
             }
         }
     }
     
     public func updateConversationListIndicator(convObjectID: NSManagedObjectID, callState: CallState){
         // We need to switch to the uiContext here because we are making changes that need to be present on the UI when the change notification fires
-        guard let uiMOC = self.syncManagedObjectContext.zm_userInterface else { return }
-        uiMOC.performGroupedBlock {
-            guard let uiConv = (try? uiMOC.existingObject(with: convObjectID)) as? ZMConversation else { return }
+        uiContext.performGroupedBlock {
+            guard let uiConv = (try? self.uiContext.existingObject(with: convObjectID)) as? ZMConversation else { return }
             
             switch callState {
             case .incoming(video: _, shouldRing: let shouldRing, degraded: _):
@@ -131,10 +134,10 @@ extension CallStateObserver : WireCallCenterCallStateObserver, WireCallCenterMis
                 break
             }
             
-            if uiMOC.zm_hasChanges {
+            if self.uiContext.zm_hasChanges {
                 NotificationDispatcher.notifyNonCoreDataChanges(objectID: convObjectID,
                                                                 changedKeys: [ZMConversationListIndicatorKey],
-                                                                uiContext: uiMOC)
+                                                                uiContext: self.uiContext)
             }
         }
     }
@@ -143,22 +146,22 @@ extension CallStateObserver : WireCallCenterCallStateObserver, WireCallCenterMis
         let callerId = (caller as? ZMUser)?.remoteIdentifier
         let conversationId = conversation.remoteIdentifier
         
-        syncManagedObjectContext.performGroupedBlock {
+        syncContext.performGroupedBlock {
             guard
                 let callerId = callerId,
                 let conversationId = conversationId,
-                let conversation = ZMConversation(remoteID: conversationId, createIfNeeded: false, in: self.syncManagedObjectContext),
-                let caller = ZMUser(remoteID: callerId, createIfNeeded: false, in: self.syncManagedObjectContext)
+                let conversation = ZMConversation(remoteID: conversationId, createIfNeeded: false, in: self.syncContext),
+                let caller = ZMUser(remoteID: callerId, createIfNeeded: false, in: self.syncContext)
                 else {
                     return
             }
             
-            if (self.userSession?.callNotificationStyle ?? .callKit) == .pushNotifications {
+            if (self.notificationStyleProvider?.callNotificationStyle ?? .callKit) == .pushNotifications {
                 self.localNotificationDispatcher.processMissedCall(in: conversation, caller: caller)
             }
             
             conversation.appendMissedCallMessage(fromUser: caller, at: timestamp)
-            self.syncManagedObjectContext.enqueueDelayedSave()
+            self.syncContext.enqueueDelayedSave()
         }
     }
     
@@ -173,7 +176,7 @@ extension CallStateObserver : WireCallCenterCallStateObserver, WireCallCenterMis
                 conversation.updateLastModified(timestamp)
             }
             
-            self.syncManagedObjectContext.enqueueDelayedSave()
+            syncContext.enqueueDelayedSave()
         default: break
         }
     }

--- a/Source/UserSession/ZMUserSession+Calling.swift
+++ b/Source/UserSession/ZMUserSession+Calling.swift
@@ -18,13 +18,20 @@
 
 import Foundation
 
-@objc extension ZMUserSession {
+@objc
+public protocol CallNotificationStyleProvider: class {
+    
+    var callNotificationStyle: CallNotificationStyle { get }
+    
+}
+
+@objc extension ZMUserSession: CallNotificationStyleProvider {
     
     public var callCenter : WireCallCenterV3? {
         return managedObjectContext.zm_callCenter
     }
     
-    internal var callNotificationStyle : CallNotificationStyle {
+    public var callNotificationStyle : CallNotificationStyle {
         return sessionManager.callNotificationStyle
     }
     

--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -189,8 +189,7 @@ ZM_EMPTY_ASSERTING_INIT()
             
             self.localNotificationDispatcher = [[LocalNotificationDispatcher alloc] initWithManagedObjectContext:self.syncManagedObjectContext];
             
-            self.callStateObserver = [[ZMCallStateObserver alloc] initWithLocalNotificationDispatcher:self.localNotificationDispatcher
-                                                                                          userSession:self];
+            self.callStateObserver = [[ZMCallStateObserver alloc] initWithLocalNotificationDispatcher:self.localNotificationDispatcher contextProvider:self callNotificationStyleProvider:self];
             
             self.transportSession = transportSession;
             self.transportSession.pushChannel.clientID = self.selfUserClient.remoteIdentifier;

--- a/Tests/Source/Calling/CallKitDelegateTests+Mocking.h
+++ b/Tests/Source/Calling/CallKitDelegateTests+Mocking.h
@@ -23,7 +23,6 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface CallKitDelegateTestsMocking: NSObject
-+ (void)mockUserSession:(id)userSession;
 + (CXCall *)mockCallWithUUID:(NSUUID *)uuid outgoing:(BOOL)outgoing;
 + (void)stopMockingMock:(NSObject *)Mock;
 

--- a/Tests/Source/Calling/CallKitDelegateTests+Mocking.m
+++ b/Tests/Source/Calling/CallKitDelegateTests+Mocking.m
@@ -23,15 +23,6 @@
 
 @implementation CallKitDelegateTestsMocking
 
-+ (void)mockUserSession:(id)userSession
-{    
-    [(id)[userSession stub] performChanges:[OCMArg checkWithBlock:^BOOL(id param) {
-        void (^passedBlock)(void) = param;
-        passedBlock();
-        return YES;
-    }]];
-}
-
 + (CXCall *)mockCallWithUUID:(NSUUID *)uuid outgoing:(BOOL)outgoing
 {
     id mockCall = [OCMockObject niceMockForClass:CXCall.class];

--- a/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -760,7 +760,9 @@ extension WireCallCenterV3Tests {
 }
 
 // Mark: - Muted state
+
 extension WireCallCenterV3Tests {
+    
     func testThatMutedStateHandlerUpdatesTheState() {
         class MuteObserver: MuteStateObserver {
             var muted: Bool? = nil
@@ -773,8 +775,7 @@ extension WireCallCenterV3Tests {
         sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         let observer = MuteObserver()
-        
-        let token = WireCallCenterV3.addMuteStateObserver(observer: observer, userSession: mockUserSession)
+        let token = WireCallCenterV3.addMuteStateObserver(observer: observer, context: uiMOC)
         
         // when
         mockAVSWrapper.muted = true
@@ -786,6 +787,7 @@ extension WireCallCenterV3Tests {
             XCTAssertEqual(true, observer.muted)
         }
     }
+    
 }
 
 // MARK: - Ignoring Calls

--- a/Tests/Source/Data Model/Conversation+DeletionTests.swift
+++ b/Tests/Source/Data Model/Conversation+DeletionTests.swift
@@ -19,7 +19,22 @@
 import XCTest
 @testable import WireSyncEngine
 
-class Conversation_DeletionTests: MessagingTest {
+class Conversation_DeletionTests: DatabaseTest {
+    
+    var mockTransportSession: MockTransportSession!
+    
+    override func setUp() {
+        super.setUp()
+        
+        mockTransportSession = MockTransportSession(dispatchGroup: dispatchGroup)
+    }
+    
+    override func tearDown() {
+        mockTransportSession.cleanUp()
+        mockTransportSession = nil
+        
+        super.tearDown()
+    }
 
     func testThatItParsesAllKnownConversationDeletionErrorResponses() {
         
@@ -47,7 +62,7 @@ class Conversation_DeletionTests: MessagingTest {
         let invalidOperationfailure = expectation(description: "Invalid Operation")
         
         // WHEN
-        conversation.delete(in: mockUserSession) { (result) in
+        conversation.delete(in: contextDirectory!, transportSession: mockTransportSession) { (result) in
             if case .failure(let error) = result {
                 if case ConversationDeletionError.invalidOperation = error {
                     invalidOperationfailure.fulfill()
@@ -67,7 +82,7 @@ class Conversation_DeletionTests: MessagingTest {
         let invalidOperationfailure = expectation(description: "Invalid Operation")
         
         // WHEN
-        conversation.delete(in: mockUserSession) { (result) in
+        conversation.delete(in: contextDirectory!, transportSession: mockTransportSession) { (result) in
             if case .failure(let error) = result {
                 if case ConversationDeletionError.invalidOperation = error {
                     invalidOperationfailure.fulfill()

--- a/Tests/Source/Data Model/ZMUserConsentTests.swift
+++ b/Tests/Source/Data Model/ZMUserConsentTests.swift
@@ -20,7 +20,23 @@
 import XCTest
 @testable import WireSyncEngine
 
-final class ZMUserConsentTests: MessagingTest {
+final class ZMUserConsentTests: DatabaseTest {
+    
+    var mockTransportSession: MockTransportSession!
+    
+    override func setUp() {
+        super.setUp()
+        
+        mockTransportSession = MockTransportSession(dispatchGroup: dispatchGroup)
+    }
+    
+    override func tearDown() {
+        mockTransportSession.cleanUp()
+        mockTransportSession = nil
+        
+        super.tearDown()
+    }
+    
     var selfUser: ZMUser {
         let selfUser = ZMUser.selfUser(in: uiMOC)
         if selfUser.remoteIdentifier == nil {
@@ -90,8 +106,7 @@ final class ZMUserConsentTests: MessagingTest {
         let fetchedData = expectation(description: "fetched data")
         
         // when
-        
-        selfUser.fetchMarketingConsent(in: mockUserSession) { result in
+        selfUser.fetchConsent(for: .marketing, on: mockTransportSession) { result in
             switch result {
             case .failure(_):
                 XCTFail()
@@ -117,7 +132,7 @@ final class ZMUserConsentTests: MessagingTest {
         let receivedError = expectation(description: "received error")
         // when
         
-        selfUser.fetchMarketingConsent(in: mockUserSession) { result in
+        selfUser.fetchConsent(for: .marketing, on: mockTransportSession) { result in
             switch result {
             case .failure(let error):
                 XCTAssertEqual(error as! WireSyncEngine.ConsentRequestError, WireSyncEngine.ConsentRequestError.unknown)
@@ -141,9 +156,9 @@ final class ZMUserConsentTests: MessagingTest {
         }
         
         let successExpectation = expectation(description: "set is successful")
-        // when
         
-        selfUser.setMarketingConsent(to: true, in: self.mockUserSession) { result in
+        // when
+        selfUser.setConsent(to: true, for: .marketing, on: mockTransportSession) { result in
             switch result {
             case .failure(_):
                 XCTFail()
@@ -166,9 +181,9 @@ final class ZMUserConsentTests: MessagingTest {
         }
         
         let receivedError = expectation(description: "received error")
-        // when
         
-        selfUser.setMarketingConsent(to: true, in: self.mockUserSession) { result in
+        // when
+        selfUser.setConsent(to: true, for: .marketing, on: mockTransportSession) { result in
             switch result {
             case .failure(let error):
                 XCTAssertEqual(error as! WireSyncEngine.ConsentRequestError, WireSyncEngine.ConsentRequestError.unknown)

--- a/Tests/Source/DatabaseTest.swift
+++ b/Tests/Source/DatabaseTest.swift
@@ -88,23 +88,6 @@ class DatabaseTest: ZMTBaseTest {
             self.syncMOC.zm_fileAssetCache = fileAssetCache
             self.uiMOC.zm_userImageCache = userImageCache
         }
-        
-//        FileAssetCache *fileAssetCache = [[FileAssetCache alloc] initWithLocation:nil];
-//        UserImageLocalCache *userImageCache = [[UserImageLocalCache alloc] initWithLocation:nil];
-//
-//        [self.uiMOC addGroup:self.dispatchGroup];
-//        self.uiMOC.userInfo[@"TestName"] = self.name;
-//
-//        [self.syncMOC performGroupedBlockAndWait:^{
-//            self.syncMOC.userInfo[@"TestName"] = self.name;
-//            [self.syncMOC addGroup:self.dispatchGroup];
-//            [self.syncMOC saveOrRollback];
-//
-//            [self.syncMOC setZm_userInterfaceContext:self.uiMOC];
-//            [self.syncMOC setPersistentStoreMetadata:@(notificationContentVisible) forKey:@"ZMShouldNotificationContentKey"];
-//            self.syncMOC.zm_fileAssetCache = fileAssetCache;
-//            self.syncMOC.zm_userImageCache = userImageCache;
-//            }];
     }
     
     override func setUp() {

--- a/Tests/Source/DatabaseTest.swift
+++ b/Tests/Source/DatabaseTest.swift
@@ -77,18 +77,53 @@ class DatabaseTest: ZMTBaseTest {
         XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
     }
     
+    private func configureCaches() {
+        let fileAssetCache = FileAssetCache(location: nil)
+        let userImageCache = UserImageLocalCache(location: nil)
+        
+        uiMOC.zm_fileAssetCache = fileAssetCache
+        uiMOC.zm_userImageCache = userImageCache
+        
+        syncMOC.performGroupedBlockAndWait {
+            self.syncMOC.zm_fileAssetCache = fileAssetCache
+            self.uiMOC.zm_userImageCache = userImageCache
+        }
+        
+//        FileAssetCache *fileAssetCache = [[FileAssetCache alloc] initWithLocation:nil];
+//        UserImageLocalCache *userImageCache = [[UserImageLocalCache alloc] initWithLocation:nil];
+//
+//        [self.uiMOC addGroup:self.dispatchGroup];
+//        self.uiMOC.userInfo[@"TestName"] = self.name;
+//
+//        [self.syncMOC performGroupedBlockAndWait:^{
+//            self.syncMOC.userInfo[@"TestName"] = self.name;
+//            [self.syncMOC addGroup:self.dispatchGroup];
+//            [self.syncMOC saveOrRollback];
+//
+//            [self.syncMOC setZm_userInterfaceContext:self.uiMOC];
+//            [self.syncMOC setPersistentStoreMetadata:@(notificationContentVisible) forKey:@"ZMShouldNotificationContentKey"];
+//            self.syncMOC.zm_fileAssetCache = fileAssetCache;
+//            self.syncMOC.zm_userImageCache = userImageCache;
+//            }];
+    }
+    
     override func setUp() {
         super.setUp()
         
         createDatabase()
+        configureCaches()
     }
     
     override func tearDown() {
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
         cleanUp()
         contextDirectory = nil
         
         super.tearDown()
     }
+    
+    // MARK: - Helper methods
     
     func performPretendingUIMocIsSyncMoc(_ block: () -> Void) {
         uiMOC.resetContextType()
@@ -96,6 +131,23 @@ class DatabaseTest: ZMTBaseTest {
         block()
         uiMOC.resetContextType()
         uiMOC.markAsUIContext()
+    }
+    
+    func event(withPayload payload: [AnyHashable: Any]?, type: ZMUpdateEventType, in conversation: ZMConversation, user: ZMUser) -> ZMUpdateEvent {
+        return ZMUpdateEvent(uuid: nil, payload: eventPayload(content: payload, type: type, in: conversation, from: user), transient: false, decrypted: true, source: .download)!
+    }
+    
+    private func eventPayload(content: [AnyHashable: Any]?,
+                              type: ZMUpdateEventType,
+                              in conversation: ZMConversation,
+                              from user: ZMUser,
+                              timestamp: Date = Date()) -> [AnyHashable: Any] {
+        return [ "conversation": conversation.remoteIdentifier!.transportString(),
+                 "data": conversation,
+                 "from": user.remoteIdentifier!.transportString(),
+                 "time": timestamp.transportString(),
+                 "type": ZMUpdateEvent.eventTypeString(for: type)!
+        ]
     }
     
 }

--- a/Tests/Source/Notifications/PushNotifications/LocalNotificationDispatcherCallingTests.swift
+++ b/Tests/Source/Notifications/PushNotifications/LocalNotificationDispatcherCallingTests.swift
@@ -20,7 +20,7 @@ import UserNotifications
 
 @testable import WireSyncEngine
 
-class LocalNotificationDispatcherCallingTests : MessagingTest {
+class LocalNotificationDispatcherCallingTests: DatabaseTest {
     
     var sut : LocalNotificationDispatcher!
     var notificationCenter : UserNotificationCenterMock!
@@ -39,8 +39,6 @@ class LocalNotificationDispatcherCallingTests : MessagingTest {
         notificationCenter = UserNotificationCenterMock()
         sut.notificationCenter = notificationCenter
         sut.callingNotifications.notificationCenter = notificationCenter
-        
-        self.mockUserSession.operationStatus.isInBackground = true
         
         syncMOC.performGroupedBlockAndWait {
             let sender = ZMUser.insertNewObject(in: self.syncMOC)

--- a/Tests/Source/Notifications/PushNotifications/LocalNotificationDispatcherTests.swift
+++ b/Tests/Source/Notifications/PushNotifications/LocalNotificationDispatcherTests.swift
@@ -21,7 +21,7 @@ import UserNotifications
 
 @testable import WireSyncEngine
 
-class LocalNotificationDispatcherTests: MessagingTest {
+class LocalNotificationDispatcherTests: DatabaseTest {
 
     typealias ZMLocalNotification = WireSyncEngine.ZMLocalNotification
     
@@ -52,8 +52,6 @@ class LocalNotificationDispatcherTests: MessagingTest {
          self.sut.failedMessageNotifications,
          self.sut.messageNotifications,
          self.sut.callingNotifications].forEach { $0.notificationCenter = notificationCenter }
-        
-        self.mockUserSession.operationStatus.isInBackground = true
         
         syncMOC.performGroupedBlockAndWait {
             self.user1 = ZMUser.insertNewObject(in: self.syncMOC)
@@ -168,7 +166,7 @@ extension LocalNotificationDispatcherTests {
 
     func testThatItDoesNotCreateANotificationForAnUnsupportedEventType() {
         // GIVEN
-        let event = self.event(withPayload: nil, in: self.conversation1, type: EventConversationTyping)!
+        let event = self.event(withPayload: nil, type: .conversationTyping, in: self.conversation1, user: self.user1)
 
         // WHEN
         self.sut.didReceive(events: [event], conversationMap: [:])


### PR DESCRIPTION
## What's new in this PR?

In order to convert the ZMUserSession to Swift we need to remove any usage of OCMock where it mocks the user session.

---

Following the strategy we've arrived at in https://github.com/wireapp/wire-ios-sync-engine/pull/1164 I'm removing more usage of the `mockTransportSession`.
