### PR TITLE
[Feature]: Hide User Profile Camera Roll Configuration Flag

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -794,6 +794,10 @@ public final class SessionManager : NSObject, SessionManagerType {
             self.activeUserSession?.userProfileImage?.updateImage(imageData: imageData)
         }
     }
+    
+    public var isCameraRollOnUserProfileEnabled: Bool {
+        return configuration.showCameraRollOnUserProfile
+    }
 
     public var callNotificationStyle: CallNotificationStyle = .callKit {
         didSet {

--- a/Source/SessionManager/SessionManagerConfiguration.swift
+++ b/Source/SessionManager/SessionManagerConfiguration.swift
@@ -62,6 +62,11 @@ public class SessionManagerConfiguration: NSObject, NSCopying, Codable {
     ///
     /// The default value of this property is `nil`, i.e. threshold is ignored
     public var failedPasswordThresholdBeforeWipe: Int?
+    
+    /// If `showCameraRollOnUserProfile` is set to true then the camera roll button when setting the user profile picture is shown
+    ///
+    /// The default value of this property is `true`
+    public var showCameraRollOnUserProfile: Bool
 
     // MARK: - Init
     
@@ -71,7 +76,8 @@ public class SessionManagerConfiguration: NSObject, NSCopying, Codable {
                 wipeOnJailbreakOrRoot: Bool = false,
                 messageRetentionInterval: TimeInterval? = nil,
                 authenticateAfterReboot: Bool = false,
-                failedPasswordThresholdBeforeWipe: Int? = nil) {
+                failedPasswordThresholdBeforeWipe: Int? = nil,
+                showCameraRollOnUserProfile: Bool = true) {
         self.wipeOnCookieInvalid = wipeOnCookieInvalid
         self.blacklistDownloadInterval = blacklistDownloadInterval
         self.blockOnJailbreakOrRoot = blockOnJailbreakOrRoot
@@ -79,6 +85,7 @@ public class SessionManagerConfiguration: NSObject, NSCopying, Codable {
         self.messageRetentionInterval = messageRetentionInterval
         self.authenticateAfterReboot = authenticateAfterReboot
         self.failedPasswordThresholdBeforeWipe = failedPasswordThresholdBeforeWipe
+        self.showCameraRollOnUserProfile = showCameraRollOnUserProfile
     }
 
     required public init(from decoder: Decoder) throws {
@@ -90,6 +97,7 @@ public class SessionManagerConfiguration: NSObject, NSCopying, Codable {
         messageRetentionInterval = try container.decodeIfPresent(TimeInterval.self, forKey: .messageRetentionInterval)
         authenticateAfterReboot = try container.decode(Bool.self, forKey: .authenticateAfterReboot)
         failedPasswordThresholdBeforeWipe = try container.decodeIfPresent(Int.self, forKey: .failedPasswordThresholdBeforeWipe)
+        showCameraRollOnUserProfile = try container.decode(Bool.self, forKey: .showCameraRollOnUserProfile)
     }
 
     // MARK: - Methods
@@ -101,7 +109,8 @@ public class SessionManagerConfiguration: NSObject, NSCopying, Codable {
                                                wipeOnJailbreakOrRoot: wipeOnJailbreakOrRoot,
                                                messageRetentionInterval: messageRetentionInterval,
                                                authenticateAfterReboot: authenticateAfterReboot,
-                                               failedPasswordThresholdBeforeWipe: failedPasswordThresholdBeforeWipe)
+                                               failedPasswordThresholdBeforeWipe: failedPasswordThresholdBeforeWipe,
+                                               showCameraRollOnUserProfile: showCameraRollOnUserProfile)
         
         return copy
     }
@@ -114,7 +123,6 @@ public class SessionManagerConfiguration: NSObject, NSCopying, Codable {
         guard let data = try? Data(contentsOf: URL) else { return nil }
         
         let decoder = JSONDecoder()
-        
         return  try? decoder.decode(SessionManagerConfiguration.self, from: data)
     }
 }
@@ -132,6 +140,7 @@ extension SessionManagerConfiguration {
         case messageRetentionInterval
         case authenticateAfterReboot
         case failedPasswordThresholdBeforeWipe
+        case showCameraRollOnUserProfile
     }
 
 }

--- a/Tests/Source/SessionManager/SessionManagerConfigurationTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerConfigurationTests.swift
@@ -33,6 +33,7 @@ class SessionManagerConfigurationTests: XCTestCase {
             "authenticateAfterReboot": false,
             "useBiometricsOrAccountPassword": true,
             "messageRetentionInterval": 3600,
+            "showCameraRollOnUserProfile": true
         }
 
         """
@@ -51,6 +52,7 @@ class SessionManagerConfigurationTests: XCTestCase {
         XCTAssertEqual(result.messageRetentionInterval, 3600)
         XCTAssertEqual(result.authenticateAfterReboot, false)
         XCTAssertEqual(result.failedPasswordThresholdBeforeWipe, nil)
+        XCTAssertEqual(result.showCameraRollOnUserProfile, true)
     }
 
 }


### PR DESCRIPTION
What's new in this PR?

from the session_manager configuration file it is now possible to show or hide the camera roll button in the user profile

Dependency

build-configuration: https://github.com/wireapp/wire-ios-build-configuration/pull/27
JIRA Ticket: https://wearezeta.atlassian.net/browse/ZIOS-13659