### PR TITLE
[Fix]: tests were failing

### DIFF
--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -212,8 +212,8 @@ public class AVSWrapper: AVSWrapperType {
         zmLog.debug("closedCallHandler: messageTime = \(messageTime)")
         let nonZeroMessageTime: UInt32 = messageTime != 0 ? messageTime : UInt32(Date().timeIntervalSince1970)
 
-        AVSWrapper.withCallCenter(contextRef, reason, conversationId, nonZeroMessageTime, userId, clientId) {
-            $0.handleCallEnd(reason: $1, conversationId: $2, messageTime: $3, userId: $4, clientId: $5)
+        AVSWrapper.withCallCenter(contextRef, reason, conversationId, nonZeroMessageTime, userId) {
+            $0.handleCallEnd(reason: $1, conversationId: $2, messageTime: $3, userId: $4)
         }
     }
 

--- a/Source/Calling/WireCallCenterV3+Events.swift
+++ b/Source/Calling/WireCallCenterV3+Events.swift
@@ -153,7 +153,7 @@ extension WireCallCenterV3 {
      * If messageTime is set to 0, the event wasn't caused by a message therefore we don't have a serverTimestamp.
      */
 
-    func handleCallEnd(reason: CallClosedReason, conversationId: UUID, messageTime: Date?, userId: UUID, clientId: String) {
+    func handleCallEnd(reason: CallClosedReason, conversationId: UUID, messageTime: Date?, userId: UUID) {
         handleEvent("closed-call") {
             self.handle(callState: .terminating(reason: reason), conversationId: conversationId, messageTime: messageTime)
         }

--- a/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -281,7 +281,7 @@ class WireCallCenterV3Tests: MessagingTest {
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         checkThatItPostsNotification(expectedCallState: .terminating(reason: .canceled), expectedCallerId: otherUserID, expectedConversationId: oneOnOneConversationID) {
-            sut.handleCallEnd(reason: .canceled, conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, clientId: otherUserClientID)
+            sut.handleCallEnd(reason: .canceled, conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID)
         }
     }
     
@@ -386,7 +386,7 @@ class WireCallCenterV3Tests: MessagingTest {
         
         // when
         sut.rejectCall(conversationId: oneOnOneConversationID)
-        sut.handleCallEnd(reason: .stillOngoing, conversationId: groupConversationID, messageTime: Date(), userId: otherUserID, clientId: otherUserClientID)
+        sut.handleCallEnd(reason: .stillOngoing, conversationId: groupConversationID, messageTime: Date(), userId: otherUserID)
 
         // then
         XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
@@ -415,7 +415,7 @@ class WireCallCenterV3Tests: MessagingTest {
         
         // when
         sut.rejectCall(conversationId: oneOnOneConversationID)
-        sut.handleCallEnd(reason: .stillOngoing, conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, clientId: otherUserClientID)
+        sut.handleCallEnd(reason: .stillOngoing, conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID)
 
         // then
         XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
@@ -840,7 +840,7 @@ extension WireCallCenterV3Tests {
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
-        sut.handleCallEnd(reason: .normal, conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, clientId: otherUserClientID)
+        sut.handleCallEnd(reason: .normal, conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then


### PR DESCRIPTION
## What's new in this PR?

### Issues

Some test after the last merge are failing

### Causes

Not updating tests before last merge

### Solutions

Remove not necessary clientId parameter from certain tests