### PR TITLE
[Fix] Don't create notifications for confirmation messages

### DIFF
--- a/Source/Notifications/Push notifications/Notification Types/LocalNotificationContentType.swift
+++ b/Source/Notifications/Push notifications/Notification Types/LocalNotificationContentType.swift
@@ -183,6 +183,8 @@ public enum LocalNotificationContentType : Equatable {
             default:
                 return .fileUpload
             }
+        case .confirmation:
+            return nil
         default:
            return .undefined
         }

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_Event.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_Event.swift
@@ -507,9 +507,20 @@ final class ZMLocalNotificationTests_Event: ZMLocalNotificationTests {
         XCTAssertNotNil(note)
         XCTAssertEqual(note!.title, "Super User")
         XCTAssertEqual(note!.body, "New message: Stimpy just joined Wire")
-        
     }
-    
+
+    func testThatItDoesNotCreateANotificationForConfirmationEvents() {
+        // given
+        let confirmation = GenericMessage(content: Confirmation(messageId: .create()))
+        let event = createUpdateEvent(.create(), conversationID: oneOnOneConversation.remoteIdentifier!, genericMessage: confirmation)
+
+        // when
+        let note = ZMLocalNotification(event: event, conversation: oneOnOneConversation, managedObjectContext: uiMOC)
+
+        // then
+        XCTAssertNil(note)
+    }
+
     // MARK: - Create system local notifications from update events
     
     func testThatItCreatesASystemLocalNotificationForRemovingTheSelfUserEvent() {


### PR DESCRIPTION
## What's new in this PR?

### Issues

User notifications (stating "New message") appear when no new message is visible.

### Causes

The notification is generated for a confirmation message (which is not visible in the conversation). 

### Solutions

Don't generate notifications for confirmation messages.

