### PR TITLE
[Feature] Only process update events when the app is in the foreground

### DIFF
--- a/Source/Data Model/Conversation+AccessMode.swift
+++ b/Source/Data Model/Conversation+AccessMode.swift
@@ -114,7 +114,7 @@ extension ZMConversation {
                 if let event = ZMUpdateEvent(fromEventStreamPayload: payload, uuid: nil) {
                     // Process `conversation.code-update` event
                     userSession.syncManagedObjectContext.performGroupedBlock {
-                        userSession.operationLoop?.syncStrategy.process(updateEvents: [event], ignoreBuffer: true)
+                        userSession.operationLoop?.syncStrategy.storeAndProcessUpdateEvents([event], ignoreBuffer: true)
                     }
                 }
             }
@@ -167,7 +167,7 @@ extension ZMConversation {
                 self.allowGuests = allowGuests
                 // Process `conversation.access-update` event
                 userSession.syncManagedObjectContext.performGroupedBlock {
-                    userSession.operationLoop?.syncStrategy.process(updateEvents: [event], ignoreBuffer: true)
+                    userSession.operationLoop?.syncStrategy.storeAndProcessUpdateEvents([event], ignoreBuffer: true)
                 }
                 completion(.success)
             } else {

--- a/Source/Data Model/Conversation+MessageDestructionTimeout.swift
+++ b/Source/Data Model/Conversation+MessageDestructionTimeout.swift
@@ -57,7 +57,8 @@ extension ZMConversation {
             if response.httpStatus.isOne(of: 200, 204),  let event = response.updateEvent {
                 // Process `conversation.message-timer-update` event
                 userSession.syncManagedObjectContext.performGroupedBlock {
-                    userSession.operationLoop?.syncStrategy.process(updateEvents: [event], ignoreBuffer: true)
+                    // TODO jacob maybe skip the event decoder since we know these events will never be encrypted.
+                    userSession.operationLoop?.syncStrategy.storeAndProcessUpdateEvents([event], ignoreBuffer: true)
                 }
                 completion(.success)
             } else {

--- a/Source/Data Model/Conversation+Participants.swift
+++ b/Source/Data Model/Conversation+Participants.swift
@@ -82,7 +82,7 @@ extension ZMConversation {
             if response.httpStatus == 200 {
                 if let payload = response.payload, let event = ZMUpdateEvent(fromEventStreamPayload: payload, uuid: nil) {
                     syncMOC.performGroupedBlock {
-                        eventProcessor.process(updateEvents: [event], ignoreBuffer: true)
+                        eventProcessor.storeAndProcessUpdateEvents([event], ignoreBuffer: true)
                     }
                 }
                 
@@ -145,7 +145,7 @@ extension ZMConversation {
                             conversation?.updateCleared(fromPostPayloadEvent: event)
                         }
                         
-                        eventProcessor.process(updateEvents: [event], ignoreBuffer: true)
+                        eventProcessor.storeAndProcessUpdateEvents([event], ignoreBuffer: true)
                     }
                 }
                 

--- a/Source/Data Model/Conversation+ReadReceiptMode.swift
+++ b/Source/Data Model/Conversation+ReadReceiptMode.swift
@@ -47,7 +47,7 @@ extension ZMConversation {
         request.add(ZMCompletionHandler(on: managedObjectContext!) { response in
             if response.httpStatus == 200, let event = response.updateEvent {
                 userSession.syncManagedObjectContext.performGroupedBlock {
-                    userSession.operationLoop?.syncStrategy.process(updateEvents: [event], ignoreBuffer: true)
+                    userSession.operationLoop?.syncStrategy.storeAndProcessUpdateEvents([event], ignoreBuffer: true)
                     userSession.managedObjectContext.performGroupedBlock {
                         completion(.success)
                     }

--- a/Source/Data Model/ServiceUser.swift
+++ b/Source/Data Model/ServiceUser.swift
@@ -320,7 +320,7 @@ public extension ZMConversation {
             
             
             contextProvider?.syncManagedObjectContext.performGroupedBlock {
-                eventProcessor.process(updateEvents: [event], ignoreBuffer: true)
+                eventProcessor.storeAndProcessUpdateEvents([event], ignoreBuffer: true)
             }
         }))
         

--- a/Source/Synchronization/Decoding/EventDecoder.swift
+++ b/Source/Synchronization/Decoding/EventDecoder.swift
@@ -66,10 +66,12 @@ private let previouslyReceivedEventIDsKey = "zm_previouslyReceivedEventIDsKey"
 // MARK: - Process events
 extension EventDecoder {
     
-    /// Decrypts passed in events and stores them in chronological order in a persisted database. It then saves the database and cryptobox
-    /// It then calls the passed in block (multiple times if necessary), returning the decrypted events
-    /// If the app crashes while processing the events, they can be recovered from the database
-    public func processEvents(_ events: [ZMUpdateEvent], block: ConsumeBlock) {
+    /// Decrypts passed in events and stores them in chronological order in a persisted database,
+    /// it then saves the database and cryptobox
+    ///
+    /// - Parameters:
+    ///   - events: Encrypted events
+    public func storeEvents(_ events: [ZMUpdateEvent]) {
         var lastIndex: Int64?
         
         eventMOC.performGroupedBlockAndWait {
@@ -87,7 +89,15 @@ extension EventDecoder {
         if !events.isEmpty {
             Logging.eventProcessing.info("Decrypted/Stored \( events.count) event(s)")
         }
-        
+    }
+    
+    /// Process previously stored and decrypted events by repeatedly calling the the consume block until
+    /// all the stored events have been processed. If the app crashes while processing the events, they
+    /// can be recovered from the database.
+    ///
+    /// - Parameters:
+    ///   - block: Event consume block which is called once for every stored event.
+    public func processStoredEvents(_ block: ConsumeBlock) {
         process(block, firstCall: true)
     }
     

--- a/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
@@ -184,7 +184,7 @@ NSUInteger const ZMMissingUpdateEventsTranscoderListPageSize = 500;
     
     ZMLogWithLevelAndTag(ZMLogLevelInfo, ZMTAG_EVENT_PROCESSING, @"Downloaded %lu event(s)", (unsigned long)parsedEvents.count);
     
-    [self.eventProcessor processUpdateEvents:parsedEvents ignoreBuffer:YES];
+    [self.eventProcessor storeUpdateEvents:parsedEvents ignoreBuffer:YES];
     [self.pushNotificationStatus didFetchEventIds:eventIds lastEventId:latestEventId finished:!self.listPaginator.hasMoreToFetch];
     
     [tp warnIfLongerThanInterval];

--- a/Source/Synchronization/ZMOperationLoop+PushChannel.swift
+++ b/Source/Synchronization/ZMOperationLoop+PushChannel.swift
@@ -26,7 +26,7 @@ extension ZMOperationLoop: ZMPushChannelConsumer {
         if let events = ZMUpdateEvent.eventsArray(fromPushChannelData: data), !events.isEmpty {
             Logging.eventProcessing.info("Received \(events.count) events from push channel")
             events.forEach({ $0.appendDebugInformation("from push channel (web socket)")})
-            syncStrategy.process(updateEvents: events, ignoreBuffer: false)
+            syncStrategy.storeAndProcessUpdateEvents(events, ignoreBuffer: false)
         }
     }
     

--- a/Source/Synchronization/ZMSyncStrategy+EventProcessing.swift
+++ b/Source/Synchronization/ZMSyncStrategy+EventProcessing.swift
@@ -21,25 +21,71 @@ import WireUtilities
 
 @objc
 public protocol UpdateEventProcessor: class {
+            
+    @objc(storeUpdateEvents:ignoreBuffer:)
+    func storeUpdateEvents(_ updateEvents: [ZMUpdateEvent], ignoreBuffer: Bool)
     
-    @objc(processUpdateEvents:ignoreBuffer:)
-    func process(updateEvents: [ZMUpdateEvent], ignoreBuffer: Bool)
-    
+    @objc(storeAndProcessUpdateEvents:ignoreBuffer:)
+    func storeAndProcessUpdateEvents(_ updateEvents: [ZMUpdateEvent], ignoreBuffer: Bool)
 }
 
-extension ZMSyncStrategy: ZMUpdateEventConsumer, UpdateEventProcessor {
-
-    public func process(updateEvents: [ZMUpdateEvent], ignoreBuffer: Bool) {
+extension ZMSyncStrategy: UpdateEventProcessor {
+         
+    /// Process previously received events after finishing the quick sync.
+    ///
+    /// - Returns: **True** if there are still more events to process
+    @objc
+    public func processEventsAfterFinishingQuickSync() -> Bool { // TODO jacob shouldn't be public
+        processAllEventsInBuffer()
+        return processEventsIfReady()
+    }
+    
+    /// Process previously received events after unlocking the database.
+    ///
+    /// - Returns: **True** if there are still more events to process
+    func processEventsAfterUnlockingDatabase() -> Bool {
+        return processEventsIfReady()
+    }
+        
+    /// Process previously received events if we are ready to process events.
+    ///
+    /// /// - Returns: **True** if there are still more events to process
+    func processEventsIfReady() -> Bool {
+        guard isReadyToProcessEvents else {
+            return  true
+        }
+        
+        if syncMOC.encryptMessagesAtRest {
+            guard let encryptionKeys = applicationStatusDirectory?.syncStatus.encryptionKeys else {
+                return true
+            }
+            
+            processStoredUpdateEvents(with: encryptionKeys)
+        } else {
+            processStoredUpdateEvents()
+        }
+        
+        applyHotFixes()
+        
+        return false
+    }
+    
+    public func storeUpdateEvents(_ updateEvents: [ZMUpdateEvent], ignoreBuffer: Bool) {
         if ignoreBuffer || isReadyToProcessEvents {
-            consume(updateEvents: updateEvents)
+            eventDecoder.storeEvents(updateEvents)
         } else {
             Logging.eventProcessing.info("Buffering \(updateEvents.count) event(s)")
             updateEvents.forEach(eventsBuffer.addUpdateEvent)
         }
     }
     
-    public func consume(updateEvents: [ZMUpdateEvent]) {
-        eventDecoder.processEvents(updateEvents) { [weak self] (decryptedUpdateEvents) in
+    public func storeAndProcessUpdateEvents(_ updateEvents: [ZMUpdateEvent], ignoreBuffer: Bool) {
+        storeUpdateEvents(updateEvents, ignoreBuffer: ignoreBuffer)
+        _ = processEventsIfReady()
+    }
+        
+    private func processStoredUpdateEvents(with encryptionKeys: EncryptionKeys? = nil) {
+        eventDecoder.processStoredEvents { [weak self] (decryptedUpdateEvents) in
             guard let `self` = self else { return }
             
             let date = Date()
@@ -47,7 +93,7 @@ extension ZMSyncStrategy: ZMUpdateEventConsumer, UpdateEventProcessor {
             let prefetchResult = syncMOC.executeFetchRequestBatchOrAssert(fetchRequest)
             
             Logging.eventProcessing.info("Consuming: [\n\(decryptedUpdateEvents.map({ "\tevent: \(ZMUpdateEvent.eventTypeString(for: $0.type) ?? "Unknown")" }).joined(separator: "\n"))\n]")
-        
+            
             for event in decryptedUpdateEvents {
                 for eventConsumer in self.eventConsumers {
                     eventConsumer.processEvents([event], liveEvents: true, prefetchResult: prefetchResult)
@@ -67,9 +113,7 @@ extension ZMSyncStrategy: ZMUpdateEventConsumer, UpdateEventProcessor {
             syncMOC.saveOrRollback()
             
             Logging.eventProcessing.debug("Events processed in \(-date.timeIntervalSinceNow): \(self.eventProcessingTracker?.debugDescription ?? "")")
-            
         }
-        
     }
      
     @objc(prefetchRequestForUpdateEvents:)

--- a/Source/Synchronization/ZMSyncStrategy+EventProcessing.swift
+++ b/Source/Synchronization/ZMSyncStrategy+EventProcessing.swift
@@ -43,7 +43,8 @@ extension ZMSyncStrategy: UpdateEventProcessor {
     /// Process previously received events after unlocking the database.
     ///
     /// - Returns: **True** if there are still more events to process
-    func processEventsAfterUnlockingDatabase() -> Bool {
+    @objc
+    public func processEventsAfterUnlockingDatabase() -> Bool { // TODO jacob shouldn't be public
         return processEventsIfReady()
     }
         

--- a/Source/Synchronization/ZMSyncStrategy.h
+++ b/Source/Synchronization/ZMSyncStrategy.h
@@ -61,7 +61,7 @@
 
 - (void)didInterruptUpdateEventsStream;
 - (void)didEstablishUpdateEventsStream;
-- (void)didFinishSync;
+- (void)applyHotFixes;
 
 - (ZMTransportRequest *_Nullable)nextRequest;
 

--- a/Source/Synchronization/ZMSyncStrategy.m
+++ b/Source/Synchronization/ZMSyncStrategy.m
@@ -133,7 +133,7 @@ ZM_EMPTY_ASSERTING_INIT()
                                      applicationStatusDirectory:applicationStatusDirectory
                                         callCenterConfiguration:callCenterConfiguration];
 
-        self.eventsBuffer = [[ZMUpdateEventsBuffer alloc] initWithUpdateEventConsumer:self];
+        self.eventsBuffer = [[ZMUpdateEventsBuffer alloc] initWithUpdateEventProcessor:self];
         self.userClientRequestStrategy = [[UserClientRequestStrategy alloc] initWithClientRegistrationStatus:applicationStatusDirectory.clientRegistrationStatus
                                                                                           clientUpdateStatus:applicationStatusDirectory.clientUpdateStatus
                                                                                                      context:self.syncMOC
@@ -283,9 +283,8 @@ ZM_EMPTY_ASSERTING_INIT()
     [self.applicationStatusDirectory.syncStatus pushChannelDidClose];
 }
 
-- (void)didFinishSync
+- (void)applyHotFixes
 {
-    [self processAllEventsInBuffer];
     [self.hotFix applyPatches];
 }
 
@@ -335,7 +334,6 @@ ZM_EMPTY_ASSERTING_INIT()
 - (void)processAllEventsInBuffer
 {
     [self.eventsBuffer processAllEventsInBuffer];
-    [self.syncMOC enqueueDelayedSave];
 }
 
 

--- a/Source/Synchronization/ZMUpdateEventsBuffer.h
+++ b/Source/Synchronization/ZMUpdateEventsBuffer.h
@@ -20,12 +20,8 @@
 @import Foundation;
 
 @class ZMUpdateEvent;
+@protocol UpdateEventProcessor;
 
-@protocol ZMUpdateEventConsumer <NSObject>
-
-- (void)consumeUpdateEvents:(NSArray<ZMUpdateEvent *>* _Nonnull)updateEvents NS_SWIFT_NAME(consume(updateEvents:));
-
-@end
 
 @protocol ZMUpdateEventsFlushableCollection <NSObject>
 
@@ -37,13 +33,7 @@
 
 @interface ZMUpdateEventsBuffer : NSObject <ZMUpdateEventsFlushableCollection>
 
-- (instancetype _Nonnull )initWithUpdateEventConsumer:(id <ZMUpdateEventConsumer> _Nonnull)eventConsumer;
-
-/// discard all events in the buffer
-- (void)discardAllUpdateEvents;
-
-/// discard the event with this identifier
-- (void)discardUpdateEventWithIdentifier:(NSUUID *_Nonnull)eventIdentifier;
+- (instancetype _Nonnull )initWithUpdateEventProcessor:(id <UpdateEventProcessor> _Nonnull)eventProcessor;
 
 - (void)addUpdateEvent:(ZMUpdateEvent *_Nonnull)event;
 

--- a/Source/Synchronization/ZMUpdateEventsBuffer.m
+++ b/Source/Synchronization/ZMUpdateEventsBuffer.m
@@ -18,10 +18,11 @@
 
 @import WireTransport;
 #import "ZMUpdateEventsBuffer.h"
+#import <WireSyncEngine/WireSyncEngine-Swift.h>
 
 @interface ZMUpdateEventsBuffer ()
 
-@property (nonatomic, readonly, weak) id<ZMUpdateEventConsumer> consumer;
+@property (nonatomic, readonly, weak) id<UpdateEventProcessor> updateEventProcessor;
 @property (nonatomic, readonly) NSMutableArray *bufferedEvents;
 
 @end
@@ -31,12 +32,12 @@
 
 @implementation ZMUpdateEventsBuffer
 
-- (instancetype)initWithUpdateEventConsumer:(id<ZMUpdateEventConsumer>)eventConsumer
+- (instancetype)initWithUpdateEventProcessor:(id<UpdateEventProcessor>)eventProcessor
 {
     self = [super self];
     if(self) {
         _bufferedEvents = [NSMutableArray array];
-        _consumer = eventConsumer;
+        _updateEventProcessor = eventProcessor;
     }
     return self;
 }
@@ -48,23 +49,8 @@
 
 - (void)processAllEventsInBuffer
 {
-    [self.consumer consumeUpdateEvents:self.bufferedEvents];
+    [self.updateEventProcessor storeUpdateEvents:self.bufferedEvents ignoreBuffer:YES];
     [self.bufferedEvents removeAllObjects];
-}
-
-- (void)discardAllUpdateEvents
-{
-    [self.bufferedEvents removeAllObjects];
-}
-
-- (void)discardUpdateEventWithIdentifier:(NSUUID *)eventIdentifier
-{
-    NSUInteger index = [self.bufferedEvents indexOfObjectPassingTest:^BOOL(ZMUpdateEvent *obj, NSUInteger __unused idx, BOOL * __unused stop) {
-        return [obj.uuid isEqual:eventIdentifier];
-    }];
-    if(index != NSNotFound) {
-        [self.bufferedEvents removeObjectAtIndex:index];
-    }
 }
 
 - (NSArray *)updateEvents

--- a/Source/UserSession/SyncStatus.swift
+++ b/Source/UserSession/SyncStatus.swift
@@ -116,7 +116,7 @@ extension Notification.Name {
     
     var encryptionKeys: EncryptionKeys? { // TODO jacob move somewhere more appropriate
         didSet {
-            DatabaseEncryptionLockNotification(databaseIsEncrypted: encryptionKeys != nil).post(in: managedObjectContext.notificationContext)
+            DatabaseEncryptionLockNotification(databaseIsEncrypted: encryptionKeys == nil).post(in: managedObjectContext.notificationContext)
         }
     }
     

--- a/Source/UserSession/ZMUserSession+EncryptionAtRest.swift
+++ b/Source/UserSession/ZMUserSession+EncryptionAtRest.swift
@@ -52,7 +52,8 @@ extension ZMUserSession {
         
     public func registerDatabaseLockedHandler(_ handler: @escaping (_ isDatabaseLocked: Bool) -> Void) -> Any {
         return NotificationInContext.addObserver(name: DatabaseEncryptionLockNotification.notificationName,
-                                                 context: managedObjectContext.notificationContext)
+                                                 context: managedObjectContext.notificationContext,
+                                                 queue: .main)
         { note in
             guard let note = note.userInfo[DatabaseEncryptionLockNotification.userInfoKey] as? DatabaseEncryptionLockNotification else { return }
             
@@ -63,14 +64,26 @@ extension ZMUserSession {
     func lockDatabase() {
         guard managedObjectContext.encryptMessagesAtRest else { return }
         
-        applicationStatusDirectory?.syncStatus.encryptionKeys = nil
+        syncManagedObjectContext.performGroupedBlock {
+            self.applicationStatusDirectory?.syncStatus.encryptionKeys = nil
+        }
     }
     
     public func unlockDatabase(with context: LAContext) throws {
         let account = Account(userName: "", userIdentifier: ZMUser.selfUser(in: managedObjectContext).remoteIdentifier)
         let keys = try EncryptionKeys.init(account: account, context: context)
         
-        applicationStatusDirectory?.syncStatus.encryptionKeys = keys
+        syncManagedObjectContext.performGroupedBlock {
+            guard let syncStrategy = self.syncStrategy else { return }
+            
+            self.applicationStatusDirectory?.syncStatus.encryptionKeys = keys
+            let hasMoreEventsToProcess = syncStrategy.processEventsAfterUnlockingDatabase()
+            
+            self.managedObjectContext.performGroupedBlock { [weak self] in
+                self?.isPerformingSync = hasMoreEventsToProcess
+                self?.updateNetworkState()
+            }
+        }
     }
     
 }

--- a/Source/UserSession/ZMUserSession.swift
+++ b/Source/UserSession/ZMUserSession.swift
@@ -414,7 +414,7 @@ extension ZMUserSession: ZMNetworkStateDelegate {
         }
     }
     
-    internal func updateNetworkState() {
+    func updateNetworkState() {
         let state: ZMNetworkState
         
         if isNetworkOnline {

--- a/Tests/Source/Integration/APNSTests+Swift.swift
+++ b/Tests/Source/Integration/APNSTests+Swift.swift
@@ -20,7 +20,9 @@ import Foundation
 import WireMockTransport
 
 class APNSTests_Swift: APNSTestsBase {
-    func testThatItSendsAConfirmationMessageWhenReceivingATextMessage() {
+    
+    // TODO jacob disabled until we send confirmation message form update events (ZIOS-13585)
+    func _testThatItSendsAConfirmationMessageWhenReceivingATextMessage() {
         guard BackgroundAPNSConfirmationStatus.sendDeliveryReceipts else {
             return
         }

--- a/Tests/Source/Integration/APNSTests.m
+++ b/Tests/Source/Integration/APNSTests.m
@@ -29,7 +29,8 @@
 
 @implementation APNSTests
 
-- (void)testThatAConversationIsCreatedFromAnAPNS
+// TODO jacob disabled since we no longer process events when receiving an APNS
+- (void)_testThatAConversationIsCreatedFromAnAPNS
 {
     // given
     XCTAssertTrue([self login]);
@@ -89,7 +90,6 @@
     }];
     WaitForAllGroupsToBeEmpty(0.2);
     NSUUID *notificationID = NSUUID.timeBasedUUID;
-    NSUUID *conversationID = [NSUUID uuidWithTransportString:convIdentifier];
     
     NSDictionary *eventPayload = [self conversationCreatePayloadWithNotificationID:notificationID
                                                                     conversationID:convIdentifier
@@ -121,8 +121,7 @@
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
-    ZMConversation *conversation = [ZMConversation fetchObjectWithRemoteIdentifier:conversationID inManagedObjectContext:self.userSession.managedObjectContext];
-    XCTAssertNotNil(conversation);
+    XCTAssertEqualObjects(self.userSession.managedObjectContext.zm_lastNotificationID, notificationID);
 }
 
 - (void)testThatItFetchesTheNotificationStreamWhenReceivingNotificationOfTypeNotice_TriesAgainWhenReceiving_401
@@ -144,7 +143,6 @@
     }];
     WaitForAllGroupsToBeEmpty(0.2);
     NSUUID *notificationID = NSUUID.timeBasedUUID;
-    NSUUID *conversationID = [NSUUID uuidWithTransportString:convIdentifier];
     
     NSDictionary *eventPayload = [self conversationCreatePayloadWithNotificationID:notificationID
                                                                     conversationID:convIdentifier
@@ -181,8 +179,7 @@
     
     // then
     XCTAssertEqual(requestCount, 2lu);
-    ZMConversation *conversation = [ZMConversation fetchObjectWithRemoteIdentifier:conversationID inManagedObjectContext:self.userSession.managedObjectContext];
-    XCTAssertNotNil(conversation);
+    XCTAssertEqualObjects(self.userSession.managedObjectContext.zm_lastNotificationID, notificationID);
 }
 
 #pragma mark - Helper

--- a/Tests/Source/Integration/APNSTests.m
+++ b/Tests/Source/Integration/APNSTests.m
@@ -29,48 +29,6 @@
 
 @implementation APNSTests
 
-// TODO jacob disabled since we no longer process events when receiving an APNS
-- (void)_testThatAConversationIsCreatedFromAnAPNS
-{
-    // given
-    XCTAssertTrue([self login]);
-    
-    [self closePushChannelAndWaitUntilClosed]; // do not use websocket
-    
-    NSString *conversationName = @"MYCONVO";
-    __block NSString *conversationID;
-    WaitForAllGroupsToBeEmpty(0.2);
-    __block NSDictionary *conversationTransportData;
-    
-    ZMConversationList *conversationsList = [ZMConversationList conversationsInUserSession:self.userSession];
-    NSUInteger oldCount = conversationsList.count;
-    
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
-        MockConversation *conversation = [session insertGroupConversationWithSelfUser:self.selfUser otherUsers:@[self.user1]];
-        [conversation changeNameByUser:self.selfUser name:conversationName];
-        conversationID = conversation.identifier;
-        conversationTransportData = (NSDictionary *)conversation.transportData;
-    }];
-    WaitForAllGroupsToBeEmpty(0.2);
-        
-    [self.application setBackground];
-    
-    // when
-    [self.userSession receivedPushNotificationWith:[self noticePayloadForLastEvent] completion:^{}];
-    WaitForAllGroupsToBeEmpty(0.5);
-    
-    // then
-    ZMConversationList *convs = [ZMConversationList conversationsInUserSession:self.userSession];
-    XCTAssertEqual(convs.count, oldCount+1);
-    NSUInteger index = [conversationsList indexOfObjectPassingTest:^BOOL(ZMConversation *conversation, NSUInteger idx, BOOL *stop) {
-        NOT_USED(idx);
-        NOT_USED(stop);
-        return [conversation.displayName isEqualToString:conversationName];
-    }];
-    XCTAssertNotEqual(index, (NSUInteger) NSNotFound);
-    
-}
-
 - (void)testThatItFetchesTheNotificationStreamWhenReceivingNotificationOfTypeNotice
 {
     XCTAssertTrue([self login]);

--- a/Tests/Source/MockUpdateEventProcessor.swift
+++ b/Tests/Source/MockUpdateEventProcessor.swift
@@ -23,9 +23,13 @@ import Foundation
 class MockUpdateEventProcessor: WireSyncEngine.UpdateEventProcessor {
     
     var processedEvents: [ZMUpdateEvent] = []
-    
-    func process(updateEvents: [ZMUpdateEvent], ignoreBuffer: Bool) {
+        
+    func storeAndProcessUpdateEvents(_ updateEvents: [ZMUpdateEvent], ignoreBuffer: Bool) {
         processedEvents.append(contentsOf: updateEvents)
+    }
+    
+    func storeUpdateEvents(_ updateEvents: [ZMUpdateEvent], ignoreBuffer: Bool) {
+        // TODO jacob this goes into a different array?
     }
     
 }

--- a/Tests/Source/MockUpdateEventProcessor.swift
+++ b/Tests/Source/MockUpdateEventProcessor.swift
@@ -29,7 +29,7 @@ class MockUpdateEventProcessor: WireSyncEngine.UpdateEventProcessor {
     }
     
     func storeUpdateEvents(_ updateEvents: [ZMUpdateEvent], ignoreBuffer: Bool) {
-        // TODO jacob this goes into a different array?
+        
     }
     
 }

--- a/Tests/Source/Synchronization/EventDecoderTests.swift
+++ b/Tests/Source/Synchronization/EventDecoderTests.swift
@@ -58,9 +58,10 @@ extension EventDecoderTest {
         syncMOC.performGroupedBlock {
             // given
             let event = self.eventStreamEvent()
+            self.sut.storeEvents([event])
             
             // when
-            self.sut.processEvents([event]) { (events) in
+            self.sut.processStoredEvents { (events) in
                 XCTAssertTrue(events.contains(event))
                 didCallBlock = true
             }
@@ -81,11 +82,11 @@ extension EventDecoderTest {
             // given
             let event1 = self.eventStreamEvent()
             let event2 = self.eventStreamEvent()
-            self.insert([event1])
+            self.sut.storeEvents([event1])
             
             // when
-            
-            self.sut.processEvents([event2]) { (events) in
+            self.sut.storeEvents([event2])
+            self.sut.processStoredEvents { (events) in
                 if callCount == 0 {
                     XCTAssertTrue(events.contains(event1))
                 } else if callCount == 1 {
@@ -115,11 +116,11 @@ extension EventDecoderTest {
             let event2 = self.eventStreamEvent()
             let event3 = self.eventStreamEvent()
             let event4 = self.eventStreamEvent()
-            
-            self.insert([event1, event2, event3])
+        
+            self.sut.storeEvents([event1, event2, event3, event4])
             
             // when
-            self.sut.processEvents([event4]) { (events) in
+            self.sut.processStoredEvents { (events) in
                 if callCount == 0 {
                     XCTAssertTrue(events.contains(event1))
                     XCTAssertTrue(events.contains(event2))
@@ -152,17 +153,17 @@ extension EventDecoderTest {
             let event3 = self.eventStreamEvent()
             let event4 = self.eventStreamEvent()
             
-            self.insert([event1])
-            
-            self.sut.processEvents([event2]) { (events) in
+            self.sut.storeEvents([event1, event2])
+                        
+            self.sut.processStoredEvents { (events) in
                 XCTAssert(events.contains(event1))
                 XCTAssert(events.contains(event2))
             }
             
-            self.insert([event3], startIndex: 1)
+            self.insert([event3, event4], startIndex: 1)
             
             // when
-            self.sut.processEvents([event4]) { (events) in
+            self.sut.processStoredEvents { (events) in
                 XCTAssertFalse(events.contains(event1))
                 XCTAssertFalse(events.contains(event2))
                 XCTAssertTrue(events.contains(event3))
@@ -184,7 +185,7 @@ extension EventDecoderTest {
             self.insert([event1, event2])
             
             // when
-            self.sut.processEvents([]) { (events) in
+            self.sut.processStoredEvents { (events) in
                 XCTAssertEqual(events, [event2])
                 didCallBlock = true
             }
@@ -209,7 +210,7 @@ extension EventDecoderTest {
             self.insert([event1, event2])
             
             // when
-            self.sut.processEvents([]) { (events) in
+            self.sut.processStoredEvents { (events) in
                 XCTAssertEqual(events, [event1, event2])
                 didCallBlock = true
             }
@@ -232,7 +233,7 @@ extension EventDecoderTest {
             self.insert([event1, event2])
             
             // when
-            self.sut.processEvents([]) { (events) in
+            self.sut.processStoredEvents { (events) in
                 XCTAssertEqual(events, [event1, event2])
                 didCallBlock = true
             }
@@ -259,7 +260,8 @@ extension EventDecoderTest {
             let streamEvent = self.eventStreamEvent()
             
             // when
-            self.sut.processEvents([pushEvent]) { (events) in
+            self.sut.storeEvents([pushEvent])
+            self.sut.processStoredEvents { (events) in
                 XCTAssertTrue(events.contains(pushEvent))
                 pushProcessed.fulfill()
             }
@@ -268,8 +270,9 @@ extension EventDecoderTest {
             XCTAssert(self.waitForCustomExpectations(withTimeout: 0.5))
             
             // and when
-            let streamProcessed = self.expectation(description: "Push event processed")
-            self.sut.processEvents([streamEvent]) { (events) in
+            let streamProcessed = self.expectation(description: "Stream event processed")
+            self.sut.storeEvents([streamEvent])
+            self.sut.processStoredEvents { (events) in
                 XCTAssertTrue(events.contains(streamEvent))
                 streamProcessed.fulfill()
             }
@@ -290,7 +293,8 @@ extension EventDecoderTest {
             let streamEvent = self.eventStreamEvent(uuid: uuid)
             
             // when
-            self.sut.processEvents([pushEvent]) { (events) in
+            self.sut.storeEvents([pushEvent])
+            self.sut.processStoredEvents { (events) in
                 XCTAssertTrue(events.contains(pushEvent))
                 pushProcessed.fulfill()
             }
@@ -299,8 +303,9 @@ extension EventDecoderTest {
             XCTAssert(self.waitForCustomExpectations(withTimeout: 0.5))
             
             // and when
-            let streamProcessed = self.expectation(description: "Push event processed")
-            self.sut.processEvents([streamEvent]) { (events) in
+            let streamProcessed = self.expectation(description: "Stream event not processed")
+            self.sut.storeEvents([streamEvent])
+            self.sut.processStoredEvents { (events) in
                 XCTAssertTrue(events.isEmpty)
                 streamProcessed.fulfill()
             }
@@ -321,7 +326,8 @@ extension EventDecoderTest {
             let streamEvent = self.eventStreamEvent(uuid: uuid)
             
             // when
-            self.sut.processEvents([pushEvent]) { (events) in
+            self.sut.storeEvents([pushEvent])
+            self.sut.processStoredEvents { (events) in
                 XCTAssertTrue(events.contains(pushEvent))
                 pushProcessed.fulfill()
             }
@@ -331,8 +337,9 @@ extension EventDecoderTest {
             XCTAssert(self.waitForCustomExpectations(withTimeout: 0.5))
             
             // and when
-            let streamProcessed = self.expectation(description: "Push event processed")
-            self.sut.processEvents([streamEvent]) { (events) in
+            let streamProcessed = self.expectation(description: "Stream event processed")
+            self.sut.storeEvents([streamEvent])
+            self.sut.processStoredEvents { (events) in
                 XCTAssertTrue(events.contains(streamEvent))
                 streamProcessed.fulfill()
             }

--- a/Tests/Source/Synchronization/Transcoders/ZMLastUpdateEventIDTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMLastUpdateEventIDTranscoderTests.m
@@ -176,8 +176,8 @@
 {
     // given
     NSUUID *uuid = [NSUUID createUUID];
-    [[(id) self.syncStrategy stub] processUpdateEvents:OCMOCK_ANY ignoreBuffer:YES];
-    [[(id) self.syncStrategy stub] processUpdateEvents:OCMOCK_ANY ignoreBuffer:NO];
+    [[(id) self.syncStrategy stub] storeAndProcessUpdateEvents:OCMOCK_ANY ignoreBuffer:YES];
+    [[(id) self.syncStrategy stub] storeAndProcessUpdateEvents:OCMOCK_ANY ignoreBuffer:NO];
     [self injectLastUpdateEventID:uuid.transportString];
     
     // expect
@@ -191,8 +191,8 @@
 {
     // given
     NSUUID *uuid = [NSUUID createUUID];
-    [[(id) self.syncStrategy stub] processUpdateEvents:OCMOCK_ANY ignoreBuffer:YES];
-    [[(id) self.syncStrategy stub] processUpdateEvents:OCMOCK_ANY ignoreBuffer:NO];
+    [[(id) self.syncStrategy stub] storeAndProcessUpdateEvents:OCMOCK_ANY ignoreBuffer:YES];
+    [[(id) self.syncStrategy stub] storeAndProcessUpdateEvents:OCMOCK_ANY ignoreBuffer:NO];
     [self injectLastUpdateEventID:uuid.transportString];
     
     // expect
@@ -208,8 +208,8 @@
 {
     // given
     NSUUID *uuid = [NSUUID createUUID];
-    [[(id) self.syncStrategy stub] processUpdateEvents:OCMOCK_ANY ignoreBuffer:YES];
-    [[(id) self.syncStrategy stub] processUpdateEvents:OCMOCK_ANY ignoreBuffer:NO];
+    [[(id) self.syncStrategy stub] storeAndProcessUpdateEvents:OCMOCK_ANY ignoreBuffer:YES];
+    [[(id) self.syncStrategy stub] storeAndProcessUpdateEvents:OCMOCK_ANY ignoreBuffer:NO];
     [self injectLastUpdateEventID:uuid.transportString];
     
     // expect
@@ -225,8 +225,8 @@
 - (void)testThatItTheLastUpdateEventIDIsNotPersistedIfTheResponseWasInvalid
 {
     // given
-    [[(id) self.syncStrategy stub] processUpdateEvents:OCMOCK_ANY ignoreBuffer:YES];
-    [[(id) self.syncStrategy stub] processUpdateEvents:OCMOCK_ANY ignoreBuffer:NO];
+    [[(id) self.syncStrategy stub] storeAndProcessUpdateEvents:OCMOCK_ANY ignoreBuffer:YES];
+    [[(id) self.syncStrategy stub] storeAndProcessUpdateEvents:OCMOCK_ANY ignoreBuffer:NO];
     [self performIgnoringZMLogError:^{
         [self injectLastUpdateEventID:@"foo"];
     }];

--- a/Tests/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoderTests.m
@@ -241,7 +241,7 @@ static NSString * const LastUpdateEventIDStoreKey = @"LastUpdateEventID";
     [expectedEvents addObjectsFromArray:[ZMUpdateEvent eventsArrayFromPushChannelData:payload2]];
 
     // expect
-    [[(id)self.syncStrategy expect] processUpdateEvents:expectedEvents ignoreBuffer:YES];
+    [[(id)self.syncStrategy expect] storeUpdateEvents:expectedEvents ignoreBuffer:YES];
     
     // when
     [(id)self.sut.listPaginator didReceiveResponse:[ZMTransportResponse responseWithPayload:payload HTTPStatus:200 transportSessionError:nil] forSingleRequest:self.requestSync];
@@ -276,7 +276,7 @@ static NSString * const LastUpdateEventIDStoreKey = @"LastUpdateEventID";
     [expectedEvents addObjectsFromArray:[ZMUpdateEvent eventsArrayFromPushChannelData:payload2]];
     
     // expect
-    [[(id)self.syncStrategy expect] processUpdateEvents:expectedEvents ignoreBuffer:YES];
+    [[(id)self.syncStrategy expect] storeUpdateEvents:expectedEvents ignoreBuffer:YES];
     
     // when
     [(id)self.sut.listPaginator didReceiveResponse:[ZMTransportResponse responseWithPayload:payload HTTPStatus:404 transportSessionError:nil] forSingleRequest:self.requestSync];

--- a/Tests/Source/Synchronization/ZMOperationLoopTests.m
+++ b/Tests/Source/Synchronization/ZMOperationLoopTests.m
@@ -657,7 +657,7 @@
     XCTAssertGreaterThan(expectedEvents.count, 0u);
     
     // expect
-    [[self.syncStrategy expect] processUpdateEvents:expectedEvents ignoreBuffer:NO];
+    [[self.syncStrategy expect] storeAndProcessUpdateEvents:expectedEvents ignoreBuffer:NO];
     
     // when
     [(id<ZMPushChannelConsumer>)self.sut pushChannel:self.mockPushChannel didReceiveTransportData:eventData];
@@ -676,8 +676,8 @@
                                 };
     
     // expect
-    [[self.syncStrategy reject] processUpdateEvents:OCMOCK_ANY ignoreBuffer:NO];
-    [[self.syncStrategy reject] processUpdateEvents:OCMOCK_ANY ignoreBuffer:YES];
+    [[self.syncStrategy reject] storeAndProcessUpdateEvents:OCMOCK_ANY ignoreBuffer:NO];
+    [[self.syncStrategy reject] storeAndProcessUpdateEvents:OCMOCK_ANY ignoreBuffer:YES];
     
     // when
     [self performIgnoringZMLogError:^{
@@ -692,8 +692,8 @@
     NSArray *eventdata = @[ @{ @"id" : @"16be010d-c284-4fc0-b636-837bcebed654" } ];
     
     // expect
-    [[self.syncStrategy reject] processUpdateEvents:OCMOCK_ANY ignoreBuffer:NO];
-    [[self.syncStrategy reject] processUpdateEvents:OCMOCK_ANY ignoreBuffer:YES];
+    [[self.syncStrategy reject] storeAndProcessUpdateEvents:OCMOCK_ANY ignoreBuffer:NO];
+    [[self.syncStrategy reject] storeAndProcessUpdateEvents:OCMOCK_ANY ignoreBuffer:YES];
     
     // when
     [self performIgnoringZMLogError:^{

--- a/Tests/Source/Synchronization/ZMSyncStrategyTests.m
+++ b/Tests/Source/Synchronization/ZMSyncStrategyTests.m
@@ -180,7 +180,7 @@
     
     self.updateEventsBuffer = [OCMockObject mockForClass:ZMUpdateEventsBuffer.class];
     [[[[self.updateEventsBuffer expect] andReturn:self.updateEventsBuffer] classMethod] alloc];
-    (void) [[[self.updateEventsBuffer stub] andReturn:self.updateEventsBuffer] initWithUpdateEventConsumer:OCMOCK_ANY];
+    (void) [[[self.updateEventsBuffer stub] andReturn:self.updateEventsBuffer] initWithUpdateEventProcessor:OCMOCK_ANY];
     [self verifyMockLater:self.updateEventsBuffer];
     
     self.syncObjects = @[
@@ -335,7 +335,7 @@
     }] processEvents:expectedEvents liveEvents:YES prefetchResult:OCMOCK_ANY];
     
     // when
-    [self.sut consumeUpdateEvents:@[expectedEvents.firstObject]];
+    [self.sut storeAndProcessUpdateEvents:@[expectedEvents.firstObject] ignoreBuffer:YES];
     
     WaitForAllGroupsToBeEmpty(0.5);
     
@@ -369,7 +369,7 @@
 
     // when
     for(id event in eventsArray) {
-        [self.sut consumeUpdateEvents:@[event]];
+        [self.sut storeAndProcessUpdateEvents:@[event] ignoreBuffer:YES];
         WaitForAllGroupsToBeEmpty(0.5);
     }
 }
@@ -397,7 +397,7 @@
                                 withEvents:eventsArray];
     
     // when
-    [self.sut processUpdateEvents:eventsArray ignoreBuffer:YES];
+    [self.sut storeAndProcessUpdateEvents:eventsArray ignoreBuffer:YES];
     WaitForAllGroupsToBeEmpty(0.5);
 }
 
@@ -426,7 +426,7 @@
                                 withEvents:expectedEvents];
     
     // when
-    [self.sut processUpdateEvents:expectedEvents ignoreBuffer:NO];
+    [self.sut storeAndProcessUpdateEvents:expectedEvents ignoreBuffer:NO];
     WaitForAllGroupsToBeEmpty(0.5);
 }
 
@@ -461,7 +461,7 @@
     }
     
     // when
-    [self.sut processUpdateEvents:expectedEvents ignoreBuffer:NO];
+    [self.sut storeAndProcessUpdateEvents:expectedEvents ignoreBuffer:NO];
     WaitForAllGroupsToBeEmpty(0.5);
 }
 
@@ -492,7 +492,7 @@
     [[self.updateEventsBuffer reject] addUpdateEvent:OCMOCK_ANY];
     
     // when
-    [self.sut processUpdateEvents:expectedEvents ignoreBuffer:YES];
+    [self.sut storeAndProcessUpdateEvents:expectedEvents ignoreBuffer:YES];
     WaitForAllGroupsToBeEmpty(0.5);
 }
 
@@ -522,7 +522,7 @@
                                 withEvents:expectedEvents];
     
     // when
-    [self.sut processUpdateEvents:expectedEvents ignoreBuffer:YES];
+    [self.sut storeAndProcessUpdateEvents:expectedEvents ignoreBuffer:YES];
     WaitForAllGroupsToBeEmpty(0.5);
 }
 
@@ -574,7 +574,7 @@
                                 withEvents:events];
     
     // when
-    [self.sut processUpdateEvents:events ignoreBuffer:YES];
+    [self.sut storeAndProcessUpdateEvents:events ignoreBuffer:YES];
     WaitForAllGroupsToBeEmpty(0.5);
 }
 
@@ -868,6 +868,8 @@
 - (void)expectSyncObjectsToProcessEvents:(BOOL)process liveEvents:(BOOL)liveEvents decryptEvents:(BOOL)decyptEvents returnIDsForPrefetching:(BOOL)returnIDs withEvents:(NSArray *)events;
 {
     NOT_USED(decyptEvents);
+    
+    [[self.syncStatusMock expect] isSyncing];
     
     for (id obj in self.syncObjects) {
         if (![obj conformsToProtocol:@protocol(ZMEventConsumer)]) {

--- a/Tests/Source/UserSession/ZMUserSessionTests+EncryptionAtRest.swift
+++ b/Tests/Source/UserSession/ZMUserSessionTests+EncryptionAtRest.swift
@@ -99,7 +99,7 @@ class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
     
     // MARK: - Database lock handler/observer
     
-    func testThatDatabaseLockedHandlerIsCalled_AfterEnteringBackground() {
+    func testThatDatabaseLockedHandlerIsCalled_AfterDatabaseIsLocked() {
         // given
         simulateLoggedInUser()
         syncMOC.saveOrRollback()

--- a/Tests/Source/UserSession/ZMUserSessionTests+EncryptionAtRest.swift
+++ b/Tests/Source/UserSession/ZMUserSessionTests+EncryptionAtRest.swift
@@ -1,0 +1,151 @@
+////
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import LocalAuthentication
+
+class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
+    
+    override func tearDown() {
+        sut.encryptMessagesAtRest = false
+        
+        super.tearDown()
+    }
+    
+    // MARK: - Database locking/unlocking
+    
+    func testThatDatabaseIsUnlocked_WhenEncryptionAtRestIsDisabled() {
+        // given
+        simulateLoggedInUser()
+        syncMOC.saveOrRollback()
+        
+        // when
+        sut.encryptMessagesAtRest = false
+        
+        // then
+        XCTAssertFalse(sut.isDatabaseLocked)
+    }
+
+    func testThatDatabaseIsUnlocked_AfterActivatingEncryptionAtRest() {
+        // given
+        simulateLoggedInUser()
+        syncMOC.saveOrRollback()
+        
+        // when
+        sut.encryptMessagesAtRest = true
+        
+        // then
+        XCTAssertFalse(sut.isDatabaseLocked)
+    }
+    
+    func testThatDatabaseIsUnlocked_AfterDeactivatingEncryptionAtRest() {
+        // given
+        simulateLoggedInUser()
+        syncMOC.saveOrRollback()
+        sut.encryptMessagesAtRest = true
+        
+        // when
+        sut.encryptMessagesAtRest = false
+        
+        // then
+        XCTAssertFalse(sut.isDatabaseLocked)
+    }
+        
+    func testThatDatabaseIsUnlocked_AfterUnlockingDatabase() throws {
+        // given
+        simulateLoggedInUser()
+        syncMOC.saveOrRollback()
+        sut.encryptMessagesAtRest = true
+        sut.applicationDidEnterBackground(nil)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        // when
+        let context = LAContext()
+        try sut.unlockDatabase(with: context)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        // then
+        XCTAssertFalse(sut.isDatabaseLocked)
+    }
+    
+    func testThatDatabaseIsLocked_AfterEnteringBackground() {
+        // given
+        simulateLoggedInUser()
+        syncMOC.saveOrRollback()
+        sut.encryptMessagesAtRest = true
+        
+        // when
+        sut.applicationDidEnterBackground(nil)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        // then
+        XCTAssertTrue(sut.isDatabaseLocked)
+    }
+    
+    // MARK: - Database lock handler/observer
+    
+    func testThatDatabaseLockedHandlerIsCalled_AfterEnteringBackground() {
+        // given
+        simulateLoggedInUser()
+        syncMOC.saveOrRollback()
+        sut.encryptMessagesAtRest = true
+        
+        // expect
+        let databaseIsLocked = expectation(description: "database is locked")
+        var token: Any? = sut.registerDatabaseLockedHandler { (isDatabaseLocked) in
+            if isDatabaseLocked {
+                databaseIsLocked.fulfill()
+            }
+        }
+        XCTAssertNotNil(token)
+        
+        // when
+        sut.applicationDidEnterBackground(nil)
+        XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
+        
+        // cleanup
+        token = nil
+    }
+    
+    func testThatDatabaseLockedHandlerIsCalled_AfterUnlockingDatabase() throws {
+        // given
+        simulateLoggedInUser()
+        syncMOC.saveOrRollback()
+        sut.encryptMessagesAtRest = true
+        sut.applicationDidEnterBackground(nil)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        // expect
+        let databaseIsUnlocked = expectation(description: "database is unlocked")
+        var token: Any? = sut.registerDatabaseLockedHandler { (isDatabaseLocked) in
+            if !isDatabaseLocked {
+                databaseIsUnlocked.fulfill()
+            }
+        }
+        XCTAssertNotNil(token)
+        
+        // when
+        let context = LAContext()
+        try sut.unlockDatabase(with: context)
+        XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
+        
+        // cleanup
+        token = nil
+    }
+    
+}

--- a/Tests/Source/UserSession/ZMUserSessionTestsBase.h
+++ b/Tests/Source/UserSession/ZMUserSessionTestsBase.h
@@ -39,6 +39,7 @@
 @class MockSessionManager;
 @class RecordingMockTransportSession;
 @class WireCallCenterConfiguration;
+@class MockSyncStateDelegate;
 
 @interface ThirdPartyServices : NSObject <ZMThirdPartyServicesDelegate>
 
@@ -75,6 +76,8 @@
 @property (nonatomic) ThirdPartyServices *thirdPartyServices;
 @property (nonatomic) id requestAvailableNotification;
 @property (nonatomic) id operationLoop;
+@property (nonatomic) SyncStatus *mockSyncStatus;
+@property (nonatomic) MockSyncStateDelegate *mockSyncStateDelegate;
 @property (nonatomic) ZMClientRegistrationStatus * clientRegistrationStatus;
 @property (nonatomic) ProxiedRequestsStatus *proxiedRequestStatus;
 @property (nonatomic) id<LocalStoreProviderProtocol> storeProvider;

--- a/Tests/Source/UserSession/ZMUserSessionTestsBase.m
+++ b/Tests/Source/UserSession/ZMUserSessionTestsBase.m
@@ -81,16 +81,20 @@
     self.clientRegistrationStatus = [[ZMClientRegistrationStatus alloc] initWithManagedObjectContext:self.syncMOC cookieStorage:self.cookieStorage registrationStatusDelegate:nil];
     self.proxiedRequestStatus = [[ProxiedRequestsStatus alloc] initWithRequestCancellation:self.transportSession];
     self.operationStatus = [[OperationStatus alloc] init];
+    self.mockSyncStateDelegate = [[MockSyncStateDelegate alloc] init];
+    self.mockSyncStatus = [[SyncStatus alloc] initWithManagedObjectContext:self.syncMOC syncStateDelegate:self.mockSyncStateDelegate];
     
     id applicationStatusDirectory = [OCMockObject niceMockForClass:[ApplicationStatusDirectory class]];
     [(ApplicationStatusDirectory *)[[(id)applicationStatusDirectory stub] andReturn:self.clientRegistrationStatus] clientRegistrationStatus];
     [(ApplicationStatusDirectory *)[[(id)applicationStatusDirectory stub] andReturn:self.proxiedRequestStatus] proxiedRequestStatus];
     [(ApplicationStatusDirectory *)[[(id)applicationStatusDirectory stub] andReturn:self.operationStatus] operationStatus];
+    [(ApplicationStatusDirectory *)[[(id)applicationStatusDirectory stub] andReturn:self.mockSyncStatus] syncStatus];
     
     self.syncStrategy = [OCMockObject mockForClass:[ZMSyncStrategy class]];
     [(ZMSyncStrategy *)[[(id)self.syncStrategy stub] andReturn:applicationStatusDirectory] applicationStatusDirectory];
     NOT_USED([[(id)self.syncStrategy stub] processAllEventsInBuffer]);
     NOT_USED([[(id)self.syncStrategy stub] processEventsAfterFinishingQuickSync]);
+    NOT_USED([[(id)self.syncStrategy stub] processEventsAfterUnlockingDatabase]);
     [self verifyMockLater:self.syncStrategy];
 
     self.operationLoop = [OCMockObject mockForClass:ZMOperationLoop.class];

--- a/Tests/Source/UserSession/ZMUserSessionTestsBase.m
+++ b/Tests/Source/UserSession/ZMUserSessionTestsBase.m
@@ -89,7 +89,8 @@
     
     self.syncStrategy = [OCMockObject mockForClass:[ZMSyncStrategy class]];
     [(ZMSyncStrategy *)[[(id)self.syncStrategy stub] andReturn:applicationStatusDirectory] applicationStatusDirectory];
-    [[(id)self.syncStrategy stub] didFinishSync];
+    NOT_USED([[(id)self.syncStrategy stub] processAllEventsInBuffer]);
+    NOT_USED([[(id)self.syncStrategy stub] processEventsAfterFinishingQuickSync]);
     [self verifyMockLater:self.syncStrategy];
 
     self.operationLoop = [OCMockObject mockForClass:ZMOperationLoop.class];

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 		1671F9FF1E2FAF50009F3150 /* ZMLocalNotificationForTests_CallState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1671F9FE1E2FAF50009F3150 /* ZMLocalNotificationForTests_CallState.swift */; };
 		1672A64523473EA100380537 /* LabelDownstreamRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1672A64423473EA100380537 /* LabelDownstreamRequestStrategy.swift */; };
 		1672A653234784B500380537 /* LabelDownstreamRequestStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1672A652234784B500380537 /* LabelDownstreamRequestStrategyTests.swift */; };
+		1673C35324CB36D800AE2714 /* ZMUserSessionTests+EncryptionAtRest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1673C35224CB36D800AE2714 /* ZMUserSessionTests+EncryptionAtRest.swift */; };
 		1675532C21B16D1E009C9FEA /* ConversationTests+ReceiptMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1675532B21B16D1E009C9FEA /* ConversationTests+ReceiptMode.swift */; };
 		1679D1CD1EF97387007B0DF5 /* ZMUserSessionTestsBase+Calling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1679D1CB1EF9730C007B0DF5 /* ZMUserSessionTestsBase+Calling.swift */; };
 		167F383B23E0416E006B6AA9 /* UnauthenticatedSession+SSO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167F383A23E0416E006B6AA9 /* UnauthenticatedSession+SSO.swift */; };
@@ -752,6 +753,7 @@
 		1671F9FE1E2FAF50009F3150 /* ZMLocalNotificationForTests_CallState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMLocalNotificationForTests_CallState.swift; sourceTree = "<group>"; };
 		1672A64423473EA100380537 /* LabelDownstreamRequestStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelDownstreamRequestStrategy.swift; sourceTree = "<group>"; };
 		1672A652234784B500380537 /* LabelDownstreamRequestStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelDownstreamRequestStrategyTests.swift; sourceTree = "<group>"; };
+		1673C35224CB36D800AE2714 /* ZMUserSessionTests+EncryptionAtRest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSessionTests+EncryptionAtRest.swift"; sourceTree = "<group>"; };
 		1675532B21B16D1E009C9FEA /* ConversationTests+ReceiptMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationTests+ReceiptMode.swift"; sourceTree = "<group>"; };
 		1679D1CB1EF9730C007B0DF5 /* ZMUserSessionTestsBase+Calling.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMUserSessionTestsBase+Calling.swift"; sourceTree = "<group>"; };
 		167F383A23E0416E006B6AA9 /* UnauthenticatedSession+SSO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UnauthenticatedSession+SSO.swift"; sourceTree = "<group>"; };
@@ -1768,6 +1770,7 @@
 				F1AE5F6E21F73388009CDBBC /* ZMUserSessionTests+Timers.swift */,
 				168474252252579A004DE9EC /* ZMUserSessionTests+Syncing.swift */,
 				16E0FBB4233119FE000E3235 /* ZMUserSessionTests+Authentication.swift */,
+				1673C35224CB36D800AE2714 /* ZMUserSessionTests+EncryptionAtRest.swift */,
 				0920C4D81B305FF500C55728 /* UserSessionGiphyRequestStateTests.swift */,
 				541228431AEE422C00D9ED1C /* ZMAuthenticationStatusTests.m */,
 				7CE017142317D07E00144905 /* ZMAuthenticationStatusTests.swift */,
@@ -2933,6 +2936,7 @@
 				541918ED195AD9D100A5023D /* SendAndReceiveMessagesTests.m in Sources */,
 				F9F846351ED307F70087C1A4 /* CallParticipantsSnapshotTests.swift in Sources */,
 				F13A26E120456002004F8E47 /* ConversationTests+Guests.swift in Sources */,
+				1673C35324CB36D800AE2714 /* ZMUserSessionTests+EncryptionAtRest.swift in Sources */,
 				54DE9BEF1DE760A900EFFB9C /* RandomHandleGeneratorTests.swift in Sources */,
 				F9C598AD1A0947B300B1F760 /* ZMBlacklistDownloaderTest.m in Sources */,
 				1672A653234784B500380537 /* LabelDownstreamRequestStrategyTests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

When we enable EAR we can only process update events when the application is running in the foreground because only then will we have access to the database key, which allows us to insert messages. Therefore I've changed it so that we only decrypt and store update events when running in the background, the event processing will happen when the app goes into foreground *or* when the database is unlocked.

In the future we might allow some events to processed background which does not need to insert messages, like conversation events.

## Notes

Sending delivery receipts is still something we need to do in background which will break now, since that's currently happening when events are processed. This will be implemented in a separate PR though.

The `ZMSyncStrategy` tests are in a bad state where the tests doesn't always reflect what's happening anymore after refactorings. For example there's a test named `testThatItAsksClientMessageTranscoderToDecryptUpdateEvents` even though the `ClientMEssageTranscoder` is not responsible for decrypting events. We should review the ZMSyncStrategy tests and remove the OCMock dependency to enable a Swift conversation.