### PR TITLE
[Feature] AVS 6: clean up handler definitions

### DIFF
--- a/Source/Calling/AVSWrapper+Handlers.swift
+++ b/Source/Calling/AVSWrapper+Handlers.swift
@@ -23,9 +23,9 @@ extension AVSWrapper {
 
     enum Handler {
 
-        typealias StringPointer = UnsafePointer<Int8>?
-        typealias VoidPointer = UnsafeMutableRawPointer?
-        typealias ContextRef = VoidPointer
+        typealias StringPtr = UnsafePointer<Int8>?
+        typealias VoidPtr = UnsafeMutableRawPointer?
+        typealias ContextRef = VoidPtr
 
         /// Callback used to inform user that call uses CBR (in both directions).
         ///
@@ -34,10 +34,7 @@ extension AVSWrapper {
         ///                                         int enabled,
         ///                                         void *arg);
 
-        typealias ConstantBitRateChange = @convention(c) (StringPointer,
-            StringPointer,
-            Int32,
-            ContextRef) -> Void
+        typealias ConstantBitRateChange = @convention(c)(StringPtr, StringPtr, Int32, ContextRef) -> Void
 
 
         /// Callback used to inform user that received video has started or stopped.
@@ -48,11 +45,7 @@ extension AVSWrapper {
         ///                                           int state,
         ///                                           void *arg);
 
-        typealias VideoStateChange = @convention(c) (StringPointer,
-            StringPointer,
-            StringPointer,
-            Int32,
-            ContextRef) -> Void
+        typealias VideoStateChange = @convention(c) (StringPtr, StringPtr, StringPtr, Int32, ContextRef) -> Void
 
         /// Callback used to inform the user of an incoming call.
         ///
@@ -64,13 +57,7 @@ extension AVSWrapper {
         ///                                 int should_ring /*bool*/,
         ///                                 void *arg);
 
-        typealias IncomingCall = @convention(c) (StringPointer,
-            UInt32,
-            StringPointer,
-            StringPointer,
-            Int32,
-            Int32,
-            ContextRef) -> Void
+        typealias IncomingCall = @convention(c) (StringPtr, UInt32, StringPtr, StringPtr, Int32, Int32, ContextRef) -> Void
 
         /// Callback used to inform the user of a missed call.
         ///
@@ -81,18 +68,13 @@ extension AVSWrapper {
         ///                               int video_call /*bool*/,
         ///                               void *arg);
 
-        typealias MissedCall = @convention(c) (StringPointer,
-            UInt32,
-            StringPointer,
-            StringPointer,
-            Int32,
-            ContextRef) -> Void
+        typealias MissedCall = @convention(c) (StringPtr, UInt32, StringPtr, StringPtr, Int32, ContextRef) -> Void
 
         /// Callback used to inform user that a 1:1 call was answered.
         ///
         /// typedef void (wcall_answered_h)(const char *convid, void *arg);
 
-        typealias AnsweredCall = @convention(c) (StringPointer, ContextRef) -> Void
+        typealias AnsweredCall = @convention(c) (StringPtr, ContextRef) -> Void
 
         /// Callback used to inform the user that a data channel was established.
         ///
@@ -101,10 +83,7 @@ extension AVSWrapper {
         ///                                        const char *clientid,
         ///                                        void *arg);
 
-        typealias DataChannelEstablished = @convention(c) (StringPointer,
-            StringPointer,
-            StringPointer,
-            ContextRef) -> Void
+        typealias DataChannelEstablished = @convention(c) (StringPtr, StringPtr, StringPtr, ContextRef) -> Void
 
         /// Callback used to inform the user that a call was established (with media).
         ///
@@ -113,10 +92,7 @@ extension AVSWrapper {
         ///                              const char *clientid,
         ///                              void *arg);
 
-        typealias CallEstablished = @convention(c) (StringPointer,
-            StringPointer,
-            StringPointer,
-            ContextRef) -> Void
+        typealias CallEstablished = @convention(c) (StringPtr, StringPtr, StringPtr, ContextRef) -> Void
 
         /// Callback used to inform the user that a call was terminated.
         ///
@@ -127,12 +103,7 @@ extension AVSWrapper {
         ///                              const char *clientid,
         ///                              void *arg);
 
-        typealias CloseCall = @convention(c) (Int32,
-            StringPointer,
-            UInt32,
-            StringPointer,
-            StringPointer,
-            ContextRef) -> Void
+        typealias CloseCall = @convention(c) (Int32, StringPtr, UInt32, StringPtr, StringPtr, ContextRef) -> Void
 
         /// Callback used to inform the user of call metrics.
         ///
@@ -140,9 +111,7 @@ extension AVSWrapper {
         ///                                const char *metrics_json,
         ///                                void *arg);
 
-        typealias CallMetrics = @convention(c) (StringPointer,
-            StringPointer,
-            ContextRef) -> Void
+        typealias CallMetrics = @convention(c) (StringPtr, StringPtr, ContextRef) -> Void
 
         /// Callback used to request a refresh of the call config.
         ///
@@ -170,16 +139,7 @@ extension AVSWrapper {
         ///                            int transient /*bool*/,
         ///                            void *arg);
 
-        typealias CallMessageSend = @convention(c) (VoidPointer,
-            StringPointer,
-            StringPointer,
-            StringPointer,
-            StringPointer,
-            StringPointer,
-            UnsafePointer<UInt8>?,
-            Int,
-            Int32,
-            ContextRef) -> Int32
+        typealias CallMessageSend = @convention(c) (VoidPtr, StringPtr, StringPtr, StringPtr, StringPtr, StringPtr, UnsafePointer<UInt8>?, Int, Int32, ContextRef) -> Int32
 
         /// Callback used to inform the user when the list of participants in a call changes.
         ///
@@ -187,15 +147,13 @@ extension AVSWrapper {
         ///                                            const char *mjson,
         ///                                            void *arg);
 
-        typealias CallParticipantChange = @convention(c) (StringPointer,
-            StringPointer,
-            ContextRef) -> Void
+        typealias CallParticipantChange = @convention(c) (StringPtr, StringPtr, ContextRef) -> Void
 
         /// Callback used to inform the user that all media has stopped.
         ///
         /// typedef void (wcall_media_stopped_h)(const char *convid, void *arg);
 
-        typealias MediaStoppedChange = @convention(c) (StringPointer, ContextRef) -> Void
+        typealias MediaStoppedChange = @convention(c) (StringPtr, ContextRef) -> Void
 
         /// Callback used to inform the user of a change in network quality for a participant.
         ///
@@ -208,14 +166,7 @@ extension AVSWrapper {
         ///                                        int downloss, /* dnstream pkt loss % */
         ///                                        void *arg);
 
-        typealias NetworkQualityChange = @convention(c) (StringPointer,
-            StringPointer,
-            StringPointer,
-            Int32,
-            Int32,
-            Int32,
-            Int32,
-            ContextRef) -> Void
+        typealias NetworkQualityChange = @convention(c) (StringPtr, StringPtr, StringPtr, Int32, Int32, Int32, Int32, ContextRef) -> Void
 
         /// Callback used to inform the user when the mute state changes.
         ///
@@ -227,6 +178,6 @@ extension AVSWrapper {
         ///
         /// typedef void (wcall_req_clients_h)(const char *convid, void *arg);
 
-        typealias RequestClients = @convention(c) (StringPointer, ContextRef) -> Void
+        typealias RequestClients = @convention(c) (StringPtr, ContextRef) -> Void
     }
 }

--- a/Source/Calling/AVSWrapper+Handlers.swift
+++ b/Source/Calling/AVSWrapper+Handlers.swift
@@ -222,5 +222,11 @@ extension AVSWrapper {
         /// typedef void (wcall_mute_h)(int muted, void *arg);
 
         typealias MuteChange = @convention(c) (Int32, ContextRef) -> Void
+
+        /// Callback used to request a the list of clients in a conversation.
+        ///
+        /// typedef void (wcall_req_clients_h)(const char *convid, void *arg);
+
+        typealias RequestClients = @convention(c) (StringPointer, ContextRef) -> Void
     }
 }

--- a/Source/Calling/AVSWrapper+Handlers.swift
+++ b/Source/Calling/AVSWrapper+Handlers.swift
@@ -19,53 +19,208 @@
 import Foundation
 import avs
 
-/// Equivalent of `wcall_audio_cbr_change_h`.
-typealias ConstantBitRateChangeHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, Int32, UnsafeMutableRawPointer?) -> Void
+extension AVSWrapper {
 
-/// Equivalent of `wcall_video_state_change_h`.
-typealias VideoStateChangeHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafePointer<Int8>?, Int32, UnsafeMutableRawPointer?) -> Void
+    enum Handler {
 
-/// Equivalent of `wcall_incoming_h`.
-typealias IncomingCallHandler = @convention(c) (UnsafePointer<Int8>?, UInt32, UnsafePointer<Int8>?, UnsafePointer<Int8>?, Int32, Int32, UnsafeMutableRawPointer?) -> Void
+        typealias StringPointer = UnsafePointer<Int8>?
+        typealias VoidPointer = UnsafeMutableRawPointer?
+        typealias ContextRef = VoidPointer
 
-/// Equivalent of `wcall_missed_h`.
-typealias MissedCallHandler = @convention(c) (UnsafePointer<Int8>?, UInt32, UnsafePointer<Int8>?, UnsafePointer<Int8>?, Int32, UnsafeMutableRawPointer?) -> Void
+        /// Callback used to inform user that call uses CBR (in both directions).
+        ///
+        /// typedef void (wcall_audio_cbr_change_h)(const char *userid,
+        ///                                         const char *clientid,
+        ///                                         int enabled,
+        ///                                         void *arg);
 
-/// Equivalent of `wcall_answered_h`.
-typealias AnsweredCallHandler = @convention(c) (UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
+        typealias ConstantBitRateChange = @convention(c) (StringPointer,
+            StringPointer,
+            Int32,
+            ContextRef) -> Void
 
-/// Equivalent of `wcall_data_chan_estab_h`.
-typealias DataChannelEstablishedHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
 
-/// Equivalent of `wcall_estab_h`.
-typealias CallEstablishedHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
+        /// Callback used to inform user that received video has started or stopped.
+        ///
+        /// typedef void (wcall_video_state_change_h)(const char *convid,
+        ///                                           const char *userid,
+        ///                                           const char *clientid,
+        ///                                           int state,
+        ///                                           void *arg);
 
-/// Equivalent of `wcall_close_h`.
-typealias CloseCallHandler = @convention(c) (Int32, UnsafePointer<Int8>?, UInt32, UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
+        typealias VideoStateChange = @convention(c) (StringPointer,
+            StringPointer,
+            StringPointer,
+            Int32,
+            ContextRef) -> Void
 
-/// Equivalent of `wcall_metrics_h`.
-typealias CallMetricsHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
+        /// Callback used to inform the user of an incoming call.
+        ///
+        /// typedef void (wcall_incoming_h)(const char *convid,
+        ///                                 uint32_t msg_time,
+        ///                                 const char *userid,
+        ///                                 const char *clientid,
+        ///                                 int video_call /*bool*/,
+        ///                                 int should_ring /*bool*/,
+        ///                                 void *arg);
 
-/// Equivalent of `wcall_config_req_h`.
-typealias CallConfigRefreshHandler = @convention(c) (UInt32, UnsafeMutableRawPointer?) -> Int32
+        typealias IncomingCall = @convention(c) (StringPointer,
+            UInt32,
+            StringPointer,
+            StringPointer,
+            Int32,
+            Int32,
+            ContextRef) -> Void
 
-/// Equivalent of `wcall_ready_h`.
-typealias CallReadyHandler = @convention(c) (Int32, UnsafeMutableRawPointer?) -> Void
+        /// Callback used to inform the user of a missed call.
+        ///
+        /// typedef void (wcall_missed_h)(const char *convid,
+        ///                               uint32_t msg_time,
+        ///                               const char *userid,
+        ///                               const char *clientid,
+        ///                               int video_call /*bool*/,
+        ///                               void *arg);
 
-/// Equivalent of `wcall_send_h`.
-typealias CallMessageSendHandler = @convention(c) (UnsafeMutableRawPointer?, UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafePointer<UInt8>?, Int, Int32, UnsafeMutableRawPointer?) -> Int32
+        typealias MissedCall = @convention(c) (StringPointer,
+            UInt32,
+            StringPointer,
+            StringPointer,
+            Int32,
+            ContextRef) -> Void
 
-/// Equivalent of `wcall_group_changed_h`.
-typealias CallGroupChangedHandler = @convention(c) (UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
+        /// Callback used to inform user that a 1:1 call was answered.
+        ///
+        /// typedef void (wcall_answered_h)(const char *convid, void *arg);
 
-/// Equivalent of `wcall_participant_changed_h`.
-typealias CallParticipantChangedHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?,  UnsafeMutableRawPointer?) -> Void
+        typealias AnsweredCall = @convention(c) (StringPointer, ContextRef) -> Void
 
-/// Equivalent of `wcall_media_stopped_h`.
-typealias MediaStoppedChangeHandler = @convention(c) (UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
+        /// Callback used to inform the user that a data channel was established.
+        ///
+        /// typedef void (wcall_data_chan_estab_h)(const char *convid,
+        ///                                        const char *userid,
+        ///                                        const char *clientid,
+        ///                                        void *arg);
 
-/// Equivalent of `wcall_network_quality_h`.
-typealias NetworkQualityChangeHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafePointer<Int8>?, Int32, Int32, Int32, Int32, UnsafeMutableRawPointer?) -> Void
+        typealias DataChannelEstablished = @convention(c) (StringPointer,
+            StringPointer,
+            StringPointer,
+            ContextRef) -> Void
 
-/// Equivalent of `wcall_set_mute_handler`.
-typealias MuteChangeHandler = @convention(c) (Int32, UnsafeMutableRawPointer?) -> Void
+        /// Callback used to inform the user that a call was established (with media).
+        ///
+        /// typedef void (wcall_estab_h)(const char *convid,
+        ///                              const char *userid,
+        ///                              const char *clientid,
+        ///                              void *arg);
+
+        typealias CallEstablished = @convention(c) (StringPointer,
+            StringPointer,
+            StringPointer,
+            ContextRef) -> Void
+
+        /// Callback used to inform the user that a call was terminated.
+        ///
+        /// typedef void (wcall_close_h)(int reason,
+        ///                              const char *convid,
+        ///                              uint32_t msg_time,
+        ///                              const char *userid,
+        ///                              const char *clientid,
+        ///                              void *arg);
+
+        typealias CloseCall = @convention(c) (Int32,
+            StringPointer,
+            UInt32,
+            StringPointer,
+            StringPointer,
+            ContextRef) -> Void
+
+        /// Callback used to inform the user of call metrics.
+        ///
+        /// typedef void (wcall_metrics_h)(const char *convid,
+        ///                                const char *metrics_json,
+        ///                                void *arg);
+
+        typealias CallMetrics = @convention(c) (StringPointer,
+            StringPointer,
+            ContextRef) -> Void
+
+        /// Callback used to request a refresh of the call config.
+        ///
+        /// typedef int (wcall_config_req_h)(WUSER_HANDLE wuser, void *arg);
+
+        typealias CallConfigRefresh = @convention(c) (UInt32, ContextRef) -> Int32
+
+        /// Callback used when the calling system is ready for calling. The version parameter specifies the call config
+        /// version to use.
+        ///
+        /// typedef void (wcall_ready_h)(int version, void *arg);
+
+        typealias CallReady = @convention(c) (Int32, ContextRef) -> Void
+
+        /// Callback used to send an OTR call message.
+        ///
+        /// typedef int (wcall_send_h)(void *ctx,
+        ///                            const char *convid,
+        ///                            const char *userid_self,
+        ///                            const char *clientid_self,
+        ///                            const char *userid_dest /*optional*/,
+        ///                            const char *clientid_dest /*optional*/,
+        ///                            const uint8_t *data,
+        ///                            size_t len,
+        ///                            int transient /*bool*/,
+        ///                            void *arg);
+
+        typealias CallMessageSend = @convention(c) (VoidPointer,
+            StringPointer,
+            StringPointer,
+            StringPointer,
+            StringPointer,
+            StringPointer,
+            UnsafePointer<UInt8>?,
+            Int,
+            Int32,
+            ContextRef) -> Int32
+
+        /// Callback used to inform the user when the list of participants in a call changes.
+        ///
+        /// typedef void (wcall_participant_changed_h)(const char *convid,
+        ///                                            const char *mjson,
+        ///                                            void *arg);
+
+        typealias CallParticipantChange = @convention(c) (StringPointer,
+            StringPointer,
+            ContextRef) -> Void
+
+        /// Callback used to inform the user that all media has stopped.
+        ///
+        /// typedef void (wcall_media_stopped_h)(const char *convid, void *arg);
+
+        typealias MediaStoppedChange = @convention(c) (StringPointer, ContextRef) -> Void
+
+        /// Callback used to inform the user of a change in network quality for a participant.
+        ///
+        /// typedef void (wcall_network_quality_h)(const char *convid,
+        ///                                        const char *userid,
+        ///                                        const char *clientid,
+        ///                                        int quality, /*  WCALL_QUALITY_ */
+        ///                                        int rtt, /* round trip time in ms */
+        ///                                        int uploss, /* upstream pkt loss % */
+        ///                                        int downloss, /* dnstream pkt loss % */
+        ///                                        void *arg);
+
+        typealias NetworkQualityChange = @convention(c) (StringPointer,
+            StringPointer,
+            StringPointer,
+            Int32,
+            Int32,
+            Int32,
+            Int32,
+            ContextRef) -> Void
+
+        /// Callback used to inform the user when the mute state changes.
+        ///
+        /// typedef void (wcall_mute_h)(int muted, void *arg);
+
+        typealias MuteChange = @convention(c) (Int32, ContextRef) -> Void
+    }
+}

--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -163,25 +163,25 @@ public class AVSWrapper: AVSWrapperType {
 
     // MARK: - C Callback Handlers
 
-    private let constantBitRateChangeHandler: ConstantBitRateChangeHandler = { userId, clientId, enabledFlag, contextRef in
+    private let constantBitRateChangeHandler: Handler.ConstantBitRateChange = { userId, clientId, enabledFlag, contextRef in
         AVSWrapper.withCallCenter(contextRef, enabledFlag) {
             $0.handleConstantBitRateChange(enabled: $1)
         }
     }
 
-    private let videoStateChangeHandler: VideoStateChangeHandler = { conversationId, userId, clientId, state, contextRef in
+    private let videoStateChangeHandler: Handler.VideoStateChange = { conversationId, userId, clientId, state, contextRef in
         AVSWrapper.withCallCenter(contextRef, userId, clientId, state) {
             $0.handleVideoStateChange(userId: $1, clientId: $2, newState: $3)
         }
     }
 
-    private let incomingCallHandler: IncomingCallHandler = { conversationId, messageTime, userId, clientId, isVideoCall, shouldRing, contextRef in
+    private let incomingCallHandler: Handler.IncomingCall = { conversationId, messageTime, userId, clientId, isVideoCall, shouldRing, contextRef in
         AVSWrapper.withCallCenter(contextRef, conversationId, messageTime, userId, clientId, isVideoCall, shouldRing) {
             $0.handleIncomingCall(conversationId: $1, messageTime: $2, userId: $3, clientId: $4, isVideoCall: $5, shouldRing: $6)
         }
     }
 
-    private let missedCallHandler: MissedCallHandler = { conversationId, messageTime, userId, clientId, isVideoCall, contextRef in
+    private let missedCallHandler: Handler.MissedCall = { conversationId, messageTime, userId, clientId, isVideoCall, contextRef in
         zmLog.debug("missedCallHandler: messageTime = \(messageTime)")
         let nonZeroMessageTime: UInt32 = messageTime != 0 ? messageTime : UInt32(Date().timeIntervalSince1970)
 
@@ -190,25 +190,25 @@ public class AVSWrapper: AVSWrapperType {
         }
     }
 
-    private let answeredCallHandler: AnsweredCallHandler = { conversationId, contextRef in
+    private let answeredCallHandler: Handler.AnsweredCall = { conversationId, contextRef in
         AVSWrapper.withCallCenter(contextRef, conversationId) {
             $0.handleAnsweredCall(conversationId: $1)
         }
     }
 
-    private let dataChannelEstablishedHandler: DataChannelEstablishedHandler = { conversationId, userId, clientId, contextRef in
+    private let dataChannelEstablishedHandler: Handler.DataChannelEstablished = { conversationId, userId, clientId, contextRef in
         AVSWrapper.withCallCenter(contextRef, conversationId, userId, clientId) {
             $0.handleDataChannelEstablishement(conversationId: $1, userId: $2, clientId: $3)
         }
     }
 
-    private let establishedCallHandler: CallEstablishedHandler = { conversationId, userId, clientId, contextRef in
+    private let establishedCallHandler: Handler.CallEstablished = { conversationId, userId, clientId, contextRef in
         AVSWrapper.withCallCenter(contextRef, conversationId, userId, clientId) {
             $0.handleEstablishedCall(conversationId: $1, userId: $2, clientId: $3)
         }
     }
 
-    private let closedCallHandler: CloseCallHandler = { reason, conversationId, messageTime, userId, clientId, contextRef in
+    private let closedCallHandler: Handler.CloseCall = { reason, conversationId, messageTime, userId, clientId, contextRef in
         zmLog.debug("closedCallHandler: messageTime = \(messageTime)")
         let nonZeroMessageTime: UInt32 = messageTime != 0 ? messageTime : UInt32(Date().timeIntervalSince1970)
 
@@ -217,26 +217,26 @@ public class AVSWrapper: AVSWrapperType {
         }
     }
 
-    private let callMetricsHandler: CallMetricsHandler = { conversationId, metrics, contextRef in
+    private let callMetricsHandler: Handler.CallMetrics = { conversationId, metrics, contextRef in
         AVSWrapper.withCallCenter(contextRef, conversationId, metrics) {
             $0.handleCallMetrics(conversationId: $1, metrics: $2)
         }
     }
 
-    private let requestCallConfigHandler: CallConfigRefreshHandler = { handle, contextRef in
+    private let requestCallConfigHandler: Handler.CallConfigRefresh = { handle, contextRef in
         zmLog.debug("AVS: requestCallConfigHandler \(String(describing: handle)) \(String(describing: contextRef))")
         return AVSWrapper.withCallCenter(contextRef) {
             $0.handleCallConfigRefreshRequest()
         }
     }
 
-    private let readyHandler: CallReadyHandler = { version, contextRef in
+    private let readyHandler: Handler.CallReady = { version, contextRef in
         AVSWrapper.withCallCenter(contextRef) {
             $0.setCallReady(version: version)
         }
     }
 
-    private let sendCallMessageHandler: CallMessageSendHandler = { token, conversationId, senderUserId, senderClientId, _, _, data, dataLength, _, contextRef in
+    private let sendCallMessageHandler: Handler.CallMessageSend = { token, conversationId, senderUserId, senderClientId, _, _, data, dataLength, _, contextRef in
         guard let token = token else {
             return EINVAL
         }
@@ -249,25 +249,25 @@ public class AVSWrapper: AVSWrapperType {
         }
     }
     
-    private let callParticipantHandler: CallParticipantChangedHandler = { conversationIdRef, json, contextRef in
+    private let callParticipantHandler: Handler.CallParticipantChange = { conversationIdRef, json, contextRef in
         AVSWrapper.withCallCenter(contextRef, json, conversationIdRef) {
             $0.handleParticipantChange(conversationId: $2, data: $1)
         }
     }
 
-    private let mediaStoppedChangeHandler: MediaStoppedChangeHandler = { conversationIdRef, contextRef in
+    private let mediaStoppedChangeHandler: Handler.MediaStoppedChange = { conversationIdRef, contextRef in
         AVSWrapper.withCallCenter(contextRef, conversationIdRef) {
             $0.handleMediaStopped(conversationId: $1)
         }
     }
 
-    private let networkQualityHandler: NetworkQualityChangeHandler = { conversationIdRef, userIdRef, clientIdRef, quality, rtt, uplinkLoss, downlinkLoss, contextRef in
+    private let networkQualityHandler: Handler.NetworkQualityChange = { conversationIdRef, userIdRef, clientIdRef, quality, rtt, uplinkLoss, downlinkLoss, contextRef in
         AVSWrapper.withCallCenter(contextRef, conversationIdRef, userIdRef, clientIdRef, quality) { (callCenter, conversationId, userId, clientId, quality) in
             callCenter.handleNetworkQualityChange(conversationId: conversationId, userId: userId, clientId: clientId, quality: quality)
         }
     }
 
-    private let muteChangeHandler: MuteChangeHandler = { muted, contextRef in
+    private let muteChangeHandler: Handler.MuteChange = { muted, contextRef in
         AVSWrapper.withCallCenter(contextRef, muted) {
             $0.handleMuteChange(muted: $1)
         }


### PR DESCRIPTION
## What's new in this PR?

This PR cleans up the AVS handler definitions to provide a bit more information about their types and what they are used for. No logic has changed.
