### PR TITLE
[Fix] Observer not being notified when clients list is empty

### DIFF
--- a/Source/UserSession/ZMUserSession+Clients.swift
+++ b/Source/UserSession/ZMUserSession+Clients.swift
@@ -73,18 +73,14 @@ extension ZMUserSession {
                 switch type {
                 case .fetchCompleted:
                     let clients = clientObjectIDs.compactMap({ self?.managedObjectContext.object(with: $0) as? UserClient })
-                    if !clients.isEmpty {
-                        observer.finishedFetching(clients)
-                    }
+                    observer.finishedFetching(clients)
                 case .fetchFailed:
                     if let error = error {
                         observer.failedToFetchClients(error)
                     }
                 case .deletionCompleted:
                     let remainingClients = clientObjectIDs.compactMap({ self?.managedObjectContext.object(with: $0) as? UserClient })
-                    if !remainingClients.isEmpty {
-                        observer.finishedDeleting(remainingClients)
-                    }
+                    observer.finishedDeleting(remainingClients)
                 case .deletionFailed:
                     if let error = error {
                         observer.failedToDeleteClients(error)


### PR DESCRIPTION
## What's new in this PR?

### Issues

The device screen shows a spinner which doesn't go away.

### Causes

Spinner is shown when fetching self clients but it never goes away since the UI never gets notified that clients have been fetched. It doesn't get notified because there's a condition not call the observer if the list of clients is empty.

### Solutions

Always notify the observer, the existing logic got broken when it was translated to Swift https://github.com/wireapp/wire-ios-sync-engine/pull/1159.