### PR TITLE
[Fix] Enable database migration for the event database

### DIFF
--- a/Source/Synchronization/NSManagedObjectContext+EventDecoder.swift
+++ b/Source/Synchronization/NSManagedObjectContext+EventDecoder.swift
@@ -105,8 +105,12 @@ private let zmLog = ZMSLog(tag: "EventDecoder")
     
     fileprivate static func addPersistentStore(_ psc: NSPersistentStoreCoordinator, at location: URL, isSecondTry: Bool = false) {
         do {
+            let options: [String: Any] = [
+                NSMigratePersistentStoresAutomaticallyOption: true,
+                NSInferMappingModelAutomaticallyOption: true
+            ]
             let storeType = StorageStack.shared.createStorageAsInMemory ? NSInMemoryStoreType : NSSQLiteStoreType
-            try psc.addPersistentStore(ofType: storeType, configurationName: nil, at: location, options: nil)
+            try psc.addPersistentStore(ofType: storeType, configurationName: nil, at: location, options: options)
         } catch {
             if isSecondTry {
                 fatal("Error adding persistent store \(error)")

--- a/Tests/Source/Synchronization/Strategies/CallingRequestStrategyTests.swift
+++ b/Tests/Source/Synchronization/Strategies/CallingRequestStrategyTests.swift
@@ -249,7 +249,7 @@ class CallingRequestStrategyTests : MessagingTest {
         guard let request = nextRequest else { return XCTFail("Expected next request") }
 
         // Then we tell backend to ignore missing clients (the non targeted conversation participants)
-        XCTAssertEqual(request.path, "/conversations/\(conversation.remoteIdentifier!.transportString())/otr/messages?ignore_missing")
+        XCTAssertEqual(request.path, "/conversations/\(conversation.remoteIdentifier!.transportString())/otr/messages?ignore_missing=true")
 
         guard
             let data = request.binaryData,


### PR DESCRIPTION
## What's new in this PR?

### Issues

Event database is dropped and re-created when upgrading to the EAR branch

### Causes

The persistent store for the event managed object context is not configured to support migration.

### Solutions

Configure the persistent store to support migration.