### PR TITLE
[Chore] Hide user notification actions when EAR is enabled

### DIFF
--- a/Source/Notifications/Push notifications/LocalNotificationDispatcher+Calling.swift
+++ b/Source/Notifications/Push notifications/LocalNotificationDispatcher+Calling.swift
@@ -32,14 +32,14 @@ extension LocalNotificationDispatcher {
         default: break
         }
         
-        let note = ZMLocalNotification(callState: callState, conversation: conversation, caller: caller)
+        let note = ZMLocalNotification(callState: callState, conversation: conversation, caller: caller, moc: syncMOC)
         callingNotifications.cancelNotifications(conversation)
         note.apply(scheduleLocalNotification)
         note.apply(callingNotifications.addObject)
     }
     
     func processMissedCall(in conversation: ZMConversation, caller: ZMUser) {
-        let note = ZMLocalNotification(callState: .terminating(reason: .canceled), conversation: conversation, caller: caller)
+        let note = ZMLocalNotification(callState: .terminating(reason: .canceled), conversation: conversation, caller: caller, moc: syncMOC)
         callingNotifications.cancelNotifications(conversation)
         note.apply(scheduleLocalNotification)
         note.apply(callingNotifications.addObject)

--- a/Source/Notifications/Push notifications/LocalNotificationDispatcher.swift
+++ b/Source/Notifications/Push notifications/LocalNotificationDispatcher.swift
@@ -141,14 +141,14 @@ extension LocalNotificationDispatcher {
         if message.visibleInConversation == nil || message.conversation?.conversationType == .self {
             return
         }
-        let note = ZMLocalNotification(expiredMessage: message)
+        let note = ZMLocalNotification(expiredMessage: message, moc: syncMOC)
         note.apply(scheduleLocalNotification)
         note.apply(failedMessageNotifications.addObject)
     }
 
     /// Informs the user that a message in a conversation failed to send
     public func didFailToSendMessage(in conversation: ZMConversation) {
-        let note = ZMLocalNotification(expiredMessageIn: conversation)
+        let note = ZMLocalNotification(expiredMessageIn: conversation, moc: syncMOC)
         note.apply(scheduleLocalNotification)
         note.apply(failedMessageNotifications.addObject)
     }

--- a/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification+AvailabilityAlert.swift
+++ b/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification+AvailabilityAlert.swift
@@ -22,8 +22,7 @@ extension ZMLocalNotification {
     
     convenience init?(availability: Availability, managedObjectContext moc: NSManagedObjectContext) {
         let builder = AvailabilityNotificationBuilder(availability: availability, managedObjectContext: moc)
-        
-        self.init(conversation: nil, builder: builder)
+        self.init(builder: builder, moc: moc)
     }
     
 }

--- a/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification+Calling.swift
+++ b/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification+Calling.swift
@@ -21,10 +21,9 @@
 
 extension ZMLocalNotification {
     
-    convenience init?(callState: CallState, conversation: ZMConversation, caller: ZMUser) {
+    convenience init?(callState: CallState, conversation: ZMConversation, caller: ZMUser, moc: NSManagedObjectContext) {
         guard let builder = CallNotificationBuilder(callState: callState, caller: caller, conversation: conversation) else { return nil }
-        
-        self.init(conversation: conversation, builder: builder)
+        self.init(builder: builder, moc: moc)
     }
     
     private class CallNotificationBuilder: NotificationBuilder {

--- a/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification+Events.swift
+++ b/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification+Events.swift
@@ -51,7 +51,7 @@ extension ZMLocalNotification {
         }
 
         if let builder = builderType?.init(event: event, conversation: conversation, managedObjectContext: moc) {
-            self.init(conversation: conversation, builder: builder)
+            self.init(builder: builder, moc: moc)
         } else {
             return nil
         }

--- a/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification+ExpiredMessages.swift
+++ b/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification+ExpiredMessages.swift
@@ -21,15 +21,14 @@
 
 extension ZMLocalNotification {
     
-    convenience init?(expiredMessage: ZMMessage) {
+    convenience init?(expiredMessage: ZMMessage, moc: NSManagedObjectContext) {
         guard let conversation = expiredMessage.conversation else { return nil }
-        self.init(expiredMessageIn: conversation)
+        self.init(expiredMessageIn: conversation, moc: moc)
     }
     
-    convenience init?(expiredMessageIn conversation: ZMConversation) {
+    convenience init?(expiredMessageIn conversation: ZMConversation, moc: NSManagedObjectContext) {
         guard let builder = FailedMessageNotificationBuilder(conversation: conversation) else { return nil }
-        
-        self.init(conversation: conversation, builder: builder)
+        self.init(builder: builder, moc: moc)
     }
     
     private class FailedMessageNotificationBuilder: NotificationBuilder {

--- a/Source/Notifications/Push notifications/Notification Types/PushNotificationCategory.swift
+++ b/Source/Notifications/Push notifications/Notification Types/PushNotificationCategory.swift
@@ -34,7 +34,7 @@ enum PushNotificationCategory: String, CaseIterable {
     case connect = "connectCategory"
     case alert = "alertCategory"
     case conversationUnderEncryptionAtRest = "conversationUnderEncryptionAtRestCategory"
-    case conversationUnderEncryptionAtRestWithMute = "conversationUnderEncryptionAtRestCategoryWithMute"
+    case conversationUnderEncryptionAtRestWithMute = "conversationUnderEncryptionAtRestWithMuteCategory"
 
     /// All the supported categories.
     static var allCategories: Set<UNNotificationCategory> {

--- a/Source/Notifications/Push notifications/Notification Types/PushNotificationCategory.swift
+++ b/Source/Notifications/Push notifications/Notification Types/PushNotificationCategory.swift
@@ -33,6 +33,8 @@ enum PushNotificationCategory: String, CaseIterable {
     case conversationWithLikeAndMute = "conversationCategoryWithLikeAndMute"
     case connect = "connectCategory"
     case alert = "alertCategory"
+    case conversationUnderEncryptionAtRest = "conversationUnderEncryptionAtRestCategory"
+    case conversationUnderEncryptionAtRestWithMute = "conversationUnderEncryptionAtRestCategoryWithMute"
 
     /// All the supported categories.
     static var allCategories: Set<UNNotificationCategory> {
@@ -60,6 +62,10 @@ enum PushNotificationCategory: String, CaseIterable {
             return [ConversationNotificationAction.connect]
         case .alert:
             return []
+        case .conversationUnderEncryptionAtRest:
+            return []
+        case .conversationUnderEncryptionAtRestWithMute:
+            return [ConversationNotificationAction.mute]
         }
     }
 

--- a/Tests/Source/Notifications/PushNotifications/LocalNotificationDispatcherTests.swift
+++ b/Tests/Source/Notifications/PushNotifications/LocalNotificationDispatcherTests.swift
@@ -188,8 +188,8 @@ extension LocalNotificationDispatcherTests {
 
     func testThatItCancelsAllNotificationsForFailingMessagesWhenCancelingAllNotifications() {
         // GIVEN
-        let note1 = ZMLocalNotification(expiredMessageIn: self.conversation1)!
-        let note2 = ZMLocalNotification(expiredMessageIn: self.conversation1)!
+        let note1 = ZMLocalNotification(expiredMessageIn: conversation1, moc: syncMOC)!
+        let note2 = ZMLocalNotification(expiredMessageIn: conversation1, moc: syncMOC)!
         self.sut.eventNotifications.addObject(note1)
         self.sut.failedMessageNotifications.addObject(note2)
 
@@ -202,10 +202,10 @@ extension LocalNotificationDispatcherTests {
 
     func testThatItCancelsNotificationsForFailingMessagesWhenCancelingNotificationsForASpecificConversation() {
         // GIVEN
-        let note1 = ZMLocalNotification(expiredMessageIn: self.conversation1)!
-        let note2 = ZMLocalNotification(expiredMessageIn: self.conversation2)!
-        let note3 = ZMLocalNotification(expiredMessageIn: self.conversation1)!
-        let note4 = ZMLocalNotification(expiredMessageIn: self.conversation2)!
+        let note1 = ZMLocalNotification(expiredMessageIn: conversation1, moc: syncMOC)!
+        let note2 = ZMLocalNotification(expiredMessageIn: conversation2, moc: syncMOC)!
+        let note3 = ZMLocalNotification(expiredMessageIn: conversation1, moc: syncMOC)!
+        let note4 = ZMLocalNotification(expiredMessageIn: conversation2, moc: syncMOC)!
         self.sut.eventNotifications.addObject(note1)
         self.sut.eventNotifications.addObject(note2)
         self.sut.failedMessageNotifications.addObject(note3)
@@ -222,8 +222,8 @@ extension LocalNotificationDispatcherTests {
         // GIVEN
         let message = conversation1.append(text: "foo") as! ZMClientMessage
         message.sender = user1
-        let note1 = ZMLocalNotification(expiredMessage: message)!
-        let note2 = ZMLocalNotification(expiredMessageIn: self.conversation1)!
+        let note1 = ZMLocalNotification(expiredMessage: message, moc: syncMOC)!
+        let note2 = ZMLocalNotification(expiredMessageIn: self.conversation1, moc: syncMOC)!
         sut.eventNotifications.addObject(note1)
         sut.eventNotifications.addObject(note2)
         conversation1.lastServerTimeStamp = Date.distantFuture

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationForTests_CallState.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationForTests_CallState.swift
@@ -48,7 +48,7 @@ class ZMLocalNotificationTests_CallState : MessagingTest {
     }
     
     func note(for callState: CallState) -> ZMLocalNotification? {
-        return ZMLocalNotification(callState: callState, conversation: conversation, caller: sender)
+        return ZMLocalNotification(callState: callState, conversation: conversation, caller: sender, moc: syncMOC)
     }
     
     func testIncomingAudioCall() {
@@ -62,7 +62,7 @@ class ZMLocalNotificationTests_CallState : MessagingTest {
         // then
         XCTAssertEqual(note.title, "Callie")
         XCTAssertEqual(note.body, "is calling")
-        XCTAssertEqual(note.category, WireSyncEngine.PushNotificationCategory.incomingCall.rawValue)
+        XCTAssertEqual(note.category, WireSyncEngine.PushNotificationCategory.incomingCall)
         XCTAssertEqual(note.sound, .call)
     }
     
@@ -113,7 +113,7 @@ class ZMLocalNotificationTests_CallState : MessagingTest {
         // then
         XCTAssertEqual(note.title, "Callie")
         XCTAssertEqual(note.body, "is calling with video")
-        XCTAssertEqual(note.category, WireSyncEngine.PushNotificationCategory.incomingCall.rawValue)
+        XCTAssertEqual(note.category, WireSyncEngine.PushNotificationCategory.incomingCall)
         XCTAssertEqual(note.sound, .call)
     }
     
@@ -137,7 +137,7 @@ class ZMLocalNotificationTests_CallState : MessagingTest {
         // then
         XCTAssertEqual(note.title, "Callie")
         XCTAssertEqual(note.body, "called")
-        XCTAssertEqual(note.category, WireSyncEngine.PushNotificationCategory.conversationWithMute.rawValue)
+        XCTAssertEqual(note.category, WireSyncEngine.PushNotificationCategory.conversationWithMute)
         XCTAssertEqual(note.sound, .newMessage)
     }
     
@@ -167,7 +167,7 @@ class ZMLocalNotificationTests_CallState : MessagingTest {
         // then
         XCTAssertEqual(note.title, "Callie")
         XCTAssertEqual(note.body, "called")
-        XCTAssertEqual(note.category, WireSyncEngine.PushNotificationCategory.missedCall.rawValue)
+        XCTAssertEqual(note.category, WireSyncEngine.PushNotificationCategory.missedCall)
         XCTAssertEqual(note.sound, .newMessage)
     }
     
@@ -175,16 +175,16 @@ class ZMLocalNotificationTests_CallState : MessagingTest {
         
         // given
         let state: CallState = .terminating(reason: .timeout)
-        let caller = ZMUser.selfUser(in: uiMOC)
+        let caller = ZMUser.selfUser(in: syncMOC)
         caller.name = "SelfUser"
         
         // when
-        guard let note = ZMLocalNotification(callState: state, conversation: conversation, caller: caller) else { return XCTFail("Did not create notification") }
+        guard let note = ZMLocalNotification(callState: state, conversation: conversation, caller: caller, moc: syncMOC) else { return XCTFail("Did not create notification") }
         
         // then
         XCTAssertEqual(note.title, "Callie")
         XCTAssertEqual(note.body, "called")
-        XCTAssertEqual(note.category, WireSyncEngine.PushNotificationCategory.missedCall.rawValue)
+        XCTAssertEqual(note.category, WireSyncEngine.PushNotificationCategory.missedCall)
         XCTAssertEqual(note.sound, .newMessage)
     }
     

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_ExpiredMessage.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_ExpiredMessage.swift
@@ -78,7 +78,7 @@ class ZMLocalNotificationTests_ExpiredMessage: MessagingTest {
             self.oneOnOneConversation.mutableMessages.add(message)
             
             // when
-            let note = ZMLocalNotification(expiredMessage: message)
+            let note = ZMLocalNotification(expiredMessage: message, moc: self.syncMOC)
             
             // then
             XCTAssertNotNil(note)
@@ -95,7 +95,7 @@ class ZMLocalNotificationTests_ExpiredMessage: MessagingTest {
             self.oneOnOneConversation.mutableMessages.add(message)
             
             // when
-            let note = ZMLocalNotification(expiredMessageIn: message.conversation!)
+            let note = ZMLocalNotification(expiredMessageIn: message.conversation!, moc: self.syncMOC)
             
             // then
             XCTAssertNotNil(note)
@@ -112,7 +112,7 @@ class ZMLocalNotificationTests_ExpiredMessage: MessagingTest {
             self.groupConversation.mutableMessages.add(message)
             
             // when
-            let note = ZMLocalNotification(expiredMessage: message)
+            let note = ZMLocalNotification(expiredMessage: message, moc: self.syncMOC)
             
             // then
             XCTAssertNotNil(note)
@@ -129,7 +129,7 @@ class ZMLocalNotificationTests_ExpiredMessage: MessagingTest {
             self.groupConversationWithoutName.mutableMessages.add(message)
             
             // when
-            let note = ZMLocalNotification(expiredMessage: message)
+            let note = ZMLocalNotification(expiredMessage: message, moc: self.syncMOC)
             
             // then
             XCTAssertNotNil(note)
@@ -149,7 +149,7 @@ class ZMLocalNotificationTests_ExpiredMessage: MessagingTest {
             connection.to = self.userWithName
             
             // when
-            let note = ZMLocalNotification(expiredMessage: message)
+            let note = ZMLocalNotification(expiredMessage: message, moc: self.syncMOC)
             
             // then
             XCTAssertNotNil(note)
@@ -169,7 +169,7 @@ class ZMLocalNotificationTests_ExpiredMessage: MessagingTest {
             connection.to = self.userWithNoName
             
             // when
-            let note = ZMLocalNotification(expiredMessage: message)
+            let note = ZMLocalNotification(expiredMessage: message, moc: self.syncMOC)
             
             // then
             XCTAssertNotNil(note)


### PR DESCRIPTION
## What's new in this PR?

### Issues

The user notification actions for replying to and liking a message do not work when encryption at rest is enabled.
### Causes

When encryption at rest is enabled, the database is locked while the app is in the background. For this reason, we can not perform these actions.

### Solutions

Hide the actions when encryption at rest is enabled.

## Notes

Encryption at rest is enabled per account. Therefore the actions are only hidden for user notification associated with accounts in which the the feature is enabled.

