### PR TITLE
[Fix] SSO detection on iOS 13

### DIFF
--- a/Source/Registration/Company/CompanyLoginRequestDetector.swift
+++ b/Source/Registration/Company/CompanyLoginRequestDetector.swift
@@ -49,7 +49,7 @@ public final class CompanyLoginRequestDetector: NSObject {
     
     private let pasteboard: Pasteboard
     private let processQueue = DispatchQueue(label: "WireSyncEngine.SharedIdentitySessionRequestDetector")
-    private var previousChangeCount: Int?
+    private var previouslyDetectedSSOCode: String?
     
     // MARK: - Initialization
 
@@ -72,19 +72,19 @@ public final class CompanyLoginRequestDetector: NSObject {
 
     public func detectCopiedRequestCode(_ completionHandler: @escaping (DetectorResult?) -> Void) {
         func complete(_ result: DetectorResult?) {
-            previousChangeCount = pasteboard.changeCount
+            previouslyDetectedSSOCode = result?.code
             DispatchQueue.main.async {
                 completionHandler(result)
             }
         }
 
-        processQueue.async { [pasteboard, previousChangeCount] in
+        processQueue.async { [pasteboard, previouslyDetectedSSOCode] in
             guard let text = pasteboard.text else { return complete(nil) }
             guard let code = CompanyLoginRequestDetector.requestCode(in: text) else { return complete(nil) }
 
-            let validText = "wire-" + code.uuidString
-            let isNew = pasteboard.changeCount != previousChangeCount
-            complete(.init(code: validText, isNew: isNew))
+            let validSSOCode = "wire-" + code.uuidString
+            let isNew = validSSOCode != previouslyDetectedSSOCode
+            complete(.init(code: validSSOCode, isNew: isNew))
         }
     }
 

--- a/Source/Utility/Pasteboard.swift
+++ b/Source/Utility/Pasteboard.swift
@@ -26,7 +26,6 @@ public protocol Pasteboard: class {
 
     /// The text copied by the user, if any.
     var text: String? { get }
-    var changeCount: Int { get }
 
 }
 

--- a/Tests/Source/MockPasteboard.swift
+++ b/Tests/Source/MockPasteboard.swift
@@ -20,5 +20,4 @@
 
 class MockPasteboard: Pasteboard {
     var text: String?
-    var changeCount: Int = 0
 }

--- a/Tests/Source/Registration/CompanyLoginRequestDetectorTests.swift
+++ b/Tests/Source/Registration/CompanyLoginRequestDetectorTests.swift
@@ -166,11 +166,10 @@ class CompanyLoginRequestDetectorTests: XCTestCase {
         XCTAssertNil(detectedCode)
     }
     
-    func testThatItSetsIsNewOnTheResultIfTheChangeCountIncreased() {
+    func testThatItSetsIsNewOnTheResultIfTheCodeHasChanged() {
         // GIVEN
         let code = "wire-81DD91BA-B3D0-46F0-BC29-E491938F0A54"
         pasteboard.text = code
-        pasteboard.changeCount = 41
         
         do {
             let detectionExpectation = expectation(description: "Detector returns a result")
@@ -197,7 +196,8 @@ class CompanyLoginRequestDetectorTests: XCTestCase {
         }
 
         // WHEN
-        pasteboard.changeCount = 42
+        let changedCode = "wire-81DD91BA-B3D0-46F0-BC29-E491938F0A55"
+        pasteboard.text = changedCode
         
         // THEN
         do {
@@ -205,7 +205,7 @@ class CompanyLoginRequestDetectorTests: XCTestCase {
             
             detector.detectCopiedRequestCode {
                 XCTAssertEqual($0?.isNew, true)
-                XCTAssertEqual($0?.code, code)
+                XCTAssertEqual($0?.code, changedCode)
                 detectionExpectation.fulfill()
             }
             
@@ -213,11 +213,10 @@ class CompanyLoginRequestDetectorTests: XCTestCase {
         }
     }
     
-    func testThatItDoesNotSetIsNewOnTheResultIfTheChangeCountDidNotIncrease() {
+    func testThatItDoesNotSetIsNewOnTheResultIfTheCodeHasChanged() {
         // GIVEN
         let code = "wire-81DD91BA-B3D0-46F0-BC29-E491938F0A54"
         pasteboard.text = code
-        pasteboard.changeCount = 42
         
         // WHEN
         do {


### PR DESCRIPTION
## What's new in this PR?

### Issues

SSO code would get detected over and over again on iOS 13.

### Causes

I suspect that `UIPasteboard.changeCount` behaves differently on iOS 13 

### Solutions

Calculate `isNew` by comparing the SSO string instead.