### PR TITLE
[Feature] AVS 6: provide a list of clients

### DIFF
--- a/Source/Calling/AVSCallMember.swift
+++ b/Source/Calling/AVSCallMember.swift
@@ -139,21 +139,9 @@ extension AVSClient: Codable {
 
     enum CodingKeys: String, CodingKey {
         
-        case userid
-        case clientid
+        case userId = "userid"
+        case clientId = "clientid"
 
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        userId = try container.decode(UUID.self, forKey: .userid)
-        clientId = try container.decode(String.self, forKey: .clientid)
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(userId, forKey: .userid)
-        try container.encode(clientId, forKey: .clientid)
     }
 
 }

--- a/Source/Calling/AVSWrapper+Handlers.swift
+++ b/Source/Calling/AVSWrapper+Handlers.swift
@@ -176,8 +176,8 @@ extension AVSWrapper {
 
         /// Callback used to request a the list of clients in a conversation.
         ///
-        /// typedef void (wcall_req_clients_h)(const char *convid, void *arg);
+        /// typedef void (wcall_req_clients_h)(WUSER_HANDLE wuser, const char *convid, void *arg);
 
-        typealias RequestClients = @convention(c) (StringPtr, ContextRef) -> Void
+        typealias RequestClients = @convention(c) (UInt32, StringPtr, ContextRef) -> Void
     }
 }

--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -94,6 +94,7 @@ public class AVSWrapper: AVSWrapperType {
         wcall_set_media_stopped_handler(handle, mediaStoppedChangeHandler)
         wcall_set_mute_handler(handle, muteChangeHandler, observer)
         wcall_set_participant_changed_handler(handle, callParticipantHandler, observer)
+        wcall_set_req_clients_handler(handle, requestClientsHandler)
     }
 
     // MARK: - Convenience Methods
@@ -278,4 +279,13 @@ public class AVSWrapper: AVSWrapperType {
             $0.handleMuteChange(muted: $1)
         }
     }
+
+    private let requestClientsHandler: Handler.RequestClients = { handle, conversationIdRef, contextRef in
+        AVSWrapper.withCallCenter(contextRef, conversationIdRef) {
+            $0.handleClientsRequest(conversationId: $1) { (clients: String) in
+                wcall_set_clients_for_conv(handle, conversationIdRef, clients)
+            }
+        }
+    }
+
 }

--- a/Source/Calling/WireCallCenterV3+Events.swift
+++ b/Source/Calling/WireCallCenterV3+Events.swift
@@ -286,8 +286,6 @@ extension WireCallCenterV3 {
         }
     }
 
-    // TODO: Test
-
     func handleClientsRequest(conversationId: UUID, completion: @escaping (_ clients: String) -> Void) {
         handleEventInContext("request-clients") { context in
             guard let conversation = ZMConversation(remoteID: conversationId, createIfNeeded: false, in: context) else {


### PR DESCRIPTION
## What's new in this PR?

A new requirement of AVS is that a list of user clients for a particular conversation must be provided on demand. AVS makes this request through the new `wcall_req_clients_h` handler (aka `Handler.RequestClients`).

When the handler is called, we must determine all clients (except the self client) in the given conversation and return it to AVS in json format. A client (aka `AVSClient`) is simply a user id and client id pair which was introduce in https://github.com/wireapp/wire-ios-sync-engine/pull/1209.

This PR enables json encoding of `AVSClient`, defines the handler and sets up the callbacks.

## Notes

The AVS binary is not yet published, therefore the current version of AVS is running in this PR. As a result this may not build or tests may fail.
