### PR TITLE
[Fix] Delete account when self client is deleted remotely

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -1037,9 +1037,10 @@ extension SessionManager: PostLoginAuthenticationObserver {
         log.debug("Authentication invalidated for \(accountId): \(error.code)")
         
         switch userSessionErrorCode {
-        case .clientDeletedRemotely,
-             .accessTokenExpired:
+        case .clientDeletedRemotely:
+            delete(account: account, reason: .sessionExpired)
             
+        case .accessTokenExpired:
             if configuration.wipeOnCookieInvalid {
                 delete(account: account, reason: .sessionExpired)
             } else {

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -466,6 +466,21 @@ class SessionManagerTests_AuthenticationFailure: IntegrationTest {
         XCTAssertFalse(sessionManager!.isSelectedAccountAuthenticated)
     }
     
+    func testThatItDeletesAccount_IfRemoteClientIsDeleted() {
+        // given
+        XCTAssertTrue(login())
+        let account = sessionManager!.accountManager.selectedAccount!
+        
+        // when
+        sessionManager?.authenticationInvalidated(NSError(code: .clientDeletedRemotely, userInfo: nil), accountId: account.userIdentifier)
+        
+        // then
+        guard let sharedContainer = Bundle.main.appGroupIdentifier.map(FileManager.sharedContainerDirectory) else { return XCTFail() }
+        let accountFolder = StorageStack.accountFolder(accountIdentifier: account.userIdentifier, applicationContainer: sharedContainer)
+        
+        XCTAssertFalse(FileManager.default.fileExists(atPath: accountFolder.path))
+    }
+    
     func testThatItTearsDownActiveUserSession_OnAuthentictionFailure() {
         // given
         XCTAssert(login())


### PR DESCRIPTION
## What's new in this PR?

### Issues

When EAR is enabled and your self client gets deleted you'll get logged out, If you log back in again your messages will not be readable.

### Causes

The message encryption is tied to your self client ID.

### Solutions

Delete the account/database if your client gets deleted remotely.