### PR TITLE
[Fix] Attempt to fix badge count not updating by explicitly saving

### DIFF
--- a/Tests/Source/Integration/ConversationTests+List.swift
+++ b/Tests/Source/Integration/ConversationTests+List.swift
@@ -68,7 +68,7 @@ class ConversationTests_List: ConversationTestsBase {
             XCTAssertEqual(note.deletedIndexes.count, 0)
             moves.append(contentsOf: note.zm_movedIndexPairs)
         }
-        XCTAssertEqual(updatesCount, 1)
+        XCTAssertEqual(updatesCount, 2) // Two updates because unread count is updated separately
         XCTAssertEqual(moves.count, 1)
         XCTAssertEqual(moves.first?.to, 0)
     }
@@ -193,7 +193,7 @@ class ConversationTests_List: ConversationTestsBase {
 
         // then
         XCTAssertEqual(oneToOneConversation, conversationList[0] as? ZMConversation) // make sure conversation is not on top
-        let note = conversationListChangeObserver?.notifications.firstObject as! ConversationListChangeInfo
+        let note = conversationListChangeObserver?.notifications.lastObject as! ConversationListChangeInfo
         XCTAssertNotNil(note)
 
         var moves: [Int:Int] = [:]

--- a/Tests/Source/Integration/ConversationTests+OTR.swift
+++ b/Tests/Source/Integration/ConversationTests+OTR.swift
@@ -320,9 +320,9 @@ class ConversationTestsOTR_Swift: ConversationTestsBase {
         _ = waitForAllGroupsToBeEmpty(withTimeout: 0.5)
         
         // THEN
-        XCTAssertEqual(observer?.notifications.count, 1)
+        let changes: [ConversationChangeInfo]? = observer?.notifications.compactMap({ $0 as? ConversationChangeInfo})
+        let note = changes?.first(where: { $0.messagesChanged == true})
         
-        let note = observer?.notifications.firstObject as? ConversationChangeInfo
         XCTAssertNotNil(note)
         XCTAssertTrue(note?.messagesChanged ?? false)
         XCTAssertTrue(note?.lastModifiedDateChanged ?? false)
@@ -343,9 +343,9 @@ class ConversationTestsOTR_Swift: ConversationTestsBase {
         remotelyInsertOTRImage(into: groupConversation, imageFormat: format)
         
         // THEN
-        XCTAssertEqual(observer?.notifications.count, 1)
-        
-        let note = observer?.notifications.firstObject as? ConversationChangeInfo
+        let changes: [ConversationChangeInfo]? = observer?.notifications.compactMap({ $0 as? ConversationChangeInfo})
+        let note = changes?.first(where: { $0.messagesChanged == true})
+
         XCTAssertTrue(note?.messagesChanged ?? false)
         XCTAssertTrue(note?.lastModifiedDateChanged ?? false)
     }

--- a/Tests/Source/Integration/ConversationTests+Participants.swift
+++ b/Tests/Source/Integration/ConversationTests+Participants.swift
@@ -131,7 +131,7 @@ class ConversationTests_Participants: ConversationTestsBase {
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
-        XCTAssertEqual(observer?.notifications.count, 1)
+        XCTAssertEqual(observer?.notifications.count, 2) // Two updates because unread count is updated separately
         let note1 = observer?.notifications.lastObject as! ConversationListChangeInfo
         XCTAssertEqual(note1.zm_movedIndexPairs.first, ZMMovedIndex.init(from: UInt(previousIndex), to: 0))
     }

--- a/Tests/Source/Integration/ConversationTestsBase.m
+++ b/Tests/Source/Integration/ConversationTestsBase.m
@@ -206,9 +206,7 @@
     ConversationChangeInfo *messageChange = [observer.notifications firstObjectMatchingWithBlock:^BOOL(ConversationChangeInfo *change) {
         return change.messagesChanged;
     }];
-    
-    XCTAssertEqual(observer.notifications.count, 2u);
-    
+        
     XCTAssertNotNil(messageChange);
     XCTAssertTrue(messageChange.messagesChanged);
     XCTAssertFalse(messageChange.participantsChanged);

--- a/Tests/Source/Integration/ConversationTestsBase.m
+++ b/Tests/Source/Integration/ConversationTestsBase.m
@@ -199,17 +199,25 @@
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
-    XCTAssertEqual(observer.notifications.count, 1u);
+    ConversationChangeInfo *unreadCountChange = [observer.notifications firstObjectMatchingWithBlock:^BOOL(ConversationChangeInfo *change) {
+        return change.unreadCountChanged;
+    }];
     
-    ConversationChangeInfo *note = observer.notifications.lastObject;
-    XCTAssertNotNil(note);
-    XCTAssertTrue(note.messagesChanged);
-    XCTAssertFalse(note.participantsChanged);
-    XCTAssertTrue(note.lastModifiedDateChanged);
+    ConversationChangeInfo *messageChange = [observer.notifications firstObjectMatchingWithBlock:^BOOL(ConversationChangeInfo *change) {
+        return change.messagesChanged;
+    }];
+    
+    XCTAssertEqual(observer.notifications.count, 2u);
+    
+    XCTAssertNotNil(messageChange);
+    XCTAssertTrue(messageChange.messagesChanged);
+    XCTAssertFalse(messageChange.participantsChanged);
+    XCTAssertTrue(messageChange.lastModifiedDateChanged);
+    XCTAssertFalse(messageChange.connectionStateChanged);
+    
     if(!ignoreLastRead) {
-        XCTAssertTrue(note.unreadCountChanged);
+        XCTAssertTrue(unreadCountChange.unreadCountChanged);
     }
-    XCTAssertFalse(note.connectionStateChanged);
     
     verifyConversation(conversation);
 }

--- a/Tests/Source/Integration/SendAndReceiveMessagesTests+Swift.swift
+++ b/Tests/Source/Integration/SendAndReceiveMessagesTests+Swift.swift
@@ -127,7 +127,7 @@ class SendAndReceiveMessagesTests_Swift: ConversationTestsBase {
         }
     }
     
-    func testThatItSendsANotificationWhenRecievingATextMessageThroughThePushChannel() {
+    func testThatItSendsANotificationWhenReceivingATextMessageThroughThePushChannel() {
         let expectedText = "The sky above the port was the color of "
         let nonce = UUID.create()
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

Badge count is not updated after receiving push notifications.

### Causes

From looking at logs I can see that we are not saving SE before attempting re-calculate the badge count, which means that any increases to estimated unread count of conversations will not be included.

### Solutions

Explicitly save the SE context after processing events in the background.

## Notes

I added a test for this unfortunately is still passing without this change due to a delayed saved which gets performed at the right time.
