### PR TITLE
[Chore] Revert to AVS 5.5.6

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-github "wireapp/wire-ios-request-strategy" ~> 189.0
+github "wireapp/wire-ios-request-strategy" ~> 192.0
 github "wireapp/avs-ios-binaries" ~> 5.3.191
 github "wireapp/ZipArchive" "v2.1.3"
 github "wireapp/libPhoneNumber-iOS" ~> 0.9.3

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-github "wireapp/avs-ios-binaries" ~> 5.6.209
-github "wireapp/wire-ios-request-strategy" ~> 192.0
+github "wireapp/wire-ios-request-strategy" ~> 189.0
+github "wireapp/avs-ios-binaries" ~> 5.3.191
 github "wireapp/ZipArchive" "v2.1.3"
 github "wireapp/libPhoneNumber-iOS" ~> 0.9.3

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,7 +1,7 @@
 github "wireapp/HTMLString" "4.1.0-beta.1-xcode_10_2"
 github "wireapp/PINCache" "2.3-swift3.1"
 github "wireapp/ZipArchive" "v2.1.3"
-github "wireapp/avs-ios-binaries" "5.6.209"
+github "wireapp/avs-ios-binaries" "5.4.199"
 github "wireapp/libPhoneNumber-iOS" "0.9.3"
 github "wireapp/ocmock" "v3.4.3"
 github "wireapp/protobuf-objc" "1.9.14"

--- a/Source/Calling/AVSWrapper+Handlers.swift
+++ b/Source/Calling/AVSWrapper+Handlers.swift
@@ -20,28 +20,28 @@ import Foundation
 import avs
 
 /// Equivalent of `wcall_audio_cbr_change_h`.
-typealias ConstantBitRateChangeHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, Int32, UnsafeMutableRawPointer?) -> Void
+typealias ConstantBitRateChangeHandler = @convention(c) (UnsafePointer<Int8>?, Int32, UnsafeMutableRawPointer?) -> Void
 
 /// Equivalent of `wcall_video_state_change_h`.
 typealias VideoStateChangeHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafePointer<Int8>?, Int32, UnsafeMutableRawPointer?) -> Void
 
 /// Equivalent of `wcall_incoming_h`.
-typealias IncomingCallHandler = @convention(c) (UnsafePointer<Int8>?, UInt32, UnsafePointer<Int8>?, UnsafePointer<Int8>?, Int32, Int32, UnsafeMutableRawPointer?) -> Void
+typealias IncomingCallHandler = @convention(c) (UnsafePointer<Int8>?, UInt32, UnsafePointer<Int8>?, Int32, Int32, UnsafeMutableRawPointer?) -> Void
 
 /// Equivalent of `wcall_missed_h`.
-typealias MissedCallHandler = @convention(c) (UnsafePointer<Int8>?, UInt32, UnsafePointer<Int8>?, UnsafePointer<Int8>?, Int32, UnsafeMutableRawPointer?) -> Void
+typealias MissedCallHandler = @convention(c) (UnsafePointer<Int8>?, UInt32, UnsafePointer<Int8>?, Int32, UnsafeMutableRawPointer?) -> Void
 
 /// Equivalent of `wcall_answered_h`.
 typealias AnsweredCallHandler = @convention(c) (UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
 
 /// Equivalent of `wcall_data_chan_estab_h`.
-typealias DataChannelEstablishedHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
+typealias DataChannelEstablishedHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
 
 /// Equivalent of `wcall_estab_h`.
-typealias CallEstablishedHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
+typealias CallEstablishedHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
 
 /// Equivalent of `wcall_close_h`.
-typealias CloseCallHandler = @convention(c) (Int32, UnsafePointer<Int8>?, UInt32, UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
+typealias CloseCallHandler = @convention(c) (Int32, UnsafePointer<Int8>?, UInt32, UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
 
 /// Equivalent of `wcall_metrics_h`.
 typealias CallMetricsHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
@@ -65,7 +65,7 @@ typealias CallParticipantChangedHandler = @convention(c) (UnsafePointer<Int8>?, 
 typealias MediaStoppedChangeHandler = @convention(c) (UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
 
 /// Equivalent of `wcall_network_quality_h`.
-typealias NetworkQualityChangeHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafePointer<Int8>?, Int32, Int32, Int32, Int32, UnsafeMutableRawPointer?) -> Void
+typealias NetworkQualityChangeHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, Int32, Int32, Int32, Int32, UnsafeMutableRawPointer?) -> Void
 
 /// Equivalent of `wcall_set_mute_handler`.
 typealias MuteChangeHandler = @convention(c) (Int32, UnsafeMutableRawPointer?) -> Void

--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -163,7 +163,7 @@ public class AVSWrapper: AVSWrapperType {
 
     // MARK: - C Callback Handlers
 
-    private let constantBitRateChangeHandler: ConstantBitRateChangeHandler = { userId, clientId, enabledFlag, contextRef in
+    private let constantBitRateChangeHandler: ConstantBitRateChangeHandler = { _, enabledFlag, contextRef in
         AVSWrapper.withCallCenter(contextRef, enabledFlag) {
             $0.handleConstantBitRateChange(enabled: $1)
         }
@@ -175,13 +175,13 @@ public class AVSWrapper: AVSWrapperType {
         }
     }
 
-    private let incomingCallHandler: IncomingCallHandler = { conversationId, messageTime, userId, clientId, isVideoCall, shouldRing, contextRef in
-        AVSWrapper.withCallCenter(contextRef, conversationId, messageTime, userId, clientId, isVideoCall, shouldRing) {
-            $0.handleIncomingCall(conversationId: $1, messageTime: $2, userId: $3, clientId: $4, isVideoCall: $5, shouldRing: $6)
+    private let incomingCallHandler: IncomingCallHandler = { conversationId, messageTime, userId, isVideoCall, shouldRing, contextRef in
+        AVSWrapper.withCallCenter(contextRef, conversationId, messageTime, userId, isVideoCall, shouldRing) {
+            $0.handleIncomingCall(conversationId: $1, messageTime: $2, userId: $3, isVideoCall: $4, shouldRing: $5)
         }
     }
 
-    private let missedCallHandler: MissedCallHandler = { conversationId, messageTime, userId, clientId, isVideoCall, contextRef in
+    private let missedCallHandler: MissedCallHandler = { conversationId, messageTime, userId, isVideoCall, contextRef in
         zmLog.debug("missedCallHandler: messageTime = \(messageTime)")
         let nonZeroMessageTime: UInt32 = messageTime != 0 ? messageTime : UInt32(Date().timeIntervalSince1970)
 
@@ -196,24 +196,24 @@ public class AVSWrapper: AVSWrapperType {
         }
     }
 
-    private let dataChannelEstablishedHandler: DataChannelEstablishedHandler = { conversationId, userId, clientId, contextRef in
-        AVSWrapper.withCallCenter(contextRef, conversationId, userId, clientId) {
-            $0.handleDataChannelEstablishement(conversationId: $1, userId: $2, clientId: $3)
+    private let dataChannelEstablishedHandler: DataChannelEstablishedHandler = { conversationId, userId, contextRef in
+        AVSWrapper.withCallCenter(contextRef, conversationId, userId) {
+            $0.handleDataChannelEstablishement(conversationId: $1, userId: $2)
         }
     }
 
-    private let establishedCallHandler: CallEstablishedHandler = { conversationId, userId, clientId, contextRef in
-        AVSWrapper.withCallCenter(contextRef, conversationId, userId, clientId) {
-            $0.handleEstablishedCall(conversationId: $1, userId: $2, clientId: $3)
+    private let establishedCallHandler: CallEstablishedHandler = { conversationId, userId, contextRef in
+        AVSWrapper.withCallCenter(contextRef, conversationId, userId) {
+            $0.handleEstablishedCall(conversationId: $1, userId: $2)
         }
     }
 
-    private let closedCallHandler: CloseCallHandler = { reason, conversationId, messageTime, userId, clientId, contextRef in
+    private let closedCallHandler: CloseCallHandler = { reason, conversationId, messageTime, userId, contextRef in
         zmLog.debug("closedCallHandler: messageTime = \(messageTime)")
         let nonZeroMessageTime: UInt32 = messageTime != 0 ? messageTime : UInt32(Date().timeIntervalSince1970)
 
-        AVSWrapper.withCallCenter(contextRef, reason, conversationId, nonZeroMessageTime, userId, clientId) {
-            $0.handleCallEnd(reason: $1, conversationId: $2, messageTime: $3, userId: $4, clientId: $5)
+        AVSWrapper.withCallCenter(contextRef, reason, conversationId, nonZeroMessageTime) {
+            $0.handleCallEnd(reason: $1, conversationId: $2, messageTime: $3, userId: UUID(rawValue: userId))
         }
     }
 
@@ -261,10 +261,10 @@ public class AVSWrapper: AVSWrapperType {
         }
     }
 
-    private let networkQualityHandler: NetworkQualityChangeHandler = { conversationIdRef, userIdRef, clientIdRef, quality, rtt, uplinkLoss, downlinkLoss, contextRef in
-        AVSWrapper.withCallCenter(contextRef, conversationIdRef, userIdRef, clientIdRef, quality) { (callCenter, conversationId, userId, clientId, quality) in
-            callCenter.handleNetworkQualityChange(conversationId: conversationId, userId: userId, clientId: clientId, quality: quality)
-        }
+    private let networkQualityHandler: NetworkQualityChangeHandler = { conversationIdRef, userIdRef, quality, rtt, uplinkLoss, downlinkLoss, contextRef in
+        AVSWrapper.withCallCenter(contextRef, conversationIdRef, userIdRef, quality, { (callCenter, conversationId, userId, quality) in
+            callCenter.handleNetworkQualityChange(conversationId: conversationId, userId: userId, quality: quality)
+        })
     }
 
     private let muteChangeHandler: MuteChangeHandler = { muted, contextRef in

--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -212,8 +212,8 @@ public class AVSWrapper: AVSWrapperType {
         zmLog.debug("closedCallHandler: messageTime = \(messageTime)")
         let nonZeroMessageTime: UInt32 = messageTime != 0 ? messageTime : UInt32(Date().timeIntervalSince1970)
 
-        AVSWrapper.withCallCenter(contextRef, reason, conversationId, nonZeroMessageTime, userId) {
-            $0.handleCallEnd(reason: $1, conversationId: $2, messageTime: $3, userId: $4)
+        AVSWrapper.withCallCenter(contextRef, reason, conversationId, nonZeroMessageTime, userId, clientId) {
+            $0.handleCallEnd(reason: $1, conversationId: $2, messageTime: $3, userId: $4, clientId: $5)
         }
     }
 

--- a/Source/Calling/CallParticipantSnapshot.swift
+++ b/Source/Calling/CallParticipantSnapshot.swift
@@ -20,101 +20,83 @@ import Foundation
 import WireUtilities
 
 class CallParticipantsSnapshot {
+    
+    public private(set) var members : OrderedSetState<AVSCallMember>
 
-    // MARK: - Properties
-
-    private unowned var callCenter: WireCallCenterV3
-    private let conversationId: UUID
-    private(set) var members: OrderedSetState<AVSCallMember>
-
-    /// Worst network quality of all the participants.
-
-    var networkQuality: NetworkQuality {
-        return members.array
-            .map(\.networkQuality)
-            .sorted { $0.rawValue < $1.rawValue }
+    // We take the worst quality of all the legs
+    public var networkQuality: NetworkQuality {
+        return members.array.map(\.networkQuality)
+            .sorted() { $0.rawValue < $1.rawValue }
             .last ?? .normal
     }
-
-    // MARK: - Life Cycle
-
+    
+    fileprivate unowned var callCenter : WireCallCenterV3
+    fileprivate let conversationId : UUID
+    
     init(conversationId: UUID, members: [AVSCallMember], callCenter: WireCallCenterV3) {
         self.callCenter = callCenter
         self.conversationId = conversationId
         self.members = type(of: self).removeDuplicateMembers(members)
     }
-
-    // MARK: - Updates
-
+    
+    // Remove duplicates see: https://wearezeta.atlassian.net/browse/ZIOS-8610
+    static func removeDuplicateMembers(_ members: [AVSCallMember]) -> OrderedSetState<AVSCallMember> {
+        let callMembers = members.reduce([AVSCallMember]()){ (filtered, member) in
+            filtered + (filtered.contains(member) ? [] : [member])
+        }
+        
+        return callMembers.toOrderedSetState()
+    }
+    
     func callParticipantsChanged(participants: [AVSCallMember]) {
         members = type(of:self).removeDuplicateMembers(participants)
         notifyChange()
     }
 
-    func callParticipantVideoStateChanged(userId: UUID, clientId: String, videoState: VideoState) {
-        updateMember(userId: userId, clientId: clientId, videoState: videoState)
+    func callParticpantVideoStateChanged(userId: UUID, clientId: String, videoState: VideoState) {
+        guard let callMember = findMember(userId: userId, clientId: clientId) else { return }
+
+        update(updatedMember: AVSCallMember(userId: userId, clientId: clientId, audioEstablished: callMember.audioEstablished, videoState: videoState))
     }
 
-    func callParticipantAudioEstablished(userId: UUID, clientId: String) {
-        updateMember(userId: userId, clientId: clientId, audioState: .established)
+    func callParticpantAudioEstablished(userId: UUID) {
+        guard let callMember = members.array.first(where: { $0.remoteId == userId }) else { return }
+
+        update(updatedMember: AVSCallMember(userId: userId, clientId: callMember.clientId, audioEstablished: true, videoState: callMember.videoState))
     }
 
-    func callParticipantNetworkQualityChanged(userId: UUID, clientId: String, networkQuality: NetworkQuality) {
-        updateMember(userId: userId, clientId: clientId, networkQuality: networkQuality)
+    func callParticpantNetworkQualityChanged(userId: UUID, networkQuality: NetworkQuality) {
+        guard let callMember = members.array.first(where: { $0.remoteId == userId }) else { return }
+
+        update(updatedMember: AVSCallMember(userId: userId, clientId: callMember.clientId, audioEstablished: callMember.audioEstablished, videoState: callMember.videoState, networkQuality: networkQuality))
     }
-
-    // MARK: - Helpers
-
-    /// Updates the locally stored member for the given userId and clientId with the given non nil properties.
-
-    private func updateMember(userId: UUID,
-                              clientId: String,
-                              audioState: AudioState? = nil,
-                              videoState: VideoState? = nil,
-                              networkQuality: NetworkQuality? = nil) {
-
-        guard let localMember = findMember(with: userId, clientId: clientId) else { return }
-
-        let updatedMember = AVSCallMember(userId: userId,
-                                          clientId: clientId,
-                                          audioState: audioState ?? localMember.audioState,
-                                          videoState: videoState ?? localMember.videoState,
-                                          networkQuality: networkQuality ?? localMember.networkQuality)
+    
+    func update(updatedMember: AVSCallMember) {
+        guard let targetMember = findMember(userId: updatedMember.remoteId, clientId: updatedMember.clientId) else { return }
 
         members = OrderedSetState(array: members.array.map({ member in
-            member == localMember ? updatedMember : member
+            member == targetMember ? updatedMember : member
         }))
     }
 
-    /// Returns the member matching the given userId and clientId.
-
-    private func findMember(with userId: UUID, clientId: String) -> AVSCallMember? {
-        return members.array.first { $0.remoteId == userId && $0.clientId == clientId }
-    }
-
-    /// Notifies observers of a potential change in the participants set.
-
-    private func notifyChange() {
+    func notifyChange() {
         guard let context = callCenter.uiMOC else { return }
         
-        let participants = members
-            .map { CallParticipant(member: $0, context: context) }
-            .compactMap(\.self)
-
-        WireCallCenterCallParticipantNotification(conversationId: conversationId, participants: participants)
-            .post(in: context.notificationContext)
+        let participants = members.map { CallParticipant(member: $0, context: context) }.compactMap(\.self)
+        WireCallCenterCallParticipantNotification(conversationId: conversationId, participants: participants).post(in: context.notificationContext)
     }
 
-}
+    public func callParticipantState(forUser userId: UUID) -> CallParticipantState {
+        guard let callMember = members.array.first(where: { $0.remoteId == userId }) else { return .unconnected }
+        
+        return callMember.callParticipantState
+    }
 
-extension CallParticipantsSnapshot {
-
-    // Remove duplicates see: https://wearezeta.atlassian.net/browse/ZIOS-8610
-    private static func removeDuplicateMembers(_ members: [AVSCallMember]) -> OrderedSetState<AVSCallMember> {
-        let callMembers = members.reduce([AVSCallMember]()) { (filtered, member) in
-            filtered + (filtered.contains(member) ? [] : [member])
-        }
-
-        return callMembers.toOrderedSetState()
+    /// Tries to find the call member with the matching userId and clientId, otherwise the first member
+    /// with the matching userId.
+    ///
+    private func findMember(userId: UUID, clientId: String?) -> AVSCallMember? {
+        let participantsByUser = members.array.filter { $0.remoteId == userId }
+        return participantsByUser.first { $0.clientId == clientId } ?? participantsByUser.first
     }
 }

--- a/Source/Calling/CallState.swift
+++ b/Source/Calling/CallState.swift
@@ -66,34 +66,17 @@ public struct CallParticipant: Hashable {
 public enum CallParticipantState: Equatable {
     /// Participant is not in the call
     case unconnected
-    /// A network problem occured but the call may still connect
-    case unconnectedButMayConnect
     /// Participant is in the process of connecting to the call
     case connecting
-    /// Participant is connected to the call and audio is flowing
-    case connected(videoState: VideoState, clientId: String)
+    /// Participant is connected to call and audio is flowing
+    case connected(videoState: VideoState, clientId: String?)
 }
-
-
-/**
- * The audio state of a participant in a call.
- */
-
-public enum AudioState: Int32, Codable {
-    /// Audio is in the process of connecting.
-    case connecting = 0
-    /// Audio has been established and is flowing.
-    case established = 1
-    /// No relay candidate, though audio may still connect.
-    case networkProblem = 2
-}
-
 
 /**
  * The state of video in the call.
  */
 
-public enum VideoState: Int32, Codable {
+public enum VideoState: Int32 {
     /// Sender is not sending video
     case stopped = 0
     /// Sender is sending video
@@ -130,6 +113,33 @@ public enum CallState: Equatable {
     case terminating(reason: CallClosedReason)
     /// Unknown call state
     case unknown
+
+    /**
+     * Creates the call state from the given AVS flag.
+     * - parameter wcallState: The state of the call as represented in AVS.
+     */
+
+    init(wcallState: Int32) {
+        switch wcallState {
+        case WCALL_STATE_NONE:
+            self = .none
+        case WCALL_STATE_INCOMING:
+            self = .incoming(video: false, shouldRing: true, degraded: false)
+        case WCALL_STATE_OUTGOING:
+            self = .outgoing(degraded: false)
+        case WCALL_STATE_ANSWERED:
+            self = .answered(degraded: false)
+        case WCALL_STATE_MEDIA_ESTAB:
+            self = .established
+        case WCALL_STATE_TERM_LOCAL: fallthrough
+        case WCALL_STATE_TERM_REMOTE:
+            self = .terminating(reason: .unknown)
+        default:
+            // WCALL_STATE_UNKNOWN can happen when we check the call state of a
+            // conversation id that isn't in the list of calls
+            self = .none
+        }
+    }
 
     /**
      * Logs the current state to the calling logs.

--- a/Source/Calling/NetworkQuality.swift
+++ b/Source/Calling/NetworkQuality.swift
@@ -22,5 +22,4 @@ public enum NetworkQuality: Int32 {
     case normal = 1
     case medium = 2
     case poor = 3
-    case problem = 4
 }

--- a/Source/Calling/WireCallCenterV3+Events.swift
+++ b/Source/Calling/WireCallCenterV3+Events.swift
@@ -153,7 +153,7 @@ extension WireCallCenterV3 {
      * If messageTime is set to 0, the event wasn't caused by a message therefore we don't have a serverTimestamp.
      */
 
-    func handleCallEnd(reason: CallClosedReason, conversationId: UUID, messageTime: Date?, userId: UUID) {
+    func handleCallEnd(reason: CallClosedReason, conversationId: UUID, messageTime: Date?, userId: UUID, clientId: String) {
         handleEvent("closed-call") {
             self.handle(callState: .terminating(reason: reason), conversationId: conversationId, messageTime: messageTime)
         }

--- a/Source/Calling/WireCallCenterV3+Events.swift
+++ b/Source/Calling/WireCallCenterV3+Events.swift
@@ -30,9 +30,7 @@ extension WireCallCenterV3 : ZMConversationObserver {
             changeInfo.securityLevelChanged,
             let conversationId = changeInfo.conversation.remoteIdentifier,
             let previousSnapshot = callSnapshots[conversationId]
-        else {
-            return
-        }
+        else { return }
 
         if changeInfo.conversation.securityLevel == .secureWithIgnored, isActive(conversationId: conversationId) {
             // If an active call degrades we end it immediately
@@ -45,13 +43,7 @@ extension WireCallCenterV3 : ZMConversationObserver {
             callSnapshots[conversationId] = previousSnapshot.update(with: updatedCallState)
 
             if let context = uiMOC, let callerId = initiatorForCall(conversationId: conversationId) {
-                let notification = WireCallCenterCallStateNotification(context: context,
-                                                                       callState: updatedCallState,
-                                                                       conversationId: conversationId,
-                                                                       callerId: callerId,
-                                                                       messageTime: Date(),
-                                                                       previousCallState: previousSnapshot.callState)
-                notification.post(in: context.notificationContext)
+                WireCallCenterCallStateNotification(context: context, callState: updatedCallState, conversationId: conversationId, callerId: callerId, messageTime: Date(), previousCallState: previousSnapshot.callState).post(in: context.notificationContext)
             }
         }
     }
@@ -87,14 +79,10 @@ extension WireCallCenterV3 {
     }
 
     /// Handles incoming calls.
-    func handleIncomingCall(conversationId: UUID, messageTime: Date, userId: UUID, clientId: String, isVideoCall: Bool, shouldRing: Bool) {
+    func handleIncomingCall(conversationId: UUID, messageTime: Date, userId: UUID, isVideoCall: Bool, shouldRing: Bool) {
         handleEvent("incoming-call") {
-            let isDegraded = self.isDegraded(conversationId: conversationId)
-            let callState = CallState.incoming(video: isVideoCall, shouldRing: shouldRing, degraded: isDegraded)
-            let members = [AVSCallMember(userId: userId, clientId: clientId)]
-
-            self.createSnapshot(callState: callState, members: members, callStarter: userId, video: isVideoCall, for: conversationId)
-            self.handle(callState: callState, conversationId: conversationId)
+            let callState : CallState = .incoming(video: isVideoCall, shouldRing: shouldRing, degraded: self.isDegraded(conversationId: conversationId))
+            self.handleCallState(callState: callState, conversationId: conversationId, userId: userId, messageTime: messageTime)
         }
     }
 
@@ -108,37 +96,22 @@ extension WireCallCenterV3 {
     /// Handles answered calls.
     func handleAnsweredCall(conversationId: UUID) {
         handleEvent("answered-call") {
-            let callState = CallState.answered(degraded: self.isDegraded(conversationId: conversationId))
-            self.handle(callState: callState, conversationId: conversationId)
+            self.handleCallState(callState: .answered(degraded: self.isDegraded(conversationId: conversationId)),
+                                 conversationId: conversationId, userId: nil)
         }
     }
 
     /// Handles when data channel gets established.
-    func handleDataChannelEstablishement(conversationId: UUID, userId: UUID, clientId: String) {
+    func handleDataChannelEstablishement(conversationId: UUID, userId: UUID) {
         handleEvent("data-channel-established") {
-            // Ignore if data channel was established after audio
-            if self.callState(conversationId: conversationId) != .established {
-                self.handle(callState: .establishedDataChannel, conversationId: conversationId)
-            }
+            self.handleCallState(callState: .establishedDataChannel, conversationId: conversationId, userId: userId)
         }
     }
 
     /// Handles established calls.
-    func handleEstablishedCall(conversationId: UUID, userId: UUID, clientId: String) {
+    func handleEstablishedCall(conversationId: UUID, userId: UUID) {
         handleEvent("established-call") {
-            // WORKAROUND: the call established handler will is called once for every participant in a
-            // group call. Until that's no longer the case we must take care to only set establishedDate once.
-            if self.callState(conversationId: conversationId) != .established {
-                self.establishedDate = Date()
-            }
-
-            self.callParticipantAudioEstablished(conversationId: conversationId, userId: userId, clientId: clientId)
-
-            if self.videoState(conversationId: conversationId) == .started {
-                self.avsWrapper.setVideoState(conversationId: conversationId, videoState: .started)
-            }
-
-            self.handle(callState: .established, conversationId: conversationId)
+            self.handleCallState(callState: .established, conversationId: conversationId, userId: userId)
         }
     }
 
@@ -153,9 +126,9 @@ extension WireCallCenterV3 {
      * If messageTime is set to 0, the event wasn't caused by a message therefore we don't have a serverTimestamp.
      */
 
-    func handleCallEnd(reason: CallClosedReason, conversationId: UUID, messageTime: Date?, userId: UUID, clientId: String) {
+    func handleCallEnd(reason: CallClosedReason, conversationId: UUID, messageTime: Date?, userId: UUID?) {
         handleEvent("closed-call") {
-            self.handle(callState: .terminating(reason: reason), conversationId: conversationId, messageTime: messageTime)
+            self.handleCallState(callState: .terminating(reason: reason), conversationId: conversationId, userId: userId, messageTime: messageTime)
         }
     }
 
@@ -163,8 +136,7 @@ extension WireCallCenterV3 {
     func handleCallMetrics(conversationId: UUID, metrics: String) {
         do {
             let metricsData = Data(metrics.utf8)
-            let jsonObject = try JSONSerialization.jsonObject(with: metricsData, options: .mutableContainers)
-            guard let attributes = jsonObject as? [String: NSObject] else { return }
+            guard let attributes = try JSONSerialization.jsonObject(with: metricsData, options: .mutableContainers) as? [String: NSObject] else { return }
             analytics?.tagEvent("calling.avs_metrics_ended_call", attributes: attributes)
         } catch {
             zmLog.error("Unable to parse call metrics JSON: \(error)")
@@ -179,11 +151,8 @@ extension WireCallCenterV3 {
     }
 
     /// Handles sending call messages
-    internal func handleCallMessageRequest(token: WireCallMessageToken,
-                                           conversationId: UUID,
-                                           senderUserId: UUID,
-                                           senderClientId: String,
-                                           data: Data) {
+    internal func handleCallMessageRequest(token: WireCallMessageToken, conversationId: UUID, senderUserId: UUID, senderClientId: String, data: Data)
+    {
         handleEvent("send-call-message") {
             self.send(
                 token: token,
@@ -210,7 +179,6 @@ extension WireCallCenterV3 {
                 zmLog.safePublic("Invalid participant change data")
                 return
             }
-
             // Example of `data`
             //  {
             //      "convid": "df371578-65cf-4f07-9f49-c72a49877ae7",
@@ -223,7 +191,6 @@ extension WireCallCenterV3 {
             //          }
             //      ]
             //}
-
             do {
                 let change = try JSONDecoder().decode(AVSParticipantsChange.self, from: data)
                 let members = change.members.map(AVSCallMember.init)
@@ -246,11 +213,7 @@ extension WireCallCenterV3 {
     /// Handles audio CBR mode enabling.
     func handleConstantBitRateChange(enabled: Bool) {
         handleEventInContext("cbr-change") {
-            let firstEstablishedCall = self.callSnapshots.first {
-                $0.value.callState == .established || $0.value.callState == .establishedDataChannel
-            }
-
-            if let establishedCall = firstEstablishedCall {
+            if let establishedCall = self.callSnapshots.first(where: { $0.value.callState == .established || $0.value.callState == .establishedDataChannel }) {
                 self.callSnapshots[establishedCall.key] = establishedCall.value.updateConstantBitrate(enabled)
                 WireCallCenterCBRNotification(enabled: enabled).post(in: $0.notificationContext)
             }
@@ -260,25 +223,16 @@ extension WireCallCenterV3 {
     /// Stopped when the media stream of a call was ended.
     func handleMediaStopped(conversationId: UUID) {
         handleEvent("media-stopped") {
-            self.handle(callState: .mediaStopped, conversationId: conversationId)
+            self.handleCallState(callState: .mediaStopped, conversationId: conversationId, userId: nil)
         }
     }
 
     /// Handles network quality change
-    func handleNetworkQualityChange(conversationId: UUID, userId: UUID, clientId: String, quality: NetworkQuality) {
+    func handleNetworkQualityChange(conversationId: UUID, userId: UUID, quality: NetworkQuality) {
         handleEventInContext("network-quality-change") {
-            self.callParticipantNetworkQualityChanged(conversationId: conversationId,
-                                                      userId: userId,
-                                                      clientId: clientId,
-                                                      quality: quality)
-
             if let call = self.callSnapshots[conversationId] {
                 self.callSnapshots[conversationId] = call.updateNetworkQuality(quality)
-                let notification = WireCallCenterNetworkQualityNotification(conversationId: conversationId,
-                                                                            userId: userId,
-                                                                            clientId: clientId,
-                                                                            networkQuality: quality)
-                notification.post(in: $0.notificationContext)
+                WireCallCenterNetworkQualityNotification(conversationId: conversationId, userId: userId, networkQuality: quality).post(in: $0.notificationContext)
             }
         }
     }

--- a/Source/Calling/WireCallCenterV3+Notifications.swift
+++ b/Source/Calling/WireCallCenterV3+Notifications.swift
@@ -41,7 +41,6 @@ struct WireCallCenterNetworkQualityNotification : SelfPostingNotification {
     static let notificationName = Notification.Name("WireCallCenterNetworkQualityNotification")
     public let conversationId: UUID
     public let userId: UUID
-    public let clientId: String
     public let networkQuality: NetworkQuality
 }
 

--- a/Tests/Source/Calling/CallParticipantsSnapshotTests.swift
+++ b/Tests/Source/Calling/CallParticipantsSnapshotTests.swift
@@ -20,24 +20,15 @@
 import Foundation
 @testable import WireSyncEngine
 
-class CallParticipantsSnapshotTests: MessagingTest {
+class CallParticipantsSnapshotTests : MessagingTest {
 
-    private typealias Sut = WireSyncEngine.CallParticipantsSnapshot
-
-    var mockWireCallCenterV3: WireCallCenterV3Mock!
-    var mockFlowManager: FlowManagerMock!
-
-    private let alice = User()
-    private let bob = User()
+    var mockWireCallCenterV3 : WireCallCenterV3Mock!
+    var mockFlowManager : FlowManagerMock!
 
     override func setUp() {
         super.setUp()
         mockFlowManager = FlowManagerMock()
-        mockWireCallCenterV3 = WireCallCenterV3Mock(userId: UUID(),
-                                                    clientId: UUID().transportString(),
-                                                    uiMOC: uiMOC,
-                                                    flowManager: mockFlowManager,
-                                                    transport: WireCallCenterTransportMock())
+        mockWireCallCenterV3 = WireCallCenterV3Mock(userId: UUID(), clientId: "foo", uiMOC: uiMOC, flowManager: mockFlowManager, transport: WireCallCenterTransportMock())
     }
     
     override func tearDown() {
@@ -46,158 +37,158 @@ class CallParticipantsSnapshotTests: MessagingTest {
         super.tearDown()
     }
 
-    private func createSut(members: [AVSCallMember]) -> Sut {
-        return Sut(conversationId: UUID(), members: members, callCenter: mockWireCallCenterV3)
-    }
-
-    // MARK: - Duplicates
-
-    func testThat_ItDoesNotCrash_WhenInitialized_WithDuplicateCallMembers(){
-        // Given
-        let member1 = AVSCallMember(userId: alice.userId, clientId: alice.iphone, audioState: .established)
-        let member2 = AVSCallMember(userId: alice.userId, clientId: alice.iphone, audioState: .connecting)
-
-        // When
-        let sut = createSut(members: [member1, member2])
-
-        
-        // Then
-        XCTAssertEqual(sut.members.array, [member1])
-    }
-    
-    func testThat_ItDoesNotCrash_WhenUpdated_WithDuplicateCallMembers(){
-        // Given
-        let member1 = AVSCallMember(userId: alice.userId, clientId: alice.iphone, audioState: .established)
-        let member2 = AVSCallMember(userId: alice.userId, clientId: alice.iphone, audioState: .connecting)
-        let sut = createSut(members: [])
+    func testThatItDoesNotCrashWhenInitializedWithDuplicateCallMembers(){
+        // given
+        let userId = UUID()
+        let callMember1 = AVSCallMember(userId: userId, audioEstablished: true)
+        let callMember2 = AVSCallMember(userId: userId, audioEstablished: false)
 
         // when
-        sut.callParticipantsChanged(participants: [member1, member2])
+        let sut = WireSyncEngine.CallParticipantsSnapshot(conversationId: UUID(),
+                                                          members: [callMember1, callMember2],
+                                                          callCenter: mockWireCallCenterV3)
         
         // then
-        XCTAssertEqual(sut.members.array, [member1])
+        // it does not crash and
+        XCTAssertEqual(sut.members.array.count, 1)
+        if let first = sut.members.array.first {
+            XCTAssertTrue(first.audioEstablished)
+        }
     }
-
-    func testThat_ItDoesNotConsider_AUserWithMultipleDevices_AsDuplicated() {
-        // Given
-        let member1 = AVSCallMember(userId: alice.userId, clientId: alice.iphone, audioState: .established)
-        let member2 = AVSCallMember(userId: alice.userId, clientId: alice.desktop, audioState: .connecting)
-
-        // When
-        let sut = createSut(members: [member1, member2])
-
-        // Then
-        XCTAssertEqual(sut.members.array, [member1, member2])
-    }
-
-    // MARK: - Network Quality
-
-    func testThat_ItTakesTheWorstNetworkQuality_FromParticipants() {
-        // Given
-        let normalQuality = AVSCallMember(userId: alice.userId, clientId: alice.iphone, networkQuality: .normal)
-        let mediumQuality = AVSCallMember(userId: alice.userId, clientId: alice.desktop, networkQuality: .medium)
-        let poorQuality = AVSCallMember(userId: bob.userId, clientId: bob.iphone, networkQuality: .poor)
-        let problemQuality = AVSCallMember(userId: bob.userId, clientId: bob.desktop, networkQuality: .problem)
-        let sut = createSut(members: [])
-
-        XCTAssertEqual(sut.networkQuality, .normal)
-
-        // When, then
-        sut.callParticipantsChanged(participants: [normalQuality])
-        XCTAssertEqual(sut.networkQuality, .normal)
-
-        // When, then
-        sut.callParticipantsChanged(participants: [mediumQuality, normalQuality])
-        XCTAssertEqual(sut.networkQuality, .medium)
-
-        // When, then
-        sut.callParticipantsChanged(participants: [poorQuality, normalQuality])
-        XCTAssertEqual(sut.networkQuality, .poor)
-
-        // When, then
-        sut.callParticipantsChanged(participants: [poorQuality, normalQuality, problemQuality])
-        XCTAssertEqual(sut.networkQuality, .problem)
-
-        // When, then
-        sut.callParticipantsChanged(participants: [mediumQuality, poorQuality])
-        XCTAssertEqual(sut.networkQuality, .poor)
-    }
-
-    // MARK: - Updates
-
-    func testThat_ItUpdatesNetworkQuality_WhenItChangesForParticipant() {
-        // Given
-        let member1 = AVSCallMember(userId: alice.userId, clientId: alice.iphone, audioState: .established, networkQuality: .normal)
-        let member2 = AVSCallMember(userId: bob.userId, clientId: bob.iphone, audioState: .established, networkQuality: .normal)
-        let sut = createSut(members: [member1, member2])
-
-        XCTAssertEqual(sut.networkQuality, .normal)
-
-        // When, then
-        sut.callParticipantNetworkQualityChanged(userId: member1.remoteId, clientId: member1.clientId, networkQuality: .medium)
-        XCTAssertEqual(sut.networkQuality, .medium)
-
-        // When, then
-        sut.callParticipantNetworkQualityChanged(userId: member2.remoteId, clientId: member2.clientId, networkQuality: .poor)
-        XCTAssertEqual(sut.networkQuality, .poor)
-
-        // When, then
-        sut.callParticipantNetworkQualityChanged(userId: member1.remoteId, clientId: member1.clientId, networkQuality: .normal)
-        sut.callParticipantNetworkQualityChanged(userId: member2.remoteId, clientId: member2.clientId, networkQuality: .normal)
-        XCTAssertEqual(sut.networkQuality, .normal)
-    }
-
-    func testThat_ItUpdatesAudioState_WhenItChangesForParticipant() {
-        // Given
-        let member1 = AVSCallMember(userId: alice.userId, clientId: alice.iphone, audioState: .connecting)
-        let member2 = AVSCallMember(userId: bob.userId, clientId: bob.iphone, audioState: .connecting)
-        let sut = createSut(members: [member1, member2])
-
-        // When
-        sut.callParticipantAudioEstablished(userId: member1.remoteId, clientId: member1.clientId)
-
-        // Then
-        let updatedMember1 = AVSCallMember(userId: alice.userId, clientId: alice.iphone, audioState: .established)
-        XCTAssertEqual(sut.members.array, [updatedMember1, member2])
-    }
-
-    func testThat_ItUpdatesVideoState_WhenItChangesForParticipant() {
-        // Given
-        let member1 = AVSCallMember(userId: alice.userId, clientId: alice.iphone, videoState: .stopped)
-        let member2 = AVSCallMember(userId: bob.userId, clientId: bob.iphone, videoState: .stopped)
-        let sut = createSut(members: [member1, member2])
-
-        // When
-        sut.callParticipantVideoStateChanged(userId: member1.remoteId, clientId: member1.clientId, videoState: .screenSharing)
-
-        // Then
-        let updatedMember1 = AVSCallMember(userId: alice.userId, clientId: alice.iphone, videoState: .screenSharing)
-        XCTAssertEqual(sut.members.array, [updatedMember1, member2])
-    }
-
-    func testThat_ItDoesNotUpdateMember_WhenNoMatchFound() {
-        // Given
-        let member1 = AVSCallMember(userId: alice.userId, clientId: alice.iphone, videoState: .stopped)
-        let member2 = AVSCallMember(userId: bob.userId, clientId: bob.iphone, videoState: .stopped)
-        let sut = createSut(members: [member1, member2])
-
-        // When
-        let unknownMember = AVSCallMember(userId: alice.userId, clientId: alice.desktop, videoState: .stopped)
-        sut.callParticipantVideoStateChanged(userId: unknownMember.remoteId, clientId: unknownMember.clientId, videoState: .screenSharing)
-
-        // Then
-        XCTAssertEqual(sut.members.array, [member1, member2])
-    }
-
-}
-
-private extension CallParticipantsSnapshotTests {
-
-    struct User {
-
+    
+    func testThatItDoesNotCrashWhenUpdatedWithDuplicateCallMembers(){
+        // given
         let userId = UUID()
-        let iphone = "String"
-        let desktop = "Desktop"
+        let callMember1 = AVSCallMember(userId: userId, audioEstablished: true)
+        let callMember2 = AVSCallMember(userId: userId, audioEstablished: false)
+        let sut = WireSyncEngine.CallParticipantsSnapshot(conversationId: UUID(),
+                                                          members: [],
+                                                          callCenter: mockWireCallCenterV3)
 
+        // when
+        sut.callParticipantsChanged(participants: [callMember1, callMember2])
+        
+        // then
+        // it does not crash and
+        XCTAssertEqual(sut.members.array.count, 1)
+        if let first = sut.members.array.first {
+            XCTAssertTrue(first.audioEstablished)
+        }
+    }
+
+    func testThatItDoesNotConsiderAUserWithMultipleDevicesAsDuplicated() {
+        // given
+        let userId = UUID()
+        let callMember1 = AVSCallMember(userId: userId, clientId: "client1", audioEstablished: true)
+        let callMember2 = AVSCallMember(userId: userId, clientId: "client2", audioEstablished: false)
+
+        // when
+        let sut = WireSyncEngine.CallParticipantsSnapshot(conversationId: UUID(),
+                                                          members: [callMember1, callMember2],
+                                                          callCenter: mockWireCallCenterV3)
+
+        // then
+        // it does not crash and
+        XCTAssertEqual(sut.members.array, [callMember1, callMember2])
+    }
+
+    func testThatItTakesTheWorstNetworkQualityFromParticipants() {
+        // given
+        let normalQuality = AVSCallMember(userId: UUID(), audioEstablished: true, videoState: .started, networkQuality: .normal)
+        let mediumQuality = AVSCallMember(userId: UUID(), audioEstablished: true, videoState: .started, networkQuality: .medium)
+        let poorQuality = AVSCallMember(userId: UUID(), audioEstablished: true, videoState: .started, networkQuality: .poor)
+
+        let sut = WireSyncEngine.CallParticipantsSnapshot(conversationId: UUID(),
+                                                          members: [],
+                                                          callCenter: mockWireCallCenterV3)
+        XCTAssertEqual(sut.networkQuality, .normal)
+
+        // when
+        sut.callParticipantsChanged(participants: [normalQuality])
+        // then
+        XCTAssertEqual(sut.networkQuality, .normal)
+
+        // when
+        sut.callParticipantsChanged(participants: [mediumQuality, normalQuality])
+        // then
+        XCTAssertEqual(sut.networkQuality, .medium)
+
+        // when
+        sut.callParticipantsChanged(participants: [poorQuality, normalQuality])
+        // then
+        XCTAssertEqual(sut.networkQuality, .poor)
+
+        // when
+        sut.callParticipantsChanged(participants: [mediumQuality, poorQuality])
+        // then
+        XCTAssertEqual(sut.networkQuality, .poor)
+    }
+
+    func testThatItUpdatesNetworkQualityWhenItChangesForParticipant() {
+        // given
+        let callMember1 = AVSCallMember(userId: UUID(), audioEstablished: true, networkQuality: .normal)
+        let callMember2 = AVSCallMember(userId: UUID(), audioEstablished: true, networkQuality: .normal)
+        let sut = WireSyncEngine.CallParticipantsSnapshot(conversationId: UUID(),
+                                                          members: [callMember1, callMember2],
+                                                          callCenter: mockWireCallCenterV3)
+        XCTAssertEqual(sut.networkQuality, .normal)
+
+        // when
+        sut.callParticpantNetworkQualityChanged(userId: callMember1.remoteId, networkQuality: .medium)
+
+        // then
+        XCTAssertEqual(sut.networkQuality, .medium)
+
+        // when
+        sut.callParticpantNetworkQualityChanged(userId: callMember2.remoteId, networkQuality: .poor)
+
+        // then
+        XCTAssertEqual(sut.networkQuality, .poor)
+
+        // when
+        sut.callParticpantNetworkQualityChanged(userId: callMember1.remoteId, networkQuality: .normal)
+        sut.callParticpantNetworkQualityChanged(userId: callMember2.remoteId, networkQuality: .normal)
+
+        // then
+        XCTAssertEqual(sut.networkQuality, .normal)
+    }
+
+    func testThatItUpdatesVideoStateOnlyWhenUserIdAndClientIdMatch() {
+        // given
+        let userId = UUID()
+        let clientId1 = "client1"
+        let clientId2 = "client2"
+
+        let callMember1 = AVSCallMember(userId: userId, clientId: clientId1, videoState: .started)
+        let callMember2 = AVSCallMember(userId: userId, clientId: clientId2, videoState: .stopped)
+
+        let sut = WireSyncEngine.CallParticipantsSnapshot(conversationId: UUID(),
+                                                          members: [callMember1, callMember2],
+                                                          callCenter: mockWireCallCenterV3)
+        // when
+        sut.callParticpantVideoStateChanged(userId: userId, clientId: clientId2, videoState: .screenSharing)
+
+        // then
+        let updatedCallMember2 = AVSCallMember(userId: userId, clientId: clientId2, videoState: .screenSharing)
+        let expectation = [callMember1, updatedCallMember2]
+        XCTAssertEqual(sut.members.array, expectation)
+    }
+
+    func testThatItUpdatesTheCallMemberWithAClientId() {
+        // given
+        let userId = UUID()
+        let clientId = "clientId"
+
+        let callMember = AVSCallMember(userId: userId, clientId: nil, videoState: .stopped)
+
+        let sut = WireSyncEngine.CallParticipantsSnapshot(conversationId: UUID(),
+                                                          members: [callMember],
+                                                          callCenter: mockWireCallCenterV3)
+        // when
+        sut.callParticpantVideoStateChanged(userId: userId, clientId: clientId, videoState: .started)
+
+        // then
+        let expectation = [AVSCallMember(userId: userId, clientId: clientId, videoState: .started)]
+        XCTAssertEqual(sut.members.array, expectation)
     }
 }

--- a/Tests/Source/Calling/VoiceChannelV3Tests.swift
+++ b/Tests/Source/Calling/VoiceChannelV3Tests.swift
@@ -87,13 +87,12 @@ class VoiceChannelV3Tests : MessagingTest {
     func testThatItForwardsNetworkQualityFromCallCenter() {
         // given
         let calledId = UUID()
-        let clientId = UUID().transportString()
         wireCallCenterMock?.setMockCallState(.established, conversationId: conversation!.remoteIdentifier!, callerId: calledId, isVideo: false)
         let quality = NetworkQuality.poor
         XCTAssertEqual(sut.networkQuality, .normal)
 
         // when
-        wireCallCenterMock?.handleNetworkQualityChange(conversationId: conversation!.remoteIdentifier!, userId: calledId, clientId: clientId, quality: quality)
+        wireCallCenterMock?.handleNetworkQualityChange(conversationId: conversation!.remoteIdentifier!, userId: calledId, quality: quality)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then

--- a/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -44,7 +44,6 @@ class WireCallCenterV3Tests: MessagingTest {
     var sut : WireCallCenterV3!
     var otherUser: ZMUser!
     let otherUserID : UUID = UUID()
-    let otherUserClientID = UUID().transportString()
     var selfUserID : UUID!
     var oneOnOneConversation: ZMConversation!
     var groupConversation: ZMConversation!
@@ -124,7 +123,6 @@ class WireCallCenterV3Tests: MessagingTest {
             sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                    messageTime: Date(),
                                    userId: otherUserID,
-                                   clientId: otherUserClientID,
                                    isVideoCall: true,
                                    shouldRing: false)
         }
@@ -135,7 +133,6 @@ class WireCallCenterV3Tests: MessagingTest {
             sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                    messageTime: Date(),
                                    userId: otherUserID,
-                                   clientId: otherUserClientID,
                                    isVideoCall: false,
                                    shouldRing: false)
         }
@@ -146,7 +143,6 @@ class WireCallCenterV3Tests: MessagingTest {
             sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                    messageTime: Date(),
                                    userId: otherUserID,
-                                   clientId: otherUserClientID,
                                    isVideoCall: true,
                                    shouldRing: true)
         }
@@ -157,7 +153,6 @@ class WireCallCenterV3Tests: MessagingTest {
             sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                    messageTime: Date(),
                                    userId: otherUserID,
-                                   clientId: otherUserClientID,
                                    isVideoCall: false,
                                    shouldRing: true)
         }
@@ -191,13 +186,7 @@ class WireCallCenterV3Tests: MessagingTest {
     
     func testThatTheAnsweredCallHandlerPostsTheRightNotification() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
-                               messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
-                               isVideoCall: false,
-                               shouldRing: true)
-
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         checkThatItPostsNotification(expectedCallState: .answered(degraded: false), expectedCallerId: otherUserID, expectedConversationId: oneOnOneConversationID) {
@@ -207,35 +196,23 @@ class WireCallCenterV3Tests: MessagingTest {
     
     func testThatTheEstablishedHandlerPostsTheRightNotification() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
-                               messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
-                               isVideoCall: false,
-                               shouldRing: true)
-
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         checkThatItPostsNotification(expectedCallState: .established, expectedCallerId: otherUserID, expectedConversationId: oneOnOneConversationID) {
-            sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
+            sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID)
         }
     }
     
     func testThatTheEstablishedHandlerSetsTheStartTime() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
-                               messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
-                               isVideoCall: false,
-                               shouldRing: true)
-
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         XCTAssertNil(sut.establishedDate)
         
         // when
         checkThatItPostsNotification(expectedCallState: .established, expectedCallerId: otherUserID, expectedConversationId: oneOnOneConversationID) {
-            sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
+            sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID)
         }
         
         // then
@@ -244,25 +221,19 @@ class WireCallCenterV3Tests: MessagingTest {
     
     func testThatTheEstablishedHandlerDoesntSetTheStartTimeIfCallIsAlreadyEstablished() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
-                               messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
-                               isVideoCall: false,
-                               shouldRing: true)
-
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         XCTAssertNil(sut.establishedDate)
         
         // call is established
-        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
+        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         XCTAssertNotNil(sut.establishedDate)
         let previousEstablishedDate = sut.establishedDate
         spinMainQueue(withTimeout: 0.1)
         
         // when
-        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
+        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then
@@ -271,29 +242,17 @@ class WireCallCenterV3Tests: MessagingTest {
     
     func testThatTheClosedCallHandlerPostsTheRightNotification() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
-                               messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
-                               isVideoCall: false,
-                               shouldRing: true)
-
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         checkThatItPostsNotification(expectedCallState: .terminating(reason: .canceled), expectedCallerId: otherUserID, expectedConversationId: oneOnOneConversationID) {
-            sut.handleCallEnd(reason: .canceled, conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, clientId: otherUserClientID)
+            sut.handleCallEnd(reason: .canceled, conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID)
         }
     }
     
     func testThatTheMediaStopppedCallHandlerPostsTheRightNotification() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
-                               messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
-                               isVideoCall: false,
-                               shouldRing: true)
-
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         checkThatItPostsNotification(expectedCallState: .mediaStopped, expectedCallerId: otherUserID, expectedConversationId: oneOnOneConversationID) {
@@ -303,20 +262,8 @@ class WireCallCenterV3Tests: MessagingTest {
     
     func testThatOtherIncomingCallsAreRejectedWhenWeAnswerCall() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
-                               messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
-                               isVideoCall: false,
-                               shouldRing: true)
-
-        sut.handleIncomingCall(conversationId: groupConversationID,
-                               messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
-                               isVideoCall: false,
-                               shouldRing: true)
-
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
+        sut.handleIncomingCall(conversationId: groupConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // when
@@ -329,14 +276,7 @@ class WireCallCenterV3Tests: MessagingTest {
     func testThatOtherOutgoingCallsAreCanceledWhenWeAnswerCall() {
         // given
         XCTAssertTrue(sut.startCall(conversation: groupConversation, video: false))
-
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
-                               messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
-                               isVideoCall: false,
-                               shouldRing: true)
-
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // when
@@ -348,13 +288,7 @@ class WireCallCenterV3Tests: MessagingTest {
     
     func testThatOtherIncomingCallsAreRejectedWhenWeStartCall() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
-                               messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
-                               isVideoCall: false,
-                               shouldRing: true)
-
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // when
@@ -366,13 +300,7 @@ class WireCallCenterV3Tests: MessagingTest {
     
     func testThatItRejectsACall_Group() {
         // given
-        sut.handleIncomingCall(conversationId: groupConversationID,
-                               messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
-                               isVideoCall: false,
-                               shouldRing: true)
-
+        sut.handleIncomingCall(conversationId: groupConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // expect
@@ -386,7 +314,7 @@ class WireCallCenterV3Tests: MessagingTest {
         
         // when
         sut.rejectCall(conversationId: oneOnOneConversationID)
-        sut.handleCallEnd(reason: .stillOngoing, conversationId: groupConversationID, messageTime: Date(), userId: otherUserID, clientId: otherUserClientID)
+        sut.handleCallEnd(reason: .stillOngoing, conversationId: groupConversationID, messageTime: Date(), userId: otherUserID)
 
         // then
         XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
@@ -395,13 +323,7 @@ class WireCallCenterV3Tests: MessagingTest {
     
     func testThatItRejectsACall_1on1() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
-                               messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
-                               isVideoCall: false,
-                               shouldRing: true)
-
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // expect
@@ -415,7 +337,7 @@ class WireCallCenterV3Tests: MessagingTest {
         
         // when
         sut.rejectCall(conversationId: oneOnOneConversationID)
-        sut.handleCallEnd(reason: .stillOngoing, conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, clientId: otherUserClientID)
+        sut.handleCallEnd(reason: .stillOngoing, conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID)
 
         // then
         XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
@@ -424,13 +346,7 @@ class WireCallCenterV3Tests: MessagingTest {
     
     func testThatItAnswersACall_oneToOne() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
-                               messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
-                               isVideoCall: false,
-                               shouldRing: true)
-
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         checkThatItPostsNotification(expectedCallState: .answered(degraded: false), expectedCallerId: otherUserID, expectedConversationId: oneOnOneConversationID) {
@@ -451,13 +367,7 @@ class WireCallCenterV3Tests: MessagingTest {
             groupConversation.addParticipantAndUpdateConversationState(user: user, role: nil)
         }
 
-        sut.handleIncomingCall(conversationId: groupConversationID,
-                               messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
-                               isVideoCall: false,
-                               shouldRing: true)
-
+        sut.handleIncomingCall(conversationId: groupConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         checkThatItPostsNotification(expectedCallState: .answered(degraded: false), expectedCallerId: otherUserID, expectedConversationId: groupConversationID) {
@@ -471,13 +381,7 @@ class WireCallCenterV3Tests: MessagingTest {
     
     func testThatItAnswersACall_audioOnly() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
-                               messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
-                               isVideoCall: true,
-                               shouldRing: true)
-
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: true, shouldRing: true)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         checkThatItPostsNotification(expectedCallState: .answered(degraded: false), expectedCallerId: otherUserID, expectedConversationId: oneOnOneConversationID) {
@@ -492,13 +396,7 @@ class WireCallCenterV3Tests: MessagingTest {
     
     func testThatItAnswersACall_withVideo() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
-                               messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
-                               isVideoCall: true,
-                               shouldRing: true)
-
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: true, shouldRing: true)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         checkThatItPostsNotification(expectedCallState: .answered(degraded: false), expectedCallerId: otherUserID, expectedConversationId: oneOnOneConversationID) {
@@ -521,7 +419,27 @@ class WireCallCenterV3Tests: MessagingTest {
             XCTAssertEqual(mockAVSWrapper.startCallArguments?.callType, AVSCallType.normal)
         }
     }
-
+    
+    func testThatItIncludesTheConnectedUserInCallParticipants_oneToOne(){
+        // given
+        let connection = ZMConnection.insertNewObject(in: uiMOC)
+        connection.status = .accepted
+        connection.to = .insertNewObject(in: uiMOC)
+        connection.to.remoteIdentifier = UUID()
+        connection.conversation = oneOnOneConversation
+        
+        
+        checkThatItPostsNotification(expectedCallState: .outgoing(degraded: false), expectedCallerId: selfUserID, expectedConversationId: oneOnOneConversationID) {
+            // when
+            _ = sut.startCall(conversation: oneOnOneConversation, video: false)
+            
+            // then
+            XCTAssertEqual(mockAVSWrapper.startCallArguments?.conversationType, AVSConversationType.oneToOne)
+            XCTAssertEqual(mockAVSWrapper.startCallArguments?.callType, AVSCallType.normal)
+            XCTAssertEqual(sut.callParticipants(conversationId: oneOnOneConversationID), [CallParticipant(user: oneOnOneConversation.connectedUser!, state: .connecting)])
+        }
+    }
+    
     func testThatItStartsACall_smallGroup(){
         checkThatItPostsNotification(expectedCallState: .outgoing(degraded: false), expectedCallerId: selfUserID, expectedConversationId: groupConversationID) {
             // when
@@ -565,13 +483,7 @@ class WireCallCenterV3Tests: MessagingTest {
     
     func testThatItSetsTheCallStartTimeBeforePostingTheNotification() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
-                               messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
-                               isVideoCall: false,
-                               shouldRing: true)
-
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         XCTAssertNil(sut.establishedDate)
         
@@ -582,7 +494,7 @@ class WireCallCenterV3Tests: MessagingTest {
         }
         
         // when
-        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
+        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID)
 
         // then
         XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
@@ -739,15 +651,9 @@ extension WireCallCenterV3Tests {
     
     func testThatCBRIsEnabledOnAudioCBRChangeHandler_whenCallIsEstablished() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
-                               messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
-                               isVideoCall: false,
-                               shouldRing: true)
-
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
+        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // when
@@ -760,15 +666,9 @@ extension WireCallCenterV3Tests {
     
     func testThatCBRIsEnabledOnAudioCBRChangeHandler_whenDataChannelIsEstablished() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
-                               messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
-                               isVideoCall: false,
-                               shouldRing: true)
-
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        sut.handleDataChannelEstablishement(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
+        sut.handleDataChannelEstablishement(conversationId: oneOnOneConversationID, userId: otherUserID)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
@@ -781,15 +681,9 @@ extension WireCallCenterV3Tests {
 
     func testThatCBRIsDisabledOnAudioCBRChangeHandler() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
-                               messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
-                               isVideoCall: false,
-                               shouldRing: true)
-
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
+        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         sut.handleConstantBitRateChange(enabled: true)
@@ -806,13 +700,7 @@ extension WireCallCenterV3Tests {
 
     func testThatCBRIsNotEnabledOnAudioCBRChangeHandlerWhenCallIsNotEstablished() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
-                               messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
-                               isVideoCall: false,
-                               shouldRing: true)
-
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
@@ -825,22 +713,16 @@ extension WireCallCenterV3Tests {
 
     func testThatCBRIsNotEnabledAfterCallIsTerminated() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
-                               messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
-                               isVideoCall: false,
-                               shouldRing: true)
-
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
+        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         sut.handleConstantBitRateChange(enabled: true)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
-        sut.handleCallEnd(reason: .normal, conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, clientId: otherUserClientID)
+        sut.handleCallEnd(reason: .normal, conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
@@ -853,13 +735,7 @@ extension WireCallCenterV3Tests {
 extension WireCallCenterV3Tests {
     func testThatNetworkQualityIsNormalInitially() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
-                               messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
-                               isVideoCall: false,
-                               shouldRing: true)
-
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
@@ -868,20 +744,14 @@ extension WireCallCenterV3Tests {
 
     func testThatNetworkQualityHandlerUpdatesTheQuality() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
-                               messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
-                               isVideoCall: false,
-                               shouldRing: true)
-
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
+        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         let quality = NetworkQuality.poor
 
         // when
-        sut.handleNetworkQualityChange(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID, quality: quality)
+        sut.handleNetworkQualityChange(conversationId: oneOnOneConversationID, userId: otherUserID, quality: quality)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
@@ -900,15 +770,9 @@ extension WireCallCenterV3Tests {
         }
         
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
-                               messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
-                               isVideoCall: false,
-                               shouldRing: true)
-
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
+        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         let observer = MuteObserver()
         let token = WireCallCenterV3.addMuteStateObserver(observer: observer, context: uiMOC)
@@ -932,13 +796,7 @@ extension WireCallCenterV3Tests {
 
     func testThatItWhenIgnoringACallItWillSetsTheCallStateToIncomingInactive() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
-                               messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
-                               isVideoCall: false,
-                               shouldRing: true)
-
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
@@ -950,13 +808,7 @@ extension WireCallCenterV3Tests {
 
     func testThatItWhenRejectingAOneOnOneCallItWilltSetTheCallStateToIncomingInactive() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
-                               messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
-                               isVideoCall: false,
-                               shouldRing: true)
-
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
@@ -968,13 +820,7 @@ extension WireCallCenterV3Tests {
 
     func testThatItWhenClosingAGroupCallItWillSetsTheCallStateToIncomingInactive() {
         // given
-        sut.handleIncomingCall(conversationId: groupConversationID,
-                               messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
-                               isVideoCall: false,
-                               shouldRing: true)
-
+        sut.handleIncomingCall(conversationId: groupConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
@@ -986,13 +832,7 @@ extension WireCallCenterV3Tests {
 
     func testThatItWhenClosingAOneOnOneCallItDoesNotSetTheCallStateToIncomingInactive() {
         // given
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
-                               messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
-                               isVideoCall: false,
-                               shouldRing: true)
-
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
@@ -1010,23 +850,15 @@ extension WireCallCenterV3Tests {
 
     func testThatItCreatesAParticipantSnapshotForAnIncomingCall() {
         // when
-        sut.handleIncomingCall(conversationId: oneOnOneConversationID,
-                               messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
-                               isVideoCall: false,
-                               shouldRing: true)
-
+        sut.handleIncomingCall(conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
         XCTAssertEqual(sut.callParticipants(conversationId: oneOnOneConversationID), [CallParticipant(user: otherUser, state: .connecting)])
     }
 
-    func callBackMemberHandler(conversationId: UUID, userId: UUID, clientId: String, audioEstablished: Bool) {
-        let audioState = audioEstablished ? AudioState.established : .connecting
-        let videoState = VideoState.stopped
-        let member = AVSParticipantsChange.Member(userid: userId, clientid: clientId, aestab: audioState, vrecv: videoState)
+    func callBackMemberHandler(conversationId: UUID, userId: UUID, audioEstablished: Bool) {
+        let member = AVSParticipantsChange.Member(userid: userId, clientid: "123", aestab: audioEstablished ? 1 : 0, vrecv: 0)
         let change = AVSParticipantsChange(convid: conversationId, members: [member])
         
         let encoded = try! JSONEncoder().encode(change)
@@ -1035,20 +867,20 @@ extension WireCallCenterV3Tests {
         sut.handleParticipantChange(conversationId: conversationId, data: string)
     }
     
-    func testThatItDoesNotIgnore_WhenGroupHandlerIsCalledForOneToOne() {
+    func testThatItIgnoresIt_WhenGroupHandlerIsCalledForOneToOne() {
         // when
         _ = sut.startCall(conversation: oneOnOneConversation, video: false)
-        callBackMemberHandler(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID, audioEstablished: false)
+        callBackMemberHandler(conversationId: oneOnOneConversationID, userId: otherUserID, audioEstablished: false)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then
-        XCTAssertEqual(sut.callParticipants(conversationId: oneOnOneConversationID), [CallParticipant(user: otherUser, state: .connecting)])
+        XCTAssertTrue(sut.callParticipants(conversationId: oneOnOneConversationID).isEmpty)
     }
 
     func testThatItUpdatesTheParticipantsWhenGroupHandlerIsCalled() {
         // when
         _ = sut.startCall(conversation: groupConversation, video: false)
-        callBackMemberHandler(conversationId: groupConversationID, userId: otherUserID, clientId: otherUserClientID, audioEstablished: false)
+        callBackMemberHandler(conversationId: groupConversationID, userId: otherUserID, audioEstablished: false)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
@@ -1057,24 +889,18 @@ extension WireCallCenterV3Tests {
 
     func testThatItUpdatesTheStateForParticipant() {
         // when
-        sut.handleIncomingCall(conversationId: groupConversationID,
-                               messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
-                               isVideoCall: false,
-                               shouldRing: true)
-        
+        sut.handleIncomingCall(conversationId: groupConversationID, messageTime: Date(), userId: otherUserID, isVideoCall: false, shouldRing: true)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
         XCTAssertEqual(sut.callParticipants(conversationId: groupConversationID), [CallParticipant(user: otherUser, state: .connecting)])
 
         // when
-        callBackMemberHandler(conversationId: groupConversationID, userId: otherUserID, clientId: otherUserClientID, audioEstablished: true)
+        callBackMemberHandler(conversationId: groupConversationID, userId: otherUserID, audioEstablished: true)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
-        XCTAssertEqual(sut.callParticipants(conversationId: groupConversationID), [CallParticipant(user: otherUser, state: .connected(videoState: .stopped, clientId: otherUserClientID))])
+        XCTAssertEqual(sut.callParticipants(conversationId: groupConversationID), [CallParticipant(user: otherUser, state: .connected(videoState: .stopped, clientId: "123"))])
     }
 }
 

--- a/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -281,7 +281,7 @@ class WireCallCenterV3Tests: MessagingTest {
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         checkThatItPostsNotification(expectedCallState: .terminating(reason: .canceled), expectedCallerId: otherUserID, expectedConversationId: oneOnOneConversationID) {
-            sut.handleCallEnd(reason: .canceled, conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID)
+            sut.handleCallEnd(reason: .canceled, conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, clientId: otherUserClientID)
         }
     }
     
@@ -386,7 +386,7 @@ class WireCallCenterV3Tests: MessagingTest {
         
         // when
         sut.rejectCall(conversationId: oneOnOneConversationID)
-        sut.handleCallEnd(reason: .stillOngoing, conversationId: groupConversationID, messageTime: Date(), userId: otherUserID)
+        sut.handleCallEnd(reason: .stillOngoing, conversationId: groupConversationID, messageTime: Date(), userId: otherUserID, clientId: otherUserClientID)
 
         // then
         XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
@@ -415,7 +415,7 @@ class WireCallCenterV3Tests: MessagingTest {
         
         // when
         sut.rejectCall(conversationId: oneOnOneConversationID)
-        sut.handleCallEnd(reason: .stillOngoing, conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID)
+        sut.handleCallEnd(reason: .stillOngoing, conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, clientId: otherUserClientID)
 
         // then
         XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
@@ -840,7 +840,7 @@ extension WireCallCenterV3Tests {
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
-        sut.handleCallEnd(reason: .normal, conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID)
+        sut.handleCallEnd(reason: .normal, conversationId: oneOnOneConversationID, messageTime: Date(), userId: otherUserID, clientId: otherUserClientID)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then


### PR DESCRIPTION
## What's new in this PR?

### Issues

There were some regressions introduced after integrating AVS 5.6. Some of these regressions can only be fixed with new changes on the AVS side. These changes are included as part of AVS 6, however AVS 6 integration is not complete yet.

So that these regressions don't block the next release, it has been decided to rollback to the previous AVS version.