### PR TITLE
[Fix] Can not enable encryption at rest keys exist in keychain

### DIFF
--- a/Source/UserSession/ZMUserSession+EncryptionAtRest.swift
+++ b/Source/UserSession/ZMUserSession+EncryptionAtRest.swift
@@ -27,14 +27,14 @@ extension ZMUserSession {
         set {
             do {
                 let account = Account(userName: "", userIdentifier: ZMUser.selfUser(in: managedObjectContext).remoteIdentifier)
-                
+
+                try EncryptionKeys.deleteKeys(for: account)
+                storeProvider.contextDirectory.clearDatabaseKeyInAllContexts()
+
                 if newValue {
                     let keys = try EncryptionKeys.createKeys(for: account)
                     applicationStatusDirectory?.syncStatus.encryptionKeys = keys
                     storeProvider.contextDirectory.storeDatabaseKeyInAllContexts(databaseKey: keys.databaseKey)
-                } else {
-                    try EncryptionKeys.deleteKeys(for: account)
-                    storeProvider.contextDirectory.clearDatabaseKeyInAllContexts()
                 }
                 
                 managedObjectContext.encryptMessagesAtRest = newValue


### PR DESCRIPTION
## What's new in this PR?

### Issues

If encryption at rest is enabled for an account on a device and then the app is reinstalled, then enabled encryption at rest again would fail.

### Causes

The encryption keys are persisted in the keychain. When the app is reinstalled and new keys are created, we get an error stating there already exists keys with the given identifier.

### Solutions

Always delete existing keys before creating new ones.

