### PR TITLE
[Fix] Missing database key after enabling encryption at rest

### DIFF
--- a/Source/UserSession/ZMUserSession+EncryptionAtRest.swift
+++ b/Source/UserSession/ZMUserSession+EncryptionAtRest.swift
@@ -31,8 +31,10 @@ extension ZMUserSession {
                 if newValue {
                     let keys = try EncryptionKeys.createKeys(for: account)
                     applicationStatusDirectory?.syncStatus.encryptionKeys = keys
+                    storeProvider.contextDirectory.storeDatabaseKeyInAllContexts(databaseKey: keys.databaseKey)
                 } else {
                     try EncryptionKeys.deleteKeys(for: account)
+                    storeProvider.contextDirectory.clearDatabaseKeyInAllContexts()
                 }
                 
                 managedObjectContext.encryptMessagesAtRest = newValue


### PR DESCRIPTION
## What's new in this PR?

### Issues

After enabling encryption at rest (and keeping the app in the foreground), no messages can be encrypted.

### Causes

The database key is not found in the managed object context because it is only set after unlocking the database after successful app lock authentication.

### Solutions

Store the database key in the managed object context after creating it. Additionally, clear the database key after deleting it.

