### PR TITLE
[Fix] Session manager configuration decoding

### DIFF
--- a/Source/Calling/WireCallCenterConfiguration.swift
+++ b/Source/Calling/WireCallCenterConfiguration.swift
@@ -23,12 +23,29 @@ import Foundation
 @objcMembers
 public class WireCallCenterConfiguration: NSObject, Codable {
 
-    /// The maximum number of participants allowed in a group video call.
+    // MARK: - Properties
 
-    public let videoParticipantsLimit = 4
+    /// The maximum number of participants allowed in a group video call.
+    ///
+    /// Defaults to `4`.
+
+    public let videoParticipantsLimit: Int
 
     /// Whether conference (SFT) calling is enabled.
+    ///
+    /// Defaults to `false`.
 
-    public let useConferenceCalling = false
+    public let useConferenceCalling: Bool
+
+    // MARK: - Init
+
+    public convenience override init() {
+        self.init(videoParticipantsLimit: 4, useConferenceCalling: false)
+    }
+
+    public init(videoParticipantsLimit: Int, useConferenceCalling: Bool) {
+        self.videoParticipantsLimit = videoParticipantsLimit
+        self.useConferenceCalling = useConferenceCalling
+    }
 
 }

--- a/Source/SessionManager/SessionManagerConfiguration.swift
+++ b/Source/SessionManager/SessionManagerConfiguration.swift
@@ -94,7 +94,7 @@ public class SessionManagerConfiguration: NSObject, NSCopying, Codable {
         blacklistDownloadInterval = try container.decode(TimeInterval.self, forKey: .blacklistDownloadInterval)
         blockOnJailbreakOrRoot = try container.decode(Bool.self, forKey: .blockOnJailbreakOrRoot)
         wipeOnJailbreakOrRoot = try container.decode(Bool.self, forKey: .wipeOnJailbreakOrRoot)
-        messageRetentionInterval = try container.decode(TimeInterval.self, forKey: .messageRetentionInterval)
+        messageRetentionInterval = try container.decodeIfPresent(TimeInterval.self, forKey: .messageRetentionInterval)
         authenticateAfterReboot = try container.decode(Bool.self, forKey: .authenticateAfterReboot)
         failedPasswordThresholdBeforeWipe = try container.decodeIfPresent(Int.self, forKey: .failedPasswordThresholdBeforeWipe)
         callCenterConfiguration = try container.decodeIfPresent(WireCallCenterConfiguration.self, forKey: .callCenterConfiguration) ?? .init()

--- a/Tests/Source/SessionManager/SessionManagerConfigurationTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerConfigurationTests.swift
@@ -1,0 +1,90 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+
+class SessionManagerConfigurationTests: XCTestCase {
+
+    func testItDecodesConfiguration() throws {
+        // Given
+        let json = """
+        {
+            "wipeOnCookieInvalid": false,
+            "blacklistDownloadInterval": 21600,
+            "blockOnJailbreakOrRoot": false,
+            "wipeOnJailbreakOrRoot": true,
+            "forceAppLock": false,
+            "appLockTimeout": 10,
+            "authenticateAfterReboot": false,
+            "useBiometricsOrAccountPassword": true,
+            "messageRetentionInterval": 3600,
+            "callCenterConfiguration": {
+                "videoParticipantsLimit": 40,
+                "useConferenceCalling": true
+            }
+        }
+
+        """
+
+        let decoder = JSONDecoder()
+        let data = json.data(using: .utf8)!
+
+        // When
+        let result = try decoder.decode(SessionManagerConfiguration.self, from: data)
+
+        // Then
+        XCTAssertEqual(result.wipeOnCookieInvalid, false)
+        XCTAssertEqual(result.blacklistDownloadInterval, 21600)
+        XCTAssertEqual(result.blockOnJailbreakOrRoot, false)
+        XCTAssertEqual(result.wipeOnJailbreakOrRoot, true)
+        XCTAssertEqual(result.messageRetentionInterval, 3600)
+        XCTAssertEqual(result.authenticateAfterReboot, false)
+        XCTAssertEqual(result.failedPasswordThresholdBeforeWipe, nil)
+        XCTAssertEqual(result.callCenterConfiguration.videoParticipantsLimit, 40)
+        XCTAssertEqual(result.callCenterConfiguration.useConferenceCalling, true)
+    }
+
+    func testItSetsDefaultCallCenterConfigurationIfNotPresent() throws {
+        // Given
+        let json = """
+        {
+            "wipeOnCookieInvalid": false,
+            "blacklistDownloadInterval": 21600,
+            "blockOnJailbreakOrRoot": false,
+            "wipeOnJailbreakOrRoot": true,
+            "forceAppLock": false,
+            "appLockTimeout": 10,
+            "authenticateAfterReboot": false,
+            "useBiometricsOrAccountPassword": true,
+            "messageRetentionInterval": 3600,
+        }
+
+        """
+
+        let decoder = JSONDecoder()
+        let data = json.data(using: .utf8)!
+
+        // When
+        let result = try decoder.decode(SessionManagerConfiguration.self, from: data)
+
+        // Then
+        XCTAssertEqual(result.callCenterConfiguration.videoParticipantsLimit, 4)
+        XCTAssertEqual(result.callCenterConfiguration.useConferenceCalling, false)
+    }
+
+}

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -447,6 +447,7 @@
 		EE5FEF0521E8948F00E24F7F /* ZMUserSession+DarwinNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5FEF0421E8948F00E24F7F /* ZMUserSession+DarwinNotificationCenter.swift */; };
 		EE6654642445D4EE00CBF8D3 /* MockAddressBook.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6654632445D4EE00CBF8D3 /* MockAddressBook.swift */; };
 		EE8987A62477E71500F65B6E /* WireCallCenterConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8987A52477E71500F65B6E /* WireCallCenterConfiguration.swift */; };
+		EE95DECD247C0049001EA010 /* SessionManagerConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE95DECC247C0049001EA010 /* SessionManagerConfigurationTests.swift */; };
 		EEA2773A211DCFF1004AF00F /* UserNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA27739211DCFF1004AF00F /* UserNotificationCenter.swift */; };
 		EEA2773D211DE4C9004AF00F /* UserNotificationCenterMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA2773C211DE4C9004AF00F /* UserNotificationCenterMock.swift */; };
 		EEEA75FA1F8A6142006D1070 /* ZMLocalNotification+Messages.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEEA75F51F8A613F006D1070 /* ZMLocalNotification+Messages.swift */; };
@@ -1120,6 +1121,7 @@
 		EE5FEF0421E8948F00E24F7F /* ZMUserSession+DarwinNotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSession+DarwinNotificationCenter.swift"; sourceTree = "<group>"; };
 		EE6654632445D4EE00CBF8D3 /* MockAddressBook.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockAddressBook.swift; sourceTree = "<group>"; };
 		EE8987A52477E71500F65B6E /* WireCallCenterConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WireCallCenterConfiguration.swift; sourceTree = "<group>"; };
+		EE95DECC247C0049001EA010 /* SessionManagerConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManagerConfigurationTests.swift; sourceTree = "<group>"; };
 		EEA27739211DCFF1004AF00F /* UserNotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNotificationCenter.swift; sourceTree = "<group>"; };
 		EEA2773C211DE4C9004AF00F /* UserNotificationCenterMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNotificationCenterMock.swift; sourceTree = "<group>"; };
 		EEB568181FA22FBE003ADA3A /* ZMLocalNotificationLocalizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ZMLocalNotificationLocalizationTests.swift; path = Tests/Source/Notifications/PushNotifications/ZMLocalNotificationLocalizationTests.swift; sourceTree = SOURCE_ROOT; };
@@ -2351,6 +2353,7 @@
 				D59F3A11206929AF0023474F /* SessionManagerTests+Backup.swift */,
 				161ACB3B23F6BE7F00ABFF33 /* SessionManagerTests+URLActions.swift */,
 				162A81D5202B5BC600F6200C /* SessionManagerAVSTests.swift */,
+				EE95DECC247C0049001EA010 /* SessionManagerConfigurationTests.swift */,
 				87DF28C61F680495007E1702 /* PushDispatcherTests.swift */,
 				161ACB3923F6BAFE00ABFF33 /* URLActionTests.swift */,
 			);
@@ -2882,6 +2885,7 @@
 				16466C0E1F9F7EDF00E3F970 /* ZMConversationTranscoderTests.swift in Sources */,
 				5430FF151CE4A359004ECFFE /* FileTransferTests.m in Sources */,
 				545434AE19AB6ADA003892D9 /* ZMUserTranscoderTests.m in Sources */,
+				EE95DECD247C0049001EA010 /* SessionManagerConfigurationTests.swift in Sources */,
 				BF2A9D581D6B5BDB00FA7DBC /* StoreUpdateEventTests.swift in Sources */,
 				A938BDCA23A7966700D4C208 /* ConversationRoleDownstreamRequestStrategyTests.swift in Sources */,
 				0920C4DA1B305FF500C55728 /* UserSessionGiphyRequestStateTests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

Can not decode session manager json file that omits an optional key.

### Causes

When decoding the key `messageRetentionInterval`, it was not being considered as optional

### Solutions

Use `decodeIfPresent`

