### PR TITLE
[Feature] Add isConferenceCall property to VoiceChannel

### DIFF
--- a/Source/Calling/AVSBridging.swift
+++ b/Source/Calling/AVSBridging.swift
@@ -166,4 +166,12 @@ extension AVSWrapper {
         return 0
     }
 
+    @discardableResult
+    static func withCallCenter<A1: AVSValue, A2: AVSValue, A3: AVSValue, A4: AVSValue, A5: AVSValue, A6: AVSValue, A7: AVSValue>(_ contextRef: UnsafeMutableRawPointer?, _ v1: A1.AVSType?, _ v2: A2.AVSType?, _ v3: A3.AVSType?, _ v4: A4.AVSType?, _ v5: A5.AVSType?, _ v6: A6.AVSType?, _ v7: A7.AVSType?, _ block: (WireCallCenterV3, A1, A2, A3, A4, A5, A6, A7) -> Void) -> Int32 {
+        guard let contextRef = contextRef, let value1 = v1.flatMap(A1.init), let value2 = v2.flatMap(A2.init), let value3 = v3.flatMap(A3.init), let value4 = v4.flatMap(A4.init), let value5 = v5.flatMap(A5.init), let value6 = v6.flatMap(A6.init), let value7 = v7.flatMap(A7.init) else { return EINVAL }
+        let callCenter = Unmanaged<WireCallCenterV3>.fromOpaque(contextRef).takeUnretainedValue()
+        block(callCenter, value1, value2, value3, value4, value5, value6, value7)
+        return 0
+    }
+
 }

--- a/Source/Calling/AVSWrapper.swift
+++ b/Source/Calling/AVSWrapper.swift
@@ -198,12 +198,14 @@ public class AVSWrapper: AVSWrapperType {
     }
 
     private let incomingCallHandler: Handler.IncomingCall = { conversationId, messageTime, userId, clientId, isVideoCall, shouldRing, conversationType, contextRef in
-        AVSWrapper.withCallCenter(contextRef, conversationId, messageTime, userId, clientId, isVideoCall, shouldRing) {
+
+        AVSWrapper.withCallCenter(contextRef, conversationId, messageTime, userId, clientId, isVideoCall, shouldRing, conversationType) {
             $0.handleIncomingCall(conversationId: $1,
                                   messageTime: $2,
                                   client: AVSClient(userId: $3, clientId: $4),
                                   isVideoCall: $5,
-                                  shouldRing: $6)
+                                  shouldRing: $6,
+                                  conversationType: $7)
         }
     }
 

--- a/Source/Calling/CallSnapshot.swift
+++ b/Source/Calling/CallSnapshot.swift
@@ -31,6 +31,7 @@ struct CallSnapshot {
     let isConstantBitRate: Bool
     let videoState: VideoState
     let networkQuality: NetworkQuality
+    let isConferenceCall: Bool
     var conversationObserverToken : NSObjectProtocol?
 
     /**
@@ -47,6 +48,7 @@ struct CallSnapshot {
                             isConstantBitRate: isConstantBitRate,
                             videoState: videoState,
                             networkQuality: networkQuality,
+                            isConferenceCall: isConferenceCall,
                             conversationObserverToken: conversationObserverToken)
     }
 
@@ -64,6 +66,7 @@ struct CallSnapshot {
                             isConstantBitRate: enabled,
                             videoState: videoState,
                             networkQuality: networkQuality,
+                            isConferenceCall: isConferenceCall,
                             conversationObserverToken: conversationObserverToken)
     }
 
@@ -81,6 +84,7 @@ struct CallSnapshot {
                             isConstantBitRate: isConstantBitRate,
                             videoState: videoState,
                             networkQuality: networkQuality,
+                            isConferenceCall: isConferenceCall,
                             conversationObserverToken: conversationObserverToken)
     }
 
@@ -98,6 +102,7 @@ struct CallSnapshot {
                             isConstantBitRate: isConstantBitRate,
                             videoState: videoState,
                             networkQuality: networkQuality,
+                            isConferenceCall: isConferenceCall,
                             conversationObserverToken: conversationObserverToken)
     }
 

--- a/Source/Calling/VoiceChannel.swift
+++ b/Source/Calling/VoiceChannel.swift
@@ -58,6 +58,8 @@ public protocol CallProperties : NSObjectProtocol {
     var videoState: VideoState { get set }
     var networkQuality: NetworkQuality { get }
     var muted: Bool { get set }
+
+    var isConferenceCall: Bool { get }
     
     func setVideoCaptureDevice(_ device: CaptureDevice) throws
 }

--- a/Source/Calling/VoiceChannelV3.swift
+++ b/Source/Calling/VoiceChannelV3.swift
@@ -116,6 +116,12 @@ public class VoiceChannelV3 : NSObject, VoiceChannel {
             callCenter?.muted = newValue
         }
     }
+
+    public var isConferenceCall: Bool {
+        guard let remoteIdentifier = conversation?.remoteIdentifier, let callCenter = self.callCenter else { return false }
+
+        return callCenter.isConferenceCall(conversationId: remoteIdentifier)
+    }
     
 }
 

--- a/Source/Calling/WireCallCenterV3+Events.swift
+++ b/Source/Calling/WireCallCenterV3+Events.swift
@@ -104,13 +104,14 @@ extension WireCallCenterV3 {
     }
 
     /// Handles incoming calls.
-    func handleIncomingCall(conversationId: UUID, messageTime: Date, client: AVSClient, isVideoCall: Bool, shouldRing: Bool) {
+    func handleIncomingCall(conversationId: UUID, messageTime: Date, client: AVSClient, isVideoCall: Bool, shouldRing: Bool, conversationType: AVSConversationType) {
         handleEvent("incoming-call") {
             let isDegraded = self.isDegraded(conversationId: conversationId)
             let callState = CallState.incoming(video: isVideoCall, shouldRing: shouldRing, degraded: isDegraded)
             let members = [AVSCallMember(client: client)]
+            let isConferenceCall = conversationType == .conference
 
-            self.createSnapshot(callState: callState, members: members, callStarter: client.userId, video: isVideoCall, for: conversationId)
+            self.createSnapshot(callState: callState, members: members, callStarter: client.userId, video: isVideoCall, for: conversationId, isConferenceCall: isConferenceCall)
             self.handle(callState: callState, conversationId: conversationId)
         }
     }

--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -168,7 +168,7 @@ extension WireCallCenterV3 {
      * - parameter conversationId: The identifier of the conversation that hosts the call.
      */
 
-    func createSnapshot(callState : CallState, members: [AVSCallMember], callStarter: UUID?, video: Bool, for conversationId: UUID) {
+    func createSnapshot(callState : CallState, members: [AVSCallMember], callStarter: UUID?, video: Bool, for conversationId: UUID, isConferenceCall: Bool) {
         guard
             let moc = uiMOC,
             let conversation = ZMConversation(remoteID: conversationId, createIfNeeded: false, in: moc)
@@ -189,6 +189,7 @@ extension WireCallCenterV3 {
             isConstantBitRate: false,
             videoState: video ? .started : .stopped,
             networkQuality: .normal,
+            isConferenceCall: isConferenceCall,
             conversationObserverToken: token
         )
     }
@@ -308,6 +309,10 @@ extension WireCallCenterV3 {
 
     public func networkQuality(conversationId: UUID) -> NetworkQuality {
         return callSnapshots[conversationId]?.networkQuality ?? .normal
+    }
+
+    public func isConferenceCall(conversationId: UUID) -> Bool {
+        return callSnapshots[conversationId]?.isConferenceCall ?? false
     }
 
 }
@@ -433,7 +438,7 @@ extension WireCallCenterV3 {
         let callState: CallState = .outgoing(degraded: isDegraded(conversationId: conversationId))
         let previousCallState = callSnapshots[conversationId]?.callState
 
-        createSnapshot(callState: callState, members: [], callStarter: selfUserId, video: video, for: conversationId)
+        createSnapshot(callState: callState, members: [], callStarter: selfUserId, video: video, for: conversationId, isConferenceCall: conversationType == .conference)
 
         if let context = uiMOC {
             WireCallCenterCallStateNotification(context: context,

--- a/Tests/Source/Calling/WireCallCenterV3Mock.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Mock.swift
@@ -149,7 +149,7 @@ public class WireCallCenterV3Mock: WireCallCenterV3 {
 
     func setMockCallState(_ state: CallState, conversationId: UUID, callerId: UUID, isVideo: Bool) {
         clearSnapshot(conversationId: conversationId)
-        createSnapshot(callState: state, members: [], callStarter: callerId, video: isVideo, for: conversationId)
+        createSnapshot(callState: state, members: [], callStarter: callerId, video: isVideo, for: conversationId, isConferenceCall: false)
     }
 
     func removeMockActiveCalls() {

--- a/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -138,7 +138,8 @@ class WireCallCenterV3Tests: MessagingTest {
                                    messageTime: Date(),
                                    client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                    isVideoCall: true,
-                                   shouldRing: false)
+                                   shouldRing: false,
+                                   conversationType: .oneToOne)
         }
     }
     
@@ -148,7 +149,8 @@ class WireCallCenterV3Tests: MessagingTest {
                                    messageTime: Date(),
                                    client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                    isVideoCall: false,
-                                   shouldRing: false)
+                                   shouldRing: false,
+                                   conversationType: .oneToOne)
         }
     }
     
@@ -158,7 +160,8 @@ class WireCallCenterV3Tests: MessagingTest {
                                    messageTime: Date(),
                                    client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                    isVideoCall: true,
-                                   shouldRing: true)
+                                   shouldRing: true,
+                                   conversationType: .oneToOne)
         }
     }
     
@@ -168,7 +171,8 @@ class WireCallCenterV3Tests: MessagingTest {
                                    messageTime: Date(),
                                    client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                    isVideoCall: false,
-                                   shouldRing: true)
+                                   shouldRing: true,
+                                   conversationType: .oneToOne)
         }
     }
     
@@ -204,7 +208,8 @@ class WireCallCenterV3Tests: MessagingTest {
                                messageTime: Date(),
                                client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
-                               shouldRing: true)
+                               shouldRing: true,
+                               conversationType: .oneToOne)
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
@@ -219,7 +224,8 @@ class WireCallCenterV3Tests: MessagingTest {
                                messageTime: Date(),
                                client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
-                               shouldRing: true)
+                               shouldRing: true,
+                               conversationType: .oneToOne)
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
@@ -234,7 +240,8 @@ class WireCallCenterV3Tests: MessagingTest {
                                messageTime: Date(),
                                client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
-                               shouldRing: true)
+                               shouldRing: true,
+                               conversationType: .oneToOne)
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         XCTAssertNil(sut.establishedDate)
@@ -254,7 +261,8 @@ class WireCallCenterV3Tests: MessagingTest {
                                messageTime: Date(),
                                client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
-                               shouldRing: true)
+                               shouldRing: true,
+                               conversationType: .oneToOne)
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         XCTAssertNil(sut.establishedDate)
@@ -280,7 +288,8 @@ class WireCallCenterV3Tests: MessagingTest {
                                messageTime: Date(),
                                client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
-                               shouldRing: true)
+                               shouldRing: true,
+                               conversationType: .oneToOne)
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
@@ -295,7 +304,8 @@ class WireCallCenterV3Tests: MessagingTest {
                                messageTime: Date(),
                                client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
-                               shouldRing: true)
+                               shouldRing: true,
+                               conversationType: .oneToOne)
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
@@ -310,13 +320,15 @@ class WireCallCenterV3Tests: MessagingTest {
                                messageTime: Date(),
                                client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
-                               shouldRing: true)
+                               shouldRing: true,
+                               conversationType: .oneToOne)
 
         sut.handleIncomingCall(conversationId: groupConversationID,
                                messageTime: Date(),
                                client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
-                               shouldRing: true)
+                               shouldRing: true,
+                               conversationType: .group)
 
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
@@ -335,7 +347,8 @@ class WireCallCenterV3Tests: MessagingTest {
                                messageTime: Date(),
                                client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
-                               shouldRing: true)
+                               shouldRing: true,
+                               conversationType: .oneToOne)
 
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
@@ -352,7 +365,8 @@ class WireCallCenterV3Tests: MessagingTest {
                                messageTime: Date(),
                                client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
-                               shouldRing: true)
+                               shouldRing: true,
+                               conversationType: .oneToOne)
 
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
@@ -369,7 +383,8 @@ class WireCallCenterV3Tests: MessagingTest {
                                messageTime: Date(),
                                client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
-                               shouldRing: true)
+                               shouldRing: true,
+                               conversationType: .group)
 
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
@@ -397,7 +412,8 @@ class WireCallCenterV3Tests: MessagingTest {
                                messageTime: Date(),
                                client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
-                               shouldRing: true)
+                               shouldRing: true,
+                               conversationType: .oneToOne)
 
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
@@ -425,7 +441,8 @@ class WireCallCenterV3Tests: MessagingTest {
                                messageTime: Date(),
                                client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
-                               shouldRing: true)
+                               shouldRing: true,
+                               conversationType: .oneToOne)
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
@@ -451,7 +468,8 @@ class WireCallCenterV3Tests: MessagingTest {
                                messageTime: Date(),
                                client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
-                               shouldRing: true)
+                               shouldRing: true,
+                               conversationType: .group)
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
@@ -470,7 +488,8 @@ class WireCallCenterV3Tests: MessagingTest {
                                messageTime: Date(),
                                client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: true,
-                               shouldRing: true)
+                               shouldRing: true,
+                               conversationType: .oneToOne)
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
@@ -490,7 +509,8 @@ class WireCallCenterV3Tests: MessagingTest {
                                messageTime: Date(),
                                client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: true,
-                               shouldRing: true)
+                               shouldRing: true,
+                               conversationType: .oneToOne)
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
@@ -575,7 +595,8 @@ class WireCallCenterV3Tests: MessagingTest {
                                messageTime: Date(),
                                client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
-                               shouldRing: true)
+                               shouldRing: true,
+                               conversationType: .oneToOne)
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         XCTAssertNil(sut.establishedDate)
@@ -729,12 +750,12 @@ class WireCallCenterV3Tests: MessagingTest {
 
         // then
         for callState in nonActiveCallStates {
-            sut.createSnapshot(callState: callState, members: [], callStarter: nil, video: false, for: groupConversation.remoteIdentifier!)
+            sut.createSnapshot(callState: callState, members: [], callStarter: nil, video: false, for: groupConversation.remoteIdentifier!, isConferenceCall: false)
             XCTAssertEqual(sut.activeCalls.count, 0)
         }
 
         for callState in activeCallStates {
-            sut.createSnapshot(callState: callState, members: [], callStarter: nil, video: false, for: groupConversation.remoteIdentifier!)
+            sut.createSnapshot(callState: callState, members: [], callStarter: nil, video: false, for: groupConversation.remoteIdentifier!, isConferenceCall: false)
             XCTAssertEqual(sut.activeCalls.count, 1)
         }
     }
@@ -749,7 +770,8 @@ extension WireCallCenterV3Tests {
                                messageTime: Date(),
                                client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
-                               shouldRing: true)
+                               shouldRing: true,
+                               conversationType: .oneToOne)
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         sut.handleEstablishedCall(conversationId: oneOnOneConversationID)
@@ -769,7 +791,8 @@ extension WireCallCenterV3Tests {
                                messageTime: Date(),
                                client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
-                               shouldRing: true)
+                               shouldRing: true,
+                               conversationType: .oneToOne)
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         sut.handleDataChannelEstablishement(conversationId: oneOnOneConversationID)
@@ -789,7 +812,8 @@ extension WireCallCenterV3Tests {
                                messageTime: Date(),
                                client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
-                               shouldRing: true)
+                               shouldRing: true,
+                               conversationType: .oneToOne)
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         sut.handleEstablishedCall(conversationId: oneOnOneConversationID)
@@ -813,7 +837,8 @@ extension WireCallCenterV3Tests {
                                messageTime: Date(),
                                client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
-                               shouldRing: true)
+                               shouldRing: true,
+                               conversationType: .oneToOne)
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
@@ -831,7 +856,8 @@ extension WireCallCenterV3Tests {
                                messageTime: Date(),
                                client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
-                               shouldRing: true)
+                               shouldRing: true,
+                               conversationType: .oneToOne)
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         sut.handleEstablishedCall(conversationId: oneOnOneConversationID)
@@ -858,7 +884,8 @@ extension WireCallCenterV3Tests {
                                messageTime: Date(),
                                client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
-                               shouldRing: true)
+                               shouldRing: true,
+                               conversationType: .oneToOne)
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
@@ -872,7 +899,8 @@ extension WireCallCenterV3Tests {
                                messageTime: Date(),
                                client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
-                               shouldRing: true)
+                               shouldRing: true,
+                               conversationType: .oneToOne)
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         sut.handleEstablishedCall(conversationId: oneOnOneConversationID)
@@ -903,7 +931,8 @@ extension WireCallCenterV3Tests {
                                messageTime: Date(),
                                client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
-                               shouldRing: true)
+                               shouldRing: true,
+                               conversationType: .oneToOne)
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         sut.handleEstablishedCall(conversationId: oneOnOneConversationID)
@@ -934,7 +963,8 @@ extension WireCallCenterV3Tests {
                                messageTime: Date(),
                                client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
-                               shouldRing: true)
+                               shouldRing: true,
+                               conversationType: .oneToOne)
 
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
@@ -951,7 +981,8 @@ extension WireCallCenterV3Tests {
                                messageTime: Date(),
                                client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
-                               shouldRing: true)
+                               shouldRing: true,
+                               conversationType: .oneToOne)
 
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
@@ -968,7 +999,8 @@ extension WireCallCenterV3Tests {
                                messageTime: Date(),
                                client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
-                               shouldRing: true)
+                               shouldRing: true,
+                               conversationType: .group)
 
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
@@ -985,7 +1017,8 @@ extension WireCallCenterV3Tests {
                                messageTime: Date(),
                                client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
-                               shouldRing: true)
+                               shouldRing: true,
+                               conversationType: .oneToOne)
 
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
@@ -1008,7 +1041,8 @@ extension WireCallCenterV3Tests {
                                messageTime: Date(),
                                client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
-                               shouldRing: true)
+                               shouldRing: true,
+                               conversationType: .oneToOne)
 
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
@@ -1061,7 +1095,8 @@ extension WireCallCenterV3Tests {
                                messageTime: Date(),
                                client: AVSClient(userId: otherUserID, clientId: otherUserClientID),
                                isVideoCall: false,
-                               shouldRing: true)
+                               shouldRing: true,
+                               conversationType: .group)
         
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 


### PR DESCRIPTION
## What's new in this PR?

When we receive an incoming call, AVS tells us what kind of call it is, whether it is a legacy group call or a conference call. This information is useful to the UI in that we can selectively remove some restrictions (such as video group limits) for conference calls only.

This PR uses this information to set the `isConferenceCall` property in the `CallProperties` protocol. This is then propagated to the `VoiceChannel` which is the main calling object used from the UI.