### PR TITLE
[Refactor] AVS 6 client discovery

### DIFF
--- a/Source/Calling/CallCenterSupport.swift
+++ b/Source/Calling/CallCenterSupport.swift
@@ -67,4 +67,5 @@ public protocol WireCallCenterTransport: class {
     func send(data: Data, conversationId: UUID, userId: UUID, completionHandler: @escaping ((_ status: Int) -> Void))
     func sendSFT(data: Data, url: URL, completionHandler: @escaping ((Result<Data>) -> Void))
     func requestCallConfig(completionHandler: @escaping CallConfigRequestCompletion)
+    func requestClientsList(conversationId: UUID, completionHandler: @escaping ClientDiscoveryRequestStrategy.RequestCompletion)
 }

--- a/Source/Calling/CallCenterSupport.swift
+++ b/Source/Calling/CallCenterSupport.swift
@@ -67,5 +67,5 @@ public protocol WireCallCenterTransport: class {
     func send(data: Data, conversationId: UUID, userId: UUID, completionHandler: @escaping ((_ status: Int) -> Void))
     func sendSFT(data: Data, url: URL, completionHandler: @escaping ((Result<Data>) -> Void))
     func requestCallConfig(completionHandler: @escaping CallConfigRequestCompletion)
-    func requestClientsList(conversationId: UUID, completionHandler: @escaping ClientDiscoveryRequestStrategy.RequestCompletion)
+    func requestClientsList(conversationId: UUID, completionHandler: @escaping ([AVSClient]) -> Void)
 }

--- a/Source/Calling/WireCallCenterV3+Events.swift
+++ b/Source/Calling/WireCallCenterV3+Events.swift
@@ -294,20 +294,9 @@ extension WireCallCenterV3 {
 
     func handleClientsRequest(conversationId: UUID, completion: @escaping (_ clients: String) -> Void) {
         handleEventInContext("request-clients") { context in
-            self.transport?.requestClientsList(conversationId: conversationId) { clientsByUserId in
-                var clients = Set<AVSClient>()
+            self.transport?.requestClientsList(conversationId: conversationId) { clients in
 
-                for (userIdString, clientIdStrings) in clientsByUserId {
-                    guard let userId = UUID(uuidString: userIdString) else { continue }
-
-                    let avsClients = clientIdStrings.map {
-                        AVSClient(userId: userId, clientId: $0)
-                    }
-
-                    clients.formUnion(avsClients)
-                }
-
-                guard let json = AVSClientList(clients: Array(clients)).json else {
+                guard let json = AVSClientList(clients: clients).json else {
                     zmLog.error("Could not encode client list to JSON")
                     return
                 }

--- a/Source/Synchronization/Strategies/CallingRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/CallingRequestStrategy.swift
@@ -29,10 +29,16 @@ public final class CallingRequestStrategy : NSObject, RequestStrategy {
     private let managedObjectContext: NSManagedObjectContext
     private let genericMessageStrategy: GenericMessageRequestStrategy
     private let flowManager: FlowManagerType
+
+    private let callEventStatus: CallEventStatus
+
     private var callConfigRequestSync: ZMSingleRequestSync! = nil
     private var callConfigCompletion: CallConfigRequestCompletion? = nil
-    private let callEventStatus: CallEventStatus
-    private let clientDiscoveryStrategy: ClientDiscoveryRequestStrategy
+
+    private var clientDiscoverySync: ZMSingleRequestSync! = nil
+    private var clientDiscoveryRequest: ClientDiscoveryRequest?
+
+
     private let ephemeralURLSession = URLSession(configuration: .ephemeral)
     
     public init(managedObjectContext: NSManagedObjectContext, clientRegistrationDelegate: ClientRegistrationDelegate, flowManager: FlowManagerType, callEventStatus: CallEventStatus) {
@@ -40,13 +46,14 @@ public final class CallingRequestStrategy : NSObject, RequestStrategy {
         self.genericMessageStrategy = GenericMessageRequestStrategy(context: managedObjectContext, clientRegistrationDelegate: clientRegistrationDelegate)
         self.flowManager = flowManager
         self.callEventStatus = callEventStatus
-        self.clientDiscoveryStrategy = ClientDiscoveryRequestStrategy(withManagedObjectContext: managedObjectContext)
-        
+
         super.init()
         
+        callConfigRequestSync = ZMSingleRequestSync(singleRequestTranscoder: self, groupQueue: managedObjectContext)
+        clientDiscoverySync = ZMSingleRequestSync(singleRequestTranscoder: self, groupQueue: managedObjectContext)
+
         let selfUser = ZMUser.selfUser(in: managedObjectContext)
-        self.callConfigRequestSync = ZMSingleRequestSync(singleRequestTranscoder: self, groupQueue: self.managedObjectContext)
-        
+
         if let userId = selfUser.remoteIdentifier, let clientId = selfUser.selfClient()?.remoteIdentifier {
             zmLog.debug("Creating callCenter from init")
             callCenter = WireCallCenterV3Factory.callCenter(withUserId: userId, clientId: clientId, uiMOC: managedObjectContext.zm_userInterface, flowManager: flowManager, analytics: managedObjectContext.analytics, transport: self)
@@ -55,8 +62,8 @@ public final class CallingRequestStrategy : NSObject, RequestStrategy {
     
     public func nextRequest() -> ZMTransportRequest? {
         let request = callConfigRequestSync.nextRequest() ??
-                        genericMessageStrategy.nextRequest() ??
-                        clientDiscoveryStrategy.nextRequest()
+                        clientDiscoverySync.nextRequest() ??
+                        genericMessageStrategy.nextRequest()
         
         request?.forceToVoipSession()
         return request
@@ -70,22 +77,82 @@ public final class CallingRequestStrategy : NSObject, RequestStrategy {
 
 
 extension CallingRequestStrategy : ZMSingleRequestTranscoder {
+
     public func request(for sync: ZMSingleRequestSync) -> ZMTransportRequest? {
-        zmLog.debug("Scheduling request to '/calls/config/v2'")
-        return ZMTransportRequest(path: "/calls/config/v2", method: .methodGET, binaryData: nil, type: "application/json", contentDisposition: nil, shouldCompress: true)
+        switch sync {
+        case callConfigRequestSync:
+            zmLog.debug("Scheduling request to '/calls/config/v2'")
+
+            return ZMTransportRequest(path: "/calls/config/v2",
+                                      method: .methodGET,
+                                      binaryData: nil,
+                                      type: "application/json",
+                                      contentDisposition: nil,
+                                      shouldCompress: true)
+
+        case clientDiscoverySync:
+            guard
+                let request = clientDiscoveryRequest,
+                let selfClient = ZMUser.selfUser(in: managedObjectContext).selfClient()
+            else {
+                return nil
+            }
+
+            zmLog.debug("Scheduling request to discover clients")
+
+            let factory = ClientMessageRequestFactory()
+            return factory.upstreamRequestForFetchingClients(conversationId: request.conversationId, selfClient: selfClient)
+
+        default:
+            return nil
+        }
+
     }
     
     public func didReceive(_ response: ZMTransportResponse, forSingleRequest sync: ZMSingleRequestSync) {
-        
-        zmLog.debug("Received response for \(self): \(response)")
-        if response.httpStatus == 200 {
-            var payloadAsString : String? = nil
-            if let payload = response.payload, let data = try? JSONSerialization.data(withJSONObject: payload, options: []) {
-                payloadAsString = String(data: data, encoding: .utf8)
+        switch sync {
+        case callConfigRequestSync:
+            zmLog.debug("Received call config response for \(self): \(response)")
+            if response.httpStatus == 200 {
+                var payloadAsString : String? = nil
+                if let payload = response.payload, let data = try? JSONSerialization.data(withJSONObject: payload, options: []) {
+                    payloadAsString = String(data: data, encoding: .utf8)
+                }
+                zmLog.debug("Callback: \(String(describing: self.callConfigCompletion))")
+                self.callConfigCompletion?(payloadAsString, response.httpStatus)
+                self.callConfigCompletion = nil
             }
-            zmLog.debug("Callback: \(String(describing: self.callConfigCompletion))")
-            self.callConfigCompletion?(payloadAsString, response.httpStatus)
-            self.callConfigCompletion = nil
+
+        case clientDiscoverySync:
+            zmLog.debug("Received client discovery response for \(self): \(response)")
+
+            defer {
+                clientDiscoveryRequest = nil
+            }
+
+            guard response.httpStatus == 412 else {
+                zmLog.warn("Expected 412 response: missing clients")
+                return
+            }
+
+            guard let jsonData = response.rawData else { return }
+
+            let decoder = JSONDecoder()
+
+            do {
+                let payload = try decoder.decode(ClientDiscoveryResponsePayload.self, from: jsonData)
+
+                let clients = payload.clients.flatMap { clients in
+                    clients.clientIds.map { AVSClient(userId: clients.userId, clientId: $0) }
+                }
+
+                clientDiscoveryRequest?.completion(clients)
+            } catch {
+                zmLog.error("Could not parse client discovery response: \(error.localizedDescription)")
+            }
+
+        default:
+            break
         }
     }
 }
@@ -236,11 +303,13 @@ extension CallingRequestStrategy : WireCallCenterTransport {
         }
     }
 
-    public func requestClientsList(conversationId: UUID,
-                                   completionHandler: @escaping ClientDiscoveryRequestStrategy.RequestCompletion) {
-
-        clientDiscoveryStrategy.requestClientList(conversationId: conversationId,
-                                                  completion: completionHandler)
+    public func requestClientsList(conversationId: UUID, completionHandler: @escaping ([AVSClient]) -> Void) {
+        self.zmLog.debug("requestClientList() called, moc = \(managedObjectContext)")
+        managedObjectContext.performGroupedBlock { [unowned self] in
+            self.clientDiscoveryRequest = ClientDiscoveryRequest(conversationId: conversationId, completion: completionHandler)
+            self.clientDiscoverySync.readyForNextRequestIfNotBusy()
+            RequestAvailableNotification.notifyNewRequestsAvailable(nil)
+        }
     }
 
     enum SFTResponseError: LocalizedError {
@@ -262,4 +331,72 @@ extension CallingRequestStrategy : WireCallCenterTransport {
 
     }
     
+}
+
+extension CallingRequestStrategy {
+
+    struct ClientDiscoveryRequest {
+
+        let conversationId: UUID
+        let completion: ([AVSClient]) -> Void
+
+    }
+
+    struct ClientDiscoveryResponsePayload: Decodable {
+
+        let clients: [Clients]
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let nestedContainer = try container.nestedContainer(keyedBy: Clients.CodingKeys.self, forKey: .missing)
+
+            let userIds = nestedContainer.allKeys.compactMap { UUID(uuidString: $0.stringValue) }
+
+            clients = try userIds.map { userId in
+                let userIdKey = Clients.CodingKeys.userId(userId)
+                let clientIds = try nestedContainer.decode([String].self, forKey: userIdKey)
+                return Clients(userId: userId, clientIds: clientIds)
+            }
+        }
+
+        enum CodingKeys: String, CodingKey {
+
+            case missing
+
+        }
+
+        struct Clients {
+
+            let userId: UUID
+            let clientIds: [String]
+
+            enum CodingKeys: CodingKey {
+
+                case userId(UUID)
+
+                var stringValue: String {
+                    switch self {
+                    case .userId(let uuid):
+                        return uuid.transportString()
+                    }
+                }
+
+                init?(stringValue: String) {
+                    guard let uuid = UUID(uuidString: stringValue) else { return nil }
+                    self = .userId(uuid)
+                }
+
+                var intValue: Int? {
+                    return nil
+                }
+
+                init?(intValue: Int) {
+                    return nil
+                }
+
+            }
+
+        }
+    }
+
 }

--- a/Source/Synchronization/Strategies/CallingRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/CallingRequestStrategy.swift
@@ -22,8 +22,10 @@ import WireDataModel
 
 @objcMembers
 public final class CallingRequestStrategy : NSObject, RequestStrategy {
+
+    // MARK: - Private Properties
     
-    fileprivate let zmLog = ZMSLog(tag: "calling")
+    private let zmLog = ZMSLog(tag: "calling")
     
     private var callCenter: WireCallCenterV3?
     private let managedObjectContext: NSManagedObjectContext
@@ -38,8 +40,9 @@ public final class CallingRequestStrategy : NSObject, RequestStrategy {
     private var clientDiscoverySync: ZMSingleRequestSync! = nil
     private var clientDiscoveryRequest: ClientDiscoveryRequest?
 
-
     private let ephemeralURLSession = URLSession(configuration: .ephemeral)
+
+    // MARK: - Init
     
     public init(managedObjectContext: NSManagedObjectContext, clientRegistrationDelegate: ClientRegistrationDelegate, flowManager: FlowManagerType, callEventStatus: CallEventStatus) {
         self.managedObjectContext = managedObjectContext
@@ -59,6 +62,8 @@ public final class CallingRequestStrategy : NSObject, RequestStrategy {
             callCenter = WireCallCenterV3Factory.callCenter(withUserId: userId, clientId: clientId, uiMOC: managedObjectContext.zm_userInterface, flowManager: flowManager, analytics: managedObjectContext.analytics, transport: self)
         }
     }
+
+    // MARK: - Methods
     
     public func nextRequest() -> ZMTransportRequest? {
         let request = callConfigRequestSync.nextRequest() ??
@@ -75,8 +80,9 @@ public final class CallingRequestStrategy : NSObject, RequestStrategy {
     
 }
 
+// MARK: - Single Request Transcoder
 
-extension CallingRequestStrategy : ZMSingleRequestTranscoder {
+extension CallingRequestStrategy: ZMSingleRequestTranscoder {
 
     public func request(for sync: ZMSingleRequestSync) -> ZMTransportRequest? {
         switch sync {
@@ -157,8 +163,9 @@ extension CallingRequestStrategy : ZMSingleRequestTranscoder {
     }
 }
 
+// MARK: - Context Change Tracker
 
-extension CallingRequestStrategy : ZMContextChangeTracker, ZMContextChangeTrackerSource {
+extension CallingRequestStrategy: ZMContextChangeTracker, ZMContextChangeTrackerSource {
     
     public var contextChangeTrackers: [ZMContextChangeTracker] {
         return [self, self.genericMessageStrategy]
@@ -190,7 +197,9 @@ extension CallingRequestStrategy : ZMContextChangeTracker, ZMContextChangeTracke
     
 }
 
-extension CallingRequestStrategy : ZMEventConsumer {
+// MARK: - Event Consumer
+
+extension CallingRequestStrategy: ZMEventConsumer {
     
     public func processEvents(_ events: [ZMUpdateEvent], liveEvents: Bool, prefetchResult: ZMFetchRequestBatchResult?) {
         
@@ -233,7 +242,9 @@ extension CallingRequestStrategy : ZMEventConsumer {
     
 }
 
-extension CallingRequestStrategy : WireCallCenterTransport {
+// MARK: - Wire Call Center Transport
+
+extension CallingRequestStrategy: WireCallCenterTransport {
     
     public func send(data: Data, conversationId: UUID, userId: UUID, completionHandler: @escaping ((Int) -> Void)) {
         
@@ -332,6 +343,8 @@ extension CallingRequestStrategy : WireCallCenterTransport {
     }
     
 }
+
+// MARK: - Client Discovery Request
 
 extension CallingRequestStrategy {
 

--- a/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -22,8 +22,8 @@ import avs
 
 class WireCallCenterTransportMock : WireCallCenterTransport {
     
-    var mockCallConfigResponse : (String, Int)?
-    var mockClientsRequestResponse: [String: [String]]?
+    var mockCallConfigResponse: (String, Int)?
+    var mockClientsRequestResponse: [AVSClient]?
     
     
     func send(data: Data, conversationId: UUID, userId: UUID, completionHandler: @escaping ((Int) -> Void)) {
@@ -40,7 +40,7 @@ class WireCallCenterTransportMock : WireCallCenterTransport {
         }
     }
 
-    func requestClientsList(conversationId: UUID, completionHandler: @escaping ClientDiscoveryRequestStrategy.RequestCompletion) {
+    func requestClientsList(conversationId: UUID, completionHandler: @escaping ([AVSClient]) -> Void) {
         if let mockClientsRequestResponse = mockClientsRequestResponse {
             completionHandler(mockClientsRequestResponse)
         }
@@ -1094,8 +1094,10 @@ extension WireCallCenterV3Tests {
         let userId2 = UUID.create()
 
         mockTransport.mockClientsRequestResponse = [
-            userId1.transportString(): ["client1", "client2"],
-            userId2.transportString(): ["client1", "client2"],
+            AVSClient(userId: userId1, clientId: "client1"),
+            AVSClient(userId: userId1, clientId: "client2"),
+            AVSClient(userId: userId2, clientId: "client1"),
+            AVSClient(userId: userId2, clientId: "client2")
         ]
 
         // when
@@ -1117,7 +1119,6 @@ extension WireCallCenterV3Tests {
             } catch {
                 XCTFail()
             }
-
         }
     }
 

--- a/Tests/Source/Synchronization/Strategies/CallingRequestStrategyTests.swift
+++ b/Tests/Source/Synchronization/Strategies/CallingRequestStrategyTests.swift
@@ -35,6 +35,8 @@ class CallingRequestStrategyTests : MessagingTest {
         mockRegistrationDelegate = nil
         super.tearDown()
     }
+
+    // MARK: - Misc
     
     func testThatItReturnsItselfAndTheGenericMessageStrategyAsContextChangeTracker(){
         // when
@@ -44,6 +46,8 @@ class CallingRequestStrategyTests : MessagingTest {
         XCTAssertTrue(trackers.first is CallingRequestStrategy)
         XCTAssertTrue(trackers.last is GenericMessageRequestStrategy)
     }
+
+    // MARK: - Call Config
     
     func testThatItGenerateCallConfigRequestAndCallsTheCompletionHandler() {
         
@@ -126,4 +130,67 @@ class CallingRequestStrategyTests : MessagingTest {
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
 
     }
+
+    // MARK: - Client List
+
+    func testThatItGenerateClientListRequestAndCallsTheCompletionHandler() {
+        // Given
+        createSelfClient()
+
+        let conversationId = UUID.create()
+        let userId1 = UUID.create()
+        let userId2 = UUID.create()
+        let clientId1 = "client1"
+        let clientId2 = "client2"
+
+        let payload = """
+        {
+            "missing": {
+                "\(userId1.transportString())": ["\(clientId1)", "\(clientId2)"],
+                "\(userId2.transportString())": ["\(clientId1)"]
+            }
+        }
+        """
+
+        let receivedClientList = expectation(description: "Received client list")
+
+        // When
+        sut.requestClientsList(conversationId: conversationId) { clients in
+            // Then
+            XCTAssertEqual(clients.count, 3)
+            XCTAssertTrue(clients.contains(AVSClient(userId: userId1, clientId: clientId1)))
+            XCTAssertTrue(clients.contains(AVSClient(userId: userId1, clientId: clientId2)))
+            XCTAssertTrue(clients.contains(AVSClient(userId: userId2, clientId: clientId1)))
+            receivedClientList.fulfill()
+        }
+
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        let request = sut.nextRequest()
+        XCTAssertNotNil(request)
+        XCTAssertEqual(request?.path, "/conversations/\(conversationId.transportString())/otr/messages")
+
+        // When
+        request?.complete(with: ZMTransportResponse(payload: payload as ZMTransportData, httpStatus: 412, transportSessionError: nil))
+
+        // Then
+        XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
+    }
+
+    func testThatItGeneratesOnlyOneClientListRequest() {
+        // Given
+        createSelfClient()
+
+        // When
+        sut.requestClientsList(conversationId: .create()) { _ in }
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // Then
+        let request = sut.nextRequest()
+        XCTAssertNotNil(request)
+
+        let secondRequest = sut.nextRequest()
+        XCTAssertNil(secondRequest)
+    }
+
 }


### PR DESCRIPTION
## What's new in this PR?


This PR extends the capability of `CallingRequestStrategy` to provide a way to fetch a list of all clients in a given conversation. This method is intended to be used to provide AVS with a client list for use with SFT calls and replaces the previous approach of generating a (potentially out of date) list via the conversation object.

It works by sending an OTR message with an empty payload and zero recipients in a specific conversation. The backend will return a 412 response indicating that the message is missing recipients (as expected). In the payload of the response we will find a list of all missing clients, which will be the list of all clients in the conversation. This list is then passed into a completion handler.

### Note

This is a follow up of https://github.com/wireapp/wire-ios-request-strategy/pull/224, where it was decided it was best to implement this functionality inside the `CallingRequestStrategy`.
