### PR TITLE
[Fix] Missing system messages when member deleted

### DIFF
--- a/Source/Synchronization/Transcoders/ZMConversationTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMConversationTranscoder.m
@@ -96,15 +96,22 @@ static NSString *const ConversationTeamManagedKey = @"managed";
         self.localNotificationDispatcher = localNotificationDispatcher;
         self.syncStatus = syncStatus;
         self.lastSyncedActiveConversations = [[NSMutableOrderedSet alloc] init];
-        self.modifiedSync = [[ZMUpstreamModifiedObjectSync alloc] initWithTranscoder:self entityName:ZMConversation.entityName updatePredicate:nil filter:nil keysToSync:self.keysToSync managedObjectContext:self.managedObjectContext];
-        self.insertedSync = [[ZMUpstreamInsertedObjectSync alloc] initWithTranscoder:self entityName:ZMConversation.entityName managedObjectContext:self.managedObjectContext];
-        NSPredicate *conversationPredicate =
-        [NSPredicate predicateWithFormat:@"%K != %@ AND (connection == nil OR (connection.status != %d AND connection.status != %d) ) AND needsToBeUpdatedFromBackend == YES",
-         [ZMConversation remoteIdentifierDataKey], nil,
-         ZMConnectionStatusPending,  ZMConnectionStatusIgnored
-         ];
-         
-        self.downstreamSync = [[ZMDownstreamObjectSync alloc] initWithTranscoder:self entityName:ZMConversation.entityName predicateForObjectsToDownload:conversationPredicate managedObjectContext:self.managedObjectContext];
+
+        self.modifiedSync = [[ZMUpstreamModifiedObjectSync alloc] initWithTranscoder:self
+                                                                          entityName:ZMConversation.entityName
+                                                                     updatePredicate:nil
+                                                                              filter:nil
+                                                                          keysToSync:self.keysToSync managedObjectContext:self.managedObjectContext];
+
+        self.insertedSync = [[ZMUpstreamInsertedObjectSync alloc] initWithTranscoder:self
+                                                                          entityName:ZMConversation.entityName
+                                                                managedObjectContext:self.managedObjectContext];
+
+        self.downstreamSync = [[ZMDownstreamObjectSync alloc] initWithTranscoder:self
+                                                                      entityName:ZMConversation.entityName
+                                                   predicateForObjectsToDownload:ZMConversationTranscoder.predicateForDownstreamSync
+                                                            managedObjectContext:self.managedObjectContext];
+
         self.listPaginator = [[ZMSimpleListRequestPaginator alloc] initWithBasePath:ConversationIDsPath
                                                                            startKey:@"start"
                                                                            pageSize:ZMConversationTranscoderListPageSize

--- a/Source/Synchronization/Transcoders/ZMConversationTranscoder.swift
+++ b/Source/Synchronization/Transcoders/ZMConversationTranscoder.swift
@@ -26,12 +26,12 @@ extension ZMConversationTranscoder {
     static public let predicateForDownstreamSync: NSPredicate = {
         let needsToBeSynced = NSPredicate(
             format: "%K != nil AND needsToBeUpdatedFromBackend == YES",
-            ZMConversation.remoteIdentifierDataKey()!
+            argumentArray: [ZMConversation.remoteIdentifierDataKey()!]
         )
 
         let hasNoPendingOrIgnoredConnection = NSPredicate(
             format: "connection == nil OR (connection.status != %d AND connection.status != %d)",
-            [ZMConnectionStatus.pending, ZMConnectionStatus.ignored]
+            argumentArray: [ZMConnectionStatus.pending.rawValue, ZMConnectionStatus.ignored.rawValue]
         )
 
         // Some of the participants may have been deleted on the backend, so we should first let them sync

--- a/Source/Synchronization/Transcoders/ZMConversationTranscoder.swift
+++ b/Source/Synchronization/Transcoders/ZMConversationTranscoder.swift
@@ -21,6 +21,28 @@ import Foundation
 private let log = ZMSLog(tag: "ConversationTranscoder")
 
 extension ZMConversationTranscoder {
+
+    @objc
+    static public let predicateForDownstreamSync: NSPredicate = {
+        let needsToBeSynced = NSPredicate(
+            format: "%K != nil AND needsToBeUpdatedFromBackend == YES",
+            ZMConversation.remoteIdentifierDataKey()!
+        )
+
+        let hasNoPendingOrIgnoredConnection = NSPredicate(
+            format: "connection == nil OR (connection.status != %d AND connection.status != %d)",
+            [ZMConnectionStatus.pending, ZMConnectionStatus.ignored]
+        )
+
+        // Some of the participants may have been deleted on the backend, so we should first let them sync
+        // before syncing the conversation.
+        let hasNoParticipantsWaitingToBeSynced = NSPredicate(
+            format: "SUBQUERY(participantRoles, $role, $role.user.needsToBeUpdatedFromBackend == YES).@count == 0"
+        )
+
+        let predicates = [needsToBeSynced, hasNoPendingOrIgnoredConnection, hasNoParticipantsWaitingToBeSynced]
+        return NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
+    }()
     
     @objc(appendSystemMessageForUpdateEvent:inConversation:)
     public func appendSystemMessage(for event: ZMUpdateEvent, conversation: ZMConversation) {

--- a/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.m
@@ -371,7 +371,7 @@ static NSString *const CONVERSATION_ID_REQUEST_PREFIX = @"/conversations?ids=";
         conversation.remoteIdentifier = [NSUUID createUUID];
         remoteID = conversation.remoteIdentifier;
         conversation.needsToBeUpdatedFromBackend = YES;
-        
+
         ZMConnection *connection = [ZMConnection insertNewObjectInManagedObjectContext:self.syncMOC];
         connection.status = status;
         connection.conversation = conversation;
@@ -3165,6 +3165,7 @@ static NSString *const CONVERSATION_ID_REQUEST_PREFIX = @"/conversations?ids=";
         // given
         ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
         selfUser.remoteIdentifier = [NSUUID createUUID];
+        selfUser.needsToBeUpdatedFromBackend = NO;
         
         conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
         conversation.conversationType = ZMConversationTypeGroup;
@@ -3201,6 +3202,7 @@ static NSString *const CONVERSATION_ID_REQUEST_PREFIX = @"/conversations?ids=";
         // given
         ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
         selfUser.remoteIdentifier = [NSUUID createUUID];
+        selfUser.needsToBeUpdatedFromBackend = NO;
         
         conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
         conversation.conversationType = ZMConversationTypeGroup;
@@ -3208,7 +3210,7 @@ static NSString *const CONVERSATION_ID_REQUEST_PREFIX = @"/conversations?ids=";
         conversation.needsToBeUpdatedFromBackend = YES;
         [conversation addParticipantAndUpdateConversationStateWithUser:[ZMUser selfUserInContext:self.syncMOC] role: nil];
         [self.syncMOC saveOrRollback];
-        
+
         for (id<ZMContextChangeTracker> tracker in self.sut.contextChangeTrackers) {
             [tracker objectsDidChange:[NSSet setWithObject:conversation]];
         }

--- a/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMConversationTranscoderTests.m
@@ -547,6 +547,30 @@ static NSString *const CONVERSATION_ID_REQUEST_PREFIX = @"/conversations?ids=";
     XCTAssertNil(request);
 }
 
+- (void)testThatNoRequestIsGeneratedForAConversationIfAnyParticipantsNeedToBeUpdatedFromBackend
+{
+    // given
+    [self.syncMOC performGroupedBlockAndWait:^{
+        ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
+        conversation.remoteIdentifier = [NSUUID createUUID];
+        conversation.needsToBeUpdatedFromBackend = YES;
+
+        ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.syncMOC];
+        user.remoteIdentifier = [NSUUID createUUID];
+        user.needsToBeUpdatedFromBackend = YES;
+
+        ParticipantRole *role = [ParticipantRole insertNewObjectInManagedObjectContext:self.syncMOC];
+        role.user = user;
+        role.conversation = conversation;
+
+        [self.syncMOC saveOrRollback];
+
+        // Then
+        ZMTransportRequest *request = [self.sut nextRequest];
+        XCTAssertNil(request);
+    }];
+}
+
 
 
 - (void)testThatItDoesNotCreateTheSelfConversationWhenReceivingAssetOrMessageEvents;


### PR DESCRIPTION
## What's new in this PR?

### Issues

When typing a message into a conversation that contains a deleted member, we discover they are deleted and remove them from the conversation, but we don't display a system message.

### Causes

Sending a message to a deleted member will cause the  member to be synced with the backend. This is how we discover if they have been deleted or not. However, existing logic will also cause the conversation to be synced to the backend. The conversation is synced first and as at result it already removes the deleted member, but it does not add the system message. When syncing the deleted member, we append a system message and remove them from all group conversations they belong to, except for the initial conversation because they have already been removed.

### Solutions

We need to sync the potentially deleted member before syncing the conversation. This can be achieved by modifying the predicate used to fetch conversations that need to be sync. We modify it so that it only fetches conversations that need to be synced and don't have any participants that are waiting to be synced.

Once the all the participants are synced, the conversation would be picked next time and synced as usual.