### PR TITLE
[Chore] add `outdatedClient` to CallClosedReason

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-github "wireapp/avs-ios-binaries" ~> 6.0.223
+github "wireapp/avs-ios-binaries" ~> 6.3.225
 github "wireapp/wire-ios-request-strategy" ~> 206.0
 github "wireapp/ZipArchive" "v2.1.3"
 github "wireapp/libPhoneNumber-iOS" ~> 0.9.3

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,7 +1,7 @@
 github "wireapp/HTMLString" "4.1.0-beta.1-xcode_11_4_1"
 github "wireapp/PINCache" "2.3-swift3.1"
 github "wireapp/ZipArchive" "v2.1.3"
-github "wireapp/avs-ios-binaries" "6.0.224"
+github "wireapp/avs-ios-binaries" "6.3.225"
 github "wireapp/libPhoneNumber-iOS" "0.9.3"
 github "wireapp/ocmock" "v3.4.3"
 github "wireapp/swift-protobuf" "1.8.0_Swift5.2.2"

--- a/Source/Calling/CallClosedReason.swift
+++ b/Source/Calling/CallClosedReason.swift
@@ -19,9 +19,6 @@
 import Foundation
 import avs
 
-/// Workaround, remove once avs is updated to latest version and `WCALL_REASON_OUTDATED_CLIENT` is available
-private let WCALL_REASON_OUTDATED_CLIENT: Int32 = 11
-
 /**
  * Reasons why a call can be terminated.
  */

--- a/Source/Calling/CallClosedReason.swift
+++ b/Source/Calling/CallClosedReason.swift
@@ -19,6 +19,9 @@
 import Foundation
 import avs
 
+/// Workaround, remove once avs is updated to latest version and `WCALL_REASON_OUTDATED_CLIENT` is available
+private let WCALL_REASON_OUTDATED_CLIENT: Int32 = 11
+
 /**
  * Reasons why a call can be terminated.
  */
@@ -45,6 +48,8 @@ public enum CallClosedReason : Int32 {
     case stillOngoing
     /// Call was dropped due to the security level degrading
     case securityDegraded
+    /// Call was closed because the client version is blacklisted for that call
+    case outdatedClient
     /// Call was closed for an unknown reason. This is most likely a bug.
     case unknown
 
@@ -76,6 +81,8 @@ public enum CallClosedReason : Int32 {
             self = .inputOutputError
         case WCALL_REASON_STILL_ONGOING:
             self = .stillOngoing
+        case WCALL_REASON_OUTDATED_CLIENT:
+            self = .outdatedClient
         default:
             self = .unknown
         }
@@ -104,6 +111,8 @@ public enum CallClosedReason : Int32 {
             return WCALL_REASON_STILL_ONGOING
         case .securityDegraded:
             return WCALL_REASON_ERROR
+        case .outdatedClient:
+            return WCALL_REASON_OUTDATED_CLIENT
         case .unknown:
             return WCALL_REASON_ERROR
         }


### PR DESCRIPTION
## What's new in this PR?

Add `outdatedClient` to `CallClosedReason` which is needed for outdated client alerts in UI

### Note

Change was originally released as a hotfix for 3.64.