### PR TITLE
[Fix] Deep link error alert while logged out

### DIFF
--- a/Source/SessionManager/SessionManager+URLActions.swift
+++ b/Source/SessionManager/SessionManager+URLActions.swift
@@ -66,6 +66,10 @@ extension SessionManager {
         if action.requiresAuthentication, let userSession = activeUserSession {
             process(urlAction: action, on: userSession)
         } else if action.requiresAuthentication {
+            guard isSelectedAccountAuthenticated else {
+                throw DeepLinkRequestError.notLoggedIn
+            }
+            
             pendingURLAction = action
         } else {
             process(urlAction: action, on: activeUnauthenticatedSession)


### PR DESCRIPTION
## What's new in this PR?

### Issues

If the app is launched with a deep link action we should show an error dialogue if the user is not logged in.

### Causes

These actions were delayed to in order to be performed when a user session becomes available.

### Solutions

Throw an error immediately if the user is not authenticated.