### PR TITLE
[Fix]: Correct Error Message For Blocked Domain During Registration

### DIFF
--- a/Resources/Base.lproj/ZMLocalizable.strings
+++ b/Resources/Base.lproj/ZMLocalizable.strings
@@ -21,6 +21,7 @@
 "conversation.username.groupingSeparator" = ", ";
 
 "user_session.error.blacklisted-email" = "This email address is not allowed";
+"user_session.error.domain-blocked" = "This email requires a team invitation. Contact your organization's IT administrators to receive an invite.";
 "user_session.error.email-exists" = "This email address has already been registered";
 "user_session.error.invalid-email" = "This email address is invalid";
 "user_session.error.invalid-code" = "Please enter a valid code";

--- a/Source/Public/NSError+ZMUserSession.h
+++ b/Source/Public/NSError+ZMUserSession.h
@@ -89,7 +89,7 @@ typedef NS_ENUM(NSUInteger, ZMUserSessionErrorCode) {
     ZMUserSessionBlacklistedEmail,
     /// Unauthorized e-mail address
     ZMUserSessionUnauthorizedEmail,
-    /// The email used in the registration is blacklisted
+    /// The email used in the registration is blocked
     ZMUserSessionDomainBlocked,
     /// User has rebooted the device
     ZMUserSessionNeedsAuthenticationAfterReboot

--- a/Source/Public/NSError+ZMUserSession.h
+++ b/Source/Public/NSError+ZMUserSession.h
@@ -89,6 +89,8 @@ typedef NS_ENUM(NSUInteger, ZMUserSessionErrorCode) {
     ZMUserSessionBlacklistedEmail,
     /// Unauthorized e-mail address
     ZMUserSessionUnauthorizedEmail,
+    /// The email used in the registration is blacklisted
+    ZMUserSessionDomainBlocked,
     /// User has rebooted the device
     ZMUserSessionNeedsAuthenticationAfterReboot
 };

--- a/Source/Registration/RegistrationStatus.swift
+++ b/Source/Registration/RegistrationStatus.swift
@@ -123,11 +123,11 @@ public class RegistrationStatus: RegistrationStatusProtocol {
     // MARK: - Event Handling
 
     func handleError(_ error: Error) {
-        switch self.phase {
+        switch phase {
         case .sendActivationCode:
-            self.delegate?.activationCodeSendingFailed(with: error)
+            delegate?.activationCodeSendingFailed(with: error)
         case .checkActivationCode:
-            self.delegate?.activationCodeValidationFailed(with: error)
+            delegate?.activationCodeValidationFailed(with: error)
         case .createTeam:
             delegate?.teamRegistrationFailed(with: error)
         case .createUser:
@@ -139,16 +139,16 @@ public class RegistrationStatus: RegistrationStatusProtocol {
     }
 
     func success() {
-        switch self.phase {
+        switch phase {
         case .sendActivationCode:
-            self.delegate?.activationCodeSent()
+            delegate?.activationCodeSent()
         case .checkActivationCode:
-            self.delegate?.activationCodeValidated()
+            delegate?.activationCodeValidated()
         case .createTeam:
-            self.completedRegistration = true
+            completedRegistration = true
             delegate?.teamRegistered()
         case .createUser:
-            self.completedRegistration = true
+            completedRegistration = true
             delegate?.userRegistered()
         case .none:
             break

--- a/Source/Synchronization/Strategies/RegistationCredentialVerificationStrategy.swift
+++ b/Source/Synchronization/Strategies/RegistationCredentialVerificationStrategy.swift
@@ -65,7 +65,8 @@ extension RegistationCredentialVerificationStrategy : ZMSingleRequestTranscoder 
                 let decodedError: NSError?
                 switch credentials {
                 case .email:
-                    decodedError = NSError.blacklistedEmail(with: response) ??
+                    decodedError = NSError.domainBlocked(with: response) ??
+                    NSError.blacklistedEmail(with: response) ??
                     NSError.emailAddressInUse(with: response) ??
                     NSError.invalidEmail(with: response)
 

--- a/Source/UserSession/NSError+ZMUserSession.m
+++ b/Source/UserSession/NSError+ZMUserSession.m
@@ -108,6 +108,14 @@ NSString * const ZMAccountDeletedReasonKey = @"account-deleted-reason";
     return nil;
 }
 
++ (instancetype)domainBlockedWithResponse:(ZMTransportResponse *)response
+{
+    if (response.HTTPStatus == 451 && [[response payloadLabel] isEqualToString:@"domain-blocked-for-registration"]) {
+        return [NSError userSessionErrorWithErrorCode:ZMUserSessionDomainBlocked userInfo:nil];
+    }
+    return nil;
+}
+
 + (instancetype)invalidEmailWithResponse:(ZMTransportResponse *)response
 {
     if (response.HTTPStatus == 400 && [[response payloadLabel] isEqualToString:@"invalid-email"]) {

--- a/Source/UserSession/NSError+ZMUserSessionInternal.h
+++ b/Source/UserSession/NSError+ZMUserSessionInternal.h
@@ -38,6 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (__nullable instancetype)emailAddressInUseErrorWithResponse:(ZMTransportResponse *)response;
 + (__nullable instancetype)blacklistedEmailWithResponse:(ZMTransportResponse *)response;
++ (__nullable instancetype)domainBlockedWithResponse:(ZMTransportResponse *)response;
 + (__nullable instancetype)invalidEmailWithResponse:(ZMTransportResponse *)response;
 + (__nullable instancetype)keyExistsErrorWithResponse:(ZMTransportResponse *)response;
 

--- a/Source/UserSession/ZMUserSessionErrorCode+Localized.swift
+++ b/Source/UserSession/ZMUserSessionErrorCode+Localized.swift
@@ -24,6 +24,8 @@ extension ZMUserSessionErrorCode: LocalizedError {
         switch self {
         case .blacklistedEmail:
             return bundle.localizedString(forKey: "user_session.error.blacklisted-email", value: nil, table: "ZMLocalizable")
+        case .domainBlocked:
+            return bundle.localizedString(forKey: "user_session.error.domain-blocked", value: nil, table: "ZMLocalizable")
         case .emailIsAlreadyRegistered:
             return bundle.localizedString(forKey: "user_session.error.email-exists", value: nil, table: "ZMLocalizable")
         case .invalidEmail:

--- a/Tests/Source/Synchronization/Strategies/EmailVerificationStrategyTests.swift
+++ b/Tests/Source/Synchronization/Strategies/EmailVerificationStrategyTests.swift
@@ -209,6 +209,10 @@ extension RegistrationCredentialVerificationStrategyTests: RegistrationStatusStr
     func testThatItNotifiesStatusAfterErrorToPhoneVerify_OtherError() {
         checkSendingPhoneCodeResponseError(with: .unknownError, errorLabel: "not-clear-what-happened", httpStatus: 414)
     }
+    
+    func testThatItNotifiesStatusAfterErrorToEmailVerify_DomainBlocked() {
+        checkSendingCodeResponseError(with: .domainBlocked, errorLabel: "domain-blocked-for-registration", httpStatus: 451)
+    }
 
     // MARK:- error tests for activation
 


### PR DESCRIPTION
## What's new in this PR?

When the server was responding that the email during the registration had a blocked domain a generic error message was shown, instead of showing an ad hoc one.

### Causes

specific status code 451 and description label "domain-blocked-for-registration" were not treated.

### Solutions

specific status code 451 and description label "domain-blocked-for-registration" are now treated.