### PR TITLE
[Refactor] Add property to safely get the current self user

### DIFF
--- a/Source/Data Model/SelfUser.swift
+++ b/Source/Data Model/SelfUser.swift
@@ -36,4 +36,10 @@ public class SelfUser {
         guard let provider = provider else { fatalError("Self user provider not set") }
         return provider.selfUser
     }
+
+    /// The current self user, if it exists.
+
+    public class var currentSafe: (UserType & ZMEditableUser)? {
+        return provider?.selfUser
+    }
 }


### PR DESCRIPTION
## What's new in this PR?

This PR adds a class property to `SelfUser` to optionally get the current self user. I realize that while in most cases can safely assume that one exists, there are also situations where we might not be so sure that one exists and need to safely access it. Such a case may be when accessing the self user in closures that for some reason exist beyond the life of a user session.
