### PR TITLE
[Feature] Pass the conversationId through the call error notification

### DIFF
--- a/Source/Calling/WireCallCenterV3+Notifications.swift
+++ b/Source/Calling/WireCallCenterV3+Notifications.swift
@@ -112,15 +112,17 @@ public struct WireCallCenterMissedCallNotification : SelfPostingNotification {
 
 // MARK:- Received call observer
 
-public protocol WireCallCenterCallErrorObserver : class {
-    func callCenterDidReceiveCallError(_ error: CallError)
+public protocol WireCallCenterCallErrorObserver: class {
+    func callCenterDidReceiveCallError(_ error: CallError, conversationId: UUID)
 }
 
 public struct WireCallCenterCallErrorNotification : SelfPostingNotification {
     static let notificationName = Notification.Name("WireCallCenterCallErrorNotification")
     
     weak var context : NSManagedObjectContext?
+
     let error: CallError
+    let conversationId: UUID
 }
 
 // MARK:- CallParticipantObserver
@@ -187,7 +189,7 @@ extension WireCallCenterV3 {
     public class func addCallErrorObserver(observer: WireCallCenterCallErrorObserver, userSession: ZMUserSession) -> Any {
         return NotificationInContext.addObserver(name: WireCallCenterCallErrorNotification.notificationName, context: userSession.managedObjectContext.notificationContext, queue: .main) { [weak observer] note in
             if let note = note.userInfo[WireCallCenterCallErrorNotification.userInfoKey] as? WireCallCenterCallErrorNotification  {
-                observer?.callCenterDidReceiveCallError(note.error)
+                observer?.callCenterDidReceiveCallError(note.error, conversationId: note.conversationId)
             }
         }
     }

--- a/Source/Calling/WireCallCenterV3+Notifications.swift
+++ b/Source/Calling/WireCallCenterV3+Notifications.swift
@@ -116,10 +116,10 @@ public protocol WireCallCenterCallErrorObserver: class {
     func callCenterDidReceiveCallError(_ error: CallError, conversationId: UUID)
 }
 
-public struct WireCallCenterCallErrorNotification : SelfPostingNotification {
+public struct WireCallCenterCallErrorNotification: SelfPostingNotification {
     static let notificationName = Notification.Name("WireCallCenterCallErrorNotification")
     
-    weak var context : NSManagedObjectContext?
+    weak var context: NSManagedObjectContext?
 
     let error: CallError
     let conversationId: UUID

--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -540,11 +540,14 @@ extension WireCallCenterV3 {
     }
     
     fileprivate func handleCallEvent(_ callEvent: CallEvent, completionHandler: @escaping () -> Void) {
-        
         let result = avsWrapper.received(callEvent: callEvent)
         
         if let context = uiMOC, let error = result {
-            WireCallCenterCallErrorNotification(context: context, error: error).post(in: context.notificationContext)
+            WireCallCenterCallErrorNotification(
+                context: context,
+                error: error,
+                conversationId: callEvent.conversationId
+            ).post(in: context.notificationContext)
         }
         
         completionHandler()

--- a/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -584,6 +584,7 @@ class WireCallCenterV3Tests: MessagingTest {
         expectation(forNotification: WireCallCenterCallErrorNotification.notificationName, object: nil) { wrappedNote in
             guard let note = wrappedNote.userInfo?[WireCallCenterCallErrorNotification.userInfoKey] as? WireCallCenterCallErrorNotification else { return false }
             XCTAssertEqual(note.error, self.mockAVSWrapper.callError)
+            XCTAssertEqual(note.conversationId, self.oneOnOneConversationID)
             return true
         }
         


### PR DESCRIPTION
## What's new in this PR?

This PR simply adds the conversationId to the `WireCallCenterCallErrorNotification`. This allows observers of the notification to determine which conversation the call error occurred in.