### PR TITLE
[Fix] User session still being retained after being torn down

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -763,11 +763,13 @@ public final class SessionManager : NSObject, SessionManagerType {
     
     // Tears down and releases all background user sessions.
     internal func tearDownAllBackgroundSessions() {
-        self.backgroundUserSessions.forEach { (accountId, session) in
-            if self.activeUserSession != session {
-                self.tearDownBackgroundSession(for: accountId)
-            }
+        let backgroundSessions = backgroundUserSessions.filter { (_, session) -> Bool in
+            return activeUserSession != session
         }
+        
+        backgroundSessions.keys.forEach({ sessionID in
+            tearDownBackgroundSession(for: sessionID)
+        })
     }
     
     fileprivate func tearDownObservers(account: UUID) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

The UserSession would be retained after being torn down after we receive a memory pressure warning.

### Causes

We where iterating over the `backgroundUserSessions` dictionary and modifying it at the same time. This was causing the user session to be retained even though it's been removed from the dictionary.

### Solutions

Extract the list of sessions to tear down into a temporary variable.