### PR TITLE
[Fix] flaky test

### DIFF
--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -1344,7 +1344,7 @@ extension SessionManagerTests {
         
         // then
         XCTAssertTrue(self.waitForCustomExpectations(withTimeout: 0.5))
-        
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         XCTAssertEqual(conversations.filter { $0.firstUnreadMessage != nil }.count, 0)
         
         // cleanup


### PR DESCRIPTION
## What's new in this PR?

### Issues

`SessionManagerTests.testThatItMarksConversationsAsRead` is flaky.

### Causes

Marking as read is performed on the sync context now so that operation is now asynchronous, which caused the test to be flaky.

### Solutions

Wait for all groups to empty to be sure that all mark as read operations have finished.