### PR TITLE
[Feature] Add conversation type parameter to incoming call handler

### DIFF
--- a/Source/Calling/AVSBridging.swift
+++ b/Source/Calling/AVSBridging.swift
@@ -45,6 +45,10 @@ protocol AVSEnum: RawRepresentable, AVSValue {}
 
 // MARK: - AVS Types
 
+extension AVSConversationType: AVSEnum {
+    typealias AVSType = RawValue
+}
+
 extension VideoState: AVSEnum {
     typealias AVSType = RawValue
 }

--- a/Source/Calling/AVSWrapper+Handlers.swift
+++ b/Source/Calling/AVSWrapper+Handlers.swift
@@ -55,9 +55,10 @@ extension AVSWrapper {
         ///                                 const char *clientid,
         ///                                 int video_call /*bool*/,
         ///                                 int should_ring /*bool*/,
+        ///                                 int conv_type /*WCALL_CONV_TYPE...*/,
         ///                                 void *arg);
 
-        typealias IncomingCall = @convention(c) (StringPtr, UInt32, StringPtr, StringPtr, Int32, Int32, ContextRef) -> Void
+        typealias IncomingCall = @convention(c) (StringPtr, UInt32, StringPtr, StringPtr, Int32, Int32, Int32, ContextRef) -> Void
 
         /// Callback used to inform the user of a missed call.
         ///

--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -197,7 +197,7 @@ public class AVSWrapper: AVSWrapperType {
         // Video state changes are now communicated through the json payload of the call participant handler.
     }
 
-    private let incomingCallHandler: Handler.IncomingCall = { conversationId, messageTime, userId, clientId, isVideoCall, shouldRing, contextRef in
+    private let incomingCallHandler: Handler.IncomingCall = { conversationId, messageTime, userId, clientId, isVideoCall, shouldRing, conversationType, contextRef in
         AVSWrapper.withCallCenter(contextRef, conversationId, messageTime, userId, clientId, isVideoCall, shouldRing) {
             $0.handleIncomingCall(conversationId: $1,
                                   messageTime: $2,


### PR DESCRIPTION
## What's new in this PR?

AVS 6.0.18 adds the conversation type to the incoming call handler. This will be used later by QA to determine which type of calls they are testing (legacy group calls or SFT conference calls). 

## Notes

This PR relies on an unpublished AVS binary and therefore will not compile in this PR. Nonetheless, if approved I would merge it to the feature branch and validate it later when possible.