### PR TITLE
[Feature] Inform AVS of client list updates when conversation changes

### DIFF
--- a/Source/Calling/WireCallCenterV3+Events.swift
+++ b/Source/Calling/WireCallCenterV3+Events.swift
@@ -26,6 +26,11 @@ private let zmLog = ZMSLog(tag: "calling")
 extension WireCallCenterV3 : ZMConversationObserver {
 
     public func conversationDidChange(_ changeInfo: ConversationChangeInfo) {
+        handleSecurityLevelChange(changeInfo)
+        handleActiveParticipantsChange(changeInfo)
+    }
+
+    private func handleSecurityLevelChange(_ changeInfo: ConversationChangeInfo) {
         guard
             changeInfo.securityLevelChanged,
             let conversationId = changeInfo.conversation.remoteIdentifier,
@@ -54,6 +59,18 @@ extension WireCallCenterV3 : ZMConversationObserver {
                 notification.post(in: context.notificationContext)
             }
         }
+    }
+
+    private func handleActiveParticipantsChange(_ changeInfo: ConversationChangeInfo) {
+        guard
+            changeInfo.activeParticipantsChanged,
+            let conversationId = changeInfo.conversation.remoteIdentifier,
+            let completion = clientsRequestCompletionsByConversationId[conversationId]
+        else {
+            return
+        }
+
+        handleClientsRequest(conversationId: conversationId, completion: completion)
     }
 
 }

--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -97,6 +97,10 @@ private let zmLog = ZMSLog(tag: "calling")
         }
     }
 
+    /// Used to store AVS completions for the clients requests. AVS will only request the list of clients
+    /// once, but we may need to provide AVS with an updated list during the call.
+    var clientsRequestCompletionsByConversationId = [UUID: (String) -> Void]()
+
     // MARK: - Initialization
     
     deinit {
@@ -137,6 +141,7 @@ extension WireCallCenterV3 {
     /// Removes the participantSnapshot and remove the conversation from the list of ignored conversations.
     func clearSnapshot(conversationId: UUID) {
         callSnapshots.removeValue(forKey: conversationId)
+        clientsRequestCompletionsByConversationId.removeValue(forKey: conversationId)
     }
 
     /**


### PR DESCRIPTION
## What's new in this PR?

### Issues

When a client starts an SFT call, AVS will ask for the list of all other clients in the conversation. However, it's possible that the list is out of sync with the backend. 

### Causes

This can happen if new participants are added to the conversation after the call connects. It can also happen if the self client is unaware of other clients in the conversation. In this case, the backend will report the missing clients when the OTR call message is sent.

### Solutions

Observe changes to the participants for the conversation and recalculate the client list and send it to AVS when needed. Observation only begins once calculate the client list for the first time, and ends when the SFT call is ended. If missing clients were detected from the backend response, then existing logic will trigger a sync of the conversation, and any changes will be propagated to the conversation observer.

## Notes

This PR relies on an unpublished AVS binary and therefore will not compile in this PR. Nonetheless, if approved I would merge it to the feature branch and validate it later when possible.
