### PR TITLE
[Feature] AVS 5.6

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 github "wireapp/wire-ios-request-strategy" ~> 195.0
-github "wireapp/avs-ios-binaries" ~> 5.3.191
+github "wireapp/avs-ios-binaries" ~> 5.6.212
 github "wireapp/ZipArchive" "v2.1.3"
 github "wireapp/libPhoneNumber-iOS" ~> 0.9.3

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,7 +1,7 @@
 github "wireapp/HTMLString" "4.1.0-beta.1-xcode_10_2"
 github "wireapp/PINCache" "2.3-swift3.1"
 github "wireapp/ZipArchive" "v2.1.3"
-github "wireapp/avs-ios-binaries" "5.4.199"
+github "wireapp/avs-ios-binaries" "5.6.212"
 github "wireapp/libPhoneNumber-iOS" "0.9.3"
 github "wireapp/ocmock" "v3.4.3"
 github "wireapp/protobuf-objc" "1.9.14"

--- a/Source/Calling/AVSCallMember.swift
+++ b/Source/Calling/AVSCallMember.swift
@@ -35,7 +35,7 @@ extension AVSCallMember {
     init(member: AVSParticipantsChange.Member) {
         remoteId = member.userid
         clientId = member.clientid
-        audioEstablished = (member.aestab == 1)
+        audioState = AudioState(rawValue: member.aestab) ?? .connecting
         videoState = VideoState(rawValue: member.vrecv) ?? .stopped
         networkQuality = .normal
     }
@@ -53,8 +53,8 @@ public struct AVSCallMember: Hashable {
     /// The client identifier of the user, this is only available after the call member has connected
     public let clientId: String?
 
-    /// Whether an audio connection was established.
-    public let audioEstablished: Bool
+    /// The state of audio connection
+    public let audioState: AudioState
 
     /// The state of video connection.
     public let videoState: VideoState
@@ -73,10 +73,10 @@ public struct AVSCallMember: Hashable {
      * - parameter networkQuality: The quality of the network connection. Defaults to `.normal`.
      */
 
-    public init(userId : UUID, clientId: String? = nil, audioEstablished: Bool = false, videoState: VideoState = .stopped, networkQuality: NetworkQuality = .normal) {
+    public init(userId : UUID, clientId: String? = nil, audioState: AudioState = .connecting, videoState: VideoState = .stopped, networkQuality: NetworkQuality = .normal) {
         self.remoteId = userId
         self.clientId = clientId
-        self.audioEstablished = audioEstablished
+        self.audioState = audioState
         self.videoState = videoState
         self.networkQuality = networkQuality
     }
@@ -85,10 +85,13 @@ public struct AVSCallMember: Hashable {
 
     /// The state of the participant.
     var callParticipantState: CallParticipantState {
-        if audioEstablished {
-            return .connected(videoState: videoState, clientId: clientId)
-        } else {
+        switch audioState {
+        case .connecting:
             return .connecting
+        case .established:
+            return .connected(videoState: videoState, clientId: clientId)
+        case .networkProblem:
+            return .unconnectButMayConnect
         }
     }
 

--- a/Source/Calling/AVSWrapper+Handlers.swift
+++ b/Source/Calling/AVSWrapper+Handlers.swift
@@ -20,28 +20,28 @@ import Foundation
 import avs
 
 /// Equivalent of `wcall_audio_cbr_change_h`.
-typealias ConstantBitRateChangeHandler = @convention(c) (UnsafePointer<Int8>?, Int32, UnsafeMutableRawPointer?) -> Void
+typealias ConstantBitRateChangeHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, Int32, UnsafeMutableRawPointer?) -> Void
 
 /// Equivalent of `wcall_video_state_change_h`.
 typealias VideoStateChangeHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafePointer<Int8>?, Int32, UnsafeMutableRawPointer?) -> Void
 
 /// Equivalent of `wcall_incoming_h`.
-typealias IncomingCallHandler = @convention(c) (UnsafePointer<Int8>?, UInt32, UnsafePointer<Int8>?, Int32, Int32, UnsafeMutableRawPointer?) -> Void
+typealias IncomingCallHandler = @convention(c) (UnsafePointer<Int8>?, UInt32, UnsafePointer<Int8>?, UnsafePointer<Int8>?, Int32, Int32, UnsafeMutableRawPointer?) -> Void
 
 /// Equivalent of `wcall_missed_h`.
-typealias MissedCallHandler = @convention(c) (UnsafePointer<Int8>?, UInt32, UnsafePointer<Int8>?, Int32, UnsafeMutableRawPointer?) -> Void
+typealias MissedCallHandler = @convention(c) (UnsafePointer<Int8>?, UInt32, UnsafePointer<Int8>?, UnsafePointer<Int8>?, Int32, UnsafeMutableRawPointer?) -> Void
 
 /// Equivalent of `wcall_answered_h`.
 typealias AnsweredCallHandler = @convention(c) (UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
 
 /// Equivalent of `wcall_data_chan_estab_h`.
-typealias DataChannelEstablishedHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
+typealias DataChannelEstablishedHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
 
 /// Equivalent of `wcall_estab_h`.
-typealias CallEstablishedHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
+typealias CallEstablishedHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
 
 /// Equivalent of `wcall_close_h`.
-typealias CloseCallHandler = @convention(c) (Int32, UnsafePointer<Int8>?, UInt32, UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
+typealias CloseCallHandler = @convention(c) (Int32, UnsafePointer<Int8>?, UInt32, UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
 
 /// Equivalent of `wcall_metrics_h`.
 typealias CallMetricsHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
@@ -65,7 +65,7 @@ typealias CallParticipantChangedHandler = @convention(c) (UnsafePointer<Int8>?, 
 typealias MediaStoppedChangeHandler = @convention(c) (UnsafePointer<Int8>?, UnsafeMutableRawPointer?) -> Void
 
 /// Equivalent of `wcall_network_quality_h`.
-typealias NetworkQualityChangeHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, Int32, Int32, Int32, Int32, UnsafeMutableRawPointer?) -> Void
+typealias NetworkQualityChangeHandler = @convention(c) (UnsafePointer<Int8>?, UnsafePointer<Int8>?, UnsafePointer<Int8>?, Int32, Int32, Int32, Int32, UnsafeMutableRawPointer?) -> Void
 
 /// Equivalent of `wcall_set_mute_handler`.
 typealias MuteChangeHandler = @convention(c) (Int32, UnsafeMutableRawPointer?) -> Void

--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -163,7 +163,7 @@ public class AVSWrapper: AVSWrapperType {
 
     // MARK: - C Callback Handlers
 
-    private let constantBitRateChangeHandler: ConstantBitRateChangeHandler = { _, enabledFlag, contextRef in
+    private let constantBitRateChangeHandler: ConstantBitRateChangeHandler = { _, _, enabledFlag, contextRef in
         AVSWrapper.withCallCenter(contextRef, enabledFlag) {
             $0.handleConstantBitRateChange(enabled: $1)
         }
@@ -175,13 +175,13 @@ public class AVSWrapper: AVSWrapperType {
         }
     }
 
-    private let incomingCallHandler: IncomingCallHandler = { conversationId, messageTime, userId, isVideoCall, shouldRing, contextRef in
+    private let incomingCallHandler: IncomingCallHandler = { conversationId, messageTime, userId, clientId, isVideoCall, shouldRing, contextRef in
         AVSWrapper.withCallCenter(contextRef, conversationId, messageTime, userId, isVideoCall, shouldRing) {
             $0.handleIncomingCall(conversationId: $1, messageTime: $2, userId: $3, isVideoCall: $4, shouldRing: $5)
         }
     }
 
-    private let missedCallHandler: MissedCallHandler = { conversationId, messageTime, userId, isVideoCall, contextRef in
+    private let missedCallHandler: MissedCallHandler = { conversationId, messageTime, userId, clientId, isVideoCall, contextRef in
         zmLog.debug("missedCallHandler: messageTime = \(messageTime)")
         let nonZeroMessageTime: UInt32 = messageTime != 0 ? messageTime : UInt32(Date().timeIntervalSince1970)
 
@@ -196,19 +196,19 @@ public class AVSWrapper: AVSWrapperType {
         }
     }
 
-    private let dataChannelEstablishedHandler: DataChannelEstablishedHandler = { conversationId, userId, contextRef in
+    private let dataChannelEstablishedHandler: DataChannelEstablishedHandler = { conversationId, userId, clientId, contextRef in
         AVSWrapper.withCallCenter(contextRef, conversationId, userId) {
             $0.handleDataChannelEstablishement(conversationId: $1, userId: $2)
         }
     }
 
-    private let establishedCallHandler: CallEstablishedHandler = { conversationId, userId, contextRef in
+    private let establishedCallHandler: CallEstablishedHandler = { conversationId, userId, clientId, contextRef in
         AVSWrapper.withCallCenter(contextRef, conversationId, userId) {
             $0.handleEstablishedCall(conversationId: $1, userId: $2)
         }
     }
 
-    private let closedCallHandler: CloseCallHandler = { reason, conversationId, messageTime, userId, contextRef in
+    private let closedCallHandler: CloseCallHandler = { reason, conversationId, messageTime, userId, clientId, contextRef in
         zmLog.debug("closedCallHandler: messageTime = \(messageTime)")
         let nonZeroMessageTime: UInt32 = messageTime != 0 ? messageTime : UInt32(Date().timeIntervalSince1970)
 
@@ -261,7 +261,7 @@ public class AVSWrapper: AVSWrapperType {
         }
     }
 
-    private let networkQualityHandler: NetworkQualityChangeHandler = { conversationIdRef, userIdRef, quality, rtt, uplinkLoss, downlinkLoss, contextRef in
+    private let networkQualityHandler: NetworkQualityChangeHandler = { conversationIdRef, userIdRef, clientId, quality, rtt, uplinkLoss, downlinkLoss, contextRef in
         AVSWrapper.withCallCenter(contextRef, conversationIdRef, userIdRef, quality, { (callCenter, conversationId, userId, quality) in
             callCenter.handleNetworkQualityChange(conversationId: conversationId, userId: userId, quality: quality)
         })

--- a/Source/Calling/CallParticipantSnapshot.swift
+++ b/Source/Calling/CallParticipantSnapshot.swift
@@ -56,19 +56,19 @@ class CallParticipantsSnapshot {
     func callParticpantVideoStateChanged(userId: UUID, clientId: String, videoState: VideoState) {
         guard let callMember = findMember(userId: userId, clientId: clientId) else { return }
 
-        update(updatedMember: AVSCallMember(userId: userId, clientId: clientId, audioEstablished: callMember.audioEstablished, videoState: videoState))
+        update(updatedMember: AVSCallMember(userId: userId, clientId: clientId, audioState: callMember.audioState, videoState: videoState))
     }
 
     func callParticpantAudioEstablished(userId: UUID) {
         guard let callMember = members.array.first(where: { $0.remoteId == userId }) else { return }
 
-        update(updatedMember: AVSCallMember(userId: userId, clientId: callMember.clientId, audioEstablished: true, videoState: callMember.videoState))
+        update(updatedMember: AVSCallMember(userId: userId, clientId: callMember.clientId, audioState: .established, videoState: callMember.videoState))
     }
 
     func callParticpantNetworkQualityChanged(userId: UUID, networkQuality: NetworkQuality) {
         guard let callMember = members.array.first(where: { $0.remoteId == userId }) else { return }
 
-        update(updatedMember: AVSCallMember(userId: userId, clientId: callMember.clientId, audioEstablished: callMember.audioEstablished, videoState: callMember.videoState, networkQuality: networkQuality))
+        update(updatedMember: AVSCallMember(userId: userId, clientId: callMember.clientId, audioState: callMember.audioState, videoState: callMember.videoState, networkQuality: networkQuality))
     }
     
     func update(updatedMember: AVSCallMember) {

--- a/Source/Calling/CallState.swift
+++ b/Source/Calling/CallState.swift
@@ -66,10 +66,24 @@ public struct CallParticipant: Hashable {
 public enum CallParticipantState: Equatable {
     /// Participant is not in the call
     case unconnected
+    /// Participant is experiencing network issues
+    case unconnectButMayConnect
     /// Participant is in the process of connecting to the call
     case connecting
     /// Participant is connected to call and audio is flowing
     case connected(videoState: VideoState, clientId: String?)
+}
+
+/**
+ * The state of audio in the call.
+ */
+public enum AudioState: Int32 {
+    /// Audio is in the proess of connecting
+    case connecting = 0
+    /// Audio has been established -- audio media flowing
+    case established = 1
+    /// No relay candidate -- audio MAY still connect
+    case networkProblem = 2
 }
 
 /**

--- a/Source/Calling/NetworkQuality.swift
+++ b/Source/Calling/NetworkQuality.swift
@@ -22,4 +22,5 @@ public enum NetworkQuality: Int32 {
     case normal = 1
     case medium = 2
     case poor = 3
+    case problem = 4
 }

--- a/Tests/Source/Calling/CallParticipantsSnapshotTests.swift
+++ b/Tests/Source/Calling/CallParticipantsSnapshotTests.swift
@@ -40,8 +40,8 @@ class CallParticipantsSnapshotTests : MessagingTest {
     func testThatItDoesNotCrashWhenInitializedWithDuplicateCallMembers(){
         // given
         let userId = UUID()
-        let callMember1 = AVSCallMember(userId: userId, audioEstablished: true)
-        let callMember2 = AVSCallMember(userId: userId, audioEstablished: false)
+        let callMember1 = AVSCallMember(userId: userId, audioState: .established)
+        let callMember2 = AVSCallMember(userId: userId, audioState: .connecting)
 
         // when
         let sut = WireSyncEngine.CallParticipantsSnapshot(conversationId: UUID(),
@@ -52,15 +52,15 @@ class CallParticipantsSnapshotTests : MessagingTest {
         // it does not crash and
         XCTAssertEqual(sut.members.array.count, 1)
         if let first = sut.members.array.first {
-            XCTAssertTrue(first.audioEstablished)
+            XCTAssertTrue(first.audioState == .established)
         }
     }
     
     func testThatItDoesNotCrashWhenUpdatedWithDuplicateCallMembers(){
         // given
         let userId = UUID()
-        let callMember1 = AVSCallMember(userId: userId, audioEstablished: true)
-        let callMember2 = AVSCallMember(userId: userId, audioEstablished: false)
+        let callMember1 = AVSCallMember(userId: userId, audioState: .established)
+        let callMember2 = AVSCallMember(userId: userId, audioState: .connecting)
         let sut = WireSyncEngine.CallParticipantsSnapshot(conversationId: UUID(),
                                                           members: [],
                                                           callCenter: mockWireCallCenterV3)
@@ -72,15 +72,15 @@ class CallParticipantsSnapshotTests : MessagingTest {
         // it does not crash and
         XCTAssertEqual(sut.members.array.count, 1)
         if let first = sut.members.array.first {
-            XCTAssertTrue(first.audioEstablished)
+            XCTAssertTrue(first.audioState == .established)
         }
     }
 
     func testThatItDoesNotConsiderAUserWithMultipleDevicesAsDuplicated() {
         // given
         let userId = UUID()
-        let callMember1 = AVSCallMember(userId: userId, clientId: "client1", audioEstablished: true)
-        let callMember2 = AVSCallMember(userId: userId, clientId: "client2", audioEstablished: false)
+        let callMember1 = AVSCallMember(userId: userId, clientId: "client1", audioState: .established)
+        let callMember2 = AVSCallMember(userId: userId, clientId: "client2", audioState: .connecting)
 
         // when
         let sut = WireSyncEngine.CallParticipantsSnapshot(conversationId: UUID(),
@@ -94,9 +94,10 @@ class CallParticipantsSnapshotTests : MessagingTest {
 
     func testThatItTakesTheWorstNetworkQualityFromParticipants() {
         // given
-        let normalQuality = AVSCallMember(userId: UUID(), audioEstablished: true, videoState: .started, networkQuality: .normal)
-        let mediumQuality = AVSCallMember(userId: UUID(), audioEstablished: true, videoState: .started, networkQuality: .medium)
-        let poorQuality = AVSCallMember(userId: UUID(), audioEstablished: true, videoState: .started, networkQuality: .poor)
+        let normalQuality = AVSCallMember(userId: UUID(), audioState: .established, videoState: .started, networkQuality: .normal)
+        let mediumQuality = AVSCallMember(userId: UUID(), audioState: .established, videoState: .started, networkQuality: .medium)
+        let poorQuality = AVSCallMember(userId: UUID(), audioState: .established, videoState: .started, networkQuality: .poor)
+        let problemQuality = AVSCallMember(userId: UUID(), audioState: .established, videoState: .started, networkQuality: .problem)
 
         let sut = WireSyncEngine.CallParticipantsSnapshot(conversationId: UUID(),
                                                           members: [],
@@ -122,12 +123,17 @@ class CallParticipantsSnapshotTests : MessagingTest {
         sut.callParticipantsChanged(participants: [mediumQuality, poorQuality])
         // then
         XCTAssertEqual(sut.networkQuality, .poor)
+
+        // when
+        sut.callParticipantsChanged(participants: [problemQuality, poorQuality])
+        // then
+        XCTAssertEqual(sut.networkQuality, .problem)
     }
 
     func testThatItUpdatesNetworkQualityWhenItChangesForParticipant() {
         // given
-        let callMember1 = AVSCallMember(userId: UUID(), audioEstablished: true, networkQuality: .normal)
-        let callMember2 = AVSCallMember(userId: UUID(), audioEstablished: true, networkQuality: .normal)
+        let callMember1 = AVSCallMember(userId: UUID(), audioState: .established, networkQuality: .normal)
+        let callMember2 = AVSCallMember(userId: UUID(), audioState: .established, networkQuality: .normal)
         let sut = WireSyncEngine.CallParticipantsSnapshot(conversationId: UUID(),
                                                           members: [callMember1, callMember2],
                                                           callCenter: mockWireCallCenterV3)


### PR DESCRIPTION
## What's new in this PR?

This PR integrates the following AVS 5.6 changes:

- new network state `problem`
- new audio state `networkProblem`
- changed callback signatures to include the client id
## Notes

The previous integration of AVS 5.6 (which has been reverted) contained several refactorings which are not included here, because it required some changes only introduced in AVS 6. This implementation solely addresses the API changes from the AVS library.
