### PR TITLE
[Fix] Is typing updates sent too often

### DIFF
--- a/Source/Data Model/Typing.swift
+++ b/Source/Data Model/Typing.swift
@@ -26,9 +26,6 @@ class Typing {
     public static let defaultTimeout: TimeInterval = 60
     #endif
 
-    /// We only send typing events to the backend every ZMTypingDefaultTimeout / ZMTypingRelativeSendTimeout seconds.
-    public static let relativeSendTimeout: TimeInterval = 5
-
     // MARK: - Properties
 
     var timeout: TimeInterval = 0

--- a/Source/Synchronization/Strategies/TypingStrategy.swift
+++ b/Source/Synchronization/Strategies/TypingStrategy.swift
@@ -52,7 +52,9 @@ public struct TypingEvent {
     }
     
     func isEqual(other: TypingEvent) -> Bool {
-        return isTyping == other.isTyping && objectID.isEqual(other.objectID) && fabs(date.timeIntervalSince(other.date)) < (Typing.defaultTimeout / Typing.relativeSendTimeout)
+        return isTyping == other.isTyping &&
+               objectID.isEqual(other.objectID) &&
+               fabs(date.timeIntervalSince(other.date)) < Typing.defaultTimeout
     }
     
 }
@@ -90,6 +92,7 @@ class TypingEventQueue {
     /// Returns the next typing event that is different from the last sent typing event
     func nextEvent() -> TypingEvent? {
         var event : TypingEvent?
+                
         while event == nil, let (convObjectID, isTyping) = conversations.popFirst() {
             event = TypingEvent.typingEvent(with: convObjectID, isTyping: isTyping, ifDifferentFrom: lastSentTypingEvent)
         }

--- a/Tests/Source/Synchronization/Strategies/TypingStrategyTests.swift
+++ b/Tests/Source/Synchronization/Strategies/TypingStrategyTests.swift
@@ -539,7 +539,7 @@ extension TypingStrategyTests {
             TypingStrategy.notifyTranscoderThatUser(isTyping: $0, in: conversation)
             XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
             if delay == .delay {
-                let interval = (MockTyping.defaultTimeout / (MockTyping.relativeSendTimeout - 1.0))
+                let interval = (MockTyping.defaultTimeout + 0.5)
                 Thread.sleep(forTimeInterval: interval)
             }
             
@@ -767,7 +767,7 @@ class TypingEventTests : MessagingTest {
         let eventACopy = TypingEvent.typingEvent(with: conversation.objectID, isTyping: true, ifDifferentFrom: eventA)
         let eventBCopy = TypingEvent.typingEvent(with: conversation.objectID, isTyping: false, ifDifferentFrom: eventB)
         
-        let interval = MockTyping.defaultTimeout / (MockTyping.relativeSendTimeout - 1.0)
+        let interval = MockTyping.defaultTimeout + 1.0
         Thread.sleep(forTimeInterval: interval)
 
         let eventADifferent = TypingEvent.typingEvent(with: conversation.objectID, isTyping: true, ifDifferentFrom: eventA)


### PR DESCRIPTION
## What's new in this PR?

### Issues

Is typing update requests are sent so often while typing that they trigger request loop warnings on internal builds.

### Causes

For every keystroke we call `ZMConversation.setIsTyping(true)` which posts a notification to the `TypingStrategy`. Upon receiving this notification the self user is marked as "typing" in that conversation, this leads to the creation of a `TypingEvent` which will create a request if the typing event is not equal to the typing event stored in `lastSentTypingEvent`. This equality is among other things based on the date when the event was created, if the event are closer in time than `Typing.defaultTimeout / Typing.relativeSendTimeout` they are considered equal. Those constants are currently defined as:

`Typing.defaultTimeout = 60`
`Typing.relativeSendTimeout = 5`

That means we'll send a request every 12 seconds while typing, which is enough to generate a request loop warning, which has it's limit set to 60 seconds.

### Solutions

Consider typing events equal if they are closer in time than 60 seconds.