### PR TITLE
[Refactor] Call center configuration

### DIFF
--- a/Source/SessionManager/SessionManagerConfiguration.swift
+++ b/Source/SessionManager/SessionManagerConfiguration.swift
@@ -65,6 +65,7 @@ public class SessionManagerConfiguration: NSObject, NSCopying, Codable {
 
     /// The `callCenterConfiguration` contains fields to customize the behavior of calls.
     ///
+    /// The default value is specified in `WireCallCenterConfiguration()`.
     public let callCenterConfiguration: WireCallCenterConfiguration
 
     // MARK: - Init

--- a/Source/SessionManager/SessionManagerConfiguration.swift
+++ b/Source/SessionManager/SessionManagerConfiguration.swift
@@ -23,6 +23,8 @@ import UIKit
 
 @objcMembers
 public class SessionManagerConfiguration: NSObject, NSCopying, Codable {
+
+    // MARK: - Properties
     
     /// If set to true then the session manager will delete account data instead of just asking the user to re-authenticate when the cookie or client gets invalidated.
     ///
@@ -61,7 +63,11 @@ public class SessionManagerConfiguration: NSObject, NSCopying, Codable {
     /// The default value of this property is `nil`, i.e. threshold is ignored
     public var failedPasswordThresholdBeforeWipe: Int?
 
+    /// The `callCenterConfiguration` contains fields to customize the behavior of calls.
+    ///
     public let callCenterConfiguration: WireCallCenterConfiguration
+
+    // MARK: - Init
     
     public init(wipeOnCookieInvalid: Bool = false,
                 blacklistDownloadInterval: TimeInterval = 6 * 60 * 60,
@@ -80,6 +86,20 @@ public class SessionManagerConfiguration: NSObject, NSCopying, Codable {
         self.failedPasswordThresholdBeforeWipe = failedPasswordThresholdBeforeWipe
         self.callCenterConfiguration = callCenterConfiguration
     }
+
+    required public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        wipeOnCookieInvalid = try container.decode(Bool.self, forKey: .wipeOnCookieInvalid)
+        blacklistDownloadInterval = try container.decode(TimeInterval.self, forKey: .blacklistDownloadInterval)
+        blockOnJailbreakOrRoot = try container.decode(Bool.self, forKey: .blockOnJailbreakOrRoot)
+        wipeOnJailbreakOrRoot = try container.decode(Bool.self, forKey: .wipeOnJailbreakOrRoot)
+        messageRetentionInterval = try container.decode(TimeInterval.self, forKey: .messageRetentionInterval)
+        authenticateAfterReboot = try container.decode(Bool.self, forKey: .authenticateAfterReboot)
+        failedPasswordThresholdBeforeWipe = try container.decodeIfPresent(Int.self, forKey: .failedPasswordThresholdBeforeWipe)
+        callCenterConfiguration = try container.decodeIfPresent(WireCallCenterConfiguration.self, forKey: .callCenterConfiguration) ?? .init()
+    }
+
+    // MARK: - Methods
     
     public func copy(with zone: NSZone? = nil) -> Any {
         let copy = SessionManagerConfiguration(wipeOnCookieInvalid: wipeOnCookieInvalid,
@@ -105,4 +125,22 @@ public class SessionManagerConfiguration: NSObject, NSCopying, Codable {
         
         return  try? decoder.decode(SessionManagerConfiguration.self, from: data)
     }
+}
+
+// MARK: - Coding Key
+
+extension SessionManagerConfiguration {
+
+    enum CodingKeys: String, CodingKey {
+
+        case wipeOnCookieInvalid
+        case blacklistDownloadInterval
+        case blockOnJailbreakOrRoot
+        case wipeOnJailbreakOrRoot
+        case messageRetentionInterval
+        case authenticateAfterReboot
+        case failedPasswordThresholdBeforeWipe
+        case callCenterConfiguration
+    }
+
 }


### PR DESCRIPTION
## What's new in this PR?

This PR allows the `callCenterConfiguration` field in `session_manager.json` to be optional. In case the field is missing, the default `WireCallCenterConfiguration` is used.
