### PR TITLE
[Fix] Crash when enabling EAR during login

### DIFF
--- a/Source/UserSession/ZMUserSession+EncryptionAtRest.swift
+++ b/Source/UserSession/ZMUserSession+EncryptionAtRest.swift
@@ -26,7 +26,8 @@ extension ZMUserSession {
         
         set {
             do {
-                let account = Account(userName: "", userIdentifier: ZMUser.selfUser(in: managedObjectContext).remoteIdentifier)
+                
+                let account = Account(userName: "", userIdentifier: storeProvider.userIdentifier)
 
                 try EncryptionKeys.deleteKeys(for: account)
                 storeProvider.contextDirectory.clearEncryptionKeysInAllContexts()
@@ -76,7 +77,7 @@ extension ZMUserSession {
     }
     
     public func unlockDatabase(with context: LAContext) throws {
-        let account = Account(userName: "", userIdentifier: ZMUser.selfUser(in: managedObjectContext).remoteIdentifier)
+        let account = Account(userName: "", userIdentifier: storeProvider.userIdentifier)
         let keys = try EncryptionKeys.init(account: account, context: context)
 
         storeProvider.contextDirectory.storeEncryptionKeysInAllContexts(encryptionKeys: keys)

--- a/Tests/Source/UserSession/ZMUserSessionTests+EncryptionAtRest.swift
+++ b/Tests/Source/UserSession/ZMUserSessionTests+EncryptionAtRest.swift
@@ -155,8 +155,8 @@ class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
         // given
         simulateLoggedInUser()
         syncMOC.saveOrRollback()
-
-        let account = Account(userName: "", userIdentifier: ZMUser.selfUser(in: syncMOC).remoteIdentifier)
+        
+        let account = Account(userName: "", userIdentifier: storeProvider.userIdentifier)
         let oldKeys = try EncryptionKeys.createKeys(for: account)
 
         // when


### PR DESCRIPTION
## What's new in this PR?

### Issues

App would crash when attempting to activate EAR during login

### Causes

When EAR is enabled by default we activate it when the user session is created, but If you have reached the maximum number of devices you will be asked to remove a device before we have a fully functional user session. Importantly the self user is not yet accessible, which causes the EAR activation to fail since it accesses the self user in order to look up the userID (remoteIdentifier). This results in a crash due to force unwrapping an optional (nil) value.

### Solutions

Look up the userID on the `storeProvider` instead