### PR TITLE
[Fix] Cancel notifications on logout instead of on tear down

### DIFF
--- a/Source/UserSession/ZMUserSession+Authentication.swift
+++ b/Source/UserSession/ZMUserSession+Authentication.swift
@@ -64,6 +64,11 @@ extension ZMUserSession {
         UserDefaults.standard.synchronize()
         UserDefaults.shared()?.synchronize()
         
+        // Clear all notifications associated with the account from the notification center
+        syncManagedObjectContext.performGroupedBlock {
+            self.localNotificationDispatcher.cancelAllNotifications()
+        }
+        
         if deleteCookie {
             deleteUserKeychainItems()
         }

--- a/Source/UserSession/ZMUserSession.m
+++ b/Source/UserSession/ZMUserSession.m
@@ -275,8 +275,6 @@ ZM_EMPTY_ASSERTING_INIT()
     [self.transportSession tearDown];
     self.transportSession = nil;
     self.applicationStatusDirectory = nil;
-    
-    [self.localNotificationDispatcher tearDown];
     self.localNotificationDispatcher = nil;
     [self.blackList tearDown];
     

--- a/Tests/Source/Calling/CallStateObserverTests.swift
+++ b/Tests/Source/Calling/CallStateObserverTests.swift
@@ -74,8 +74,6 @@ class CallStateObserverTests : DatabaseTest, CallNotificationStyleProvider {
     }
     
     override func tearDown() {
-        localNotificationDispatcher.tearDown()
-        
         sut = nil
         sender = nil
         receiver = nil

--- a/Tests/Source/Notifications/PushNotifications/LocalNotificationDispatcherCallingTests.swift
+++ b/Tests/Source/Notifications/PushNotifications/LocalNotificationDispatcherCallingTests.swift
@@ -59,7 +59,6 @@ class LocalNotificationDispatcherCallingTests: DatabaseTest {
     }
     
     override func tearDown() {
-        sut.tearDown()
         sut = nil
         notificationCenter = nil
         sender = nil

--- a/Tests/Source/Notifications/PushNotifications/LocalNotificationDispatcherTests.swift
+++ b/Tests/Source/Notifications/PushNotifications/LocalNotificationDispatcherTests.swift
@@ -83,7 +83,6 @@ class LocalNotificationDispatcherTests: DatabaseTest {
         self.user2 = nil
         self.conversation1 = nil
         self.conversation2 = nil
-        self.sut.tearDown()
         self.sut = nil
         super.tearDown()
     }

--- a/Tests/Source/Synchronization/ZMSyncStrategyTests.m
+++ b/Tests/Source/Synchronization/ZMSyncStrategyTests.m
@@ -133,7 +133,6 @@
     [self.syncMOC saveOrRollback];
     
     self.mockDispatcher = [OCMockObject mockForClass:[LocalNotificationDispatcher class]];
-    [(LocalNotificationDispatcher *)[self.mockDispatcher stub] tearDown];
     [(LocalNotificationDispatcher *)[self.mockDispatcher stub] processEvents:OCMOCK_ANY liveEvents:YES prefetchResult:OCMOCK_ANY];
     self.mockUpstreamSync1 = [OCMockObject mockForClass:[ZMUpstreamModifiedObjectSync class]];
     self.mockUpstreamSync2 = [OCMockObject mockForClass:[ZMUpstreamModifiedObjectSync class]];


### PR DESCRIPTION
## What's new in this PR?

### Issues

The `LocalNotificationDispatcher` was canceling notifications and performing a delayed save from its `tearDown` method. This is problematic since: 
- The user session is not in a known state during tear down and causes flakyness in tests.
- This could in theory get triggered when the system is under memory pressure, and we release our background user sessions. That would have the side effect of clearing all notifications from the Notification Center, which doesn't make any sense.

### Solutions

Remove the `tearDown` method and cancel notifications on logout instead.