### PR TITLE
[Refactor] Integrate AVS 5.6

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 github "wireapp/wire-ios-request-strategy" ~> 189.0
-github "wireapp/avs-ios-binaries" ~> 5.6.208
+github "wireapp/avs-ios-binaries" ~> 5.6.209
 github "wireapp/ZipArchive" "v2.1.3"
 github "wireapp/libPhoneNumber-iOS" ~> 0.9.3

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 github "wireapp/wire-ios-request-strategy" ~> 189.0
-github "wireapp/avs-ios-binaries" ~> 5.3.191
+github "wireapp/avs-ios-binaries" ~> 5.6.207
 github "wireapp/ZipArchive" "v2.1.3"
 github "wireapp/libPhoneNumber-iOS" ~> 0.9.3

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 github "wireapp/wire-ios-request-strategy" ~> 189.0
-github "wireapp/avs-ios-binaries" ~> 5.6.207
+github "wireapp/avs-ios-binaries" ~> 5.6.208
 github "wireapp/ZipArchive" "v2.1.3"
 github "wireapp/libPhoneNumber-iOS" ~> 0.9.3

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,7 +1,7 @@
 github "wireapp/HTMLString" "4.1.0-beta.1-xcode_10_2"
 github "wireapp/PINCache" "2.3-swift3.1"
 github "wireapp/ZipArchive" "v2.1.3"
-github "wireapp/avs-ios-binaries" "5.4.199"
+github "wireapp/avs-ios-binaries" "5.6.207"
 github "wireapp/libPhoneNumber-iOS" "0.9.3"
 github "wireapp/ocmock" "v3.4.3"
 github "wireapp/protobuf-objc" "1.9.14"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,7 +1,7 @@
 github "wireapp/HTMLString" "4.1.0-beta.1-xcode_10_2"
 github "wireapp/PINCache" "2.3-swift3.1"
 github "wireapp/ZipArchive" "v2.1.3"
-github "wireapp/avs-ios-binaries" "5.6.208"
+github "wireapp/avs-ios-binaries" "5.6.209"
 github "wireapp/libPhoneNumber-iOS" "0.9.3"
 github "wireapp/ocmock" "v3.4.3"
 github "wireapp/protobuf-objc" "1.9.14"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,7 +1,7 @@
 github "wireapp/HTMLString" "4.1.0-beta.1-xcode_10_2"
 github "wireapp/PINCache" "2.3-swift3.1"
 github "wireapp/ZipArchive" "v2.1.3"
-github "wireapp/avs-ios-binaries" "5.6.207"
+github "wireapp/avs-ios-binaries" "5.6.208"
 github "wireapp/libPhoneNumber-iOS" "0.9.3"
 github "wireapp/ocmock" "v3.4.3"
 github "wireapp/protobuf-objc" "1.9.14"

--- a/Source/Calling/AVSCallMember.swift
+++ b/Source/Calling/AVSCallMember.swift
@@ -39,9 +39,9 @@ extension AVSCallMember {
     init(member: AVSParticipantsChange.Member) {
         remoteId = member.userid
         clientId = member.clientid
-        audioEstablished = member.aestab == .established
+        audioState = member.aestab
         videoState = member.vrecv
-        networkQuality = .normal // Do we update this here depending on the audio state?
+        networkQuality = .normal
     }
 }
 
@@ -57,8 +57,8 @@ public struct AVSCallMember: Hashable {
     /// The client identifier of the user, this is only available after the call member has connected
     public let clientId: String?
 
-    /// Whether an audio connection was established.
-    public let audioEstablished: Bool
+    /// The state of the audio connection.
+    public let audioState: AudioState
 
     /// The state of video connection.
     public let videoState: VideoState
@@ -72,15 +72,20 @@ public struct AVSCallMember: Hashable {
      * Creates the call member from its values.
      * - parameter userId: The remote identifier of the user.
      * - parameter clientId: The client identifier of the user. Default to `nil`
-     * - parameter audioEstablished: Whether an audio connection was established. Defaults to `false`.
+     * - parameter audioState: The state of the audio connection. Defaults to `.connecting`.
      * - parameter videoState: The state of video connection. Defaults to `stopped`.
      * - parameter networkQuality: The quality of the network connection. Defaults to `.normal`.
      */
 
-    public init(userId : UUID, clientId: String? = nil, audioEstablished: Bool = false, videoState: VideoState = .stopped, networkQuality: NetworkQuality = .normal) {
+    public init(userId: UUID,
+                clientId: String? = nil,
+                audioState: AudioState = .connecting,
+                videoState: VideoState = .stopped,
+                networkQuality: NetworkQuality = .normal)
+    {
         self.remoteId = userId
         self.clientId = clientId
-        self.audioEstablished = audioEstablished
+        self.audioState = audioState
         self.videoState = videoState
         self.networkQuality = networkQuality
     }
@@ -89,10 +94,14 @@ public struct AVSCallMember: Hashable {
 
     /// The state of the participant.
     var callParticipantState: CallParticipantState {
-        if audioEstablished {
-            return .connected(videoState: videoState, clientId: clientId)
-        } else {
+        switch audioState {
+        case .connecting:
             return .connecting
+        case .established:
+            return .connected(videoState: videoState, clientId: clientId)
+        case .networkProblem:
+            return .unconnectedButMayConnect
+
         }
     }
 

--- a/Source/Calling/AVSCallMember.swift
+++ b/Source/Calling/AVSCallMember.swift
@@ -35,13 +35,13 @@ public struct AVSParticipantsChange: Codable {
 }
 
 extension AVSCallMember {
-    
+
     init(member: AVSParticipantsChange.Member) {
         remoteId = member.userid
         clientId = member.clientid
         audioEstablished = member.aestab == .established
         videoState = member.vrecv
-        networkQuality = .normal
+        networkQuality = .normal // Do we update this here depending on the audio state?
     }
 }
 

--- a/Source/Calling/AVSCallMember.swift
+++ b/Source/Calling/AVSCallMember.swift
@@ -35,6 +35,7 @@ public struct AVSParticipantsChange: Codable {
 }
 
 extension AVSCallMember {
+    
     init(member: AVSParticipantsChange.Member) {
         remoteId = member.userid
         clientId = member.clientid

--- a/Source/Calling/AVSCallMember.swift
+++ b/Source/Calling/AVSCallMember.swift
@@ -21,22 +21,25 @@ import avs
 
 
 public struct AVSParticipantsChange: Codable {
-    public struct Member: Codable {
-        let userid: UUID
-        let clientid: String
-        let aestab: Int32
-        let vrecv: Int32
-    }
+
     let convid: UUID
     let members: [Member]
+
+    public struct Member: Codable {
+
+        let userid: UUID
+        let clientid: String
+        let aestab: AudioState
+        let vrecv: VideoState
+    }
 }
 
 extension AVSCallMember {
     init(member: AVSParticipantsChange.Member) {
         remoteId = member.userid
         clientId = member.clientid
-        audioEstablished = (member.aestab == 1)
-        videoState = VideoState(rawValue: member.vrecv) ?? .stopped
+        audioEstablished = member.aestab == .established
+        videoState = member.vrecv
         networkQuality = .normal
     }
 }

--- a/Source/Calling/AVSCallMember.swift
+++ b/Source/Calling/AVSCallMember.swift
@@ -54,8 +54,8 @@ public struct AVSCallMember: Hashable {
     /// The remote identifier of the user.
     public let remoteId: UUID
     
-    /// The client identifier of the user, this is only available after the call member has connected
-    public let clientId: String?
+    /// The client identifier of the user.
+    public let clientId: String
 
     /// The state of the audio connection.
     public let audioState: AudioState
@@ -78,7 +78,7 @@ public struct AVSCallMember: Hashable {
      */
 
     public init(userId: UUID,
-                clientId: String? = nil,
+                clientId: String,
                 audioState: AudioState = .connecting,
                 videoState: VideoState = .stopped,
                 networkQuality: NetworkQuality = .normal)

--- a/Source/Calling/AVSWrapper+Handlers.swift
+++ b/Source/Calling/AVSWrapper+Handlers.swift
@@ -20,7 +20,7 @@ import Foundation
 import avs
 
 /// Equivalent of `wcall_audio_cbr_change_h`.
-typealias ConstantBitRateChangeHandler = @convention(c) (UnsafePointer<Int8>?, Int32, UnsafeMutableRawPointer?) -> Void
+typealias ConstantBitRateChangeHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, Int32, UnsafeMutableRawPointer?) -> Void
 
 /// Equivalent of `wcall_video_state_change_h`.
 typealias VideoStateChangeHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafePointer<Int8>?, Int32, UnsafeMutableRawPointer?) -> Void
@@ -35,13 +35,13 @@ typealias MissedCallHandler = @convention(c) (UnsafePointer<Int8>?, UInt32, Unsa
 typealias AnsweredCallHandler = @convention(c) (UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
 
 /// Equivalent of `wcall_data_chan_estab_h`.
-typealias DataChannelEstablishedHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
+typealias DataChannelEstablishedHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
 
 /// Equivalent of `wcall_estab_h`.
-typealias CallEstablishedHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
+typealias CallEstablishedHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
 
 /// Equivalent of `wcall_close_h`.
-typealias CloseCallHandler = @convention(c) (Int32, UnsafePointer<Int8>?, UInt32, UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
+typealias CloseCallHandler = @convention(c) (Int32, UnsafePointer<Int8>?, UInt32, UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
 
 /// Equivalent of `wcall_metrics_h`.
 typealias CallMetricsHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
@@ -65,7 +65,7 @@ typealias CallParticipantChangedHandler = @convention(c) (UnsafePointer<Int8>?, 
 typealias MediaStoppedChangeHandler = @convention(c) (UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
 
 /// Equivalent of `wcall_network_quality_h`.
-typealias NetworkQualityChangeHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, Int32, Int32, Int32, Int32, UnsafeMutableRawPointer?) -> Void
+typealias NetworkQualityChangeHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafePointer<Int8>?, Int32, Int32, Int32, Int32, UnsafeMutableRawPointer?) -> Void
 
 /// Equivalent of `wcall_set_mute_handler`.
 typealias MuteChangeHandler = @convention(c) (Int32, UnsafeMutableRawPointer?) -> Void

--- a/Source/Calling/AVSWrapper+Handlers.swift
+++ b/Source/Calling/AVSWrapper+Handlers.swift
@@ -26,10 +26,10 @@ typealias ConstantBitRateChangeHandler = @convention(c) (UnsafePointer<Int8>?, U
 typealias VideoStateChangeHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafePointer<Int8>?, Int32, UnsafeMutableRawPointer?) -> Void
 
 /// Equivalent of `wcall_incoming_h`.
-typealias IncomingCallHandler = @convention(c) (UnsafePointer<Int8>?, UInt32, UnsafePointer<Int8>?, Int32, Int32, UnsafeMutableRawPointer?) -> Void
+typealias IncomingCallHandler = @convention(c) (UnsafePointer<Int8>?, UInt32, UnsafePointer<Int8>?, UnsafePointer<Int8>?, Int32, Int32, UnsafeMutableRawPointer?) -> Void
 
 /// Equivalent of `wcall_missed_h`.
-typealias MissedCallHandler = @convention(c) (UnsafePointer<Int8>?, UInt32, UnsafePointer<Int8>?, Int32, UnsafeMutableRawPointer?) -> Void
+typealias MissedCallHandler = @convention(c) (UnsafePointer<Int8>?, UInt32, UnsafePointer<Int8>?, UnsafePointer<Int8>?, Int32, UnsafeMutableRawPointer?) -> Void
 
 /// Equivalent of `wcall_answered_h`.
 typealias AnsweredCallHandler = @convention(c) (UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void

--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -209,13 +209,12 @@ public class AVSWrapper: AVSWrapperType {
         }
     }
 
-    // TODO: Pass clientId down or discard it.
     private let closedCallHandler: CloseCallHandler = { reason, conversationId, messageTime, userId, clientId, contextRef in
         zmLog.debug("closedCallHandler: messageTime = \(messageTime)")
         let nonZeroMessageTime: UInt32 = messageTime != 0 ? messageTime : UInt32(Date().timeIntervalSince1970)
 
-        AVSWrapper.withCallCenter(contextRef, reason, conversationId, nonZeroMessageTime) {
-            $0.handleCallEnd(reason: $1, conversationId: $2, messageTime: $3, userId: UUID(rawValue: userId))
+        AVSWrapper.withCallCenter(contextRef, reason, conversationId, nonZeroMessageTime, clientId) {
+            $0.handleCallEnd(reason: $1, conversationId: $2, messageTime: $3, userId: UUID(rawValue: userId), clientId: $4)
         }
     }
 

--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -197,17 +197,15 @@ public class AVSWrapper: AVSWrapperType {
         }
     }
 
-
     private let dataChannelEstablishedHandler: DataChannelEstablishedHandler = { conversationId, userId, clientId, contextRef in
         AVSWrapper.withCallCenter(contextRef, conversationId, userId, clientId) {
             $0.handleDataChannelEstablishement(conversationId: $1, userId: $2, clientId: $3)
         }
     }
 
-    // TODO: Pass clientId down or discard it.
     private let establishedCallHandler: CallEstablishedHandler = { conversationId, userId, clientId, contextRef in
-        AVSWrapper.withCallCenter(contextRef, conversationId, userId) {
-            $0.handleEstablishedCall(conversationId: $1, userId: $2)
+        AVSWrapper.withCallCenter(contextRef, conversationId, userId, clientId) {
+            $0.handleEstablishedCall(conversationId: $1, userId: $2, clientId: $3)
         }
     }
 

--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -163,8 +163,7 @@ public class AVSWrapper: AVSWrapperType {
 
     // MARK: - C Callback Handlers
 
-    // TODO: Pass clientId down or discard it.
-    private let constantBitRateChangeHandler: ConstantBitRateChangeHandler = { _, clientId, enabledFlag, contextRef in
+    private let constantBitRateChangeHandler: ConstantBitRateChangeHandler = { userId, clientId, enabledFlag, contextRef in
         AVSWrapper.withCallCenter(contextRef, enabledFlag) {
             $0.handleConstantBitRateChange(enabled: $1)
         }

--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -175,13 +175,13 @@ public class AVSWrapper: AVSWrapperType {
         }
     }
 
-    private let incomingCallHandler: IncomingCallHandler = { conversationId, messageTime, userId, isVideoCall, shouldRing, contextRef in
-        AVSWrapper.withCallCenter(contextRef, conversationId, messageTime, userId, isVideoCall, shouldRing) {
-            $0.handleIncomingCall(conversationId: $1, messageTime: $2, userId: $3, isVideoCall: $4, shouldRing: $5)
+    private let incomingCallHandler: IncomingCallHandler = { conversationId, messageTime, userId, clientId, isVideoCall, shouldRing, contextRef in
+        AVSWrapper.withCallCenter(contextRef, conversationId, messageTime, userId, clientId, isVideoCall, shouldRing) {
+            $0.handleIncomingCall(conversationId: $1, messageTime: $2, userId: $3, clientId: $4, isVideoCall: $5, shouldRing: $6)
         }
     }
 
-    private let missedCallHandler: MissedCallHandler = { conversationId, messageTime, userId, isVideoCall, contextRef in
+    private let missedCallHandler: MissedCallHandler = { conversationId, messageTime, userId, clientId, isVideoCall, contextRef in
         zmLog.debug("missedCallHandler: messageTime = \(messageTime)")
         let nonZeroMessageTime: UInt32 = messageTime != 0 ? messageTime : UInt32(Date().timeIntervalSince1970)
 

--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -163,6 +163,7 @@ public class AVSWrapper: AVSWrapperType {
 
     // MARK: - C Callback Handlers
 
+    // TODO: Pass clientId down or discard it.
     private let constantBitRateChangeHandler: ConstantBitRateChangeHandler = { _, clientId, enabledFlag, contextRef in
         AVSWrapper.withCallCenter(contextRef, enabledFlag) {
             $0.handleConstantBitRateChange(enabled: $1)
@@ -196,18 +197,21 @@ public class AVSWrapper: AVSWrapperType {
         }
     }
 
+    // TODO: Pass clientId down or discard it.
     private let dataChannelEstablishedHandler: DataChannelEstablishedHandler = { conversationId, userId, clientId, contextRef in
         AVSWrapper.withCallCenter(contextRef, conversationId, userId) {
             $0.handleDataChannelEstablishement(conversationId: $1, userId: $2)
         }
     }
 
+    // TODO: Pass clientId down or discard it.
     private let establishedCallHandler: CallEstablishedHandler = { conversationId, userId, clientId, contextRef in
         AVSWrapper.withCallCenter(contextRef, conversationId, userId) {
             $0.handleEstablishedCall(conversationId: $1, userId: $2)
         }
     }
 
+    // TODO: Pass clientId down or discard it.
     private let closedCallHandler: CloseCallHandler = { reason, conversationId, messageTime, userId, clientId, contextRef in
         zmLog.debug("closedCallHandler: messageTime = \(messageTime)")
         let nonZeroMessageTime: UInt32 = messageTime != 0 ? messageTime : UInt32(Date().timeIntervalSince1970)
@@ -261,6 +265,7 @@ public class AVSWrapper: AVSWrapperType {
         }
     }
 
+    // TODO: Pass clientId down.
     private let networkQualityHandler: NetworkQualityChangeHandler = { conversationIdRef, userIdRef, clientId, quality, rtt, uplinkLoss, downlinkLoss, contextRef in
         AVSWrapper.withCallCenter(contextRef, conversationIdRef, userIdRef, quality, { (callCenter, conversationId, userId, quality) in
             callCenter.handleNetworkQualityChange(conversationId: conversationId, userId: userId, quality: quality)

--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -163,7 +163,7 @@ public class AVSWrapper: AVSWrapperType {
 
     // MARK: - C Callback Handlers
 
-    private let constantBitRateChangeHandler: ConstantBitRateChangeHandler = { _, enabledFlag, contextRef in
+    private let constantBitRateChangeHandler: ConstantBitRateChangeHandler = { _, clientId, enabledFlag, contextRef in
         AVSWrapper.withCallCenter(contextRef, enabledFlag) {
             $0.handleConstantBitRateChange(enabled: $1)
         }
@@ -196,19 +196,19 @@ public class AVSWrapper: AVSWrapperType {
         }
     }
 
-    private let dataChannelEstablishedHandler: DataChannelEstablishedHandler = { conversationId, userId, contextRef in
+    private let dataChannelEstablishedHandler: DataChannelEstablishedHandler = { conversationId, userId, clientId, contextRef in
         AVSWrapper.withCallCenter(contextRef, conversationId, userId) {
             $0.handleDataChannelEstablishement(conversationId: $1, userId: $2)
         }
     }
 
-    private let establishedCallHandler: CallEstablishedHandler = { conversationId, userId, contextRef in
+    private let establishedCallHandler: CallEstablishedHandler = { conversationId, userId, clientId, contextRef in
         AVSWrapper.withCallCenter(contextRef, conversationId, userId) {
             $0.handleEstablishedCall(conversationId: $1, userId: $2)
         }
     }
 
-    private let closedCallHandler: CloseCallHandler = { reason, conversationId, messageTime, userId, contextRef in
+    private let closedCallHandler: CloseCallHandler = { reason, conversationId, messageTime, userId, clientId, contextRef in
         zmLog.debug("closedCallHandler: messageTime = \(messageTime)")
         let nonZeroMessageTime: UInt32 = messageTime != 0 ? messageTime : UInt32(Date().timeIntervalSince1970)
 
@@ -261,7 +261,7 @@ public class AVSWrapper: AVSWrapperType {
         }
     }
 
-    private let networkQualityHandler: NetworkQualityChangeHandler = { conversationIdRef, userIdRef, quality, rtt, uplinkLoss, downlinkLoss, contextRef in
+    private let networkQualityHandler: NetworkQualityChangeHandler = { conversationIdRef, userIdRef, clientId, quality, rtt, uplinkLoss, downlinkLoss, contextRef in
         AVSWrapper.withCallCenter(contextRef, conversationIdRef, userIdRef, quality, { (callCenter, conversationId, userId, quality) in
             callCenter.handleNetworkQualityChange(conversationId: conversationId, userId: userId, quality: quality)
         })

--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -212,8 +212,8 @@ public class AVSWrapper: AVSWrapperType {
         zmLog.debug("closedCallHandler: messageTime = \(messageTime)")
         let nonZeroMessageTime: UInt32 = messageTime != 0 ? messageTime : UInt32(Date().timeIntervalSince1970)
 
-        AVSWrapper.withCallCenter(contextRef, reason, conversationId, nonZeroMessageTime, clientId) {
-            $0.handleCallEnd(reason: $1, conversationId: $2, messageTime: $3, userId: UUID(rawValue: userId), clientId: $4)
+        AVSWrapper.withCallCenter(contextRef, reason, conversationId, nonZeroMessageTime, userId, clientId) {
+            $0.handleCallEnd(reason: $1, conversationId: $2, messageTime: $3, userId: $4, clientId: $5)
         }
     }
 

--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -265,11 +265,10 @@ public class AVSWrapper: AVSWrapperType {
         }
     }
 
-    // TODO: Pass clientId down.
-    private let networkQualityHandler: NetworkQualityChangeHandler = { conversationIdRef, userIdRef, clientId, quality, rtt, uplinkLoss, downlinkLoss, contextRef in
-        AVSWrapper.withCallCenter(contextRef, conversationIdRef, userIdRef, quality, { (callCenter, conversationId, userId, quality) in
-            callCenter.handleNetworkQualityChange(conversationId: conversationId, userId: userId, quality: quality)
-        })
+    private let networkQualityHandler: NetworkQualityChangeHandler = { conversationIdRef, userIdRef, clientIdRef, quality, rtt, uplinkLoss, downlinkLoss, contextRef in
+        AVSWrapper.withCallCenter(contextRef, conversationIdRef, userIdRef, clientIdRef, quality) { (callCenter, conversationId, userId, clientId, quality) in
+            callCenter.handleNetworkQualityChange(conversationId: conversationId, userId: userId, clientId: clientId, quality: quality)
+        }
     }
 
     private let muteChangeHandler: MuteChangeHandler = { muted, contextRef in

--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -197,10 +197,10 @@ public class AVSWrapper: AVSWrapperType {
         }
     }
 
-    // TODO: Pass clientId down or discard it.
+
     private let dataChannelEstablishedHandler: DataChannelEstablishedHandler = { conversationId, userId, clientId, contextRef in
-        AVSWrapper.withCallCenter(contextRef, conversationId, userId) {
-            $0.handleDataChannelEstablishement(conversationId: $1, userId: $2)
+        AVSWrapper.withCallCenter(contextRef, conversationId, userId, clientId) {
+            $0.handleDataChannelEstablishement(conversationId: $1, userId: $2, clientId: $3)
         }
     }
 

--- a/Source/Calling/CallParticipantSnapshot.swift
+++ b/Source/Calling/CallParticipantSnapshot.swift
@@ -46,14 +46,6 @@ class CallParticipantsSnapshot {
 
     // MARK: - Updates
 
-    // Should we update this?
-
-    func callParticipantState(forUser userId: UUID) -> CallParticipantState {
-        guard let callMember = findMembers(with: userId).first else { return .unconnected }
-
-        return callMember.callParticipantState
-    }
-
     func callParticipantsChanged(participants: [AVSCallMember]) {
         members = type(of:self).removeDuplicateMembers(participants)
         notifyChange()

--- a/Source/Calling/CallParticipantSnapshot.swift
+++ b/Source/Calling/CallParticipantSnapshot.swift
@@ -51,16 +51,16 @@ class CallParticipantsSnapshot {
         notifyChange()
     }
 
-    func callParticpantVideoStateChanged(userId: UUID, clientId: String, videoState: VideoState) {
+    func callParticipantVideoStateChanged(userId: UUID, clientId: String, videoState: VideoState) {
         updateMember(userId: userId, clientId: clientId, videoState: videoState)
     }
 
-    func callParticpantAudioEstablished(userId: UUID, clientId: String) {
+    func callParticipantAudioEstablished(userId: UUID, clientId: String) {
         updateMember(userId: userId, clientId: clientId, audioState: .established)
     }
 
     // FIXME: This never get's called. We would likely want to call this for the new network state.
-    func callParticpantNetworkQualityChanged(userId: UUID, clientId: String, networkQuality: NetworkQuality) {
+    func callParticipantNetworkQualityChanged(userId: UUID, clientId: String, networkQuality: NetworkQuality) {
         updateMember(userId: userId, clientId: clientId, networkQuality: networkQuality)
     }
 

--- a/Source/Calling/CallParticipantSnapshot.swift
+++ b/Source/Calling/CallParticipantSnapshot.swift
@@ -67,10 +67,6 @@ class CallParticipantsSnapshot {
     // MARK: - Helpers
 
     /// Updates the locally stored member for the given userId and clientId with the given non nil properties.
-    ///
-    /// The locally stored member may not yet have a clientId; we know the userId from the incoming call event but
-    /// only get the clientId once the call connects. In this case, if we can't find a member matching both ids
-    /// then we take the first where the userId matches and clientId is nil.
 
     private func updateMember(userId: UUID,
                               clientId: String,
@@ -78,11 +74,7 @@ class CallParticipantsSnapshot {
                               videoState: VideoState? = nil,
                               networkQuality: NetworkQuality? = nil) {
 
-        let candidateMembers = findMembers(with: userId)
-        let targetMember = candidateMembers.first { $0.clientId == clientId }
-        let fallBackMember = candidateMembers.first { $0.clientId == nil }
-
-        guard let localMember = targetMember ?? fallBackMember else { return }
+        guard let localMember = findMember(with: userId, clientId: clientId) else { return }
 
         let updatedMember = AVSCallMember(userId: userId,
                                           clientId: clientId,
@@ -95,10 +87,10 @@ class CallParticipantsSnapshot {
         }))
     }
 
-    /// Returns all members matching the given userId.
+    /// Returns the member matching the given userId and clientId.
 
-    private func findMembers(with userId: UUID) -> [AVSCallMember] {
-        return members.array.filter { $0.remoteId == userId }
+    private func findMember(with userId: UUID, clientId: String) -> AVSCallMember? {
+        return members.array.first { $0.remoteId == userId && $0.clientId == clientId }
     }
 
     /// Notifies observers of a potential change in the participants set.

--- a/Source/Calling/CallParticipantSnapshot.swift
+++ b/Source/Calling/CallParticipantSnapshot.swift
@@ -56,20 +56,36 @@ class CallParticipantsSnapshot {
     func callParticpantVideoStateChanged(userId: UUID, clientId: String, videoState: VideoState) {
         guard let callMember = findMember(userId: userId, clientId: clientId) else { return }
 
-        update(updatedMember: AVSCallMember(userId: userId, clientId: clientId, audioEstablished: callMember.audioEstablished, videoState: videoState))
+        let member = AVSCallMember(userId: userId,
+                                   clientId: clientId,
+                                   audioState: callMember.audioState,
+                                   videoState: videoState)
+
+        update(updatedMember: member)
     }
 
     func callParticpantAudioEstablished(userId: UUID) {
         guard let callMember = members.array.first(where: { $0.remoteId == userId }) else { return }
 
-        update(updatedMember: AVSCallMember(userId: userId, clientId: callMember.clientId, audioEstablished: true, videoState: callMember.videoState))
+        let member = AVSCallMember(userId: userId,
+                                   clientId: callMember.clientId,
+                                   audioState: .established,
+                                   videoState: callMember.videoState)
+
+        update(updatedMember: member)
     }
 
     // FIXME: This never get's called. We would likely want to call this for the new network state.
     func callParticpantNetworkQualityChanged(userId: UUID, networkQuality: NetworkQuality) {
         guard let callMember = members.array.first(where: { $0.remoteId == userId }) else { return }
 
-        update(updatedMember: AVSCallMember(userId: userId, clientId: callMember.clientId, audioEstablished: callMember.audioEstablished, videoState: callMember.videoState, networkQuality: networkQuality))
+        let member = AVSCallMember(userId: userId,
+                                   clientId: callMember.clientId,
+                                   audioState: callMember.audioState,
+                                   videoState: callMember.videoState,
+                                   networkQuality: networkQuality)
+
+        update(updatedMember: member)
     }
     
     func update(updatedMember: AVSCallMember) {

--- a/Source/Calling/CallParticipantSnapshot.swift
+++ b/Source/Calling/CallParticipantSnapshot.swift
@@ -76,10 +76,10 @@ class CallParticipantsSnapshot {
     }
 
     // FIXME: This never get's called. We would likely want to call this for the new network state.
-    func callParticpantNetworkQualityChanged(userId: UUID, networkQuality: NetworkQuality) {
-        guard let callMember = members.array.first(where: { $0.remoteId == userId }) else { return }
+    func callParticpantNetworkQualityChanged(userId: UUID, clientId: String, networkQuality: NetworkQuality) {
+        guard let callMember = findMember(userId: userId, clientId: clientId) else { return }
 
-        let member = AVSCallMember(userId: userId,
+        let member = AVSCallMember(userId: callMember.remoteId,
                                    clientId: callMember.clientId,
                                    audioState: callMember.audioState,
                                    videoState: callMember.videoState,

--- a/Source/Calling/CallParticipantSnapshot.swift
+++ b/Source/Calling/CallParticipantSnapshot.swift
@@ -65,6 +65,7 @@ class CallParticipantsSnapshot {
         update(updatedMember: AVSCallMember(userId: userId, clientId: callMember.clientId, audioEstablished: true, videoState: callMember.videoState))
     }
 
+    // FIXME: This never get's called. We would likely want to call this for the new network state.
     func callParticpantNetworkQualityChanged(userId: UUID, networkQuality: NetworkQuality) {
         guard let callMember = members.array.first(where: { $0.remoteId == userId }) else { return }
 

--- a/Source/Calling/CallParticipantSnapshot.swift
+++ b/Source/Calling/CallParticipantSnapshot.swift
@@ -53,7 +53,9 @@ class CallParticipantsSnapshot {
     }
 
     func callParticpantVideoStateChanged(userId: UUID, clientId: String, videoState: VideoState) {
-        guard let callMember = findMember(userId: userId, clientId: clientId) else { return }
+        let exactCallMember = findMember(userId: userId, clientId: clientId)
+
+        guard let callMember = exactCallMember ?? findMembers(with: userId).first  else { return }
 
         let member = AVSCallMember(userId: userId,
                                    clientId: clientId,

--- a/Source/Calling/CallParticipantSnapshot.swift
+++ b/Source/Calling/CallParticipantSnapshot.swift
@@ -44,6 +44,8 @@ class CallParticipantsSnapshot {
         self.members = type(of: self).removeDuplicateMembers(members)
     }
 
+    // MARK: - Updates
+
     // Should we update this?
 
     func callParticipantState(forUser userId: UUID) -> CallParticipantState {

--- a/Source/Calling/CallParticipantSnapshot.swift
+++ b/Source/Calling/CallParticipantSnapshot.swift
@@ -59,7 +59,6 @@ class CallParticipantsSnapshot {
         updateMember(userId: userId, clientId: clientId, audioState: .established)
     }
 
-    // FIXME: This never get's called. We would likely want to call this for the new network state.
     func callParticipantNetworkQualityChanged(userId: UUID, clientId: String, networkQuality: NetworkQuality) {
         updateMember(userId: userId, clientId: clientId, networkQuality: networkQuality)
     }

--- a/Source/Calling/CallParticipantSnapshot.swift
+++ b/Source/Calling/CallParticipantSnapshot.swift
@@ -64,11 +64,11 @@ class CallParticipantsSnapshot {
         update(updatedMember: member)
     }
 
-    func callParticpantAudioEstablished(userId: UUID) {
-        guard let callMember = members.array.first(where: { $0.remoteId == userId }) else { return }
+    func callParticpantAudioEstablished(userId: UUID, clientId: String) {
+        guard let callMember = findMember(userId: userId, clientId: clientId) else { return }
 
         let member = AVSCallMember(userId: userId,
-                                   clientId: callMember.clientId,
+                                   clientId: clientId,
                                    audioState: .established,
                                    videoState: callMember.videoState)
 

--- a/Source/Calling/CallState.swift
+++ b/Source/Calling/CallState.swift
@@ -71,7 +71,7 @@ public enum CallParticipantState: Equatable {
     /// Participant is in the process of connecting to the call
     case connecting
     /// Participant is connected to call and audio is flowing
-    case connected(videoState: VideoState, clientId: String?)
+    case connected(videoState: VideoState, clientId: String)
 }
 
 

--- a/Source/Calling/CallState.swift
+++ b/Source/Calling/CallState.swift
@@ -132,33 +132,6 @@ public enum CallState: Equatable {
     case unknown
 
     /**
-     * Creates the call state from the given AVS flag.
-     * - parameter wcallState: The state of the call as represented in AVS.
-     */
-
-    init(wcallState: Int32) {
-        switch wcallState {
-        case WCALL_STATE_NONE:
-            self = .none
-        case WCALL_STATE_INCOMING:
-            self = .incoming(video: false, shouldRing: true, degraded: false)
-        case WCALL_STATE_OUTGOING:
-            self = .outgoing(degraded: false)
-        case WCALL_STATE_ANSWERED:
-            self = .answered(degraded: false)
-        case WCALL_STATE_MEDIA_ESTAB:
-            self = .established
-        case WCALL_STATE_TERM_LOCAL: fallthrough
-        case WCALL_STATE_TERM_REMOTE:
-            self = .terminating(reason: .unknown)
-        default:
-            // WCALL_STATE_UNKNOWN can happen when we check the call state of a
-            // conversation id that isn't in the list of calls
-            self = .none
-        }
-    }
-
-    /**
      * Logs the current state to the calling logs.
      */
 

--- a/Source/Calling/CallState.swift
+++ b/Source/Calling/CallState.swift
@@ -93,7 +93,7 @@ enum AudioState: Int32, Codable {
  * The state of video in the call.
  */
 
-public enum VideoState: Int32 {
+public enum VideoState: Int32, Codable {
     /// Sender is not sending video
     case stopped = 0
     /// Sender is sending video

--- a/Source/Calling/CallState.swift
+++ b/Source/Calling/CallState.swift
@@ -74,6 +74,21 @@ public enum CallParticipantState: Equatable {
     case connected(videoState: VideoState, clientId: String?)
 }
 
+
+/**
+ * The audio state of a participant in a call.
+ */
+
+enum AudioState: Int32, Codable {
+    /// Audio is in the process of connecting.
+    case connecting = 0
+    /// Audio has been established and is flowing.
+    case established = 1
+    /// No relay candidate, though audio may still connect.
+    case networkProblem = 2
+}
+
+
 /**
  * The state of video in the call.
  */

--- a/Source/Calling/CallState.swift
+++ b/Source/Calling/CallState.swift
@@ -79,7 +79,7 @@ public enum CallParticipantState: Equatable {
  * The audio state of a participant in a call.
  */
 
-enum AudioState: Int32, Codable {
+public enum AudioState: Int32, Codable {
     /// Audio is in the process of connecting.
     case connecting = 0
     /// Audio has been established and is flowing.

--- a/Source/Calling/CallState.swift
+++ b/Source/Calling/CallState.swift
@@ -66,11 +66,11 @@ public struct CallParticipant: Hashable {
 public enum CallParticipantState: Equatable {
     /// Participant is not in the call
     case unconnected
-    /// A network problem occured but calls may still connect
+    /// A network problem occured but the call may still connect
     case unconnectedButMayConnect
     /// Participant is in the process of connecting to the call
     case connecting
-    /// Participant is connected to call and audio is flowing
+    /// Participant is connected to the call and audio is flowing
     case connected(videoState: VideoState, clientId: String)
 }
 

--- a/Source/Calling/CallState.swift
+++ b/Source/Calling/CallState.swift
@@ -66,6 +66,8 @@ public struct CallParticipant: Hashable {
 public enum CallParticipantState: Equatable {
     /// Participant is not in the call
     case unconnected
+    /// A network problem occured but calls may still connect
+    case unconnectedButMayConnect
     /// Participant is in the process of connecting to the call
     case connecting
     /// Participant is connected to call and audio is flowing

--- a/Source/Calling/NetworkQuality.swift
+++ b/Source/Calling/NetworkQuality.swift
@@ -22,4 +22,5 @@ public enum NetworkQuality: Int32 {
     case normal = 1
     case medium = 2
     case poor = 3
+    case problem = 4
 }

--- a/Source/Calling/WireCallCenterV3+Events.swift
+++ b/Source/Calling/WireCallCenterV3+Events.swift
@@ -226,9 +226,10 @@ extension WireCallCenterV3 {
     }
 
     /// Handles network quality change
-    func handleNetworkQualityChange(conversationId: UUID, userId: UUID, quality: NetworkQuality) {
+    func handleNetworkQualityChange(conversationId: UUID, userId: UUID, clientId: String, quality: NetworkQuality) {
         handleEventInContext("network-quality-change") {
 
+            // TODO: Use clientId
             // TODO: Here is where we would tell the call participant snapshot to update the participant's network quality.
 
             if let call = self.callSnapshots[conversationId] {

--- a/Source/Calling/WireCallCenterV3+Events.swift
+++ b/Source/Calling/WireCallCenterV3+Events.swift
@@ -124,7 +124,7 @@ extension WireCallCenterV3 {
      * If messageTime is set to 0, the event wasn't caused by a message therefore we don't have a serverTimestamp.
      */
 
-    func handleCallEnd(reason: CallClosedReason, conversationId: UUID, messageTime: Date?, userId: UUID?, clientId: String) {
+    func handleCallEnd(reason: CallClosedReason, conversationId: UUID, messageTime: Date?, userId: UUID, clientId: String) {
         handleEvent("closed-call") {
             self.handleCallState(callState: .terminating(reason: reason), conversationId: conversationId, userId: userId, clientId: clientId, messageTime: messageTime)
         }

--- a/Source/Calling/WireCallCenterV3+Events.swift
+++ b/Source/Calling/WireCallCenterV3+Events.swift
@@ -262,7 +262,6 @@ extension WireCallCenterV3 {
         }
     }
 
-    // TODO: Propagate clientId in the notification.
     /// Handles network quality change
     func handleNetworkQualityChange(conversationId: UUID, userId: UUID, clientId: String, quality: NetworkQuality) {
         handleEventInContext("network-quality-change") {
@@ -275,6 +274,7 @@ extension WireCallCenterV3 {
                 self.callSnapshots[conversationId] = call.updateNetworkQuality(quality)
                 let notification = WireCallCenterNetworkQualityNotification(conversationId: conversationId,
                                                                             userId: userId,
+                                                                            clientId: clientId,
                                                                             networkQuality: quality)
                 notification.post(in: $0.notificationContext)
             }

--- a/Source/Calling/WireCallCenterV3+Events.swift
+++ b/Source/Calling/WireCallCenterV3+Events.swift
@@ -228,9 +228,10 @@ extension WireCallCenterV3 {
     /// Handles network quality change
     func handleNetworkQualityChange(conversationId: UUID, userId: UUID, clientId: String, quality: NetworkQuality) {
         handleEventInContext("network-quality-change") {
-
-            // TODO: Use clientId
-            // TODO: Here is where we would tell the call participant snapshot to update the participant's network quality.
+            self.callParticipantNetworkQualityChanged(conversationId: conversationId,
+                                                      userId: userId,
+                                                      clientId: clientId,
+                                                      quality: quality)
 
             if let call = self.callSnapshots[conversationId] {
                 self.callSnapshots[conversationId] = call.updateNetworkQuality(quality)

--- a/Source/Calling/WireCallCenterV3+Events.swift
+++ b/Source/Calling/WireCallCenterV3+Events.swift
@@ -77,10 +77,10 @@ extension WireCallCenterV3 {
     }
 
     /// Handles incoming calls.
-    func handleIncomingCall(conversationId: UUID, messageTime: Date, userId: UUID, isVideoCall: Bool, shouldRing: Bool) {
+    func handleIncomingCall(conversationId: UUID, messageTime: Date, userId: UUID, clientId: String, isVideoCall: Bool, shouldRing: Bool) {
         handleEvent("incoming-call") {
-            let callState : CallState = .incoming(video: isVideoCall, shouldRing: shouldRing, degraded: self.isDegraded(conversationId: conversationId))
-            self.handleCallState(callState: callState, conversationId: conversationId, userId: userId, messageTime: messageTime)
+            let callState: CallState = .incoming(video: isVideoCall, shouldRing: shouldRing, degraded: self.isDegraded(conversationId: conversationId))
+            self.handleCallState(callState: callState, conversationId: conversationId, userId: userId, clientId: clientId, messageTime: messageTime)
         }
     }
 

--- a/Source/Calling/WireCallCenterV3+Events.swift
+++ b/Source/Calling/WireCallCenterV3+Events.swift
@@ -100,9 +100,9 @@ extension WireCallCenterV3 {
     }
 
     /// Handles when data channel gets established.
-    func handleDataChannelEstablishement(conversationId: UUID, userId: UUID) {
+    func handleDataChannelEstablishement(conversationId: UUID, userId: UUID, clientId: String) {
         handleEvent("data-channel-established") {
-            self.handleCallState(callState: .establishedDataChannel, conversationId: conversationId, userId: userId)
+            self.handleCallState(callState: .establishedDataChannel, conversationId: conversationId, userId: userId, clientId: clientId)
         }
     }
 

--- a/Source/Calling/WireCallCenterV3+Events.swift
+++ b/Source/Calling/WireCallCenterV3+Events.swift
@@ -124,9 +124,9 @@ extension WireCallCenterV3 {
      * If messageTime is set to 0, the event wasn't caused by a message therefore we don't have a serverTimestamp.
      */
 
-    func handleCallEnd(reason: CallClosedReason, conversationId: UUID, messageTime: Date?, userId: UUID?) {
+    func handleCallEnd(reason: CallClosedReason, conversationId: UUID, messageTime: Date?, userId: UUID?, clientId: String) {
         handleEvent("closed-call") {
-            self.handleCallState(callState: .terminating(reason: reason), conversationId: conversationId, userId: userId, messageTime: messageTime)
+            self.handleCallState(callState: .terminating(reason: reason), conversationId: conversationId, userId: userId, clientId: clientId, messageTime: messageTime)
         }
     }
 

--- a/Source/Calling/WireCallCenterV3+Events.swift
+++ b/Source/Calling/WireCallCenterV3+Events.swift
@@ -228,6 +228,9 @@ extension WireCallCenterV3 {
     /// Handles network quality change
     func handleNetworkQualityChange(conversationId: UUID, userId: UUID, quality: NetworkQuality) {
         handleEventInContext("network-quality-change") {
+
+            // TODO: Here is where we would tell the call participant snapshot to update the participant's network quality.
+
             if let call = self.callSnapshots[conversationId] {
                 self.callSnapshots[conversationId] = call.updateNetworkQuality(quality)
                 WireCallCenterNetworkQualityNotification(conversationId: conversationId, userId: userId, networkQuality: quality).post(in: $0.notificationContext)

--- a/Source/Calling/WireCallCenterV3+Events.swift
+++ b/Source/Calling/WireCallCenterV3+Events.swift
@@ -107,9 +107,9 @@ extension WireCallCenterV3 {
     }
 
     /// Handles established calls.
-    func handleEstablishedCall(conversationId: UUID, userId: UUID) {
+    func handleEstablishedCall(conversationId: UUID, userId: UUID, clientId: String) {
         handleEvent("established-call") {
-            self.handleCallState(callState: .established, conversationId: conversationId, userId: userId)
+            self.handleCallState(callState: .established, conversationId: conversationId, userId: userId, clientId: clientId)
         }
     }
 

--- a/Source/Calling/WireCallCenterV3+Notifications.swift
+++ b/Source/Calling/WireCallCenterV3+Notifications.swift
@@ -41,6 +41,7 @@ struct WireCallCenterNetworkQualityNotification : SelfPostingNotification {
     static let notificationName = Notification.Name("WireCallCenterNetworkQualityNotification")
     public let conversationId: UUID
     public let userId: UUID
+    public let clientId: String
     public let networkQuality: NetworkQuality
 }
 

--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -326,12 +326,12 @@ extension WireCallCenterV3 {
                                           videoState: VideoState) {
 
         let snapshot = callSnapshots[conversationId]?.callParticipants
-        snapshot?.callParticpantVideoStateChanged(userId: userId, clientId: clientId, videoState: videoState)
+        snapshot?.callParticipantVideoStateChanged(userId: userId, clientId: clientId, videoState: videoState)
     }
 
     /// Call this method when the client established an audio connection with another user, and avs calls the `wcall_estab_h`.
     func callParticipantAudioEstablished(conversationId: UUID, userId: UUID, clientId: String) {
-        callSnapshots[conversationId]?.callParticipants.callParticpantAudioEstablished(userId: userId, clientId: clientId)
+        callSnapshots[conversationId]?.callParticipants.callParticipantAudioEstablished(userId: userId, clientId: clientId)
     }
 
     /// Call this method when the network quality of a participant changes and avs calls the `wcall_network_quality_h`.
@@ -341,7 +341,7 @@ extension WireCallCenterV3 {
                                               quality: NetworkQuality) {
 
         let snapshot = callSnapshots[conversationId]?.callParticipants
-        snapshot?.callParticpantNetworkQualityChanged(userId: userId, clientId: clientId, networkQuality: quality)
+        snapshot?.callParticipantNetworkQualityChanged(userId: userId, clientId: clientId, networkQuality: quality)
     }
     
 }

--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -553,10 +553,11 @@ extension WireCallCenterV3 {
      * Handles a change in calling state.
      * - parameter conversationId: The ID of the conversation where the calling state has changed.
      * - parameter userId: The identifier of the user that caused the event.
+     * - parameter clientId: The identifier of the user's client that caused the event.
      * - parameter messageTime: The timestamp of the event.
      */
 
-    func handleCallState(callState: CallState, conversationId: UUID, userId: UUID?, messageTime: Date? = nil) {
+    func handleCallState(callState: CallState, conversationId: UUID, userId: UUID?, clientId: String? = nil, messageTime: Date? = nil) {
         callState.logState()
         var callState = callState
 

--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -314,9 +314,8 @@ extension WireCallCenterV3 {
         return callSnapshots[conversationId]?.callStarter
     }
 
-    /// Call this method when the callParticipants changed and avs calls the handler `wcall_group_changed_h`
+    /// Call this method when the callParticipants changed and avs calls the handler `wcall_participant_changed_h`
     func callParticipantsChanged(conversationId: UUID, participants: [AVSCallMember]) {
-        guard callSnapshots[conversationId]?.isGroup == true else { return }
         callSnapshots[conversationId]?.callParticipants.callParticipantsChanged(participants: participants)
     }
 
@@ -415,14 +414,8 @@ extension WireCallCenterV3 {
         let started = avsWrapper.startCall(conversationId: conversationId, callType: callType, conversationType: conversationType, useCBR: useConstantBitRateAudio)
         if started {
             let callState: CallState = .outgoing(degraded: isDegraded(conversationId: conversationId))
-            
-            let members: [AVSCallMember] = {
-                guard let user = conversation.connectedUser, conversation.conversationType == .oneOnOne else { return [] }
-                return [AVSCallMember(userId: user.remoteIdentifier)]
-            }()
-
             let previousCallState = callSnapshots[conversationId]?.callState
-            createSnapshot(callState: callState, members: members, callStarter: selfUserId, video: video, for: conversationId)
+            createSnapshot(callState: callState, members: [], callStarter: selfUserId, video: video, for: conversationId)
             
             if let context = uiMOC {
                 WireCallCenterCallStateNotification(context: context, callState: callState, conversationId: conversationId, callerId: selfUserId, messageTime: nil, previousCallState: previousCallState).post(in: context.notificationContext)

--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -549,15 +549,21 @@ extension WireCallCenterV3 {
         completionHandler()
     }
 
-    /**
-     * Handles a change in calling state.
-     * - parameter conversationId: The ID of the conversation where the calling state has changed.
-     * - parameter userId: The identifier of the user that caused the event.
-     * - parameter clientId: The identifier of the user's client that caused the event.
-     * - parameter messageTime: The timestamp of the event.
-     */
+    /// Handles a change in calling state.
+    ///
+    /// - Parameters:
+    ///     - callState: The state to handle.
+    ///     - conversationId: The id of the conversation where teh calling state has changed.
+    ///     - userId: The id of the user that caused the event, if applicable.
+    ///     - clientId: The id of the user's client that caused the event, if applicable.
+    ///     - messageTime: The timestamp of the event.
 
-    func handleCallState(callState: CallState, conversationId: UUID, userId: UUID?, clientId: String? = nil, messageTime: Date? = nil) {
+    func handleCallState(callState: CallState,
+                         conversationId: UUID,
+                         userId: UUID?,
+                         clientId: String? = nil,
+                         messageTime: Date? = nil)
+    {
         callState.logState()
         var callState = callState
 

--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -575,14 +575,16 @@ extension WireCallCenterV3 {
             callState = .incoming(video: false, shouldRing: false, degraded: isDegraded(conversationId: conversationId))
         }
 
+        let callerId = initiatorForCall(conversationId: conversationId)
+        let previousCallState = callSnapshots[conversationId]?.callState
+
         if case .terminating = callState {
             clearSnapshot(conversationId: conversationId)
         } else if let previousSnapshot = callSnapshots[conversationId] {
             callSnapshots[conversationId] = previousSnapshot.update(with: callState)
         }
 
-        if let context = uiMOC, let callerId = initiatorForCall(conversationId: conversationId)  {
-            let previousCallState = callSnapshots[conversationId]?.callState
+        if let context = uiMOC, let callerId = callerId  {
             let notification = WireCallCenterCallStateNotification(context: context,
                                                                    callState: callState,
                                                                    conversationId: conversationId,

--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -584,7 +584,7 @@ extension WireCallCenterV3 {
 
         switch callState {
         case .incoming(video: let video, shouldRing: _, degraded: _):
-            createSnapshot(callState: callState, members: [AVSCallMember(userId: userId!)], callStarter: userId, video: video, for: conversationId)
+            createSnapshot(callState: callState, members: [AVSCallMember(userId: userId!, clientId: clientId!)], callStarter: userId, video: video, for: conversationId)
         case .established:
             // WORKAROUND: the call established handler will is called once for every participant in a
             // group call. Until that's no longer the case we must take care to only set establishedDate once.

--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -326,8 +326,8 @@ extension WireCallCenterV3 {
     }
 
     /// Call this method when the client established an audio connection with another user, and avs calls the `wcall_estab_h`.
-    func callParticipantAudioEstablished(conversationId: UUID, userId: UUID) {
-        callSnapshots[conversationId]?.callParticipants.callParticpantAudioEstablished(userId: userId)
+    func callParticipantAudioEstablished(conversationId: UUID, userId: UUID, clientId: String) {
+        callSnapshots[conversationId]?.callParticipants.callParticpantAudioEstablished(userId: userId, clientId: clientId)
     }
     
 }
@@ -577,8 +577,8 @@ extension WireCallCenterV3 {
                 establishedDate = Date()
             }
 
-            if let userId = userId {
-                callParticipantAudioEstablished(conversationId: conversationId, userId: userId)
+            if let userId = userId, let clientId = clientId {
+                callParticipantAudioEstablished(conversationId: conversationId, userId: userId, clientId: clientId)
             }
 
             if videoState(conversationId: conversationId) == .started {

--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -321,13 +321,28 @@ extension WireCallCenterV3 {
     }
 
     /// Call this method when the video state of a participant changes and avs calls the `wcall_video_state_change_h`.
-    func callParticipantVideoStateChanged(conversationId: UUID, userId: UUID, clientId: String, videoState: VideoState) {
-        callSnapshots[conversationId]?.callParticipants.callParticpantVideoStateChanged(userId: userId, clientId: clientId, videoState: videoState)
+    func callParticipantVideoStateChanged(conversationId: UUID,
+                                          userId: UUID,
+                                          clientId: String,
+                                          videoState: VideoState) {
+
+        let snapshot = callSnapshots[conversationId]?.callParticipants
+        snapshot?.callParticpantVideoStateChanged(userId: userId, clientId: clientId, videoState: videoState)
     }
 
     /// Call this method when the client established an audio connection with another user, and avs calls the `wcall_estab_h`.
     func callParticipantAudioEstablished(conversationId: UUID, userId: UUID, clientId: String) {
         callSnapshots[conversationId]?.callParticipants.callParticpantAudioEstablished(userId: userId, clientId: clientId)
+    }
+
+    /// Call this method when the network quality of a participant changes and avs calls the `wcall_network_quality_h`.
+    func callParticipantNetworkQualityChanged(conversationId: UUID,
+                                              userId: UUID,
+                                              clientId: String,
+                                              quality: NetworkQuality) {
+
+        let snapshot = callSnapshots[conversationId]?.callParticipants
+        snapshot?.callParticpantNetworkQualityChanged(userId: userId, clientId: clientId, networkQuality: quality)
     }
     
 }

--- a/Tests/Source/Calling/CallParticipantsSnapshotTests.swift
+++ b/Tests/Source/Calling/CallParticipantsSnapshotTests.swift
@@ -134,16 +134,16 @@ class CallParticipantsSnapshotTests: MessagingTest {
         XCTAssertEqual(sut.networkQuality, .normal)
 
         // When, then
-        sut.callParticpantNetworkQualityChanged(userId: member1.remoteId, clientId: member1.clientId, networkQuality: .medium)
+        sut.callParticipantNetworkQualityChanged(userId: member1.remoteId, clientId: member1.clientId, networkQuality: .medium)
         XCTAssertEqual(sut.networkQuality, .medium)
 
         // When, then
-        sut.callParticpantNetworkQualityChanged(userId: member2.remoteId, clientId: member2.clientId, networkQuality: .poor)
+        sut.callParticipantNetworkQualityChanged(userId: member2.remoteId, clientId: member2.clientId, networkQuality: .poor)
         XCTAssertEqual(sut.networkQuality, .poor)
 
         // When, then
-        sut.callParticpantNetworkQualityChanged(userId: member1.remoteId, clientId: member1.clientId, networkQuality: .normal)
-        sut.callParticpantNetworkQualityChanged(userId: member2.remoteId, clientId: member2.clientId, networkQuality: .normal)
+        sut.callParticipantNetworkQualityChanged(userId: member1.remoteId, clientId: member1.clientId, networkQuality: .normal)
+        sut.callParticipantNetworkQualityChanged(userId: member2.remoteId, clientId: member2.clientId, networkQuality: .normal)
         XCTAssertEqual(sut.networkQuality, .normal)
     }
 
@@ -154,7 +154,7 @@ class CallParticipantsSnapshotTests: MessagingTest {
         let sut = createSut(members: [member1, member2])
 
         // When
-        sut.callParticpantAudioEstablished(userId: member1.remoteId, clientId: member1.clientId)
+        sut.callParticipantAudioEstablished(userId: member1.remoteId, clientId: member1.clientId)
 
         // Then
         let updatedMember1 = AVSCallMember(userId: alice.userId, clientId: alice.iphone, audioState: .established)
@@ -168,7 +168,7 @@ class CallParticipantsSnapshotTests: MessagingTest {
         let sut = createSut(members: [member1, member2])
 
         // When
-        sut.callParticpantVideoStateChanged(userId: member1.remoteId, clientId: member1.clientId, videoState: .screenSharing)
+        sut.callParticipantVideoStateChanged(userId: member1.remoteId, clientId: member1.clientId, videoState: .screenSharing)
 
         // Then
         let updatedMember1 = AVSCallMember(userId: alice.userId, clientId: alice.iphone, videoState: .screenSharing)
@@ -183,7 +183,7 @@ class CallParticipantsSnapshotTests: MessagingTest {
 
         // When
         let unknownMember = AVSCallMember(userId: alice.userId, clientId: alice.desktop, videoState: .stopped)
-        sut.callParticpantVideoStateChanged(userId: unknownMember.remoteId, clientId: unknownMember.clientId, videoState: .screenSharing)
+        sut.callParticipantVideoStateChanged(userId: unknownMember.remoteId, clientId: unknownMember.clientId, videoState: .screenSharing)
 
         // Then
         XCTAssertEqual(sut.members.array, [member1, member2])

--- a/Tests/Source/Calling/CallParticipantsSnapshotTests.swift
+++ b/Tests/Source/Calling/CallParticipantsSnapshotTests.swift
@@ -20,17 +20,21 @@
 import Foundation
 @testable import WireSyncEngine
 
-class CallParticipantsSnapshotTests : MessagingTest {
+class CallParticipantsSnapshotTests: MessagingTest {
 
     private typealias Sut = WireSyncEngine.CallParticipantsSnapshot
 
-    var mockWireCallCenterV3 : WireCallCenterV3Mock!
-    var mockFlowManager : FlowManagerMock!
+    var mockWireCallCenterV3: WireCallCenterV3Mock!
+    var mockFlowManager: FlowManagerMock!
 
     override func setUp() {
         super.setUp()
         mockFlowManager = FlowManagerMock()
-        mockWireCallCenterV3 = WireCallCenterV3Mock(userId: UUID(), clientId: "foo", uiMOC: uiMOC, flowManager: mockFlowManager, transport: WireCallCenterTransportMock())
+        mockWireCallCenterV3 = WireCallCenterV3Mock(userId: UUID(),
+                                                    clientId: UUID().transportString(),
+                                                    uiMOC: uiMOC,
+                                                    flowManager: mockFlowManager,
+                                                    transport: WireCallCenterTransportMock())
     }
     
     override func tearDown() {

--- a/Tests/Source/Calling/VoiceChannelV3Tests.swift
+++ b/Tests/Source/Calling/VoiceChannelV3Tests.swift
@@ -87,12 +87,13 @@ class VoiceChannelV3Tests : MessagingTest {
     func testThatItForwardsNetworkQualityFromCallCenter() {
         // given
         let calledId = UUID()
+        let clientId = UUID().transportString()
         wireCallCenterMock?.setMockCallState(.established, conversationId: conversation!.remoteIdentifier!, callerId: calledId, isVideo: false)
         let quality = NetworkQuality.poor
         XCTAssertEqual(sut.networkQuality, .normal)
 
         // when
-        wireCallCenterMock?.handleNetworkQualityChange(conversationId: conversation!.remoteIdentifier!, userId: calledId, quality: quality)
+        wireCallCenterMock?.handleNetworkQualityChange(conversationId: conversation!.remoteIdentifier!, userId: calledId, clientId: clientId, quality: quality)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then

--- a/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -44,6 +44,7 @@ class WireCallCenterV3Tests: MessagingTest {
     var sut : WireCallCenterV3!
     var otherUser: ZMUser!
     let otherUserID : UUID = UUID()
+    let otherUserClientID = UUID().transportString()
     var selfUserID : UUID!
     var oneOnOneConversation: ZMConversation!
     var groupConversation: ZMConversation!
@@ -200,7 +201,7 @@ class WireCallCenterV3Tests: MessagingTest {
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         checkThatItPostsNotification(expectedCallState: .established, expectedCallerId: otherUserID, expectedConversationId: oneOnOneConversationID) {
-            sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID)
+            sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
         }
     }
     
@@ -212,7 +213,7 @@ class WireCallCenterV3Tests: MessagingTest {
         
         // when
         checkThatItPostsNotification(expectedCallState: .established, expectedCallerId: otherUserID, expectedConversationId: oneOnOneConversationID) {
-            sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID)
+            sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
         }
         
         // then
@@ -226,14 +227,14 @@ class WireCallCenterV3Tests: MessagingTest {
         XCTAssertNil(sut.establishedDate)
         
         // call is established
-        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID)
+        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         XCTAssertNotNil(sut.establishedDate)
         let previousEstablishedDate = sut.establishedDate
         spinMainQueue(withTimeout: 0.1)
         
         // when
-        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID)
+        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then
@@ -246,7 +247,7 @@ class WireCallCenterV3Tests: MessagingTest {
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         checkThatItPostsNotification(expectedCallState: .terminating(reason: .canceled), expectedCallerId: otherUserID, expectedConversationId: oneOnOneConversationID) {
-            sut.handleCallEnd(reason: .canceled, conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID)
+            sut.handleCallEnd(reason: .canceled, conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, clientId: otherUserClientID)
         }
     }
     
@@ -314,7 +315,7 @@ class WireCallCenterV3Tests: MessagingTest {
         
         // when
         sut.rejectCall(conversationId: oneOnOneConversationID)
-        sut.handleCallEnd(reason: .stillOngoing, conversationId: groupConversationID, messageTime: Date(), userId: otherUserID)
+        sut.handleCallEnd(reason: .stillOngoing, conversationId: groupConversationID, messageTime: Date(), userId: otherUserID, clientId: otherUserClientID)
 
         // then
         XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
@@ -337,7 +338,7 @@ class WireCallCenterV3Tests: MessagingTest {
         
         // when
         sut.rejectCall(conversationId: oneOnOneConversationID)
-        sut.handleCallEnd(reason: .stillOngoing, conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID)
+        sut.handleCallEnd(reason: .stillOngoing, conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, clientId: otherUserClientID)
 
         // then
         XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
@@ -494,7 +495,7 @@ class WireCallCenterV3Tests: MessagingTest {
         }
         
         // when
-        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID)
+        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
 
         // then
         XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
@@ -653,7 +654,7 @@ extension WireCallCenterV3Tests {
         // given
         sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID)
+        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // when
@@ -668,7 +669,7 @@ extension WireCallCenterV3Tests {
         // given
         sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        sut.handleDataChannelEstablishement(conversationId: oneOnOneConversationID, userId: otherUserID)
+        sut.handleDataChannelEstablishement(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
@@ -683,7 +684,7 @@ extension WireCallCenterV3Tests {
         // given
         sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID)
+        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         sut.handleConstantBitRateChange(enabled: true)
@@ -715,14 +716,14 @@ extension WireCallCenterV3Tests {
         // given
         sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID)
+        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         sut.handleConstantBitRateChange(enabled: true)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
-        sut.handleCallEnd(reason: .normal, conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID)
+        sut.handleCallEnd(reason: .normal, conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, clientId: otherUserClientID)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
@@ -746,12 +747,12 @@ extension WireCallCenterV3Tests {
         // given
         sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID)
+        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         let quality = NetworkQuality.poor
 
         // when
-        sut.handleNetworkQualityChange(conversationId: oneOnOneConversationID, userId: otherUserID, quality: quality)
+        sut.handleNetworkQualityChange(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID, quality: quality)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
@@ -772,7 +773,7 @@ extension WireCallCenterV3Tests {
         // given
         sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID)
+        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         let observer = MuteObserver()
         let token = WireCallCenterV3.addMuteStateObserver(observer: observer, context: uiMOC)
@@ -857,8 +858,10 @@ extension WireCallCenterV3Tests {
         XCTAssertEqual(sut.callParticipants(conversationId: oneOnOneConversationID), [CallParticipant(user: otherUser, state: .connecting)])
     }
 
-    func callBackMemberHandler(conversationId: UUID, userId: UUID, audioEstablished: Bool) {
-        let member = AVSParticipantsChange.Member(userid: userId, clientid: "123", aestab: audioEstablished ? 1 : 0, vrecv: 0)
+    func callBackMemberHandler(conversationId: UUID, userId: UUID, clientId: String, audioEstablished: Bool) {
+        let audioState = audioEstablished ? AudioState.established : .connecting
+        let videoState = VideoState.stopped
+        let member = AVSParticipantsChange.Member(userid: userId, clientid: clientId, aestab: audioState, vrecv: videoState)
         let change = AVSParticipantsChange(convid: conversationId, members: [member])
         
         let encoded = try! JSONEncoder().encode(change)
@@ -870,7 +873,7 @@ extension WireCallCenterV3Tests {
     func testThatItIgnoresIt_WhenGroupHandlerIsCalledForOneToOne() {
         // when
         _ = sut.startCall(conversation: oneOnOneConversation, video: false)
-        callBackMemberHandler(conversationId: oneOnOneConversationID, userId: otherUserID, audioEstablished: false)
+        callBackMemberHandler(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID, audioEstablished: false)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then
@@ -880,7 +883,7 @@ extension WireCallCenterV3Tests {
     func testThatItUpdatesTheParticipantsWhenGroupHandlerIsCalled() {
         // when
         _ = sut.startCall(conversation: groupConversation, video: false)
-        callBackMemberHandler(conversationId: groupConversationID, userId: otherUserID, audioEstablished: false)
+        callBackMemberHandler(conversationId: groupConversationID, userId: otherUserID, clientId: otherUserClientID, audioEstablished: false)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
@@ -896,11 +899,11 @@ extension WireCallCenterV3Tests {
         XCTAssertEqual(sut.callParticipants(conversationId: groupConversationID), [CallParticipant(user: otherUser, state: .connecting)])
 
         // when
-        callBackMemberHandler(conversationId: groupConversationID, userId: otherUserID, audioEstablished: true)
+        callBackMemberHandler(conversationId: groupConversationID, userId: otherUserID, clientId: otherUserClientID, audioEstablished: true)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
-        XCTAssertEqual(sut.callParticipants(conversationId: groupConversationID), [CallParticipant(user: otherUser, state: .connected(videoState: .stopped, clientId: "123"))])
+        XCTAssertEqual(sut.callParticipants(conversationId: groupConversationID), [CallParticipant(user: otherUser, state: .connected(videoState: .stopped, clientId: otherUserClientID))])
     }
 }
 

--- a/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -124,6 +124,7 @@ class WireCallCenterV3Tests: MessagingTest {
             sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                    messageTime: Date(),
                                    userId: otherUserID,
+                                   clientId: otherUserClientID,
                                    isVideoCall: true,
                                    shouldRing: false)
         }
@@ -134,6 +135,7 @@ class WireCallCenterV3Tests: MessagingTest {
             sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                    messageTime: Date(),
                                    userId: otherUserID,
+                                   clientId: otherUserClientID,
                                    isVideoCall: false,
                                    shouldRing: false)
         }
@@ -144,6 +146,7 @@ class WireCallCenterV3Tests: MessagingTest {
             sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                    messageTime: Date(),
                                    userId: otherUserID,
+                                   clientId: otherUserClientID,
                                    isVideoCall: true,
                                    shouldRing: true)
         }
@@ -154,6 +157,7 @@ class WireCallCenterV3Tests: MessagingTest {
             sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                    messageTime: Date(),
                                    userId: otherUserID,
+                                   clientId: otherUserClientID,
                                    isVideoCall: false,
                                    shouldRing: true)
         }
@@ -187,7 +191,13 @@ class WireCallCenterV3Tests: MessagingTest {
     
     func testThatTheAnsweredCallHandlerPostsTheRightNotification() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
+                               messageTime: Date(),
+                               userId: otherUserID,
+                               clientId: otherUserClientID,
+                               isVideoCall: false,
+                               shouldRing: true)
+
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         checkThatItPostsNotification(expectedCallState: .answered(degraded: false), expectedCallerId: otherUserID, expectedConversationId: oneOnOneConversationID) {
@@ -197,7 +207,13 @@ class WireCallCenterV3Tests: MessagingTest {
     
     func testThatTheEstablishedHandlerPostsTheRightNotification() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
+                               messageTime: Date(),
+                               userId: otherUserID,
+                               clientId: otherUserClientID,
+                               isVideoCall: false,
+                               shouldRing: true)
+
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         checkThatItPostsNotification(expectedCallState: .established, expectedCallerId: otherUserID, expectedConversationId: oneOnOneConversationID) {
@@ -207,7 +223,13 @@ class WireCallCenterV3Tests: MessagingTest {
     
     func testThatTheEstablishedHandlerSetsTheStartTime() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
+                               messageTime: Date(),
+                               userId: otherUserID,
+                               clientId: otherUserClientID,
+                               isVideoCall: false,
+                               shouldRing: true)
+
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         XCTAssertNil(sut.establishedDate)
         
@@ -222,7 +244,13 @@ class WireCallCenterV3Tests: MessagingTest {
     
     func testThatTheEstablishedHandlerDoesntSetTheStartTimeIfCallIsAlreadyEstablished() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
+                               messageTime: Date(),
+                               userId: otherUserID,
+                               clientId: otherUserClientID,
+                               isVideoCall: false,
+                               shouldRing: true)
+
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         XCTAssertNil(sut.establishedDate)
         
@@ -243,7 +271,13 @@ class WireCallCenterV3Tests: MessagingTest {
     
     func testThatTheClosedCallHandlerPostsTheRightNotification() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
+                               messageTime: Date(),
+                               userId: otherUserID,
+                               clientId: otherUserClientID,
+                               isVideoCall: false,
+                               shouldRing: true)
+
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         checkThatItPostsNotification(expectedCallState: .terminating(reason: .canceled), expectedCallerId: otherUserID, expectedConversationId: oneOnOneConversationID) {
@@ -253,7 +287,13 @@ class WireCallCenterV3Tests: MessagingTest {
     
     func testThatTheMediaStopppedCallHandlerPostsTheRightNotification() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
+                               messageTime: Date(),
+                               userId: otherUserID,
+                               clientId: otherUserClientID,
+                               isVideoCall: false,
+                               shouldRing: true)
+
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         checkThatItPostsNotification(expectedCallState: .mediaStopped, expectedCallerId: otherUserID, expectedConversationId: oneOnOneConversationID) {
@@ -263,8 +303,20 @@ class WireCallCenterV3Tests: MessagingTest {
     
     func testThatOtherIncomingCallsAreRejectedWhenWeAnswerCall() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
-        sut.handleIncomingCall(conversationId: groupConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
+                               messageTime: Date(),
+                               userId: otherUserID,
+                               clientId: otherUserClientID,
+                               isVideoCall: false,
+                               shouldRing: true)
+
+        sut.handleIncomingCall(conversationId: groupConversationID,
+                               messageTime: Date(),
+                               userId: otherUserID,
+                               clientId: otherUserClientID,
+                               isVideoCall: false,
+                               shouldRing: true)
+
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // when
@@ -277,7 +329,14 @@ class WireCallCenterV3Tests: MessagingTest {
     func testThatOtherOutgoingCallsAreCanceledWhenWeAnswerCall() {
         // given
         XCTAssertTrue(sut.startCall(conversation: groupConversation, video: false))
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
+
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
+                               messageTime: Date(),
+                               userId: otherUserID,
+                               clientId: otherUserClientID,
+                               isVideoCall: false,
+                               shouldRing: true)
+
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // when
@@ -289,7 +348,13 @@ class WireCallCenterV3Tests: MessagingTest {
     
     func testThatOtherIncomingCallsAreRejectedWhenWeStartCall() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
+                               messageTime: Date(),
+                               userId: otherUserID,
+                               clientId: otherUserClientID,
+                               isVideoCall: false,
+                               shouldRing: true)
+
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // when
@@ -301,7 +366,13 @@ class WireCallCenterV3Tests: MessagingTest {
     
     func testThatItRejectsACall_Group() {
         // given
-        sut.handleIncomingCall(conversationId: groupConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
+        sut.handleIncomingCall(conversationId: groupConversationID,
+                               messageTime: Date(),
+                               userId: otherUserID,
+                               clientId: otherUserClientID,
+                               isVideoCall: false,
+                               shouldRing: true)
+
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // expect
@@ -324,7 +395,13 @@ class WireCallCenterV3Tests: MessagingTest {
     
     func testThatItRejectsACall_1on1() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
+                               messageTime: Date(),
+                               userId: otherUserID,
+                               clientId: otherUserClientID,
+                               isVideoCall: false,
+                               shouldRing: true)
+
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // expect
@@ -347,7 +424,13 @@ class WireCallCenterV3Tests: MessagingTest {
     
     func testThatItAnswersACall_oneToOne() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
+                               messageTime: Date(),
+                               userId: otherUserID,
+                               clientId: otherUserClientID,
+                               isVideoCall: false,
+                               shouldRing: true)
+
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         checkThatItPostsNotification(expectedCallState: .answered(degraded: false), expectedCallerId: otherUserID, expectedConversationId: oneOnOneConversationID) {
@@ -368,7 +451,13 @@ class WireCallCenterV3Tests: MessagingTest {
             groupConversation.addParticipantAndUpdateConversationState(user: user, role: nil)
         }
 
-        sut.handleIncomingCall(conversationId: groupConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
+        sut.handleIncomingCall(conversationId: groupConversationID,
+                               messageTime: Date(),
+                               userId: otherUserID,
+                               clientId: otherUserClientID,
+                               isVideoCall: false,
+                               shouldRing: true)
+
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         checkThatItPostsNotification(expectedCallState: .answered(degraded: false), expectedCallerId: otherUserID, expectedConversationId: groupConversationID) {
@@ -382,7 +471,13 @@ class WireCallCenterV3Tests: MessagingTest {
     
     func testThatItAnswersACall_audioOnly() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: true, shouldRing: true)
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
+                               messageTime: Date(),
+                               userId: otherUserID,
+                               clientId: otherUserClientID,
+                               isVideoCall: true,
+                               shouldRing: true)
+
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         checkThatItPostsNotification(expectedCallState: .answered(degraded: false), expectedCallerId: otherUserID, expectedConversationId: oneOnOneConversationID) {
@@ -397,7 +492,13 @@ class WireCallCenterV3Tests: MessagingTest {
     
     func testThatItAnswersACall_withVideo() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: true, shouldRing: true)
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
+                               messageTime: Date(),
+                               userId: otherUserID,
+                               clientId: otherUserClientID,
+                               isVideoCall: true,
+                               shouldRing: true)
+
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         checkThatItPostsNotification(expectedCallState: .answered(degraded: false), expectedCallerId: otherUserID, expectedConversationId: oneOnOneConversationID) {
@@ -420,27 +521,7 @@ class WireCallCenterV3Tests: MessagingTest {
             XCTAssertEqual(mockAVSWrapper.startCallArguments?.callType, AVSCallType.normal)
         }
     }
-    
-    func testThatItIncludesTheConnectedUserInCallParticipants_oneToOne(){
-        // given
-        let connection = ZMConnection.insertNewObject(in: uiMOC)
-        connection.status = .accepted
-        connection.to = .insertNewObject(in: uiMOC)
-        connection.to.remoteIdentifier = UUID()
-        connection.conversation = oneOnOneConversation
-        
-        
-        checkThatItPostsNotification(expectedCallState: .outgoing(degraded: false), expectedCallerId: selfUserID, expectedConversationId: oneOnOneConversationID) {
-            // when
-            _ = sut.startCall(conversation: oneOnOneConversation, video: false)
-            
-            // then
-            XCTAssertEqual(mockAVSWrapper.startCallArguments?.conversationType, AVSConversationType.oneToOne)
-            XCTAssertEqual(mockAVSWrapper.startCallArguments?.callType, AVSCallType.normal)
-            XCTAssertEqual(sut.callParticipants(conversationId: oneOnOneConversationID), [CallParticipant(user: oneOnOneConversation.connectedUser!, state: .connecting)])
-        }
-    }
-    
+
     func testThatItStartsACall_smallGroup(){
         checkThatItPostsNotification(expectedCallState: .outgoing(degraded: false), expectedCallerId: selfUserID, expectedConversationId: groupConversationID) {
             // when
@@ -484,7 +565,13 @@ class WireCallCenterV3Tests: MessagingTest {
     
     func testThatItSetsTheCallStartTimeBeforePostingTheNotification() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
+                               messageTime: Date(),
+                               userId: otherUserID,
+                               clientId: otherUserClientID,
+                               isVideoCall: false,
+                               shouldRing: true)
+
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         XCTAssertNil(sut.establishedDate)
         
@@ -652,7 +739,13 @@ extension WireCallCenterV3Tests {
     
     func testThatCBRIsEnabledOnAudioCBRChangeHandler_whenCallIsEstablished() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
+                               messageTime: Date(),
+                               userId: otherUserID,
+                               clientId: otherUserClientID,
+                               isVideoCall: false,
+                               shouldRing: true)
+
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
@@ -667,7 +760,13 @@ extension WireCallCenterV3Tests {
     
     func testThatCBRIsEnabledOnAudioCBRChangeHandler_whenDataChannelIsEstablished() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
+                               messageTime: Date(),
+                               userId: otherUserID,
+                               clientId: otherUserClientID,
+                               isVideoCall: false,
+                               shouldRing: true)
+
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         sut.handleDataChannelEstablishement(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
@@ -682,7 +781,13 @@ extension WireCallCenterV3Tests {
 
     func testThatCBRIsDisabledOnAudioCBRChangeHandler() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
+                               messageTime: Date(),
+                               userId: otherUserID,
+                               clientId: otherUserClientID,
+                               isVideoCall: false,
+                               shouldRing: true)
+
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
@@ -701,7 +806,13 @@ extension WireCallCenterV3Tests {
 
     func testThatCBRIsNotEnabledOnAudioCBRChangeHandlerWhenCallIsNotEstablished() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
+                               messageTime: Date(),
+                               userId: otherUserID,
+                               clientId: otherUserClientID,
+                               isVideoCall: false,
+                               shouldRing: true)
+
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
@@ -714,7 +825,13 @@ extension WireCallCenterV3Tests {
 
     func testThatCBRIsNotEnabledAfterCallIsTerminated() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
+                               messageTime: Date(),
+                               userId: otherUserID,
+                               clientId: otherUserClientID,
+                               isVideoCall: false,
+                               shouldRing: true)
+
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
@@ -736,7 +853,13 @@ extension WireCallCenterV3Tests {
 extension WireCallCenterV3Tests {
     func testThatNetworkQualityIsNormalInitially() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
+                               messageTime: Date(),
+                               userId: otherUserID,
+                               clientId: otherUserClientID,
+                               isVideoCall: false,
+                               shouldRing: true)
+
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
@@ -745,7 +868,13 @@ extension WireCallCenterV3Tests {
 
     func testThatNetworkQualityHandlerUpdatesTheQuality() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
+                               messageTime: Date(),
+                               userId: otherUserID,
+                               clientId: otherUserClientID,
+                               isVideoCall: false,
+                               shouldRing: true)
+
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
@@ -771,7 +900,13 @@ extension WireCallCenterV3Tests {
         }
         
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
+                               messageTime: Date(),
+                               userId: otherUserID,
+                               clientId: otherUserClientID,
+                               isVideoCall: false,
+                               shouldRing: true)
+
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
@@ -797,7 +932,13 @@ extension WireCallCenterV3Tests {
 
     func testThatItWhenIgnoringACallItWillSetsTheCallStateToIncomingInactive() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
+                               messageTime: Date(),
+                               userId: otherUserID,
+                               clientId: otherUserClientID,
+                               isVideoCall: false,
+                               shouldRing: true)
+
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
@@ -809,7 +950,13 @@ extension WireCallCenterV3Tests {
 
     func testThatItWhenRejectingAOneOnOneCallItWilltSetTheCallStateToIncomingInactive() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
+                               messageTime: Date(),
+                               userId: otherUserID,
+                               clientId: otherUserClientID,
+                               isVideoCall: false,
+                               shouldRing: true)
+
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
@@ -821,7 +968,13 @@ extension WireCallCenterV3Tests {
 
     func testThatItWhenClosingAGroupCallItWillSetsTheCallStateToIncomingInactive() {
         // given
-        sut.handleIncomingCall(conversationId: groupConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
+        sut.handleIncomingCall(conversationId: groupConversationID,
+                               messageTime: Date(),
+                               userId: otherUserID,
+                               clientId: otherUserClientID,
+                               isVideoCall: false,
+                               shouldRing: true)
+
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
@@ -833,7 +986,13 @@ extension WireCallCenterV3Tests {
 
     func testThatItWhenClosingAOneOnOneCallItDoesNotSetTheCallStateToIncomingInactive() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
+                               messageTime: Date(),
+                               userId: otherUserID,
+                               clientId: otherUserClientID,
+                               isVideoCall: false,
+                               shouldRing: true)
+
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
@@ -851,7 +1010,13 @@ extension WireCallCenterV3Tests {
 
     func testThatItCreatesAParticipantSnapshotForAnIncomingCall() {
         // when
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
+                               messageTime: Date(),
+                               userId: otherUserID,
+                               clientId: otherUserClientID,
+                               isVideoCall: false,
+                               shouldRing: true)
+
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
@@ -870,14 +1035,14 @@ extension WireCallCenterV3Tests {
         sut.handleParticipantChange(conversationId: conversationId, data: string)
     }
     
-    func testThatItIgnoresIt_WhenGroupHandlerIsCalledForOneToOne() {
+    func testThatItDoesNotIgnore_WhenGroupHandlerIsCalledForOneToOne() {
         // when
         _ = sut.startCall(conversation: oneOnOneConversation, video: false)
         callBackMemberHandler(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID, audioEstablished: false)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then
-        XCTAssertTrue(sut.callParticipants(conversationId: oneOnOneConversationID).isEmpty)
+        XCTAssertEqual(sut.callParticipants(conversationId: oneOnOneConversationID), [CallParticipant(user: otherUser, state: .connecting)])
     }
 
     func testThatItUpdatesTheParticipantsWhenGroupHandlerIsCalled() {
@@ -892,7 +1057,13 @@ extension WireCallCenterV3Tests {
 
     func testThatItUpdatesTheStateForParticipant() {
         // when
-        sut.handleIncomingCall(conversationId: groupConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
+        sut.handleIncomingCall(conversationId: groupConversationID,
+                               messageTime: Date(),
+                               userId: otherUserID,
+                               clientId: otherUserClientID,
+                               isVideoCall: false,
+                               shouldRing: true)
+        
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then


### PR DESCRIPTION
## What's new in this PR?

This PR integrates [API changes](https://github.com/wearezeta/avs/blob/master/docs/api/api_changes_5.6.txt) for AVS 5.6

### Refactoring

We now get the clientId in more callbacks, which allows us to refactor how we maintain the list of call participants. Currently, we only get the clientId when the video state changes or the list of participants changes. A consequence of this is that any changes to the participants where we only have the userId might update the wrong participant (since a single userId can be shared with different participants). This issue is now resolved with these changes.
