### PR TITLE
[Feature] AVS 6: send SFT call message

### DIFF
--- a/Source/Calling/AVSWrapper+Handlers.swift
+++ b/Source/Calling/AVSWrapper+Handlers.swift
@@ -179,5 +179,11 @@ extension AVSWrapper {
         /// typedef void (wcall_req_clients_h)(WUSER_HANDLE wuser, const char *convid, void *arg);
 
         typealias RequestClients = @convention(c) (UInt32, StringPtr, ContextRef) -> Void
+
+        /// Callback used to request SFT communication.
+        ///
+        /// typedef int (wcall_sft_req_h)(void *ctx, const char *url, const uint8_t *data, size_t len, void *arg);
+
+        typealias SFTCallMessageSend = @convention(c) (VoidPtr, StringPtr, UnsafePointer<UInt8>?, Int, ContextRef) -> Int32
     }
 }

--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -78,6 +78,7 @@ public class AVSWrapper: AVSWrapperType {
                               clientId,
                               readyHandler,
                               sendCallMessageHandler,
+                              sendSFTCallMessageHandler,
                               incomingCallHandler,
                               missedCallHandler,
                               answeredCallHandler,

--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -220,14 +220,14 @@ public class AVSWrapper: AVSWrapperType {
     }
 
     private let dataChannelEstablishedHandler: Handler.DataChannelEstablished = { conversationId, userId, clientId, contextRef in
-        AVSWrapper.withCallCenter(contextRef, conversationId, userId, clientId) {
-            $0.handleDataChannelEstablishement(conversationId: $1, client: AVSClient(userId: $2, clientId: $3))
+        AVSWrapper.withCallCenter(contextRef, conversationId) {
+            $0.handleDataChannelEstablishement(conversationId: $1)
         }
     }
 
     private let establishedCallHandler: Handler.CallEstablished = { conversationId, userId, clientId, contextRef in
-        AVSWrapper.withCallCenter(contextRef, conversationId, userId, clientId) {
-            $0.handleEstablishedCall(conversationId: $1, client: AVSClient(userId: $2, clientId: $3))
+        AVSWrapper.withCallCenter(contextRef, conversationId) {
+            $0.handleEstablishedCall(conversationId: $1)
         }
     }
 

--- a/Source/Calling/CallCenterSupport.swift
+++ b/Source/Calling/CallCenterSupport.swift
@@ -63,7 +63,8 @@ public typealias CallConfigRequestCompletion = (String?, Int) -> Void
  * An object that can perform requests on behalf of the call center.
  */
 
-@objc public protocol WireCallCenterTransport: class {
+public protocol WireCallCenterTransport: class {
     func send(data: Data, conversationId: UUID, userId: UUID, completionHandler: @escaping ((_ status: Int) -> Void))
+    func sendSFT(data: Data, url: URL, completionHandler: @escaping ((Result<Data>) -> Void))
     func requestCallConfig(completionHandler: @escaping CallConfigRequestCompletion)
 }

--- a/Source/Calling/WireCallCenterV3+Events.swift
+++ b/Source/Calling/WireCallCenterV3+Events.swift
@@ -114,7 +114,7 @@ extension WireCallCenterV3 {
     }
 
     /// Handles when data channel gets established.
-    func handleDataChannelEstablishement(conversationId: UUID, client: AVSClient) {
+    func handleDataChannelEstablishement(conversationId: UUID) {
         handleEvent("data-channel-established") {
             // Ignore if data channel was established after audio
             if self.callState(conversationId: conversationId) != .established {
@@ -124,7 +124,7 @@ extension WireCallCenterV3 {
     }
 
     /// Handles established calls.
-    func handleEstablishedCall(conversationId: UUID, client: AVSClient) {
+    func handleEstablishedCall(conversationId: UUID) {
         handleEvent("established-call") {
             // WORKAROUND: the call established handler will is called once for every participant in a
             // group call. Until that's no longer the case we must take care to only set establishedDate once.

--- a/Source/Calling/WireCallCenterV3+Events.swift
+++ b/Source/Calling/WireCallCenterV3+Events.swift
@@ -296,6 +296,12 @@ extension WireCallCenterV3 {
             completion(json)
         }
     }
+
+    func handleSFTCallMessageRequest(token: WireCallMessageToken, url: String, data: Data) {
+        handleEvent("send-sft-call-message") {
+            self.sendSFT(token: token, url: url, data: data)
+        }
+    }
 }
 
 private extension Set where Element == ZMUser {

--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -513,6 +513,28 @@ extension WireCallCenterV3 {
         })
     }
 
+    /// Sends an SFT call message when requested by AVS through `wcall_sft_req_h`.
+    func sendSFT(token: WireCallMessageToken, url: String, data: Data) {
+        zmLog.debug("\(self): send SFT call message, transport = \(String(describing: transport))")
+
+        guard let endpoint = URL(string: url) else {
+            zmLog.error("SFT request failed. Invalid url: \(url)")
+            avsWrapper.handleSFTResponse(data: nil, context: token)
+            return
+        }
+
+        transport?.sendSFT(data: data, url: endpoint) { [weak self] result in
+            switch result {
+            case let .failure(error):
+                zmLog.error("SFT request failed: \(error.localizedDescription)")
+                self?.avsWrapper.handleSFTResponse(data: nil, context: token)
+
+            case let .success(data):
+                self?.avsWrapper.handleSFTResponse(data: data, context: token)
+            }
+        }
+    }
+
     /// Sends the config request when requested by AVS through `wcall_config_req_h`.
     func requestCallConfig() {
         zmLog.debug("\(self): requestCallConfig(), transport = \(String(describing: transport))")

--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -388,7 +388,7 @@ extension WireCallCenterV3 {
         endAllCalls(exluding: conversationId)
         clearSnapshot(conversationId: conversationId) // make sure we don't have an old state for this conversation
         
-        let conversationType: AVSConversationType = conversation.conversationType == .group ? .group : .oneToOne
+        let conversationType: AVSConversationType = conversation.conversationType == .group ? .conference : .oneToOne
         let callType: AVSCallType
         if conversation.localParticipants.count > videoParticipantsLimit {
             callType = .audioOnly

--- a/Source/Synchronization/Strategies/CallingRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/CallingRequestStrategy.swift
@@ -193,7 +193,7 @@ extension CallingRequestStrategy : WireCallCenterTransport {
 
     public func sendSFT(data: Data, url: URL, completionHandler: @escaping ((Result<Data>) -> Void)) {
         var request = URLRequest(url: url)
-        request.httpMethod = "PUT"
+        request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.httpBody = data

--- a/Source/Synchronization/Strategies/CallingRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/CallingRequestStrategy.swift
@@ -32,6 +32,8 @@ public final class CallingRequestStrategy : NSObject, RequestStrategy {
     fileprivate var callConfigRequestSync   : ZMSingleRequestSync! = nil
     fileprivate var callConfigCompletion    : CallConfigRequestCompletion? = nil
     fileprivate let callEventStatus         : CallEventStatus
+
+    private let ephemeralURLSession = URLSession(configuration: .ephemeral)
     
     public init(managedObjectContext: NSManagedObjectContext, clientRegistrationDelegate: ClientRegistrationDelegate, flowManager: FlowManagerType, callEventStatus: CallEventStatus) {
         self.managedObjectContext = managedObjectContext
@@ -198,7 +200,7 @@ extension CallingRequestStrategy : WireCallCenterTransport {
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.httpBody = data
 
-        URLSession(configuration: .ephemeral).task(with: request) { data, response, error in
+        ephemeralURLSession.task(with: request) { data, response, error in
             if let error = error {
                 completionHandler(.failure(SFTResponseError.transport(error: error)))
                 return

--- a/Source/Synchronization/Strategies/CallingRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/CallingRequestStrategy.swift
@@ -190,7 +190,37 @@ extension CallingRequestStrategy : WireCallCenterTransport {
             }
         }
     }
-    
+
+    public func sendSFT(data: Data, url: URL, completionHandler: @escaping ((Result<Data>) -> Void)) {
+        var request = URLRequest(url: url)
+        request.httpMethod = "PUT"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.httpBody = data
+
+        URLSession.shared.task(with: request) { data, response, error in
+            if let error = error {
+                completionHandler(.failure(SFTResponseError.transport(error: error)))
+                return
+            }
+
+            guard
+                let response = response as? HTTPURLResponse,
+                let data = data
+            else {
+                completionHandler(.failure(SFTResponseError.missingData))
+                return
+            }
+
+            guard (200...299).contains(response.statusCode) else {
+                completionHandler(.failure(SFTResponseError.server(status: response.statusCode)))
+                return
+            }
+
+            completionHandler(.success(data))
+        }.resume()
+    }
+
     public func requestCallConfig(completionHandler: @escaping CallConfigRequestCompletion) {
         self.zmLog.debug("requestCallConfig() called, moc = \(managedObjectContext)")
         managedObjectContext.performGroupedBlock { [unowned self] in
@@ -200,6 +230,25 @@ extension CallingRequestStrategy : WireCallCenterTransport {
             self.callConfigRequestSync.readyForNextRequestIfNotBusy()
             RequestAvailableNotification.notifyNewRequestsAvailable(nil)
         }
+    }
+
+    enum SFTResponseError: LocalizedError {
+
+        case server(status: Int)
+        case transport(error: Error)
+        case missingData
+
+        var errorDescription: String? {
+            switch self {
+            case let .server(status: status):
+                return "Server http status code: \(status)"
+            case let .transport(error: error):
+                return "Transport error: \(error.localizedDescription)"
+            case .missingData:
+                return "Response body missing data"
+            }
+        }
+
     }
     
 }

--- a/Source/Synchronization/Strategies/CallingRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/CallingRequestStrategy.swift
@@ -198,7 +198,7 @@ extension CallingRequestStrategy : WireCallCenterTransport {
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.httpBody = data
 
-        URLSession.shared.task(with: request) { data, response, error in
+        URLSession(configuration: .ephemeral).task(with: request) { data, response, error in
             if let error = error {
                 completionHandler(.failure(SFTResponseError.transport(error: error)))
                 return

--- a/Tests/Source/Calling/WireCallCenterV3Mock.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Mock.swift
@@ -78,6 +78,10 @@ public class MockAVSWrapper : AVSWrapperType {
     public func handleResponse(httpStatus: Int, reason: String, context: WireCallMessageToken) {
         // do nothing
     }
+
+    public func handleSFTResponse(data: Data?, context: WireCallMessageToken) {
+        // do nothing
+    }
     
     public func update(callConfig: String?, httpStatusCode: Int) {
         didUpdateCallConfig = true

--- a/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -28,6 +28,10 @@ class WireCallCenterTransportMock : WireCallCenterTransport {
     func send(data: Data, conversationId: UUID, userId: UUID, completionHandler: @escaping ((Int) -> Void)) {
         
     }
+
+    func sendSFT(data: Data, url: URL, completionHandler: @escaping ((Result<Data>) -> Void)) {
+        
+    }
     
     func requestCallConfig(completionHandler: @escaping CallConfigRequestCompletion) {
         if let mockCallConfigResponse = mockCallConfigResponse {

--- a/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -510,7 +510,7 @@ class WireCallCenterV3Tests: MessagingTest {
             _ = sut.startCall(conversation: groupConversation, video: false)
             
             // then
-            XCTAssertEqual(mockAVSWrapper.startCallArguments?.conversationType, AVSConversationType.group)
+            XCTAssertEqual(mockAVSWrapper.startCallArguments?.conversationType, AVSConversationType.conference)
             XCTAssertEqual(mockAVSWrapper.startCallArguments?.callType, AVSCallType.normal)
         }
     }
@@ -521,7 +521,7 @@ class WireCallCenterV3Tests: MessagingTest {
             _ = sut.startCall(conversation: groupConversation, video: true)
             
             // then
-            XCTAssertEqual(mockAVSWrapper.startCallArguments?.conversationType, AVSConversationType.group)
+            XCTAssertEqual(mockAVSWrapper.startCallArguments?.conversationType, AVSConversationType.conference)
             XCTAssertEqual(mockAVSWrapper.startCallArguments?.callType, AVSCallType.video)
         }
     }
@@ -540,7 +540,7 @@ class WireCallCenterV3Tests: MessagingTest {
             _ = sut.startCall(conversation: groupConversation, video: true)
             
             // then
-            XCTAssertEqual(mockAVSWrapper.startCallArguments?.conversationType, AVSConversationType.group)
+            XCTAssertEqual(mockAVSWrapper.startCallArguments?.conversationType, AVSConversationType.conference)
             XCTAssertEqual(mockAVSWrapper.startCallArguments?.callType, AVSCallType.audioOnly)
         }
     }


### PR DESCRIPTION
## What's new in this PR?

This PR implements the logic to send an SFT calling message. 

The SFT call begins by setting the conversation type to `conference`. AVS will then invoke the `wcall_sft_req_h` handler (aka `SFTCallMessageSend`). In this handler we need to trigger a PUT request to the given url and passing the given data. After the request is made and the response received, the result is then passed back to AVS through the `wcall_sft_resp` function.

## Notes

This PR relies on an unpublished AVS binary and therefore will not compile in this PR. Nonetheless, if approved I would merge it to the feature branch and validate it later when possible.
