### PR TITLE
[Feature] AVS 6: Use participant change handler for audio / video state updates

### DIFF
--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -171,9 +171,7 @@ public class AVSWrapper: AVSWrapperType {
     }
 
     private let videoStateChangeHandler: Handler.VideoStateChange = { conversationId, userId, clientId, state, contextRef in
-        AVSWrapper.withCallCenter(contextRef, userId, clientId, state) {
-            $0.handleVideoStateChange(client: AVSClient(userId: $1, clientId: $2), newState: $3)
-        }
+        // Video state changes are now communicated through the json payload of the call participant handler.
     }
 
     private let incomingCallHandler: Handler.IncomingCall = { conversationId, messageTime, userId, clientId, isVideoCall, shouldRing, contextRef in

--- a/Source/Calling/CallParticipantSnapshot.swift
+++ b/Source/Calling/CallParticipantSnapshot.swift
@@ -51,38 +51,20 @@ class CallParticipantsSnapshot {
         notifyChange()
     }
 
-    func callParticipantVideoStateChanged(client: AVSClient, videoState: VideoState) {
-        updateMember(client: client, videoState: videoState)
-    }
-
-    func callParticipantAudioEstablished(client: AVSClient) {
-        updateMember(client: client, audioState: .established)
-    }
-
     func callParticipantNetworkQualityChanged(client: AVSClient, networkQuality: NetworkQuality) {
-        updateMember(client: client, networkQuality: networkQuality)
-    }
-
-    // MARK: - Helpers
-
-    /// Updates the locally stored member for the given userId and clientId with the given non nil properties.
-
-    private func updateMember(client: AVSClient,
-                              audioState: AudioState? = nil,
-                              videoState: VideoState? = nil,
-                              networkQuality: NetworkQuality? = nil) {
-
         guard let localMember = findMember(with: client) else { return }
 
         let updatedMember = AVSCallMember(client: client,
-                                          audioState: audioState ?? localMember.audioState,
-                                          videoState: videoState ?? localMember.videoState,
-                                          networkQuality: networkQuality ?? localMember.networkQuality)
+                                          audioState: localMember.audioState,
+                                          videoState: localMember.videoState,
+                                          networkQuality: networkQuality)
 
         members = OrderedSetState(array: members.array.map({ member in
             member == localMember ? updatedMember : member
         }))
     }
+
+    // MARK: - Helpers
 
     /// Returns the member matching the given userId and clientId.
 

--- a/Source/Calling/WireCallCenterV3+Events.swift
+++ b/Source/Calling/WireCallCenterV3+Events.swift
@@ -132,8 +132,6 @@ extension WireCallCenterV3 {
                 self.establishedDate = Date()
             }
 
-            self.callParticipantAudioEstablished(conversationId: conversationId, client: client)
-
             if self.videoState(conversationId: conversationId) == .started {
                 self.avsWrapper.setVideoState(conversationId: conversationId, videoState: .started)
             }
@@ -230,15 +228,6 @@ extension WireCallCenterV3 {
                 self.callParticipantsChanged(conversationId: change.convid, participants: members)
             } catch {
                 zmLog.safePublic("Cannot decode participant change JSON")
-            }
-        }
-    }
-
-    /// Handles video state changes.
-    func handleVideoStateChange(client: AVSClient, newState: VideoState) {
-        handleEvent("video-state-change") {
-            self.nonIdleCalls.forEach {
-                self.callParticipantVideoStateChanged(conversationId: $0.key, client: client, videoState: newState)
             }
         }
     }

--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -322,18 +322,6 @@ extension WireCallCenterV3 {
         callSnapshots[conversationId]?.callParticipants.callParticipantsChanged(participants: participants)
     }
 
-    /// Call this method when the video state of a participant changes and avs calls the `wcall_video_state_change_h`.
-    func callParticipantVideoStateChanged(conversationId: UUID, client: AVSClient, videoState: VideoState) {
-
-        let snapshot = callSnapshots[conversationId]?.callParticipants
-        snapshot?.callParticipantVideoStateChanged(client: client, videoState: videoState)
-    }
-
-    /// Call this method when the client established an audio connection with another user, and avs calls the `wcall_estab_h`.
-    func callParticipantAudioEstablished(conversationId: UUID, client: AVSClient) {
-        callSnapshots[conversationId]?.callParticipants.callParticipantAudioEstablished(client: client)
-    }
-
     /// Call this method when the network quality of a participant changes and avs calls the `wcall_network_quality_h`.
     func callParticipantNetworkQualityChanged(conversationId: UUID, client: AVSClient, quality: NetworkQuality) {
 

--- a/Tests/Source/Calling/CallParticipantsSnapshotTests.swift
+++ b/Tests/Source/Calling/CallParticipantsSnapshotTests.swift
@@ -157,6 +157,21 @@ class CallParticipantsSnapshotTests: MessagingTest {
         XCTAssertEqual(sut.networkQuality, .normal)
     }
 
+    func testThat_ItDoesNotUpdateNetworkQuality_WhenNoMatchFound() {
+        // Given
+        let member1 = AVSCallMember(client: aliceIphone, videoState: .stopped)
+        let member2 = AVSCallMember(client: bobIphone, videoState: .stopped)
+        let sut = createSut(members: [member1, member2])
+
+        // When
+        let unknownMember = AVSCallMember(client: aliceDesktop, videoState: .stopped)
+        sut.callParticipantNetworkQualityChanged(client: unknownMember.client, networkQuality: .problem)
+
+        // Then
+        XCTAssertEqual(sut.members.array, [member1, member2])
+    }
+
+
     func testThat_ItUpdatesAudioState_WhenItChangesForParticipant() {
         // Given
         let member1 = AVSCallMember(client: aliceIphone, audioState: .connecting)
@@ -164,10 +179,10 @@ class CallParticipantsSnapshotTests: MessagingTest {
         let sut = createSut(members: [member1, member2])
 
         // When
-        sut.callParticipantAudioEstablished(client: member1.client)
+        let updatedMember1 = member1.with(audioState: .established)
+        sut.callParticipantsChanged(participants: [updatedMember1, member2])
 
         // Then
-        let updatedMember1 = AVSCallMember(client: aliceIphone, audioState: .established)
         XCTAssertEqual(sut.members.array, [updatedMember1, member2])
     }
 
@@ -178,26 +193,29 @@ class CallParticipantsSnapshotTests: MessagingTest {
         let sut = createSut(members: [member1, member2])
 
         // When
-        sut.callParticipantVideoStateChanged(client: member1.client, videoState: .screenSharing)
+        let updatedMember1 = member1.with(videoState: .screenSharing)
+        sut.callParticipantsChanged(participants: [updatedMember1, member2])
 
         // Then
-        let updatedMember1 = AVSCallMember(client: aliceIphone, videoState: .screenSharing)
         XCTAssertEqual(sut.members.array, [updatedMember1, member2])
-    }
-
-    func testThat_ItDoesNotUpdateMember_WhenNoMatchFound() {
-        // Given
-        let member1 = AVSCallMember(client: aliceIphone, videoState: .stopped)
-        let member2 = AVSCallMember(client: bobIphone, videoState: .stopped)
-        let sut = createSut(members: [member1, member2])
-
-        // When
-        let unknownMember = AVSCallMember(client: aliceDesktop, videoState: .stopped)
-        sut.callParticipantVideoStateChanged(client: unknownMember.client, videoState: .screenSharing)
-
-        // Then
-        XCTAssertEqual(sut.members.array, [member1, member2])
     }
 
 }
 
+private extension AVSCallMember {
+
+    func with(audioState: AudioState) -> AVSCallMember {
+        return AVSCallMember(client: client,
+                             audioState: audioState,
+                             videoState: videoState,
+                             networkQuality: networkQuality)
+    }
+
+    func with(videoState: VideoState) -> AVSCallMember {
+        return AVSCallMember(client: client,
+                             audioState: audioState,
+                             videoState: videoState,
+                             networkQuality: networkQuality)
+    }
+
+}


### PR DESCRIPTION
## What's new in this PR?

### Issues

There are two different flows for handling participant change updates depending whether the call is a group call or not. Group participant changes are communicated together in a json payload, delivered through the  participant change handler. For 1:1 calls, the audio and video states are communicated separately through the audio established and video state changed handlers. 

With the refactoring for AVS 5.6, the first flow (participant change handler) was [opened up also for 1:1 conversations](https://github.com/wireapp/wire-ios-sync-engine/pull/1207/files#diff-695f8fc6ef3bd31aa718582c2abc2c7bL319).

This led to some unwanted [side effects](https://wearezeta.atlassian.net/browse/ZIOS-12718) due to the two different code paths. After some some adjustments on the AVS side to make the participants change handler be called more reliably, we are able to eliminate the old handlers and rely solely on the participants changed handler.

### Solutions

Remove the conflicting logic from `CallParticipantSnapshot` and related code in `WireCallCenterV3`.

## Notes

This PR relies on an unpublished AVS binary and therefore will not compile in this PR. Nonetheless,  if approved I would merge it to the feature branch and validate it later when possible.