### PR TITLE
expose wipeDatabase for deleting all accounts

### DIFF
--- a/Source/Public/NSError+ZMUserSession.h
+++ b/Source/Public/NSError+ZMUserSession.h
@@ -28,7 +28,9 @@ typedef NS_ENUM(NSUInteger, ZMAccountDeletedReason) {
     /// The user account was deleted because the session expired
     ZMAccountDeletedReasonSessionExpired,
     /// The user account was deleted because the limit of failed password attempts was reached
-    ZMAccountDeletedReasonFailedPasswordLimitReached
+    ZMAccountDeletedReasonFailedPasswordLimitReached,
+    /// The user account was deleted because user chose to wipe the database (when he/she forgot the passcode)
+    ZMAccountDeletedReasonDatabaseWipped
 };
 
 typedef NS_ENUM(NSUInteger, ZMUserSessionErrorCode) {

--- a/Source/Public/NSError+ZMUserSession.h
+++ b/Source/Public/NSError+ZMUserSession.h
@@ -20,19 +20,6 @@
 @import Foundation;
 
 
-typedef NS_ENUM(NSUInteger, ZMAccountDeletedReason) {
-    /// The user account was deleted by the user
-    ZMAccountDeletedReasonUserInitiated = 0,
-    /// The user account was deleted because a jailbreak was detected
-    ZMAccountDeletedReasonJailbreakDetected,
-    /// The user account was deleted because the session expired
-    ZMAccountDeletedReasonSessionExpired,
-    /// The user account was deleted because the limit of failed password attempts was reached
-    ZMAccountDeletedReasonFailedPasswordLimitReached,
-    /// The user account was deleted because user chose to wipe the database (when he/she forgot the passcode)
-    ZMAccountDeletedReasonDatabaseWiped
-};
-
 typedef NS_ENUM(NSUInteger, ZMUserSessionErrorCode) {
     ZMUserSessionNoError = 0,
     /// ???

--- a/Source/Public/ZMAccountDeletedReason.swift
+++ b/Source/Public/ZMAccountDeletedReason.swift
@@ -18,9 +18,9 @@
 
 import Foundation
 
-enum ZMAccountDeletedReason {
+public enum ZMAccountDeletedReason: Int {
     /// The user account was deleted by the user
-    case userInitiated
+    case userInitiated = 0
     /// The user account was deleted because a jailbreak was detected
     case jailbreakDetected
     /// The user account was deleted because the session expired

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -524,6 +524,10 @@ public final class SessionManager : NSObject, SessionManagerType {
         delete(account: account, reason: .userInitiated)
     }
     
+    public func wipeDatabase() {
+        deleteAllAccounts(reason: .databaseWiped)
+    }
+    
     fileprivate func deleteAllAccounts(reason: ZMAccountDeletedReason) {
         let inactiveAccounts = accountManager.accounts.filter({ $0 != accountManager.selectedAccount })
         inactiveAccounts.forEach({ delete(account: $0, reason: reason) })

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -524,7 +524,7 @@ public final class SessionManager : NSObject, SessionManagerType {
         delete(account: account, reason: .userInitiated)
     }
     
-    fileprivate func deleteAllAccounts(reason: ZMAccountDeletedReason) {
+    public func deleteAllAccounts(reason: ZMAccountDeletedReason) {
         let inactiveAccounts = accountManager.accounts.filter({ $0 != accountManager.selectedAccount })
         inactiveAccounts.forEach({ delete(account: $0, reason: reason) })
         

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -524,7 +524,7 @@ public final class SessionManager : NSObject, SessionManagerType {
         delete(account: account, reason: .userInitiated)
     }
     
-    public func deleteAllAccounts(reason: ZMAccountDeletedReason) {
+    fileprivate func deleteAllAccounts(reason: ZMAccountDeletedReason) {
         let inactiveAccounts = accountManager.accounts.filter({ $0 != accountManager.selectedAccount })
         inactiveAccounts.forEach({ delete(account: $0, reason: reason) })
         

--- a/Source/SessionManager/ZMAccountDeletedReason.swift
+++ b/Source/SessionManager/ZMAccountDeletedReason.swift
@@ -1,0 +1,32 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+enum ZMAccountDeletedReason {
+    /// The user account was deleted by the user
+    case userInitiated
+    /// The user account was deleted because a jailbreak was detected
+    case jailbreakDetected
+    /// The user account was deleted because the session expired
+    case sessionExpired
+    /// The user account was deleted because the limit of failed password attempts was reached
+    case failedPasswordLimitReached
+    /// The user account was deleted because user chose to wipe the database (when he/she forgot the passcode)
+    case databaseWiped
+}

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -401,6 +401,7 @@
 		A95D0B1223F6B75A0057014F /* AVSLogObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95D0B1123F6B75A0057014F /* AVSLogObserver.swift */; };
 		A96190CA23A6DDCE00B8665F /* WireDataModel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A96190C923A6DDCE00B8665F /* WireDataModel.framework */; };
 		A9692F8A1986476900849241 /* NSString_NormalizationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A9692F881986476900849241 /* NSString_NormalizationTests.m */; };
+		A9B53AAA24E12E240066FCC6 /* ZMAccountDeletedReason.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B53AA924E12E240066FCC6 /* ZMAccountDeletedReason.swift */; };
 		AF6415A41C9C17FF00A535F5 /* EncryptedBase64EncondedExternalMessageTestFixture.txt in Resources */ = {isa = PBXBuildFile; fileRef = AF6415A01C9C151700A535F5 /* EncryptedBase64EncondedExternalMessageTestFixture.txt */; };
 		AF6415A51C9C180200A535F5 /* ExternalMessageTextFixture.txt in Resources */ = {isa = PBXBuildFile; fileRef = AF6415A11C9C151700A535F5 /* ExternalMessageTextFixture.txt */; };
 		BF00441B1C737CE9007A6EA4 /* PushNotificationStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF00441A1C737CE9007A6EA4 /* PushNotificationStatus.swift */; };
@@ -1058,6 +1059,7 @@
 		A95D0B1123F6B75A0057014F /* AVSLogObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVSLogObserver.swift; sourceTree = "<group>"; };
 		A96190C923A6DDCE00B8665F /* WireDataModel.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WireDataModel.framework; path = Carthage/Build/iOS/WireDataModel.framework; sourceTree = "<group>"; };
 		A9692F881986476900849241 /* NSString_NormalizationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSString_NormalizationTests.m; sourceTree = "<group>"; };
+		A9B53AA924E12E240066FCC6 /* ZMAccountDeletedReason.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMAccountDeletedReason.swift; sourceTree = "<group>"; };
 		AF6415A01C9C151700A535F5 /* EncryptedBase64EncondedExternalMessageTestFixture.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = EncryptedBase64EncondedExternalMessageTestFixture.txt; sourceTree = "<group>"; };
 		AF6415A11C9C151700A535F5 /* ExternalMessageTextFixture.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ExternalMessageTextFixture.txt; sourceTree = "<group>"; };
 		B40964971DAD3D110098667A /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Push.strings; sourceTree = "<group>"; };
@@ -2424,6 +2426,7 @@
 				7C5B94F522DC6BC500A6F8BB /* JailbreakDetector.swift */,
 				F159F4151F1E4C4C001B7D80 /* LocalStoreProvider.swift */,
 				BF2AD9FF1F41A3DF000980E8 /* SessionFactories.swift */,
+				A9B53AA924E12E240066FCC6 /* ZMAccountDeletedReason.swift */,
 				F19F1D371EFBF61800275E27 /* SessionManager.swift */,
 				16FF474B1F0D54B20044C491 /* SessionManager+Logs.swift */,
 				1634958A1F0254CB004E80DB /* SessionManager+ServerConnection.swift */,
@@ -3105,6 +3108,7 @@
 				160C31271E6434500012E4BC /* OperationStatus.swift in Sources */,
 				165911531DEF38EC007FA847 /* CallStateObserver.swift in Sources */,
 				5498162B1A432BC800A7CE2E /* ZMConversationTranscoder.m in Sources */,
+				A9B53AAA24E12E240066FCC6 /* ZMAccountDeletedReason.swift in Sources */,
 				54E2C1E01E682DC400536569 /* LocalNotificationDispatcher.swift in Sources */,
 				879634401F7BEA4700FC79BA /* DispatchQueue+SerialAsync.swift in Sources */,
 				F93A75F21C1F219800252586 /* ConversationStatusStrategy.swift in Sources */,

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -1481,6 +1481,7 @@
 			isa = PBXGroup;
 			children = (
 				542049EF196AB84B000D8A94 /* WireSyncEngine.h */,
+				A9B53AA924E12E240066FCC6 /* ZMAccountDeletedReason.swift */,
 				3E05F247192A4F8900F22D80 /* NSError+ZMUserSession.h */,
 				54D9331C1AE1643A00C0B91C /* ZMCredentials.h */,
 				546D45FD19E29D92004C478D /* ZMNetworkState.h */,
@@ -2426,7 +2427,6 @@
 				7C5B94F522DC6BC500A6F8BB /* JailbreakDetector.swift */,
 				F159F4151F1E4C4C001B7D80 /* LocalStoreProvider.swift */,
 				BF2AD9FF1F41A3DF000980E8 /* SessionFactories.swift */,
-				A9B53AA924E12E240066FCC6 /* ZMAccountDeletedReason.swift */,
 				F19F1D371EFBF61800275E27 /* SessionManager.swift */,
 				16FF474B1F0D54B20044C491 /* SessionManager+Logs.swift */,
 				1634958A1F0254CB004E80DB /* SessionManager+ServerConnection.swift */,


### PR DESCRIPTION
## What's new in this PR?

expose `SessionManager.deleteAllAccounts` and add new reason `ZMAccountDeletedReasonDatabaseWipped`