### PR TITLE
[Feature] Targeted calling messages

### DIFF
--- a/Source/Calling/AVSWrapper+Handlers.swift
+++ b/Source/Calling/AVSWrapper+Handlers.swift
@@ -129,12 +129,25 @@ extension AVSWrapper {
 
         /// Callback used to send an OTR call message.
         ///
+        /// The `targets` argument contains a json payload listing the clients for which the message is targeted.
+        /// They payload has the following structure:
+        ///
+        /// ```
+        /// {
+        ///     "clients": [
+        ///         {"userid": "xxxx", "clientid" "xxxx"},
+        ///         {"userid": "xxxx", "clientid" "xxxx"},
+        ///         ...
+        ///     ]
+        /// }
+        /// ```
+        ///
         /// typedef int (wcall_send_h)(void *ctx,
         ///                            const char *convid,
         ///                            const char *userid_self,
         ///                            const char *clientid_self,
-        ///                            const char *userid_dest /*optional*/,
-        ///                            const char *clientid_dest /*optional*/,
+        ///                            const char *targets /*optional*/,
+        ///                            const char *clientid_dest /*deprecated - always null*/,
         ///                            const uint8_t *data,
         ///                            size_t len,
         ///                            int transient /*bool*/,

--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -262,7 +262,7 @@ public class AVSWrapper: AVSWrapperType {
         }
     }
 
-    private let sendCallMessageHandler: Handler.CallMessageSend = { token, conversationId, senderUserId, senderClientId, targetsRef, _, data, dataLength, _, contextRef in
+    private let sendCallMessageHandler: Handler.CallMessageSend = { token, conversationId, senderUserId, senderClientId, targetsCString, _, data, dataLength, _, contextRef in
         guard let token = token else {
             return EINVAL
         }
@@ -270,7 +270,7 @@ public class AVSWrapper: AVSWrapperType {
         let bytes = UnsafeBufferPointer<UInt8>(start: data, count: dataLength)
         let transformedData = Data(buffer: bytes)
 
-        let targets = targetsRef
+        let targets = targetsCString
             .flatMap { String(cString: $0)?.data(using: .utf8) }
             .flatMap { AVSClientList($0) }
 

--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -262,7 +262,7 @@ public class AVSWrapper: AVSWrapperType {
         }
     }
 
-    private let sendCallMessageHandler: Handler.CallMessageSend = { token, conversationId, senderUserId, senderClientId, _, _, data, dataLength, _, contextRef in
+    private let sendCallMessageHandler: Handler.CallMessageSend = { token, conversationId, senderUserId, senderClientId, targetsRef, _, data, dataLength, _, contextRef in
         guard let token = token else {
             return EINVAL
         }
@@ -270,8 +270,13 @@ public class AVSWrapper: AVSWrapperType {
         let bytes = UnsafeBufferPointer<UInt8>(start: data, count: dataLength)
         let transformedData = Data(buffer: bytes)
 
+        let targets = targetsRef
+            .flatMap { String(cString: $0)?.data(using: .utf8) }
+            .flatMap { AVSClientList($0) }
+
+
         return AVSWrapper.withCallCenter(contextRef, conversationId, senderUserId, senderClientId) {
-            $0.handleCallMessageRequest(token: token, conversationId: $1, senderUserId: $2, senderClientId: $3, data: transformedData)
+            $0.handleCallMessageRequest(token: token, conversationId: $1, senderUserId: $2, senderClientId: $3, targets: targets, data: transformedData)
         }
     }
     

--- a/Source/Calling/CallCenterSupport.swift
+++ b/Source/Calling/CallCenterSupport.swift
@@ -66,7 +66,7 @@ public typealias CallConfigRequestCompletion = (String?, Int) -> Void
 
 public protocol WireCallCenterTransport: class {
 
-    /// Sends a calling OTR message.
+    /// Sends a calling message.
     ///
     /// - Parameters:
     ///     - data: The message payload.
@@ -76,7 +76,7 @@ public protocol WireCallCenterTransport: class {
 
     func send(data: Data, conversationId: UUID, targets: [AVSClient]?, completionHandler: @escaping ((_ status: Int) -> Void))
 
-    /// Send an calling message to the SFT server (for conference calling).
+    /// Send a calling message to the SFT server (for conference calling).
     ///
     /// - Parameters:
     ///     - data: The message payload.

--- a/Source/Calling/CallCenterSupport.swift
+++ b/Source/Calling/CallCenterSupport.swift
@@ -19,53 +19,85 @@
 import Foundation
 
 /// An opaque OTR calling message.
+
 public typealias WireCallMessageToken = UnsafeMutableRawPointer
 
-/**
- * The possible types of call.
- */
+
+/// The possible types of call.
 
 public enum AVSCallType: Int32 {
+
     case normal = 0
     case video = 1
     case audioOnly = 2
+
 }
 
-/**
- * Possible types of conversation in which calls can be initiated.
- */
+/// Possible types of conversation in which calls can be initiated.
 
 public enum AVSConversationType: Int32 {
+
     case oneToOne = 0
     case group = 1
     case conference = 2
+
 }
 
-/**
- * An object that represents a calling event.
- */
+ /// An object that represents a calling event.
 
 public struct CallEvent {
+
     let data: Data
     let currentTimestamp: Date
     let serverTimestamp: Date
     let conversationId: UUID
     let userId: UUID
     let clientId: String
+
 }
 
 // MARK: - Call center transport
 
 /// A block of code executed when the config request finishes.
+
 public typealias CallConfigRequestCompletion = (String?, Int) -> Void
 
-/**
- * An object that can perform requests on behalf of the call center.
- */
+/// An object that can perform requests on behalf of the call center.
 
 public protocol WireCallCenterTransport: class {
-    func send(data: Data, conversationId: UUID, userId: UUID, completionHandler: @escaping ((_ status: Int) -> Void))
+
+    /// Sends a calling OTR message.
+    ///
+    /// - Parameters:
+    ///     - data: The message payload.
+    ///     - conversationId: The conversation in which the message is sent.
+    ///     - targets: Exact recipients of the message. If `nil`, all conversation participants are recipients.
+    ///     - completionHandler: A handler when the network request completes with http status code.
+
+    func send(data: Data, conversationId: UUID, targets: [AVSClient]?, completionHandler: @escaping ((_ status: Int) -> Void))
+
+    /// Send an calling message to the SFT server (for conference calling).
+    ///
+    /// - Parameters:
+    ///     - data: The message payload.
+    ///     - url: The url of the server.
+    ///     - completionHandler: A handler when the network request completes with the response payload.
+
     func sendSFT(data: Data, url: URL, completionHandler: @escaping ((Result<Data>) -> Void))
+
+    /// Request the call configuration from the backend.
+    ///
+    /// - Parameters:
+    ///     - completionHandler: A handler when the network request completes with the response payload.
+
     func requestCallConfig(completionHandler: @escaping CallConfigRequestCompletion)
+
+    /// Request the client list for a conversation.
+    ///
+    /// - Parameters:
+    ///     - conversationId: A conversation from which the client list is queried.
+    ///     - completionHandler: A handler when the network request completes with the list of clients.
+
     func requestClientsList(conversationId: UUID, completionHandler: @escaping ([AVSClient]) -> Void)
+
 }

--- a/Source/Calling/WireCallCenterV3+Events.swift
+++ b/Source/Calling/WireCallCenterV3+Events.swift
@@ -200,7 +200,18 @@ extension WireCallCenterV3 {
                                            senderClientId: String,
                                            targets: AVSClientList?,
                                            data: Data) {
-        handleEvent("send-call-message") {
+
+        handleEventInContext("send-call-message") { managedObjectContext in
+            let selfUser = ZMUser.selfUser(in: managedObjectContext)
+
+            guard
+                selfUser.remoteIdentifier == senderUserId,
+                selfUser.selfClient()?.remoteIdentifier == senderClientId
+            else {
+                zmLog.warn("Received request to send calling message from non self user and/or client")
+                return
+            }
+
             self.send(
                 token: token,
                 conversationId: conversationId,

--- a/Source/Calling/WireCallCenterV3+Events.swift
+++ b/Source/Calling/WireCallCenterV3+Events.swift
@@ -198,13 +198,13 @@ extension WireCallCenterV3 {
                                            conversationId: UUID,
                                            senderUserId: UUID,
                                            senderClientId: String,
+                                           targets: AVSClientList?,
                                            data: Data) {
         handleEvent("send-call-message") {
             self.send(
                 token: token,
                 conversationId: conversationId,
-                userId: senderUserId,
-                clientId: senderClientId,
+                targets: targets,
                 data: data,
                 dataLength: data.count
             )

--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -531,9 +531,9 @@ extension WireCallCenterV3 {
 extension WireCallCenterV3 {
 
     /// Sends a call OTR message when requested by AVS through `wcall_send_h`.
-    func send(token: WireCallMessageToken, conversationId: UUID, userId: UUID, clientId: String, data: Data, dataLength: Int) {
+    func send(token: WireCallMessageToken, conversationId: UUID, targets: AVSClientList?, data: Data, dataLength: Int) {
         zmLog.debug("\(self): send call message, transport = \(String(describing: transport))")
-        transport?.send(data: data, conversationId: conversationId, userId: userId, completionHandler: { [weak self] status in
+        transport?.send(data: data, conversationId: conversationId, targets: targets.map(\.clients), completionHandler: { [weak self] status in
             self?.avsWrapper.handleResponse(httpStatus: status, reason: "", context: token)
         })
     }

--- a/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -26,7 +26,7 @@ class WireCallCenterTransportMock : WireCallCenterTransport {
     var mockClientsRequestResponse: [AVSClient]?
     
     
-    func send(data: Data, conversationId: UUID, userId: UUID, completionHandler: @escaping ((Int) -> Void)) {
+    func send(data: Data, conversationId: UUID, targets: [AVSClient]?, completionHandler: @escaping ((Int) -> Void)) {
         
     }
 

--- a/Tests/Source/Synchronization/Strategies/CallingRequestStrategyTests.swift
+++ b/Tests/Source/Synchronization/Strategies/CallingRequestStrategyTests.swift
@@ -27,7 +27,13 @@ class CallingRequestStrategyTests : MessagingTest {
     override func setUp() {
         super.setUp()
         mockRegistrationDelegate = MockClientRegistrationDelegate()
-        sut = CallingRequestStrategy(managedObjectContext: uiMOC, clientRegistrationDelegate: mockRegistrationDelegate, flowManager: FlowManagerMock(), callEventStatus: CallEventStatus(), configuration: .init())
+        sut = CallingRequestStrategy(
+            managedObjectContext: syncMOC,
+            clientRegistrationDelegate: mockRegistrationDelegate,
+            flowManager: FlowManagerMock(),
+            callEventStatus: CallEventStatus(),
+            configuration: .init()
+        )
     }
     
     override func tearDown() {
@@ -191,6 +197,162 @@ class CallingRequestStrategyTests : MessagingTest {
 
         let secondRequest = sut.nextRequest()
         XCTAssertNil(secondRequest)
+    }
+
+    // MARK: - Targeted Calling Messages
+
+    func testThatItTargetsCallMessagesIfTargetClientsAreSpecified() {
+        // Given
+        let selfClient = createSelfClient()
+
+        // One user with two clients connected to self
+        let user1 = ZMUser.insertNewObject(in: syncMOC)
+        user1.remoteIdentifier = .create()
+
+        let client1 = createClient(for: user1, connectedTo: selfClient)
+        createClient(for: user1, connectedTo: selfClient)
+
+        // Another user with two clients connected to self
+        let user2 = ZMUser.insertNewObject(in: syncMOC)
+        user2.remoteIdentifier = .create()
+
+        let client2 = createClient(for: user2, connectedTo: selfClient)
+        createClient(for: user2, connectedTo: selfClient)
+
+        // A conversation with both users and self
+        let conversation = ZMConversation.insertNewObject(in: syncMOC)
+        conversation.remoteIdentifier = .create()
+        conversation.addParticipantsAndUpdateConversationState(users: Set(arrayLiteral: ZMUser.selfUser(in: syncMOC), user1, user2), role: nil)
+        conversation.needsToBeUpdatedFromBackend = false
+
+        syncMOC.saveOrRollback()
+
+        // Targeting two specific clients
+        let avsClient1 = AVSClient(userId: user1.remoteIdentifier, clientId: client1.remoteIdentifier!)
+        let avsClient2 = AVSClient(userId: user2.remoteIdentifier, clientId: client2.remoteIdentifier!)
+        let targets = [avsClient1, avsClient2]
+
+        var nextRequest: ZMTransportRequest?
+
+        // When we schedule the targeted message
+        syncMOC.performGroupedBlock {
+            self.sut.send(data: Data(), conversationId: conversation.remoteIdentifier!, targets: targets) { _ in }
+        }
+
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        syncMOC.performGroupedBlock {
+            nextRequest = self.sut.nextRequest()
+        }
+
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        guard let request = nextRequest else { return XCTFail("Expected next request") }
+
+        // Then we told backend to ignore missing clients (the non targeted conversation participants)
+        XCTAssertEqual(request.path, "/conversations/\(conversation.remoteIdentifier!.transportString())/otr/messages?ignore_missing")
+
+        guard
+            let data = request.binaryData,
+            let otrMessage = try? NewOtrMessage(serializedData: data)
+        else {
+            return XCTFail("Expected OTR message")
+        }
+
+        // Then we only sent the otr message to the targeted clients
+        XCTAssertEqual(otrMessage.recipients.count, 2)
+
+        guard let recipient1 = otrMessage.recipients.first(where: { $0.user == user1.userId }) else {
+            return XCTFail("Expected user1 to be recipient")
+        }
+
+        XCTAssertEqual(recipient1.clients.map(\.client), [client1.clientId])
+
+        guard let recipient2 = otrMessage.recipients.first(where: { $0.user == user2.userId }) else {
+            return XCTFail("Expected user2 to be recipient")
+        }
+
+        XCTAssertEqual(recipient2.clients.map(\.client), [client2.clientId])
+    }
+
+    func testThatItDoesNotTargetCallMessagesIfNoTargetClientsAreSpecified() {
+        // Given
+        let selfClient = createSelfClient()
+
+        // One user with two clients connected to self
+        let user1 = ZMUser.insertNewObject(in: syncMOC)
+        user1.remoteIdentifier = .create()
+
+        let client1 = createClient(for: user1, connectedTo: selfClient)
+        let client2 = createClient(for: user1, connectedTo: selfClient)
+
+        // Another user with two clients connected to self
+        let user2 = ZMUser.insertNewObject(in: syncMOC)
+        user2.remoteIdentifier = .create()
+
+        let client3 = createClient(for: user2, connectedTo: selfClient)
+        let client4 = createClient(for: user2, connectedTo: selfClient)
+
+        // A conversation with both users and self
+        let conversation = ZMConversation.insertNewObject(in: syncMOC)
+        conversation.remoteIdentifier = .create()
+        conversation.addParticipantsAndUpdateConversationState(users: Set(arrayLiteral: ZMUser.selfUser(in: syncMOC), user1, user2), role: nil)
+        conversation.needsToBeUpdatedFromBackend = false
+
+        syncMOC.saveOrRollback()
+
+        var nextRequest: ZMTransportRequest?
+
+        // When we schedule the message with no targets
+        syncMOC.performGroupedBlock {
+            self.sut.send(data: Data(), conversationId: conversation.remoteIdentifier!, targets: nil) { _ in }
+        }
+
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        syncMOC.performGroupedBlock {
+            nextRequest = self.sut.nextRequest()
+        }
+
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        guard let request = nextRequest else { return XCTFail("Expected next request") }
+
+        // Then we did not tell backend to ignore missing clients
+        XCTAssertEqual(request.path, "/conversations/\(conversation.remoteIdentifier!.transportString())/otr/messages")
+
+        guard
+            let data = request.binaryData,
+            let otrMessage = try? NewOtrMessage(serializedData: data)
+        else {
+            return XCTFail("Expected OTR message")
+        }
+
+        // Then we sent the otr message to all clients in the conversation
+        XCTAssertEqual(otrMessage.recipients.count, 2)
+
+        guard let recipient1 = otrMessage.recipients.first(where: { $0.user == user1.userId }) else {
+            return XCTFail("Expected user1 to be recipient")
+        }
+
+        XCTAssertEqual(Set(recipient1.clients.map(\.client)), Set([client1, client2].map(\.clientId)))
+
+        guard let recipient2 = otrMessage.recipients.first(where: { $0.user == user2.userId }) else {
+            return XCTFail("Expected user2 to be recipient")
+        }
+
+        XCTAssertEqual(Set(recipient2.clients.map(\.client)), Set([client3, client4].map(\.clientId)))
+    }
+
+    @discardableResult
+    private func createClient(for user: ZMUser, connectedTo userClient: UserClient) -> UserClient {
+        let client = UserClient.insertNewObject(in: syncMOC)
+        client.remoteIdentifier = NSString.createAlphanumerical() as String
+        client.user = user
+
+        XCTAssertTrue(userClient.establishSessionWithClient(client, usingPreKey: try! userClient.keysStore.lastPreKey()))
+
+        return client
     }
 
 }

--- a/Tests/Source/Synchronization/Strategies/CallingRequestStrategyTests.swift
+++ b/Tests/Source/Synchronization/Strategies/CallingRequestStrategyTests.swift
@@ -249,7 +249,7 @@ class CallingRequestStrategyTests : MessagingTest {
 
         guard let request = nextRequest else { return XCTFail("Expected next request") }
 
-        // Then we told backend to ignore missing clients (the non targeted conversation participants)
+        // Then we tell backend to ignore missing clients (the non targeted conversation participants)
         XCTAssertEqual(request.path, "/conversations/\(conversation.remoteIdentifier!.transportString())/otr/messages?ignore_missing")
 
         guard
@@ -259,7 +259,7 @@ class CallingRequestStrategyTests : MessagingTest {
             return XCTFail("Expected OTR message")
         }
 
-        // Then we only sent the otr message to the targeted clients
+        // Then we send the message to the targeted clients
         XCTAssertEqual(otrMessage.recipients.count, 2)
 
         guard let recipient1 = otrMessage.recipients.first(where: { $0.user == user1.userId }) else {
@@ -318,7 +318,7 @@ class CallingRequestStrategyTests : MessagingTest {
 
         guard let request = nextRequest else { return XCTFail("Expected next request") }
 
-        // Then we did not tell backend to ignore missing clients
+        // Then we do not tell backend to ignore missing clients
         XCTAssertEqual(request.path, "/conversations/\(conversation.remoteIdentifier!.transportString())/otr/messages")
 
         guard
@@ -328,7 +328,7 @@ class CallingRequestStrategyTests : MessagingTest {
             return XCTFail("Expected OTR message")
         }
 
-        // Then we sent the otr message to all clients in the conversation
+        // Then we send the message to all clients in the conversation
         XCTAssertEqual(otrMessage.recipients.count, 2)
 
         guard let recipient1 = otrMessage.recipients.first(where: { $0.user == user1.userId }) else {


### PR DESCRIPTION
## What's new in this PR?

This PR includes changes to send targeted calling messages when requested by AVS. Only some messages should be targeted, in which case AVS will invoke the `wcall_send_h` handler with a list of target clients passed in through the `targets` argument. If `targets` is `null`, then the message is not targeted and all clients participating in the conversation will receive the message.

**JIRA:** https://wearezeta.atlassian.net/browse/ZIOS-13424