### PR TITLE
[Performance] Disable observation system during quick sync

### DIFF
--- a/Source/UserSession/ZMUserSession.swift
+++ b/Source/UserSession/ZMUserSession.swift
@@ -459,6 +459,7 @@ extension ZMUserSession: ZMSyncStateDelegate {
     
     public func didStartQuickSync() {
         managedObjectContext.performGroupedBlock { [weak self] in
+            self?.notificationDispatcher.isDisabled = true
             self?.isPerformingSync = true
             self?.updateNetworkState()
         }
@@ -470,7 +471,9 @@ extension ZMUserSession: ZMSyncStateDelegate {
         syncStrategy.processAllEventsInBuffer()
         let hasMoreEventsToProcess = syncStrategy.processEventsAfterFinishingQuickSync()
         
+
         managedObjectContext.performGroupedBlock { [weak self] in
+            self?.notificationDispatcher.isDisabled = hasMoreEventsToProcess
             self?.isPerformingSync = hasMoreEventsToProcess
             self?.updateNetworkState()
             self?.notifyThirdPartyServices()

--- a/Tests/Source/UserSession/ZMUserSessionTests+Syncing.swift
+++ b/Tests/Source/UserSession/ZMUserSessionTests+Syncing.swift
@@ -118,6 +118,22 @@ class ZMUserSessionTests_Syncing: ZMUserSessionTestsBase {
     
     // MARK: Quick Sync
 
+    func testThatObserverSystemIsDisabledDuringQuickSync() {
+        // when
+        sut.didStartQuickSync()
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // then
+        XCTAssertTrue(sut.notificationDispatcher.isDisabled)
+
+        // when
+        sut.didFinishQuickSync()
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // then
+        XCTAssertFalse(sut.notificationDispatcher.isDisabled)
+    }
+
     func testThatPerformingSyncIsFinishedAfterQuickSync() {
         
         // given


### PR DESCRIPTION
## What's new in this PR?

### Issues

When the app comes to the foreground after accumulating several update events, it can take a while to complete syncing.

### Causes

Previously update events were processed in the background when we received remote pushes. After implementing encryption at rest, this is no longer the case and most update events are now processed when the app returns to the foreground. It can easily happen that a device accumulates a lot of update events needing processing, which can lead to slow synchronization times.

### Solutions

A way we can speed this up is to disable the observation system during this event processing stage. The observation system is used to keep the UI up-to-date when events are processed, however it is quite an expensive and makes little sense during the quick sync phase, as it essentially "replays" the history of the update events as they are being processed. By disabling this system during quick sync, the UI will be updated in a single step once all buffered events have been processed.

## Notes

**JIRA:** https://wearezeta.atlassian.net/browse/ZIOS-13814

