### PR TITLE
[FIX] Missing "You called" message after hanging up

### DIFF
--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -212,8 +212,8 @@ public class AVSWrapper: AVSWrapperType {
         zmLog.debug("closedCallHandler: messageTime = \(messageTime)")
         let nonZeroMessageTime: UInt32 = messageTime != 0 ? messageTime : UInt32(Date().timeIntervalSince1970)
 
-        AVSWrapper.withCallCenter(contextRef, reason, conversationId, nonZeroMessageTime, userId, clientId) {
-            $0.handleCallEnd(reason: $1, conversationId: $2, messageTime: $3, userId: $4, clientId: $5)
+        AVSWrapper.withCallCenter(contextRef, reason, conversationId, nonZeroMessageTime, userId) {
+            $0.handleCallEnd(reason: $1, conversationId: $2, messageTime: $3, userId: $4)
         }
     }
 

--- a/Source/Calling/WireCallCenterV3+Events.swift
+++ b/Source/Calling/WireCallCenterV3+Events.swift
@@ -153,7 +153,7 @@ extension WireCallCenterV3 {
      * If messageTime is set to 0, the event wasn't caused by a message therefore we don't have a serverTimestamp.
      */
 
-    func handleCallEnd(reason: CallClosedReason, conversationId: UUID, messageTime: Date?, userId: UUID, clientId: String) {
+    func handleCallEnd(reason: CallClosedReason, conversationId: UUID, messageTime: Date?, userId: UUID) {
         handleEvent("closed-call") {
             self.handle(callState: .terminating(reason: reason), conversationId: conversationId, messageTime: messageTime)
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

 No system message saying "You called" shows up after calling and hanging up

### Causes

client id was returning nil and it was not necessary

### Solutions

Removed not necessary handling clientId parameter 
