### PR TITLE
[Fix] provide public interface to set conference calling property

### DIFF
--- a/Source/Data Model/NSManagedObjectContext+CTCallCenter.swift
+++ b/Source/Data Model/NSManagedObjectContext+CTCallCenter.swift
@@ -55,4 +55,19 @@ public extension NSManagedObjectContext {
         
     }
     
+    private static let ConferenceCallingKey = "ConferenceCallingKey"
+    
+    var zm_useConferenceCalling : Bool {
+        
+        get {
+            precondition(zm_isUserInterfaceContext, "zm_useConferenceCalling can only be accessed on the ui context")
+            return userInfo[NSManagedObjectContext.ConferenceCallingKey] as? Bool ?? false
+        }
+        
+        set {
+            precondition(zm_isUserInterfaceContext, "zm_useConferenceCalling can only be accessed on the ui context")
+            userInfo[NSManagedObjectContext.ConferenceCallingKey] = newValue
+        }
+        
+    }
 }

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -825,6 +825,12 @@ public final class SessionManager : NSObject, SessionManagerType {
             activeUserSession?.useConstantBitRateAudio = useConstantBitRateAudio
         }
     }
+    
+    public var useConferenceCalling: Bool = false {
+        didSet {
+            activeUserSession?.useConferenceCalling = useConferenceCalling
+        }
+    }
 
     internal func checkJailbreakIfNeeded() {
         guard configuration.blockOnJailbreakOrRoot || configuration.wipeOnJailbreakOrRoot else { return }

--- a/Source/UserSession/ZMUserSession+Calling.swift
+++ b/Source/UserSession/ZMUserSession+Calling.swift
@@ -50,4 +50,15 @@ public protocol CallNotificationStyleProvider: class {
         }
     }
     
+    var useConferenceCalling: Bool {
+        set {
+            managedObjectContext.zm_useConferenceCalling = newValue
+            callCenter?.useConferenceCalling = newValue
+        }
+        
+        get {
+            return managedObjectContext.zm_useConferenceCalling
+        }
+    }
+    
 }


### PR DESCRIPTION
## What's new in this PR?

UI needs a way to set the `useConferenceCalling` property on `WireCallCenterV3`.
This is done similarly to the way `useConstantBitRate` is set.
