### PR TITLE
[Feature] Refresh user data when adding a participant to a group fails

### DIFF
--- a/Source/Data Model/Conversation+Participants.swift
+++ b/Source/Data Model/Conversation+Participants.swift
@@ -92,6 +92,13 @@ extension ZMConversation {
                 completion(.success) // users were already added to the conversation
             }
             else {
+                if response.httpStatus == 403 {
+                    // Refresh user data since this operation might have failed
+                    // due to a team member being removed/deleted from the team.
+                    users.filter(\.isTeamMember).forEach({ $0.refreshData() })
+                    contextProvider?.managedObjectContext.enqueueDelayedSave()
+                }
+                
                 let error = ConversationAddParticipantsError(response: response) ?? .unknown
                 zmLog.debug("Error adding participants: \(error)")
                 completion(.failure(error))


### PR DESCRIPTION
## What's new in this PR?

In large teams you'll lazily discover that team users have been deleted by sending them a message, if you try to add them to a group conversation before that it will fail and we should recover by re-fetching the user profiles of the users you tried to add.