### PR TITLE
App crash at lazy.filter

### DIFF
--- a/Source/Synchronization/Strategies/SearchUserImageStrategy.swift
+++ b/Source/Synchronization/Strategies/SearchUserImageStrategy.swift
@@ -90,13 +90,14 @@ public class SearchUserImageStrategy : AbstractRequestStrategy {
     }
     
     func fetchAssetRequest() -> ZMTransportRequest? {
-        
-        if let previewAssetRequest = requestedPreviewAssets.first(where: {
+        let previewAssetRequestA = requestedPreviewAssets.first(where: {
             !(self.requestedPreviewAssetsInProgress.contains($0.key) ||
                 $0.value == nil)
-            }),
-            let assetKeys = previewAssetRequest.value,
-            let request = request(for: assetKeys, size: .preview, user: previewAssetRequest.key) {
+        })
+        
+        if let previewAssetRequest = previewAssetRequestA,
+           let assetKeys = previewAssetRequest.value,
+           let request = request(for: assetKeys, size: .preview, user: previewAssetRequest.key) {
             requestedPreviewAssetsInProgress.insert(previewAssetRequest.key)
             
             request.add(ZMCompletionHandler(on: syncContext, block: { [weak self] (response) in
@@ -106,12 +107,14 @@ public class SearchUserImageStrategy : AbstractRequestStrategy {
             return request
         }
         
-        if let completeAssetRequest = requestedCompleteAssets.first(where: {
+        let completeAssetRequestA = requestedCompleteAssets.first(where: {
             !(self.requestedCompleteAssetsInProgress.contains($0.key) ||
                 $0.value == nil)
-            }),
-            let assetKeys = completeAssetRequest.value,
-            let request = request(for: assetKeys, size: .complete, user: completeAssetRequest.key) {
+        })
+        
+        if let completeAssetRequest = completeAssetRequestA,
+           let assetKeys = completeAssetRequest.value,
+           let request = request(for: assetKeys, size: .complete, user: completeAssetRequest.key) {
             requestedCompleteAssetsInProgress.insert(completeAssetRequest.key)
             
             request.add(ZMCompletionHandler(on: syncContext, block: { [weak self] (response) in

--- a/Source/Synchronization/Strategies/SearchUserImageStrategy.swift
+++ b/Source/Synchronization/Strategies/SearchUserImageStrategy.swift
@@ -90,10 +90,13 @@ public class SearchUserImageStrategy : AbstractRequestStrategy {
     }
     
     func fetchAssetRequest() -> ZMTransportRequest? {
-        let previewAssetRequestA = requestedPreviewAssets.lazy.filter({ !self.requestedPreviewAssetsInProgress.contains($0.key) && $0.value != nil }).first
-        let completeAssetRequestA = requestedCompleteAssets.lazy.filter({ !self.requestedCompleteAssetsInProgress.contains($0.key) && $0.value != nil}).first
         
-        if let previewAssetRequest = previewAssetRequestA, let assetKeys = previewAssetRequest.value, let request = request(for: assetKeys, size: .preview, user: previewAssetRequest.key) {
+        if let previewAssetRequest = requestedPreviewAssets.first(where: {
+            !(self.requestedPreviewAssetsInProgress.contains($0.key) ||
+                $0.value == nil)
+            }),
+            let assetKeys = previewAssetRequest.value,
+            let request = request(for: assetKeys, size: .preview, user: previewAssetRequest.key) {
             requestedPreviewAssetsInProgress.insert(previewAssetRequest.key)
             
             request.add(ZMCompletionHandler(on: syncContext, block: { [weak self] (response) in
@@ -103,7 +106,12 @@ public class SearchUserImageStrategy : AbstractRequestStrategy {
             return request
         }
         
-        if let completeAssetRequest = completeAssetRequestA, let assetKeys = completeAssetRequest.value, let request = request(for: assetKeys, size: .complete, user: completeAssetRequest.key) {
+        if let completeAssetRequest = requestedCompleteAssets.first(where: {
+            !(self.requestedCompleteAssetsInProgress.contains($0.key) ||
+                $0.value == nil)
+            }),
+            let assetKeys = completeAssetRequest.value,
+            let request = request(for: assetKeys, size: .complete, user: completeAssetRequest.key) {
             requestedCompleteAssetsInProgress.insert(completeAssetRequest.key)
             
             request.add(ZMCompletionHandler(on: syncContext, block: { [weak self] (response) in


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crash at `requestedPreviewAssets.lazy.filter` where `requestedPreviewAssets` is `[UUID : SearchUserAssetKeys?]`

### Causes

Unkown, but the `lazy.filter` can be refactored. 

### Solutions

User `first(where:)` instead and refactor with De Morgan's laws.