### PR TITLE
[Feature]: Disable/Enable Cut, Save, Copy, Paste Flag

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -788,6 +788,10 @@ public final class SessionManager : NSObject, SessionManagerType {
     @objc public var isUserSessionActive: Bool {
         return activeUserSession != nil
     }
+    
+    public var isCopyAndPasteEnable: Bool {
+        return configuration.enableCopyAndPaste
+    }
 
     func updateProfileImage(imageData: Data) {
         activeUserSession?.enqueue {
@@ -820,7 +824,7 @@ public final class SessionManager : NSObject, SessionManagerType {
         }
     }
     
-    public var useConstantBitRateAudio : Bool = false {
+    public var useConstantBitRateAudio: Bool = false {
         didSet {
             activeUserSession?.useConstantBitRateAudio = useConstantBitRateAudio
         }

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -789,8 +789,8 @@ public final class SessionManager : NSObject, SessionManagerType {
         return activeUserSession != nil
     }
     
-    public var isCopyAndPasteEnable: Bool {
-        return configuration.enableCopyAndPaste
+    public var isDisabledClipboard: Bool {
+        return configuration.disableClipboard
     }
 
     func updateProfileImage(imageData: Data) {

--- a/Source/SessionManager/SessionManagerConfiguration.swift
+++ b/Source/SessionManager/SessionManagerConfiguration.swift
@@ -63,10 +63,10 @@ public class SessionManagerConfiguration: NSObject, NSCopying, Codable {
     /// The default value of this property is `nil`, i.e. threshold is ignored
     public var failedPasswordThresholdBeforeWipe: Int?
     
-    /// If `enableCopyAndPaste` is false the copy & pasting functionality is disabled in the conversation screen.
+    /// If `disableClipboard` is true the cut, save, copy & paste functionality is disabled in the conversation screen.
     ///
-    /// The default value of this property is `true`.
-    public var enableCopyAndPaste: Bool
+    /// The default value of this property is `false`.
+    public var disableClipboard: Bool
 
     // MARK: - Init
     
@@ -77,7 +77,7 @@ public class SessionManagerConfiguration: NSObject, NSCopying, Codable {
                 messageRetentionInterval: TimeInterval? = nil,
                 authenticateAfterReboot: Bool = false,
                 failedPasswordThresholdBeforeWipe: Int? = nil,
-                enableCopyAndPaste: Bool = true) {
+                disableClipboard: Bool = false) {
         self.wipeOnCookieInvalid = wipeOnCookieInvalid
         self.blacklistDownloadInterval = blacklistDownloadInterval
         self.blockOnJailbreakOrRoot = blockOnJailbreakOrRoot
@@ -85,7 +85,7 @@ public class SessionManagerConfiguration: NSObject, NSCopying, Codable {
         self.messageRetentionInterval = messageRetentionInterval
         self.authenticateAfterReboot = authenticateAfterReboot
         self.failedPasswordThresholdBeforeWipe = failedPasswordThresholdBeforeWipe
-        self.enableCopyAndPaste = enableCopyAndPaste
+        self.disableClipboard = disableClipboard
     }
 
     required public init(from decoder: Decoder) throws {
@@ -97,7 +97,7 @@ public class SessionManagerConfiguration: NSObject, NSCopying, Codable {
         messageRetentionInterval = try container.decodeIfPresent(TimeInterval.self, forKey: .messageRetentionInterval)
         authenticateAfterReboot = try container.decode(Bool.self, forKey: .authenticateAfterReboot)
         failedPasswordThresholdBeforeWipe = try container.decodeIfPresent(Int.self, forKey: .failedPasswordThresholdBeforeWipe)
-        enableCopyAndPaste = try container.decode(Bool.self, forKey: .enableCopyAndPaste)
+        disableClipboard = try container.decode(Bool.self, forKey: .disableClipboard)
     }
 
     // MARK: - Methods
@@ -110,7 +110,7 @@ public class SessionManagerConfiguration: NSObject, NSCopying, Codable {
                                                messageRetentionInterval: messageRetentionInterval,
                                                authenticateAfterReboot: authenticateAfterReboot,
                                                failedPasswordThresholdBeforeWipe: failedPasswordThresholdBeforeWipe,
-                                               enableCopyAndPaste: enableCopyAndPaste)
+                                               disableClipboard: disableClipboard)
         
         return copy
     }
@@ -141,7 +141,7 @@ extension SessionManagerConfiguration {
         case messageRetentionInterval
         case authenticateAfterReboot
         case failedPasswordThresholdBeforeWipe
-        case enableCopyAndPaste
+        case disableClipboard
     }
 
 }

--- a/Source/SessionManager/SessionManagerConfiguration.swift
+++ b/Source/SessionManager/SessionManagerConfiguration.swift
@@ -62,6 +62,11 @@ public class SessionManagerConfiguration: NSObject, NSCopying, Codable {
     ///
     /// The default value of this property is `nil`, i.e. threshold is ignored
     public var failedPasswordThresholdBeforeWipe: Int?
+    
+    /// If `enableCopyAndPaste` is false the copy & pasting functionality is disabled in the conversation screen.
+    ///
+    /// The default value of this property is `true`.
+    public var enableCopyAndPaste: Bool
 
     // MARK: - Init
     
@@ -71,7 +76,8 @@ public class SessionManagerConfiguration: NSObject, NSCopying, Codable {
                 wipeOnJailbreakOrRoot: Bool = false,
                 messageRetentionInterval: TimeInterval? = nil,
                 authenticateAfterReboot: Bool = false,
-                failedPasswordThresholdBeforeWipe: Int? = nil) {
+                failedPasswordThresholdBeforeWipe: Int? = nil,
+                enableCopyAndPaste: Bool = true) {
         self.wipeOnCookieInvalid = wipeOnCookieInvalid
         self.blacklistDownloadInterval = blacklistDownloadInterval
         self.blockOnJailbreakOrRoot = blockOnJailbreakOrRoot
@@ -79,6 +85,7 @@ public class SessionManagerConfiguration: NSObject, NSCopying, Codable {
         self.messageRetentionInterval = messageRetentionInterval
         self.authenticateAfterReboot = authenticateAfterReboot
         self.failedPasswordThresholdBeforeWipe = failedPasswordThresholdBeforeWipe
+        self.enableCopyAndPaste = enableCopyAndPaste
     }
 
     required public init(from decoder: Decoder) throws {
@@ -90,6 +97,7 @@ public class SessionManagerConfiguration: NSObject, NSCopying, Codable {
         messageRetentionInterval = try container.decodeIfPresent(TimeInterval.self, forKey: .messageRetentionInterval)
         authenticateAfterReboot = try container.decode(Bool.self, forKey: .authenticateAfterReboot)
         failedPasswordThresholdBeforeWipe = try container.decodeIfPresent(Int.self, forKey: .failedPasswordThresholdBeforeWipe)
+        enableCopyAndPaste = try container.decode(Bool.self, forKey: .enableCopyAndPaste)
     }
 
     // MARK: - Methods
@@ -101,7 +109,8 @@ public class SessionManagerConfiguration: NSObject, NSCopying, Codable {
                                                wipeOnJailbreakOrRoot: wipeOnJailbreakOrRoot,
                                                messageRetentionInterval: messageRetentionInterval,
                                                authenticateAfterReboot: authenticateAfterReboot,
-                                               failedPasswordThresholdBeforeWipe: failedPasswordThresholdBeforeWipe)
+                                               failedPasswordThresholdBeforeWipe: failedPasswordThresholdBeforeWipe,
+                                               enableCopyAndPaste: enableCopyAndPaste)
         
         return copy
     }
@@ -132,6 +141,7 @@ extension SessionManagerConfiguration {
         case messageRetentionInterval
         case authenticateAfterReboot
         case failedPasswordThresholdBeforeWipe
+        case enableCopyAndPaste
     }
 
 }

--- a/Tests/Source/SessionManager/SessionManagerConfigurationTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerConfigurationTests.swift
@@ -52,7 +52,7 @@ class SessionManagerConfigurationTests: XCTestCase {
         XCTAssertEqual(result.messageRetentionInterval, 3600)
         XCTAssertEqual(result.authenticateAfterReboot, false)
         XCTAssertEqual(result.failedPasswordThresholdBeforeWipe, nil)
-        XCTAssertEqual(result.enableCopyAndPaste, true)
+        XCTAssertEqual(result.disableClipboard, true)
     }
 
 }

--- a/Tests/Source/SessionManager/SessionManagerConfigurationTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerConfigurationTests.swift
@@ -33,6 +33,7 @@ class SessionManagerConfigurationTests: XCTestCase {
             "authenticateAfterReboot": false,
             "useBiometricsOrAccountPassword": true,
             "messageRetentionInterval": 3600,
+            "enableCopyAndPaste": true
         }
 
         """
@@ -51,6 +52,7 @@ class SessionManagerConfigurationTests: XCTestCase {
         XCTAssertEqual(result.messageRetentionInterval, 3600)
         XCTAssertEqual(result.authenticateAfterReboot, false)
         XCTAssertEqual(result.failedPasswordThresholdBeforeWipe, nil)
+        XCTAssertEqual(result.enableCopyAndPaste, true)
     }
 
 }


### PR DESCRIPTION
## What's new in this PR?

from the session_manager confirmation file it is not possible to enable and disable the cut, save, copy and paste action in the conversation

## Dependency

JIRA Ticket: https://wearezeta.atlassian.net/browse/ZIOS-13657
build-configuration: https://github.com/wireapp/wire-ios-build-configuration/pull/26