### PR TITLE
[Feature] Add protocol type to help UI trigger remote data fetching

### DIFF
--- a/Source/Data Model/TeamMetadataFetchTrigger.swift
+++ b/Source/Data Model/TeamMetadataFetchTrigger.swift
@@ -1,0 +1,70 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+public protocol TeamMetadataFetchTriggerType: class {
+
+    func triggerUserFetch(for user: UserType)
+    func triggerUserRichprofileFetch(for user: UserType)
+    func triggerMembershipFetch(for user: UserType)
+    func triggerTeamFetch(for team: TeamType)
+
+}
+
+/// A helper type that is able to trigger fetching metadata from the backend.
+///
+/// For use primarily from the UI where we don't have concrete model types.
+
+public final class TeamMetadataFetchTrigger: TeamMetadataFetchTriggerType {
+
+    public init() { }
+
+    public func triggerUserFetch(for user: UserType) {
+        concreteUser(from: user)?.needsToBeUpdatedFromBackend = true
+    }
+
+    public func triggerUserRichprofileFetch(for user: UserType) {
+        concreteUser(from: user)?.needsRichProfileUpdate = true
+    }
+
+    public func triggerMembershipFetch(for user: UserType) {
+        concreteUser(from: user)?.membership?.needsToBeUpdatedFromBackend = true
+    }
+
+    public func triggerTeamFetch(for team: TeamType) {
+        concreteTeam(from: team)?.needsToBeUpdatedFromBackend = true
+    }
+
+    // MARK: - Helpers
+
+    private func concreteUser(from user: UserType) -> ZMUser? {
+        if let zmUser = user as? ZMUser {
+            return zmUser
+        } else if let searchUser = user as? ZMSearchUser {
+            return searchUser.user
+        } else {
+            return nil
+        }
+    }
+
+    private func concreteTeam(from team: TeamType) -> Team? {
+        return team as? Team
+    }
+
+}

--- a/Tests/Source/Data Model/TeamMetadataFetchTriggerTests.swift
+++ b/Tests/Source/Data Model/TeamMetadataFetchTriggerTests.swift
@@ -1,0 +1,81 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+@testable import WireSyncEngine
+
+class TeamMetadataFetchTriggerTests: DatabaseTest {
+
+    func testItTriggersUserFetch() {
+        // Given
+        let sut = TeamMetadataFetchTrigger()
+        let user = ZMUser.insertNewObject(in: uiMOC)
+        user.needsToBeUpdatedFromBackend = false
+
+        // When
+        sut.triggerUserFetch(for: user)
+
+        // Then
+        XCTAssertTrue(user.needsToBeUpdatedFromBackend)
+    }
+
+    func testItTriggersUserRichProfileFetch() {
+        // Given
+        let sut = TeamMetadataFetchTrigger()
+        let user = ZMUser.insertNewObject(in: uiMOC)
+        user.needsRichProfileUpdate = false
+
+        // When
+        sut.triggerUserRichprofileFetch(for: user)
+
+        // Then
+        XCTAssertTrue(user.needsRichProfileUpdate)
+    }
+
+    func testItTriggersMembershipFetch() {
+        // Given
+        let sut = TeamMetadataFetchTrigger()
+        let user = ZMUser.insertNewObject(in: uiMOC)
+        let team = Team.insertNewObject(in: uiMOC)
+
+        let membership = Member.insertNewObject(in: uiMOC)
+        membership.user = user
+        membership.team = team
+        membership.needsToBeUpdatedFromBackend = false
+
+        // When
+        sut.triggerMembershipFetch(for: user)
+
+        // Then
+        XCTAssertTrue(membership.needsToBeUpdatedFromBackend)
+    }
+
+    func testItTriggersTeamFetch() {
+        // Given
+        let sut = TeamMetadataFetchTrigger()
+
+        let team = Team.insertNewObject(in: uiMOC)
+        team.needsToBeUpdatedFromBackend = false
+
+        // When
+        sut.triggerTeamFetch(for: team)
+
+        // Then
+        XCTAssertTrue(team.needsToBeUpdatedFromBackend)
+    }
+
+}

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -441,6 +441,7 @@
 		EE1DEBC423D5F1970087EE1F /* Conversation+TypingUsers.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1DEBC223D5F1920087EE1F /* Conversation+TypingUsers.swift */; };
 		EE1DEBC723D5F1F30087EE1F /* NSManagedObjectContext+TypingUsers.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1DEBC523D5F1D00087EE1F /* NSManagedObjectContext+TypingUsers.swift */; };
 		EE2AF301243222F3004F0986 /* TeamMetadataFetchTrigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2AF300243222F3004F0986 /* TeamMetadataFetchTrigger.swift */; };
+		EE2AF30F24322DC0004F0986 /* TeamMetadataFetchTriggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2AF30E24322DC0004F0986 /* TeamMetadataFetchTriggerTests.swift */; };
 		EE5BF6351F8F907C00B49D06 /* ZMLocalNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5BF6341F8F907C00B49D06 /* ZMLocalNotificationTests.swift */; };
 		EE5BF6371F8F9D6100B49D06 /* ZMLocalNotificationTests_Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5BF6361F8F9D6100B49D06 /* ZMLocalNotificationTests_Event.swift */; };
 		EE5FEF0521E8948F00E24F7F /* ZMUserSession+DarwinNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5FEF0421E8948F00E24F7F /* ZMUserSession+DarwinNotificationCenter.swift */; };
@@ -1113,6 +1114,7 @@
 		EE1DEBC223D5F1920087EE1F /* Conversation+TypingUsers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Conversation+TypingUsers.swift"; sourceTree = "<group>"; };
 		EE1DEBC523D5F1D00087EE1F /* NSManagedObjectContext+TypingUsers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+TypingUsers.swift"; sourceTree = "<group>"; };
 		EE2AF300243222F3004F0986 /* TeamMetadataFetchTrigger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamMetadataFetchTrigger.swift; sourceTree = "<group>"; };
+		EE2AF30E24322DC0004F0986 /* TeamMetadataFetchTriggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TeamMetadataFetchTriggerTests.swift; path = "Tests/Source/Data Model/TeamMetadataFetchTriggerTests.swift"; sourceTree = SOURCE_ROOT; };
 		EE5BF6341F8F907C00B49D06 /* ZMLocalNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ZMLocalNotificationTests.swift; path = Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests.swift; sourceTree = SOURCE_ROOT; };
 		EE5BF6361F8F9D6100B49D06 /* ZMLocalNotificationTests_Event.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ZMLocalNotificationTests_Event.swift; path = Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_Event.swift; sourceTree = SOURCE_ROOT; };
 		EE5FEF0421E8948F00E24F7F /* ZMUserSession+DarwinNotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSession+DarwinNotificationCenter.swift"; sourceTree = "<group>"; };
@@ -1723,6 +1725,7 @@
 				16519D6C231EAAF300C9D76D /* Conversation+DeletionTests.swift */,
 				872A2EE71FFFBC3900900B22 /* ServiceUserTests.swift */,
 				878ACB5820AF12C10016E68A /* ZMUserConsentTests.swift */,
+				EE2AF30E24322DC0004F0986 /* TeamMetadataFetchTriggerTests.swift */,
 			);
 			path = "Data Model";
 			sourceTree = "<group>";
@@ -2882,6 +2885,7 @@
 				A938BDCA23A7966700D4C208 /* ConversationRoleDownstreamRequestStrategyTests.swift in Sources */,
 				0920C4DA1B305FF500C55728 /* UserSessionGiphyRequestStateTests.swift in Sources */,
 				169BC10F22BD17FF0003159B /* LegalHoldRequestStrategyTests.swift in Sources */,
+				EE2AF30F24322DC0004F0986 /* TeamMetadataFetchTriggerTests.swift in Sources */,
 				87AEA67D1EFBF46600C94BF3 /* DiskDatabaseTest.swift in Sources */,
 				541918ED195AD9D100A5023D /* SendAndReceiveMessagesTests.m in Sources */,
 				F9F846351ED307F70087C1A4 /* CallParticipantsSnapshotTests.swift in Sources */,

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -440,6 +440,7 @@
 		EE1DEBBE23D5E12F0087EE1F /* TypingUsersTimeout+Key.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1DEBBC23D5E0390087EE1F /* TypingUsersTimeout+Key.swift */; };
 		EE1DEBC423D5F1970087EE1F /* Conversation+TypingUsers.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1DEBC223D5F1920087EE1F /* Conversation+TypingUsers.swift */; };
 		EE1DEBC723D5F1F30087EE1F /* NSManagedObjectContext+TypingUsers.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1DEBC523D5F1D00087EE1F /* NSManagedObjectContext+TypingUsers.swift */; };
+		EE2AF301243222F3004F0986 /* TeamMetadataFetchTrigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2AF300243222F3004F0986 /* TeamMetadataFetchTrigger.swift */; };
 		EE5BF6351F8F907C00B49D06 /* ZMLocalNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5BF6341F8F907C00B49D06 /* ZMLocalNotificationTests.swift */; };
 		EE5BF6371F8F9D6100B49D06 /* ZMLocalNotificationTests_Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5BF6361F8F9D6100B49D06 /* ZMLocalNotificationTests_Event.swift */; };
 		EE5FEF0521E8948F00E24F7F /* ZMUserSession+DarwinNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5FEF0421E8948F00E24F7F /* ZMUserSession+DarwinNotificationCenter.swift */; };
@@ -1111,6 +1112,7 @@
 		EE1DEBBC23D5E0390087EE1F /* TypingUsersTimeout+Key.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TypingUsersTimeout+Key.swift"; sourceTree = "<group>"; };
 		EE1DEBC223D5F1920087EE1F /* Conversation+TypingUsers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Conversation+TypingUsers.swift"; sourceTree = "<group>"; };
 		EE1DEBC523D5F1D00087EE1F /* NSManagedObjectContext+TypingUsers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+TypingUsers.swift"; sourceTree = "<group>"; };
+		EE2AF300243222F3004F0986 /* TeamMetadataFetchTrigger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamMetadataFetchTrigger.swift; sourceTree = "<group>"; };
 		EE5BF6341F8F907C00B49D06 /* ZMLocalNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ZMLocalNotificationTests.swift; path = Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests.swift; sourceTree = SOURCE_ROOT; };
 		EE5BF6361F8F9D6100B49D06 /* ZMLocalNotificationTests_Event.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ZMLocalNotificationTests_Event.swift; path = Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_Event.swift; sourceTree = SOURCE_ROOT; };
 		EE5FEF0421E8948F00E24F7F /* ZMUserSession+DarwinNotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSession+DarwinNotificationCenter.swift"; sourceTree = "<group>"; };
@@ -1521,6 +1523,7 @@
 				EEF4010023A8DFC6007B1A97 /* Conversation+Role.swift */,
 				EE1DEBC223D5F1920087EE1F /* Conversation+TypingUsers.swift */,
 				878ACB4720AEFB980016E68A /* ZMUser+Consent.swift */,
+				EE2AF300243222F3004F0986 /* TeamMetadataFetchTrigger.swift */,
 			);
 			path = "Data Model";
 			sourceTree = "<group>";
@@ -3069,6 +3072,7 @@
 				EFF940402240FF12004F3115 /* DeepLinkError.swift in Sources */,
 				F90EC5A31E7BF1AC00A6779E /* AVSWrapper.swift in Sources */,
 				5E8BB8992147CD3F00EEA64B /* AVSBridging.swift in Sources */,
+				EE2AF301243222F3004F0986 /* TeamMetadataFetchTrigger.swift in Sources */,
 				16F5F16C1E4092C00062F0AE /* NSManagedObjectContext+CTCallCenter.swift in Sources */,
 				16962EE420286D690069D88D /* LocalNotificationType+Configuration.swift in Sources */,
 				BF00441B1C737CE9007A6EA4 /* PushNotificationStatus.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

The UI may need to trigger remote data fetches for certain objects. This is typically done by setting flags such as `needsToBeUpdatedFromBackend`, which will automatically schedule downstream requests to the backend.

These properties however are defined on concrete managed objects and are therefore not exposed through the various abstraction protocols, such as `UserType` and `TeamType`.

### Solutions

To avoid casting to concrete types in the UI, a helper class is needed. It simply accepts an abstract type, casts to the concrete type and sets the flags. An additional benefit of this helper is that it will be easier to test that the UI code calls these trigger methods.
