### PR TITLE
[Fix] make conference calling setting property mutable

### DIFF
--- a/Source/Calling/WireCallCenterConfiguration.swift
+++ b/Source/Calling/WireCallCenterConfiguration.swift
@@ -35,7 +35,7 @@ public class WireCallCenterConfiguration: NSObject, Codable {
     ///
     /// Defaults to `false`.
 
-    public let useConferenceCalling: Bool
+    public var useConferenceCalling: Bool
 
     // MARK: - Init
 


### PR DESCRIPTION
## What's new in this PR?

- Make the `useConferenceCalling` property mutable to allow UI to toggle conference calling