### PR TITLE
[Feature] Update badge count when processing notifications in the background

### DIFF
--- a/Source/Notifications/Push notifications/LocalNotificationDispatcher.swift
+++ b/Source/Notifications/Push notifications/LocalNotificationDispatcher.swift
@@ -107,6 +107,8 @@ extension LocalNotificationDispatcher: ZMEventConsumer {
             }
                         
             let note = ZMLocalNotification(event: event, conversation: conversation, managedObjectContext: self.syncMOC)
+            
+            note?.increaseEstimatedUnreadCount(on: conversation)
             note.apply(eventNotifications.addObject)
             note.apply(scheduleLocalNotification)
         }

--- a/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification.swift
+++ b/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification.swift
@@ -153,6 +153,68 @@ extension ZMLocalNotification {
     }
 }
 
+// MARK: - Unread Count
+
+extension ZMLocalNotification {
+            
+    func increaseEstimatedUnreadCount(on conversation: ZMConversation?) {
+        if shouldIncreaseUnreadCount {
+            conversation?.internalEstimatedUnreadCount += 1
+        }
+        
+        if shouldIncreaseUnreadMentionCount {
+            conversation?.internalEstimatedUnreadSelfMentionCount += 1
+        }
+        
+        if shouldIncreaseUnreadReplyCount {
+            conversation?.internalEstimatedUnreadSelfReplyCount += 1
+        }
+    }
+    
+    var shouldIncreaseUnreadCount: Bool {
+        switch type {
+        case .event(.connectionRequestPending):
+            return true
+        case .message(let contentType):
+            switch contentType {
+            case .messageTimerUpdate:
+                return false
+            default:
+                return true
+            }
+        default:
+            return false
+        }
+    }
+    
+    var shouldIncreaseUnreadMentionCount: Bool {
+        guard case LocalNotificationType.message(let contentType) = type else {
+            return false
+        }
+        
+        switch contentType {
+        case .text(_, isMention: true, isReply: _):
+            return true
+        default:
+            return false
+        }
+    }
+    
+    var shouldIncreaseUnreadReplyCount: Bool {
+        guard case LocalNotificationType.message(let contentType) = type else {
+            return false
+        }
+        
+        switch contentType {
+        case .text(_, isMention: _, isReply: true):
+            return true
+        default:
+            return false
+        }
+    }
+    
+}
+
 // Helper function inserted by Swift 4.2 migrator.
 fileprivate func convertToUNNotificationSoundName(_ input: String) -> UNNotificationSoundName {
 	return UNNotificationSoundName(rawValue: input)

--- a/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification.swift
+++ b/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification.swift
@@ -158,26 +158,29 @@ extension ZMLocalNotification {
 extension ZMLocalNotification {
             
     func increaseEstimatedUnreadCount(on conversation: ZMConversation?) {
-        if shouldIncreaseUnreadCount {
+                
+        if type.shouldIncreaseUnreadCount {
             conversation?.internalEstimatedUnreadCount += 1
         }
         
-        if shouldIncreaseUnreadMentionCount {
+        if type.shouldIncreaseUnreadMentionCount {
             conversation?.internalEstimatedUnreadSelfMentionCount += 1
         }
         
-        if shouldIncreaseUnreadReplyCount {
+        if type.shouldIncreaseUnreadReplyCount {
             conversation?.internalEstimatedUnreadSelfReplyCount += 1
         }
     }
     
+}
+
+extension LocalNotificationType {
+    
     var shouldIncreaseUnreadCount: Bool {
-        switch type {
-        case .event(.connectionRequestPending):
-            return true
+        switch self {
         case .message(let contentType):
             switch contentType {
-            case .messageTimerUpdate:
+            case .messageTimerUpdate, .participantsAdded, .participantsRemoved, .reaction:
                 return false
             default:
                 return true
@@ -188,12 +191,13 @@ extension ZMLocalNotification {
     }
     
     var shouldIncreaseUnreadMentionCount: Bool {
-        guard case LocalNotificationType.message(let contentType) = type else {
+        guard case LocalNotificationType.message(let contentType) = self else {
             return false
         }
         
         switch contentType {
-        case .text(_, isMention: true, isReply: _):
+        case .text(_, isMention: true, isReply: _),
+             .ephemeral(isMention: true, isReply: _):
             return true
         default:
             return false
@@ -201,12 +205,13 @@ extension ZMLocalNotification {
     }
     
     var shouldIncreaseUnreadReplyCount: Bool {
-        guard case LocalNotificationType.message(let contentType) = type else {
+        guard case LocalNotificationType.message(let contentType) = self else {
             return false
         }
         
         switch contentType {
-        case .text(_, isMention: _, isReply: true):
+        case .text(_, isMention: _, isReply: true),
+             .ephemeral(isMention: _, isReply: true):
             return true
         default:
             return false

--- a/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification.swift
+++ b/Source/Notifications/Push notifications/Notification Types/Content/ZMLocalNotification.swift
@@ -177,16 +177,15 @@ extension ZMLocalNotification {
 extension LocalNotificationType {
     
     var shouldIncreaseUnreadCount: Bool {
-        switch self {
-        case .message(let contentType):
-            switch contentType {
-            case .messageTimerUpdate, .participantsAdded, .participantsRemoved, .reaction:
-                return false
-            default:
-                return true
-            }
-        default:
+        guard case LocalNotificationType.message(let contentType) = self else {
             return false
+        }
+        
+        switch contentType {
+        case .messageTimerUpdate, .participantsAdded, .participantsRemoved, .reaction:
+            return false
+        default:
+            return true
         }
     }
     

--- a/Source/Notifications/Push notifications/Notification Types/LocalNotificationContentType.swift
+++ b/Source/Notifications/Push notifications/Notification Types/LocalNotificationContentType.swift
@@ -23,7 +23,7 @@ public enum LocalNotificationEventType {
     case connectionRequestAccepted, connectionRequestPending, newConnection, conversationCreated, conversationDeleted
 }
 
-public enum LocalNotificationContentType : Equatable {
+public enum LocalNotificationContentType: Equatable {
     
     case text(String, isMention: Bool, isReply: Bool)
     case image

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_UnreadCount.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_UnreadCount.swift
@@ -1,0 +1,69 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+@testable import WireSyncEngine
+
+class ZMLocalNotificationTests_UnreadCount: ZMLocalNotificationTests {
+    
+    func testThatUnreadCountIsIncreased_ForContentTypes() {
+        let bar: [LocalNotificationContentType] = [.image,
+                                                   .audio,
+                                                   .video,
+                                                   .fileUpload,
+                                                   .ephemeral(isMention: false, isReply: false),
+                                                   .hidden,
+                                                   .knock,
+                                                   .location,
+                                                   .text("Hello World", isMention: false, isReply: false)]
+        
+        bar.forEach { contentType in
+            XCTAssertTrue(LocalNotificationType.message(contentType).shouldIncreaseUnreadCount)
+        }
+    }
+    
+    func testThatUnreadMentionCountIsIncreased_WhenSelfUserIsMentioned() {
+        let bar: [LocalNotificationContentType] = [.ephemeral(isMention: true, isReply: false),
+                                                   .text("Hello World", isMention: true, isReply: false)]
+        
+        bar.forEach { contentType in
+            XCTAssertTrue(LocalNotificationType.message(contentType).shouldIncreaseUnreadMentionCount)
+        }
+    }
+    
+    func testThatUnreadSelfReplyCountIsIncreased_WhenSelfUserIsReplied() {
+        let bar: [LocalNotificationContentType] = [.ephemeral(isMention: false, isReply: true),
+                                                   .text("Hello World", isMention: false, isReply: true)]
+        
+        bar.forEach { contentType in
+            XCTAssertTrue(LocalNotificationType.message(contentType).shouldIncreaseUnreadReplyCount)
+        }
+    }
+    
+    func testThatUnreadCountIsntIncreased_ForContentTypesWithoutUserGeneratedContent() {
+        let bar: [LocalNotificationContentType] = [.messageTimerUpdate(nil),
+                                                   .participantsAdded,
+                                                   .participantsRemoved,
+                                                   .reaction(emoji: "❤️")]
+        
+        bar.forEach { contentType in
+            XCTAssertFalse(LocalNotificationType.message(contentType).shouldIncreaseUnreadCount)
+        }
+    }
+    
+}

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_UnreadCount.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_UnreadCount.swift
@@ -22,46 +22,46 @@ import Foundation
 class ZMLocalNotificationTests_UnreadCount: ZMLocalNotificationTests {
     
     func testThatUnreadCountIsIncreased_ForContentTypes() {
-        let bar: [LocalNotificationContentType] = [.image,
-                                                   .audio,
-                                                   .video,
-                                                   .fileUpload,
-                                                   .ephemeral(isMention: false, isReply: false),
-                                                   .hidden,
-                                                   .knock,
-                                                   .location,
-                                                   .text("Hello World", isMention: false, isReply: false)]
+        let contentTypes: [LocalNotificationContentType] = [.image,
+                                                            .audio,
+                                                            .video,
+                                                            .fileUpload,
+                                                            .ephemeral(isMention: false, isReply: false),
+                                                            .hidden,
+                                                            .knock,
+                                                            .location,
+                                                            .text("Hello World", isMention: false, isReply: false)]
         
-        bar.forEach { contentType in
+        contentTypes.forEach { contentType in
             XCTAssertTrue(LocalNotificationType.message(contentType).shouldIncreaseUnreadCount)
         }
     }
     
     func testThatUnreadMentionCountIsIncreased_WhenSelfUserIsMentioned() {
-        let bar: [LocalNotificationContentType] = [.ephemeral(isMention: true, isReply: false),
-                                                   .text("Hello World", isMention: true, isReply: false)]
+        let contentTypes: [LocalNotificationContentType] = [.ephemeral(isMention: true, isReply: false),
+                                                            .text("Hello World", isMention: true, isReply: false)]
         
-        bar.forEach { contentType in
+        contentTypes.forEach { contentType in
             XCTAssertTrue(LocalNotificationType.message(contentType).shouldIncreaseUnreadMentionCount)
         }
     }
     
     func testThatUnreadSelfReplyCountIsIncreased_WhenSelfUserIsReplied() {
-        let bar: [LocalNotificationContentType] = [.ephemeral(isMention: false, isReply: true),
-                                                   .text("Hello World", isMention: false, isReply: true)]
+        let contentTypes: [LocalNotificationContentType] = [.ephemeral(isMention: false, isReply: true),
+                                                            .text("Hello World", isMention: false, isReply: true)]
         
-        bar.forEach { contentType in
+        contentTypes.forEach { contentType in
             XCTAssertTrue(LocalNotificationType.message(contentType).shouldIncreaseUnreadReplyCount)
         }
     }
     
     func testThatUnreadCountIsntIncreased_ForContentTypesWithoutUserGeneratedContent() {
-        let bar: [LocalNotificationContentType] = [.messageTimerUpdate(nil),
-                                                   .participantsAdded,
-                                                   .participantsRemoved,
-                                                   .reaction(emoji: "❤️")]
+        let contentTypes: [LocalNotificationContentType] = [.messageTimerUpdate(nil),
+                                                            .participantsAdded,
+                                                            .participantsRemoved,
+                                                            .reaction(emoji: "❤️")]
         
-        bar.forEach { contentType in
+        contentTypes.forEach { contentType in
             XCTAssertFalse(LocalNotificationType.message(contentType).shouldIncreaseUnreadCount)
         }
     }

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -177,6 +177,7 @@
 		16ED865F23E3145C00CB1766 /* ZMUserSession+Clients.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16ED865E23E3145C00CB1766 /* ZMUserSession+Clients.swift */; };
 		16F5F16C1E4092C00062F0AE /* NSManagedObjectContext+CTCallCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16F5F16B1E4092C00062F0AE /* NSManagedObjectContext+CTCallCenter.swift */; };
 		16F6BB381EDEA659009EA803 /* SearchResult+AddressBook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16F6BB371EDEA659009EA803 /* SearchResult+AddressBook.swift */; };
+		16F7343C250F588100AB93B1 /* ZMLocalNotificationTests_UnreadCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16F7343B250F588100AB93B1 /* ZMLocalNotificationTests_UnreadCount.swift */; };
 		16FF47441F0BF5C70044C491 /* IntegrationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16FF47431F0BF5C70044C491 /* IntegrationTest.swift */; };
 		16FF47471F0CD58A0044C491 /* IntegrationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 16FF47461F0CD58A0044C491 /* IntegrationTest.m */; };
 		16FF474C1F0D54B20044C491 /* SessionManager+Logs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16FF474B1F0D54B20044C491 /* SessionManager+Logs.swift */; };
@@ -806,6 +807,7 @@
 		16ED865E23E3145C00CB1766 /* ZMUserSession+Clients.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSession+Clients.swift"; sourceTree = "<group>"; };
 		16F5F16B1E4092C00062F0AE /* NSManagedObjectContext+CTCallCenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+CTCallCenter.swift"; sourceTree = "<group>"; };
 		16F6BB371EDEA659009EA803 /* SearchResult+AddressBook.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SearchResult+AddressBook.swift"; sourceTree = "<group>"; };
+		16F7343B250F588100AB93B1 /* ZMLocalNotificationTests_UnreadCount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMLocalNotificationTests_UnreadCount.swift; sourceTree = "<group>"; };
 		16FF47431F0BF5C70044C491 /* IntegrationTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntegrationTest.swift; sourceTree = "<group>"; };
 		16FF47461F0CD58A0044C491 /* IntegrationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IntegrationTest.m; sourceTree = "<group>"; };
 		16FF47481F0CD6610044C491 /* IntegrationTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IntegrationTest.h; sourceTree = "<group>"; };
@@ -1983,6 +1985,7 @@
 				EE5BF6361F8F9D6100B49D06 /* ZMLocalNotificationTests_Event.swift */,
 				1639A8532264C52600868AB9 /* ZMLocalNotificationTests_Alerts.swift */,
 				EE01E0381F90FEC1001AA33C /* ZMLocalNotificationTests_ExpiredMessage.swift */,
+				16F7343B250F588100AB93B1 /* ZMLocalNotificationTests_UnreadCount.swift */,
 				546F815A1E685F1A00775059 /* LocalNotificationDispatcherTests.swift */,
 				160195601E30C9CF00ACBFAC /* LocalNotificationDispatcherCallingTests.swift */,
 				F9E4779D1D21640E003A99AC /* ZMLocalNotificationSetTests.swift */,
@@ -2881,6 +2884,7 @@
 				161ACB3A23F6BAFE00ABFF33 /* URLActionTests.swift in Sources */,
 				16519D5C231EA13A00C9D76D /* ConversationTests+Deletion.swift in Sources */,
 				F9B171FA1C0F320200E6EEC6 /* ClientManagementTests.m in Sources */,
+				16F7343C250F588100AB93B1 /* ZMLocalNotificationTests_UnreadCount.swift in Sources */,
 				163BB8131EE1A6EE00DF9384 /* IntegrationTest+Search.swift in Sources */,
 				16849B1C23EDA1FD00C025A8 /* MockUpdateEventProcessor.swift in Sources */,
 				545F601C1D6C336D00C2C55B /* AddressBookSearchTests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

After we split the event processing into two phases the badge count is no longer updated when a push notification is received.

### Causes

The badge count is updated by calculating the number of conversation which has unread messages. The number of unread messages in a conversation is updated when we read or insert new messages in a conversation, but since we no longer insert messages in the database during the first event phase the unread message count doesn't get updated until open the app.

### Solutions

Update the unread count when displaying a notification for a message which should increase the badge count. This will only be an estimation of the unread count because this solution doesn't take into account that you might have read messages on a second device. The correct unread count will be calculated during the second event processing phase when the app is put into the foreground.
## Notes

- This solution should also work when displaying notifications using the Notification Service Extension.
- This solution currently doesn't update the badge count when you receive an incoming connection request, since that would require either refactoring how we count pending connections or start processing connection request events in the background.
