### PR TITLE
Fix: app crash during registration, UserChangeInfo.add(observer:)

### DIFF
--- a/Source/Data Model/UserChangeInfo+UserSession.swift
+++ b/Source/Data Model/UserChangeInfo+UserSession.swift
@@ -29,7 +29,9 @@ extension UserChangeInfo {
     public static func add(observer: ZMUserObserver,
                            for user: UserType,
                            in userSession: ZMUserSession) -> NSObjectProtocol? {
-        guard let managedObjectContext = userSession.managedObjectContext else { return nil }
+        guard let managedObjectContext = userSession.managedObjectContext else {
+            return nil            
+        }
         
         return add(observer: observer, for: user, in: managedObjectContext)
     }

--- a/Source/Data Model/UserChangeInfo+UserSession.swift
+++ b/Source/Data Model/UserChangeInfo+UserSession.swift
@@ -26,6 +26,7 @@ extension UserChangeInfo {
     /// Adds an observer for a user conforming to UserType. You must hold on to the token until you want to stop
     /// observing.
     ///
+    @objc(addObserver:forUser:inUserSession:)
     public static func add(observer: ZMUserObserver,
                            for user: UserType,
                            in userSession: ZMUserSession) -> NSObjectProtocol? {

--- a/Source/Data Model/UserChangeInfo+UserSession.swift
+++ b/Source/Data Model/UserChangeInfo+UserSession.swift
@@ -26,9 +26,12 @@ extension UserChangeInfo {
     /// Adds an observer for a user conforming to UserType. You must hold on to the token until you want to stop
     /// observing.
     ///
-    @objc(addObserver:forUser:inUserSession:)
-    public static func add(observer: ZMUserObserver, for user: UserType, in userSession: ZMUserSession) -> NSObjectProtocol? {
-        return add(observer: observer, for: user, in: userSession.managedObjectContext)
+    public static func add(observer: ZMUserObserver,
+                           for user: UserType,
+                           in userSession: ZMUserSession) -> NSObjectProtocol? {
+        guard let managedObjectContext = userSession.managedObjectContext else { return nil }
+        
+        return add(observer: observer, for: user, in: managedObjectContext)
     }
 
     // MARK: - Registering UserObservers

--- a/Source/SessionManager/LocalStoreProvider.swift
+++ b/Source/SessionManager/LocalStoreProvider.swift
@@ -34,7 +34,7 @@ public extension Bundle {
 
 /// Encapsulates all storage related data and methods. LocalStoreProviderProtocol protocol
 /// is used instead of concrete class to let us inject a custom implementation in tests
-@objc public class LocalStoreProvider: NSObject, LocalStoreProviderProtocol {
+public final class LocalStoreProvider: NSObject, LocalStoreProviderProtocol {
     public let userIdentifier: UUID
     public let applicationContainer: URL
     public let contextDirectory: ManagedObjectContextDirectory

--- a/Source/UserSession/ZMUserSession+Authentication.swift
+++ b/Source/UserSession/ZMUserSession+Authentication.swift
@@ -72,7 +72,7 @@ extension ZMUserSession {
             deleteUserKeychainItems()
         }
         
-        let uiMOC = managedObjectContext
+        let uiMOC = managedObjectContext!
         let syncMOC = syncManagedObjectContext
         
         uiMOC.performGroupedBlockAndWait {}

--- a/Source/UserSession/ZMUserSession.swift
+++ b/Source/UserSession/ZMUserSession.swift
@@ -63,10 +63,7 @@ public class ZMUserSession: NSObject, ZMManagedObjectContextProvider {
     public var topConversationsDirectory: TopConversationsDirectory
     
     public var managedObjectContext: NSManagedObjectContext! { // TODO jacob we don't want this to be public
-        guard let uiContext = storeProvider?.contextDirectory.uiContext else {
-            fatal("uiContext is nil")
-        }
-        return uiContext
+        return storeProvider?.contextDirectory.uiContext
     }
     
     public var syncManagedObjectContext: NSManagedObjectContext { // TODO jacob we don't want this to be public

--- a/Source/UserSession/ZMUserSession.swift
+++ b/Source/UserSession/ZMUserSession.swift
@@ -62,8 +62,11 @@ public class ZMUserSession: NSObject, ZMManagedObjectContextProvider {
     
     public var topConversationsDirectory: TopConversationsDirectory
     
-    public var managedObjectContext: NSManagedObjectContext { // TODO jacob we don't want this to be public
-        return storeProvider.contextDirectory.uiContext
+    public var managedObjectContext: NSManagedObjectContext! { // TODO jacob we don't want this to be public
+        guard let uiContext = storeProvider?.contextDirectory.uiContext else {
+            fatal("uiContext is nil")
+        }
+        return uiContext
     }
     
     public var syncManagedObjectContext: NSManagedObjectContext { // TODO jacob we don't want this to be public

--- a/Tests/Source/SessionManager/SessionManagerTests+Backup.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests+Backup.swift
@@ -20,7 +20,7 @@ import XCTest
 import WireTesting
 @testable import WireSyncEngine
 
-class SessionManagerTests_Backup: IntegrationTest {
+final class SessionManagerTests_Backup: IntegrationTest {
     
     override var useInMemoryStore: Bool {
         return false

--- a/Tests/Source/SessionManager/SessionManagerTests+Backup.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests+Backup.swift
@@ -71,7 +71,7 @@ class SessionManagerTests_Backup: IntegrationTest {
         guard let url = result.value else { return XCTFail("\(result.error!)") }
         
         let decryptedURL = createTemporaryURL()
-        let moc = sessionManager!.activeUserSession!.managedObjectContext
+        let moc = sessionManager!.activeUserSession!.managedObjectContext!
         try SessionManager.decrypt(from: url, to: decryptedURL, password: "12345678", accountId: ZMUser.selfUser(in: moc).remoteIdentifier!)
         
         guard decryptedURL.unzip(to: unzippedURL) else { return XCTFail("Decompression failed") }
@@ -107,7 +107,7 @@ class SessionManagerTests_Backup: IntegrationTest {
         guard let url = backupResult.value else { return XCTFail("\(backupResult.error!)") }
         
         let moc = sessionManager!.activeUserSession!.managedObjectContext
-        let userId = ZMUser.selfUser(in: moc).remoteIdentifier!
+        let userId = ZMUser.selfUser(in: moc!).remoteIdentifier!
         let accountFolder = StorageStack.accountFolder(accountIdentifier: userId, applicationContainer: sharedContainer)
         let fm = FileManager.default
         try fm.removeItem(at: accountFolder)
@@ -131,7 +131,7 @@ class SessionManagerTests_Backup: IntegrationTest {
         let randomData = Data.secureRandomData(length: 1024)
         try randomData.write(to: dataURL)
         let encryptedURL = createTemporaryURL()
-        let moc = sessionManager!.activeUserSession!.managedObjectContext
+        let moc = sessionManager!.activeUserSession!.managedObjectContext!
         try SessionManager.encrypt(from: dataURL, to: encryptedURL, password: "notsorandom", accountId: ZMUser.selfUser(in: moc).remoteIdentifier!)
 
         // When
@@ -186,13 +186,13 @@ class SessionManagerTests_Backup: IntegrationTest {
             
             let message = conversation.append(text: "foo") as! ZMClientMessage
             message.nonce = nonce
-            message.sender = ZMUser.insertNewObject(in: moc)
+            message.sender = ZMUser.insertNewObject(in: moc!)
             message.sender?.remoteIdentifier = .create()
             XCTAssert(message.startSelfDestructionIfNeeded())
             XCTAssertNotNil(message.destructionDate)
             XCTAssertNotNil(message.textMessageData?.messageText)
             XCTAssertNotNil(message.sender)
-            XCTAssert(moc.saveOrRollback())
+            XCTAssert(moc!.saveOrRollback())
             XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         }
         


### PR DESCRIPTION
## What's new in this PR?

### Issues

The app sometimes crashes during the registration process.

### Causes

`userSession.managedObjectContext` would be nil when login is not yet done.

### Solutions

Mark`userSession.managedObjectContext` as optional. Add a guard for this case in `UserChangeInfo.add(observer:)`