### PR TITLE
[Feature] AVS 6: introduce AVSClient

### DIFF
--- a/Source/Calling/AVSCallMember.swift
+++ b/Source/Calling/AVSCallMember.swift
@@ -91,7 +91,7 @@ public struct AVSCallMember: Hashable {
         case .connecting:
             return .connecting
         case .established:
-            return .connected(videoState: videoState, clientId: client.clientId)
+            return .connected(videoState: videoState)
         case .networkProblem:
             return .unconnectedButMayConnect
 

--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -171,13 +171,17 @@ public class AVSWrapper: AVSWrapperType {
 
     private let videoStateChangeHandler: Handler.VideoStateChange = { conversationId, userId, clientId, state, contextRef in
         AVSWrapper.withCallCenter(contextRef, userId, clientId, state) {
-            $0.handleVideoStateChange(userId: $1, clientId: $2, newState: $3)
+            $0.handleVideoStateChange(client: AVSClient(userId: $1, clientId: $2), newState: $3)
         }
     }
 
     private let incomingCallHandler: Handler.IncomingCall = { conversationId, messageTime, userId, clientId, isVideoCall, shouldRing, contextRef in
         AVSWrapper.withCallCenter(contextRef, conversationId, messageTime, userId, clientId, isVideoCall, shouldRing) {
-            $0.handleIncomingCall(conversationId: $1, messageTime: $2, userId: $3, clientId: $4, isVideoCall: $5, shouldRing: $6)
+            $0.handleIncomingCall(conversationId: $1,
+                                  messageTime: $2,
+                                  client: AVSClient(userId: $3, clientId: $4),
+                                  isVideoCall: $5,
+                                  shouldRing: $6)
         }
     }
 
@@ -198,13 +202,13 @@ public class AVSWrapper: AVSWrapperType {
 
     private let dataChannelEstablishedHandler: Handler.DataChannelEstablished = { conversationId, userId, clientId, contextRef in
         AVSWrapper.withCallCenter(contextRef, conversationId, userId, clientId) {
-            $0.handleDataChannelEstablishement(conversationId: $1, userId: $2, clientId: $3)
+            $0.handleDataChannelEstablishement(conversationId: $1, client: AVSClient(userId: $2, clientId: $3))
         }
     }
 
     private let establishedCallHandler: Handler.CallEstablished = { conversationId, userId, clientId, contextRef in
         AVSWrapper.withCallCenter(contextRef, conversationId, userId, clientId) {
-            $0.handleEstablishedCall(conversationId: $1, userId: $2, clientId: $3)
+            $0.handleEstablishedCall(conversationId: $1, client: AVSClient(userId: $2, clientId: $3))
         }
     }
 
@@ -262,8 +266,10 @@ public class AVSWrapper: AVSWrapperType {
     }
 
     private let networkQualityHandler: Handler.NetworkQualityChange = { conversationIdRef, userIdRef, clientIdRef, quality, rtt, uplinkLoss, downlinkLoss, contextRef in
-        AVSWrapper.withCallCenter(contextRef, conversationIdRef, userIdRef, clientIdRef, quality) { (callCenter, conversationId, userId, clientId, quality) in
-            callCenter.handleNetworkQualityChange(conversationId: conversationId, userId: userId, clientId: clientId, quality: quality)
+        AVSWrapper.withCallCenter(contextRef, conversationIdRef, userIdRef, clientIdRef, quality) {
+            $0.handleNetworkQualityChange(conversationId: $1,
+                                                  client: AVSClient(userId: $2, clientId: $3),
+                                                  quality: $4)
         }
     }
 

--- a/Source/Calling/CallParticipantSnapshot.swift
+++ b/Source/Calling/CallParticipantSnapshot.swift
@@ -51,32 +51,30 @@ class CallParticipantsSnapshot {
         notifyChange()
     }
 
-    func callParticipantVideoStateChanged(userId: UUID, clientId: String, videoState: VideoState) {
-        updateMember(userId: userId, clientId: clientId, videoState: videoState)
+    func callParticipantVideoStateChanged(client: AVSClient, videoState: VideoState) {
+        updateMember(client: client, videoState: videoState)
     }
 
-    func callParticipantAudioEstablished(userId: UUID, clientId: String) {
-        updateMember(userId: userId, clientId: clientId, audioState: .established)
+    func callParticipantAudioEstablished(client: AVSClient) {
+        updateMember(client: client, audioState: .established)
     }
 
-    func callParticipantNetworkQualityChanged(userId: UUID, clientId: String, networkQuality: NetworkQuality) {
-        updateMember(userId: userId, clientId: clientId, networkQuality: networkQuality)
+    func callParticipantNetworkQualityChanged(client: AVSClient, networkQuality: NetworkQuality) {
+        updateMember(client: client, networkQuality: networkQuality)
     }
 
     // MARK: - Helpers
 
     /// Updates the locally stored member for the given userId and clientId with the given non nil properties.
 
-    private func updateMember(userId: UUID,
-                              clientId: String,
+    private func updateMember(client: AVSClient,
                               audioState: AudioState? = nil,
                               videoState: VideoState? = nil,
                               networkQuality: NetworkQuality? = nil) {
 
-        guard let localMember = findMember(with: userId, clientId: clientId) else { return }
+        guard let localMember = findMember(with: client) else { return }
 
-        let updatedMember = AVSCallMember(userId: userId,
-                                          clientId: clientId,
+        let updatedMember = AVSCallMember(client: client,
                                           audioState: audioState ?? localMember.audioState,
                                           videoState: videoState ?? localMember.videoState,
                                           networkQuality: networkQuality ?? localMember.networkQuality)
@@ -88,8 +86,8 @@ class CallParticipantsSnapshot {
 
     /// Returns the member matching the given userId and clientId.
 
-    private func findMember(with userId: UUID, clientId: String) -> AVSCallMember? {
-        return members.array.first { $0.remoteId == userId && $0.clientId == clientId }
+    private func findMember(with client: AVSClient) -> AVSCallMember? {
+        return members.array.first { $0.client == client }
     }
 
     /// Notifies observers of a potential change in the participants set.

--- a/Source/Calling/CallState.swift
+++ b/Source/Calling/CallState.swift
@@ -28,25 +28,18 @@ private let zmLog = ZMSLog(tag: "calling")
 public struct CallParticipant: Hashable {
     
     public let user: ZMUser
+    public let clientId: String
     public let state: CallParticipantState
 
-    public init(user: ZMUser, state: CallParticipantState) {
+    public init(user: ZMUser, clientId: String, state: CallParticipantState) {
         self.user = user
+        self.clientId = clientId
         self.state = state
     }
 
     init?(member: AVSCallMember, context: NSManagedObjectContext) {
         guard let user = ZMUser(remoteID: member.client.userId, createIfNeeded: false, in: context) else { return nil }
-        self.init(user: user, state: member.callParticipantState)
-    }
-
-    // MARK: - Computed Properties
-
-    private var clientId: String? {
-        switch state {
-        case .connected(_, let clientId): return clientId
-        default: return nil
-        }
+        self.init(user: user, clientId: member.client.clientId, state: member.callParticipantState)
     }
 
     // MARK: - Hashable
@@ -71,7 +64,7 @@ public enum CallParticipantState: Equatable {
     /// Participant is in the process of connecting to the call
     case connecting
     /// Participant is connected to the call and audio is flowing
-    case connected(videoState: VideoState, clientId: String)
+    case connected(videoState: VideoState)
 }
 
 

--- a/Source/Calling/CallState.swift
+++ b/Source/Calling/CallState.swift
@@ -36,7 +36,7 @@ public struct CallParticipant: Hashable {
     }
 
     init?(member: AVSCallMember, context: NSManagedObjectContext) {
-        guard let user = ZMUser(remoteID: member.remoteId, createIfNeeded: false, in: context) else { return nil }
+        guard let user = ZMUser(remoteID: member.client.userId, createIfNeeded: false, in: context) else { return nil }
         self.init(user: user, state: member.callParticipantState)
     }
 

--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -300,12 +300,15 @@ extension WireCallCenterV3 {
     
     /// Returns the callParticipants currently in the conversation
     func callParticipants(conversationId: UUID) -> [CallParticipant] {
-        guard let context = uiMOC,
-              let callParticipants = callSnapshots[conversationId]?.callParticipants
-        else { return [] }
+        guard
+            let context = uiMOC,
+            let callParticipants = callSnapshots[conversationId]?.callParticipants
+        else {
+            return []
+        }
         
-        return callParticipants.members.map {
-            CallParticipant(user: ZMUser(remoteID: $0.client.userId, createIfNeeded: false, in: context)!, state: $0.callParticipantState)
+        return callParticipants.members.array.compactMap {
+            CallParticipant(member: $0, context: context)
         }
     }
 

--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -305,7 +305,7 @@ extension WireCallCenterV3 {
         else { return [] }
         
         return callParticipants.members.map {
-            CallParticipant(user: ZMUser(remoteID: $0.remoteId, createIfNeeded: false, in: context)!, state: $0.callParticipantState)
+            CallParticipant(user: ZMUser(remoteID: $0.client.userId, createIfNeeded: false, in: context)!, state: $0.callParticipantState)
         }
     }
 
@@ -320,28 +320,22 @@ extension WireCallCenterV3 {
     }
 
     /// Call this method when the video state of a participant changes and avs calls the `wcall_video_state_change_h`.
-    func callParticipantVideoStateChanged(conversationId: UUID,
-                                          userId: UUID,
-                                          clientId: String,
-                                          videoState: VideoState) {
+    func callParticipantVideoStateChanged(conversationId: UUID, client: AVSClient, videoState: VideoState) {
 
         let snapshot = callSnapshots[conversationId]?.callParticipants
-        snapshot?.callParticipantVideoStateChanged(userId: userId, clientId: clientId, videoState: videoState)
+        snapshot?.callParticipantVideoStateChanged(client: client, videoState: videoState)
     }
 
     /// Call this method when the client established an audio connection with another user, and avs calls the `wcall_estab_h`.
-    func callParticipantAudioEstablished(conversationId: UUID, userId: UUID, clientId: String) {
-        callSnapshots[conversationId]?.callParticipants.callParticipantAudioEstablished(userId: userId, clientId: clientId)
+    func callParticipantAudioEstablished(conversationId: UUID, client: AVSClient) {
+        callSnapshots[conversationId]?.callParticipants.callParticipantAudioEstablished(client: client)
     }
 
     /// Call this method when the network quality of a participant changes and avs calls the `wcall_network_quality_h`.
-    func callParticipantNetworkQualityChanged(conversationId: UUID,
-                                              userId: UUID,
-                                              clientId: String,
-                                              quality: NetworkQuality) {
+    func callParticipantNetworkQualityChanged(conversationId: UUID, client: AVSClient, quality: NetworkQuality) {
 
         let snapshot = callSnapshots[conversationId]?.callParticipants
-        snapshot?.callParticipantNetworkQualityChanged(userId: userId, clientId: clientId, networkQuality: quality)
+        snapshot?.callParticipantNetworkQualityChanged(client: client, networkQuality: quality)
     }
     
 }

--- a/Tests/Source/Calling/CallParticipantsSnapshotTests.swift
+++ b/Tests/Source/Calling/CallParticipantsSnapshotTests.swift
@@ -27,8 +27,10 @@ class CallParticipantsSnapshotTests: MessagingTest {
     var mockWireCallCenterV3: WireCallCenterV3Mock!
     var mockFlowManager: FlowManagerMock!
 
-    private let alice = User()
-    private let bob = User()
+    private var aliceIphone: AVSClient!
+    private var aliceDesktop: AVSClient!
+    private var bobIphone: AVSClient!
+    private var bobDesktop: AVSClient!
 
     override func setUp() {
         super.setUp()
@@ -38,6 +40,14 @@ class CallParticipantsSnapshotTests: MessagingTest {
                                                     uiMOC: uiMOC,
                                                     flowManager: mockFlowManager,
                                                     transport: WireCallCenterTransportMock())
+
+        let aliceId = UUID()
+        let bobId = UUID()
+
+        aliceIphone = AVSClient(userId: aliceId, clientId: "iphone")
+        aliceDesktop = AVSClient(userId: aliceId, clientId: "desktop")
+        bobIphone = AVSClient(userId: bobId, clientId: "iphone")
+        bobDesktop = AVSClient(userId: bobId, clientId: "desktop")
     }
     
     override func tearDown() {
@@ -54,8 +64,8 @@ class CallParticipantsSnapshotTests: MessagingTest {
 
     func testThat_ItDoesNotCrash_WhenInitialized_WithDuplicateCallMembers(){
         // Given
-        let member1 = AVSCallMember(userId: alice.userId, clientId: alice.iphone, audioState: .established)
-        let member2 = AVSCallMember(userId: alice.userId, clientId: alice.iphone, audioState: .connecting)
+        let member1 = AVSCallMember(client: aliceIphone, audioState: .established)
+        let member2 = AVSCallMember(client: aliceIphone, audioState: .connecting)
 
         // When
         let sut = createSut(members: [member1, member2])
@@ -67,8 +77,8 @@ class CallParticipantsSnapshotTests: MessagingTest {
     
     func testThat_ItDoesNotCrash_WhenUpdated_WithDuplicateCallMembers(){
         // Given
-        let member1 = AVSCallMember(userId: alice.userId, clientId: alice.iphone, audioState: .established)
-        let member2 = AVSCallMember(userId: alice.userId, clientId: alice.iphone, audioState: .connecting)
+        let member1 = AVSCallMember(client: aliceIphone, audioState: .established)
+        let member2 = AVSCallMember(client: aliceIphone, audioState: .connecting)
         let sut = createSut(members: [])
 
         // when
@@ -80,8 +90,8 @@ class CallParticipantsSnapshotTests: MessagingTest {
 
     func testThat_ItDoesNotConsider_AUserWithMultipleDevices_AsDuplicated() {
         // Given
-        let member1 = AVSCallMember(userId: alice.userId, clientId: alice.iphone, audioState: .established)
-        let member2 = AVSCallMember(userId: alice.userId, clientId: alice.desktop, audioState: .connecting)
+        let member1 = AVSCallMember(client: aliceIphone, audioState: .established)
+        let member2 = AVSCallMember(client: aliceDesktop, audioState: .connecting)
 
         // When
         let sut = createSut(members: [member1, member2])
@@ -94,10 +104,10 @@ class CallParticipantsSnapshotTests: MessagingTest {
 
     func testThat_ItTakesTheWorstNetworkQuality_FromParticipants() {
         // Given
-        let normalQuality = AVSCallMember(userId: alice.userId, clientId: alice.iphone, networkQuality: .normal)
-        let mediumQuality = AVSCallMember(userId: alice.userId, clientId: alice.desktop, networkQuality: .medium)
-        let poorQuality = AVSCallMember(userId: bob.userId, clientId: bob.iphone, networkQuality: .poor)
-        let problemQuality = AVSCallMember(userId: bob.userId, clientId: bob.desktop, networkQuality: .problem)
+        let normalQuality = AVSCallMember(client: aliceIphone, networkQuality: .normal)
+        let mediumQuality = AVSCallMember(client: aliceDesktop, networkQuality: .medium)
+        let poorQuality = AVSCallMember(client: bobIphone, networkQuality: .poor)
+        let problemQuality = AVSCallMember(client: bobDesktop, networkQuality: .problem)
         let sut = createSut(members: [])
 
         XCTAssertEqual(sut.networkQuality, .normal)
@@ -127,63 +137,63 @@ class CallParticipantsSnapshotTests: MessagingTest {
 
     func testThat_ItUpdatesNetworkQuality_WhenItChangesForParticipant() {
         // Given
-        let member1 = AVSCallMember(userId: alice.userId, clientId: alice.iphone, audioState: .established, networkQuality: .normal)
-        let member2 = AVSCallMember(userId: bob.userId, clientId: bob.iphone, audioState: .established, networkQuality: .normal)
+        let member1 = AVSCallMember(client: aliceIphone, audioState: .established, networkQuality: .normal)
+        let member2 = AVSCallMember(client: bobIphone, audioState: .established, networkQuality: .normal)
         let sut = createSut(members: [member1, member2])
 
         XCTAssertEqual(sut.networkQuality, .normal)
 
         // When, then
-        sut.callParticipantNetworkQualityChanged(userId: member1.remoteId, clientId: member1.clientId, networkQuality: .medium)
+        sut.callParticipantNetworkQualityChanged(client: member1.client, networkQuality: .medium)
         XCTAssertEqual(sut.networkQuality, .medium)
 
         // When, then
-        sut.callParticipantNetworkQualityChanged(userId: member2.remoteId, clientId: member2.clientId, networkQuality: .poor)
+        sut.callParticipantNetworkQualityChanged(client: member2.client, networkQuality: .poor)
         XCTAssertEqual(sut.networkQuality, .poor)
 
         // When, then
-        sut.callParticipantNetworkQualityChanged(userId: member1.remoteId, clientId: member1.clientId, networkQuality: .normal)
-        sut.callParticipantNetworkQualityChanged(userId: member2.remoteId, clientId: member2.clientId, networkQuality: .normal)
+        sut.callParticipantNetworkQualityChanged(client: member1.client, networkQuality: .normal)
+        sut.callParticipantNetworkQualityChanged(client: member2.client, networkQuality: .normal)
         XCTAssertEqual(sut.networkQuality, .normal)
     }
 
     func testThat_ItUpdatesAudioState_WhenItChangesForParticipant() {
         // Given
-        let member1 = AVSCallMember(userId: alice.userId, clientId: alice.iphone, audioState: .connecting)
-        let member2 = AVSCallMember(userId: bob.userId, clientId: bob.iphone, audioState: .connecting)
+        let member1 = AVSCallMember(client: aliceIphone, audioState: .connecting)
+        let member2 = AVSCallMember(client: bobIphone, audioState: .connecting)
         let sut = createSut(members: [member1, member2])
 
         // When
-        sut.callParticipantAudioEstablished(userId: member1.remoteId, clientId: member1.clientId)
+        sut.callParticipantAudioEstablished(client: member1.client)
 
         // Then
-        let updatedMember1 = AVSCallMember(userId: alice.userId, clientId: alice.iphone, audioState: .established)
+        let updatedMember1 = AVSCallMember(client: aliceIphone, audioState: .established)
         XCTAssertEqual(sut.members.array, [updatedMember1, member2])
     }
 
     func testThat_ItUpdatesVideoState_WhenItChangesForParticipant() {
         // Given
-        let member1 = AVSCallMember(userId: alice.userId, clientId: alice.iphone, videoState: .stopped)
-        let member2 = AVSCallMember(userId: bob.userId, clientId: bob.iphone, videoState: .stopped)
+        let member1 = AVSCallMember(client: aliceIphone, videoState: .stopped)
+        let member2 = AVSCallMember(client: bobIphone, videoState: .stopped)
         let sut = createSut(members: [member1, member2])
 
         // When
-        sut.callParticipantVideoStateChanged(userId: member1.remoteId, clientId: member1.clientId, videoState: .screenSharing)
+        sut.callParticipantVideoStateChanged(client: member1.client, videoState: .screenSharing)
 
         // Then
-        let updatedMember1 = AVSCallMember(userId: alice.userId, clientId: alice.iphone, videoState: .screenSharing)
+        let updatedMember1 = AVSCallMember(client: aliceIphone, videoState: .screenSharing)
         XCTAssertEqual(sut.members.array, [updatedMember1, member2])
     }
 
     func testThat_ItDoesNotUpdateMember_WhenNoMatchFound() {
         // Given
-        let member1 = AVSCallMember(userId: alice.userId, clientId: alice.iphone, videoState: .stopped)
-        let member2 = AVSCallMember(userId: bob.userId, clientId: bob.iphone, videoState: .stopped)
+        let member1 = AVSCallMember(client: aliceIphone, videoState: .stopped)
+        let member2 = AVSCallMember(client: bobIphone, videoState: .stopped)
         let sut = createSut(members: [member1, member2])
 
         // When
-        let unknownMember = AVSCallMember(userId: alice.userId, clientId: alice.desktop, videoState: .stopped)
-        sut.callParticipantVideoStateChanged(userId: unknownMember.remoteId, clientId: unknownMember.clientId, videoState: .screenSharing)
+        let unknownMember = AVSCallMember(client: aliceDesktop, videoState: .stopped)
+        sut.callParticipantVideoStateChanged(client: unknownMember.client, videoState: .screenSharing)
 
         // Then
         XCTAssertEqual(sut.members.array, [member1, member2])
@@ -191,13 +201,3 @@ class CallParticipantsSnapshotTests: MessagingTest {
 
 }
 
-private extension CallParticipantsSnapshotTests {
-
-    struct User {
-
-        let userId = UUID()
-        let iphone = "String"
-        let desktop = "Desktop"
-
-    }
-}

--- a/Tests/Source/Calling/VoiceChannelV3Tests.swift
+++ b/Tests/Source/Calling/VoiceChannelV3Tests.swift
@@ -86,14 +86,14 @@ class VoiceChannelV3Tests : MessagingTest {
 
     func testThatItForwardsNetworkQualityFromCallCenter() {
         // given
-        let calledId = UUID()
-        let clientId = UUID().transportString()
-        wireCallCenterMock?.setMockCallState(.established, conversationId: conversation!.remoteIdentifier!, callerId: calledId, isVideo: false)
+        let caller = AVSClient(userId: UUID(), clientId: UUID().transportString())
+        wireCallCenterMock?.setMockCallState(.established, conversationId: conversation!.remoteIdentifier!, callerId: caller.userId, isVideo: false)
         let quality = NetworkQuality.poor
         XCTAssertEqual(sut.networkQuality, .normal)
 
         // when
-        wireCallCenterMock?.handleNetworkQualityChange(conversationId: conversation!.remoteIdentifier!, userId: calledId, clientId: clientId, quality: quality)
+
+        wireCallCenterMock?.handleNetworkQualityChange(conversationId: conversation!.remoteIdentifier!, client: caller, quality: quality)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then

--- a/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -123,8 +123,7 @@ class WireCallCenterV3Tests: MessagingTest {
         checkThatItPostsNotification(expectedCallState: .incoming(video: true, shouldRing: false, degraded: false), expectedCallerId: otherUserID, expectedConversationId: oneOnOneConversationID) {
             sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                    messageTime: Date(),
-                                   userId: otherUserID,
-                                   clientId: otherUserClientID,
+                                   client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                    isVideoCall: true,
                                    shouldRing: false)
         }
@@ -134,8 +133,7 @@ class WireCallCenterV3Tests: MessagingTest {
         checkThatItPostsNotification(expectedCallState: .incoming(video: false, shouldRing: false, degraded: false), expectedCallerId: otherUserID, expectedConversationId: oneOnOneConversationID) {
             sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                    messageTime: Date(),
-                                   userId: otherUserID,
-                                   clientId: otherUserClientID,
+                                   client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                    isVideoCall: false,
                                    shouldRing: false)
         }
@@ -145,8 +143,7 @@ class WireCallCenterV3Tests: MessagingTest {
         checkThatItPostsNotification(expectedCallState: .incoming(video: true, shouldRing: true, degraded: false), expectedCallerId: otherUserID, expectedConversationId: oneOnOneConversationID) {
             sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                    messageTime: Date(),
-                                   userId: otherUserID,
-                                   clientId: otherUserClientID,
+                                   client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                    isVideoCall: true,
                                    shouldRing: true)
         }
@@ -156,8 +153,7 @@ class WireCallCenterV3Tests: MessagingTest {
         checkThatItPostsNotification(expectedCallState: .incoming(video: false, shouldRing: true, degraded: false), expectedCallerId: otherUserID, expectedConversationId: oneOnOneConversationID) {
             sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                    messageTime: Date(),
-                                   userId: otherUserID,
-                                   clientId: otherUserClientID,
+                                   client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                    isVideoCall: false,
                                    shouldRing: true)
         }
@@ -193,8 +189,7 @@ class WireCallCenterV3Tests: MessagingTest {
         // given
         sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
+                               client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
                                shouldRing: true)
 
@@ -209,15 +204,14 @@ class WireCallCenterV3Tests: MessagingTest {
         // given
         sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
+                               client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
                                shouldRing: true)
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         checkThatItPostsNotification(expectedCallState: .established, expectedCallerId: otherUserID, expectedConversationId: oneOnOneConversationID) {
-            sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
+            sut.handleEstablishedCall(conversationId: oneOnOneConversationID, client: AVSClient(userId: otherUserID, clientId: otherUserClientID))
         }
     }
     
@@ -225,8 +219,7 @@ class WireCallCenterV3Tests: MessagingTest {
         // given
         sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
+                               client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
                                shouldRing: true)
 
@@ -235,7 +228,7 @@ class WireCallCenterV3Tests: MessagingTest {
         
         // when
         checkThatItPostsNotification(expectedCallState: .established, expectedCallerId: otherUserID, expectedConversationId: oneOnOneConversationID) {
-            sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
+            sut.handleEstablishedCall(conversationId: oneOnOneConversationID, client: AVSClient(userId: otherUserID, clientId: otherUserClientID))
         }
         
         // then
@@ -246,8 +239,7 @@ class WireCallCenterV3Tests: MessagingTest {
         // given
         sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
+                               client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
                                shouldRing: true)
 
@@ -255,14 +247,14 @@ class WireCallCenterV3Tests: MessagingTest {
         XCTAssertNil(sut.establishedDate)
         
         // call is established
-        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
+        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, client: AVSClient(userId: otherUserID, clientId: otherUserClientID))
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         XCTAssertNotNil(sut.establishedDate)
         let previousEstablishedDate = sut.establishedDate
         spinMainQueue(withTimeout: 0.1)
         
         // when
-        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
+        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, client: AVSClient(userId: otherUserID, clientId: otherUserClientID))
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then
@@ -273,8 +265,7 @@ class WireCallCenterV3Tests: MessagingTest {
         // given
         sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
+                               client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
                                shouldRing: true)
 
@@ -289,8 +280,7 @@ class WireCallCenterV3Tests: MessagingTest {
         // given
         sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
+                               client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
                                shouldRing: true)
 
@@ -305,15 +295,13 @@ class WireCallCenterV3Tests: MessagingTest {
         // given
         sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
+                               client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
                                shouldRing: true)
 
         sut.handleIncomingCall(conversationId: groupConversationID,
                                messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
+                               client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
                                shouldRing: true)
 
@@ -332,8 +320,7 @@ class WireCallCenterV3Tests: MessagingTest {
 
         sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
+                               client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
                                shouldRing: true)
 
@@ -350,8 +337,7 @@ class WireCallCenterV3Tests: MessagingTest {
         // given
         sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
+                               client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
                                shouldRing: true)
 
@@ -368,8 +354,7 @@ class WireCallCenterV3Tests: MessagingTest {
         // given
         sut.handleIncomingCall(conversationId: groupConversationID,
                                messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
+                               client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
                                shouldRing: true)
 
@@ -397,8 +382,7 @@ class WireCallCenterV3Tests: MessagingTest {
         // given
         sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
+                               client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
                                shouldRing: true)
 
@@ -426,8 +410,7 @@ class WireCallCenterV3Tests: MessagingTest {
         // given
         sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
+                               client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
                                shouldRing: true)
 
@@ -453,8 +436,7 @@ class WireCallCenterV3Tests: MessagingTest {
 
         sut.handleIncomingCall(conversationId: groupConversationID,
                                messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
+                               client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
                                shouldRing: true)
 
@@ -473,8 +455,7 @@ class WireCallCenterV3Tests: MessagingTest {
         // given
         sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
+                               client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: true,
                                shouldRing: true)
 
@@ -494,8 +475,7 @@ class WireCallCenterV3Tests: MessagingTest {
         // given
         sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
+                               client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: true,
                                shouldRing: true)
 
@@ -567,8 +547,7 @@ class WireCallCenterV3Tests: MessagingTest {
         // given
         sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
+                               client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
                                shouldRing: true)
 
@@ -582,7 +561,7 @@ class WireCallCenterV3Tests: MessagingTest {
         }
         
         // when
-        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
+        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, client: AVSClient(userId: otherUserID, clientId: otherUserClientID))
 
         // then
         XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
@@ -741,13 +720,12 @@ extension WireCallCenterV3Tests {
         // given
         sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
+                               client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
                                shouldRing: true)
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
+        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, client: AVSClient(userId: otherUserID, clientId: otherUserClientID))
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // when
@@ -762,13 +740,12 @@ extension WireCallCenterV3Tests {
         // given
         sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
+                               client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
                                shouldRing: true)
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        sut.handleDataChannelEstablishement(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
+        sut.handleDataChannelEstablishement(conversationId: oneOnOneConversationID, client: AVSClient(userId: otherUserID, clientId: otherUserClientID))
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
@@ -783,13 +760,12 @@ extension WireCallCenterV3Tests {
         // given
         sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
+                               client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
                                shouldRing: true)
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
+        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, client: AVSClient(userId: otherUserID, clientId: otherUserClientID))
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         sut.handleConstantBitRateChange(enabled: true)
@@ -808,8 +784,7 @@ extension WireCallCenterV3Tests {
         // given
         sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
+                               client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
                                shouldRing: true)
 
@@ -827,13 +802,12 @@ extension WireCallCenterV3Tests {
         // given
         sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
+                               client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
                                shouldRing: true)
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
+        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, client: AVSClient(userId: otherUserID, clientId: otherUserClientID))
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         sut.handleConstantBitRateChange(enabled: true)
@@ -855,8 +829,7 @@ extension WireCallCenterV3Tests {
         // given
         sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
+                               client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
                                shouldRing: true)
 
@@ -870,18 +843,17 @@ extension WireCallCenterV3Tests {
         // given
         sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
+                               client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
                                shouldRing: true)
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
+        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, client: AVSClient(userId: otherUserID, clientId: otherUserClientID))
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         let quality = NetworkQuality.poor
 
         // when
-        sut.handleNetworkQualityChange(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID, quality: quality)
+        sut.handleNetworkQualityChange(conversationId: oneOnOneConversationID, client: AVSClient(userId: otherUserID, clientId: otherUserClientID), quality: quality)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
@@ -902,13 +874,12 @@ extension WireCallCenterV3Tests {
         // given
         sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
+                               client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
                                shouldRing: true)
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, userId: otherUserID, clientId: otherUserClientID)
+        sut.handleEstablishedCall(conversationId: oneOnOneConversationID, client: AVSClient(userId: otherUserID, clientId: otherUserClientID))
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         let observer = MuteObserver()
         let token = WireCallCenterV3.addMuteStateObserver(observer: observer, context: uiMOC)
@@ -934,8 +905,7 @@ extension WireCallCenterV3Tests {
         // given
         sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
+                               client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
                                shouldRing: true)
 
@@ -952,8 +922,7 @@ extension WireCallCenterV3Tests {
         // given
         sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
+                               client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
                                shouldRing: true)
 
@@ -970,8 +939,7 @@ extension WireCallCenterV3Tests {
         // given
         sut.handleIncomingCall(conversationId: groupConversationID,
                                messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
+                               client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
                                shouldRing: true)
 
@@ -988,8 +956,7 @@ extension WireCallCenterV3Tests {
         // given
         sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
+                               client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
                                shouldRing: true)
 
@@ -1012,8 +979,7 @@ extension WireCallCenterV3Tests {
         // when
         sut.handleIncomingCall(conversationId: oneOnOneConversationID,
                                messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
+                               client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
                                shouldRing: true)
 
@@ -1059,8 +1025,7 @@ extension WireCallCenterV3Tests {
         // when
         sut.handleIncomingCall(conversationId: groupConversationID,
                                messageTime: Date(),
-                               userId: otherUserID,
-                               clientId: otherUserClientID,
+                               client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
                                shouldRing: true)
         

--- a/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -986,7 +986,9 @@ extension WireCallCenterV3Tests {
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
-        XCTAssertEqual(sut.callParticipants(conversationId: oneOnOneConversationID), [CallParticipant(user: otherUser, state: .connecting)])
+        let actual = sut.callParticipants(conversationId: oneOnOneConversationID)
+        let expected = [CallParticipant(user: otherUser, clientId: otherUserClientID, state: .connecting)]
+        XCTAssertEqual(actual, expected)
     }
 
     func callBackMemberHandler(conversationId: UUID, userId: UUID, clientId: String, audioEstablished: Bool) {
@@ -1008,7 +1010,9 @@ extension WireCallCenterV3Tests {
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then
-        XCTAssertEqual(sut.callParticipants(conversationId: oneOnOneConversationID), [CallParticipant(user: otherUser, state: .connecting)])
+        let actual = sut.callParticipants(conversationId: oneOnOneConversationID)
+        let expected = [CallParticipant(user: otherUser, clientId: otherUserClientID, state: .connecting)]
+        XCTAssertEqual(actual, expected)
     }
 
     func testThatItUpdatesTheParticipantsWhenGroupHandlerIsCalled() {
@@ -1018,7 +1022,9 @@ extension WireCallCenterV3Tests {
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
-        XCTAssertEqual(sut.callParticipants(conversationId: groupConversationID), [CallParticipant(user: otherUser, state: .connecting)])
+        let actual = sut.callParticipants(conversationId: groupConversationID)
+        let expected = [CallParticipant(user: otherUser, clientId: otherUserClientID, state: .connecting)]
+        XCTAssertEqual(actual, expected)
     }
 
     func testThatItUpdatesTheStateForParticipant() {
@@ -1032,14 +1038,18 @@ extension WireCallCenterV3Tests {
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
-        XCTAssertEqual(sut.callParticipants(conversationId: groupConversationID), [CallParticipant(user: otherUser, state: .connecting)])
+        var actual = sut.callParticipants(conversationId: groupConversationID)
+        var expected = [CallParticipant(user: otherUser, clientId: otherUserClientID, state: .connecting)]
+        XCTAssertEqual(actual, expected)
 
         // when
         callBackMemberHandler(conversationId: groupConversationID, userId: otherUserID, clientId: otherUserClientID, audioEstablished: true)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
-        XCTAssertEqual(sut.callParticipants(conversationId: groupConversationID), [CallParticipant(user: otherUser, state: .connected(videoState: .stopped, clientId: otherUserClientID))])
+        actual = sut.callParticipants(conversationId: groupConversationID)
+        expected = [CallParticipant(user: otherUser, clientId: otherUserClientID, state: .connected(videoState: .stopped))]
+        XCTAssertEqual(actual, expected)
     }
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

A call participant is identified by both a user id and a client id. Currently the client id of a participant is shared by AVS through certain callbacks. As a result, we often have an incomplete / insufficient data to uniquely identify participants and it leads to the extra complexity of having an optional client id when it should be non optional.

### Solutions

With AVS 6, we are given the client id in more callbacks, which allows us to make the call participants client id non optional. This leads to further refactoring, such as modeling an `AVSClient` as a pair of user id and client id, to represent some device in a call.

## Notes

The AVS binary is not yet published, therefore the current version of AVS is running in this PR. As a result this may not build or tests may fail.
