### PR TITLE
[Feature] Add performance tests for event processing

### DIFF
--- a/Tests/Source/Integration/APNSTestsBase.h
+++ b/Tests/Source/Integration/APNSTestsBase.h
@@ -20,7 +20,6 @@
 
 @interface APNSTestsBase: IntegrationTest
 
-- (void)closePushChannelAndWaitUntilClosed;
 - (NSDictionary *)noticePayloadForLastEvent;
 - (NSDictionary *)noticePayloadWithIdentifier:(NSUUID *)uuid;
 

--- a/Tests/Source/Integration/APNSTestsBase.m
+++ b/Tests/Source/Integration/APNSTestsBase.m
@@ -32,15 +32,6 @@
     [self createExtraUsersAndConversations];
 }
 
-- (void)closePushChannelAndWaitUntilClosed
-{
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
-        session.pushChannel.keepOpen = NO;
-        [session simulatePushChannelClosed];
-    }];
-    WaitForAllGroupsToBeEmpty(0.2);
-}
-
 - (NSDictionary *)noticePayloadForLastEvent
 {
     ZMUpdateEvent *lastEvent = self.mockTransportSession.updateEvents.lastObject;

--- a/Tests/Source/Integration/EventProcessingPerformanceTests.swift
+++ b/Tests/Source/Integration/EventProcessingPerformanceTests.swift
@@ -118,7 +118,6 @@ extension MockConversation {
         (1...count).forEach { (_) in
             let knock = try! GenericMessage(content: Knock.with { $0.hotKnock = false }).serializedData()
             insertClientMessage(from: users.randomElement()!, data: knock)
-//            insertKnock(from: users.randomElement()!, nonce: UUID())
         }
     }
         

--- a/Tests/Source/Integration/EventProcessingPerformanceTests.swift
+++ b/Tests/Source/Integration/EventProcessingPerformanceTests.swift
@@ -1,0 +1,132 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/// These tests are measuring the performance of processing events of
+/// in different scenarios.
+///
+/// NOTE that we are not receiving encrypted events since we are not
+/// interested in measuring decryption performance here.
+class EventProcessingPerformanceTests: IntegrationTest {
+    
+    override func setUp() {
+        super.setUp()
+        
+        createSelfUserAndConversation()
+        createTeamAndConversations()
+    }
+    
+    var users: [MockUser]!
+    var conversations: [MockConversation]!
+    
+    func testTextEventProcessingPerformance_InLargeGroups() {
+        // given
+        createUsersAndConversations(userCount: 100, conversationCount: 10)
+        XCTAssertTrue(login())
+        
+        simulateApplicationDidEnterBackground()
+        mockTransportSession.performRemoteChanges { (session) in
+            self.conversations.forEach { (conversation) in
+                conversation.insertRandomTextMessages(count: 100, from: self.users)
+            }
+        }
+        
+        // then
+        measure {
+            simulateApplicationWillEnterForeground()
+            XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        }
+    }
+    
+    func testTextEventProcessingPerformance_inSmallGroups() {
+        // given
+        createUsersAndConversations(userCount: 5, conversationCount: 10)
+        XCTAssertTrue(login())
+        
+        simulateApplicationDidEnterBackground()
+        mockTransportSession.performRemoteChanges { (session) in
+            self.conversations.forEach { (conversation) in
+                conversation.insertRandomTextMessages(count: 100, from: self.users)
+            }
+        }
+        
+        // then
+        measure {
+            simulateApplicationWillEnterForeground()
+            XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        }
+    }
+
+    func testKnockEventProcessingPerformance() {
+        // given
+        createUsersAndConversations(userCount: 5, conversationCount: 10)
+        XCTAssertTrue(login())
+        
+        simulateApplicationDidEnterBackground()
+        mockTransportSession.performRemoteChanges { (session) in
+            self.conversations.forEach { (conversation) in
+                conversation.insertRandomKnocks(count: 100, from: self.users)
+            }
+        }
+        
+        // then
+        measure {
+            simulateApplicationWillEnterForeground()
+            XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        }
+    }
+    
+    // MARK: Helpers
+            
+    func createUsersAndConversations(userCount: Int, conversationCount: Int) {
+        mockTransportSession.performRemoteChanges { (session) in
+            self.users = (1...userCount).map({
+                session.insertUser(withName: "User \($0)")
+            })
+            
+            let usersIncludingSelfUser = self.users + [self.selfUser!]
+            
+            self.conversations = (1...conversationCount).map({
+                let conversation = session.insertTeamConversation(to: self.team, with: usersIncludingSelfUser, creator: self.selfUser)
+                conversation.changeName(by: self.selfUser, name: "Team conversation \($0)")
+                return conversation
+            })
+        }
+    }
+    
+}
+
+extension MockConversation {
+    
+    func insertRandomKnocks(count: Int, from users: [MockUser]) {
+        (1...count).forEach { (_) in
+            let knock = try! GenericMessage(content: Knock.with { $0.hotKnock = false }).serializedData()
+            insertClientMessage(from: users.randomElement()!, data: knock)
+//            insertKnock(from: users.randomElement()!, nonce: UUID())
+        }
+    }
+        
+    func insertRandomTextMessages(count: Int, from users: [MockUser]) {
+        (1...count).forEach { (counter) in
+            let text = try! GenericMessage(content: Text(content: "Random message \(counter)")).serializedData()
+            insertClientMessage(from: users.randomElement()!, data: text)
+        }
+    }
+    
+}

--- a/Tests/Source/Integration/IntegrationTest.swift
+++ b/Tests/Source/Integration/IntegrationTest.swift
@@ -580,6 +580,25 @@ extension IntegrationTest {
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
     }
     
+    func closePushChannelAndWaitUntilClosed() {
+        mockTransportSession.performRemoteChanges { session in
+            self.mockTransportSession.pushChannel.keepOpen = false
+            session.simulatePushChannelClosed()
+        }
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+    }
+    
+    func simulateApplicationWillEnterForeground() {
+        application?.simulateApplicationWillEnterForeground()
+    }
+    
+    func simulateApplicationDidEnterBackground() {
+        closePushChannelAndWaitUntilClosed() // do not use websocket
+        application?.setBackground()
+        application?.simulateApplicationDidEnterBackground()
+        _ = waitForAllGroupsToBeEmpty(withTimeout: 0.5)
+    }
+    
 }
 
 extension IntegrationTest {

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -147,6 +147,7 @@
 		16962EE52028A86D0069D88D /* ZMLocalNotificationLocalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB568181FA22FBE003ADA3A /* ZMLocalNotificationLocalizationTests.swift */; };
 		169BC10F22BD17FF0003159B /* LegalHoldRequestStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 169BC10E22BD17FF0003159B /* LegalHoldRequestStrategyTests.swift */; };
 		169E303320D29C670012C219 /* PushRegistryMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 169E303120D29C200012C219 /* PushRegistryMock.swift */; };
+		169E55F62518FF810092CD53 /* EventProcessingPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 169E55F52518FF810092CD53 /* EventProcessingPerformanceTests.swift */; };
 		16A5FE21215B584200AEEBBD /* MockLinkPreviewDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A5FE20215B584200AEEBBD /* MockLinkPreviewDetector.swift */; };
 		16A5FE23215B5FD000AEEBBD /* LinkPreviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A5FE22215B5FD000AEEBBD /* LinkPreviewTests.swift */; };
 		16A702D01E92998100B8410D /* ApplicationStatusDirectoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A702CF1E92998100B8410D /* ApplicationStatusDirectoryTests.swift */; };
@@ -781,6 +782,7 @@
 		16962EE320286D690069D88D /* LocalNotificationType+Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalNotificationType+Configuration.swift"; sourceTree = "<group>"; };
 		169BC10E22BD17FF0003159B /* LegalHoldRequestStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegalHoldRequestStrategyTests.swift; sourceTree = "<group>"; };
 		169E303120D29C200012C219 /* PushRegistryMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushRegistryMock.swift; sourceTree = "<group>"; };
+		169E55F52518FF810092CD53 /* EventProcessingPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventProcessingPerformanceTests.swift; sourceTree = "<group>"; };
 		16A5FE20215B584200AEEBBD /* MockLinkPreviewDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLinkPreviewDetector.swift; sourceTree = "<group>"; };
 		16A5FE22215B5FD000AEEBBD /* LinkPreviewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkPreviewTests.swift; sourceTree = "<group>"; };
 		16A702CF1E92998100B8410D /* ApplicationStatusDirectoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplicationStatusDirectoryTests.swift; sourceTree = "<group>"; };
@@ -2138,6 +2140,7 @@
 				EF797FE71FB5E8DB00F7FF21 /* RegistrationTests.swift */,
 				F188BB852223F372002BF204 /* UserRichProfileIntegrationTests.swift */,
 				5502C6E922B7D4DA000684B7 /* ZMUserSessionLegalHoldTests.swift */,
+				169E55F52518FF810092CD53 /* EventProcessingPerformanceTests.swift */,
 			);
 			path = Integration;
 			sourceTree = "<group>";
@@ -2794,6 +2797,7 @@
 				BF325E9D1EC067D600772145 /* RequestLoopAnalyticsTrackerTests.swift in Sources */,
 				06BBF6FF2472F3AC00A26626 /* SendAndReceiveMessagesTests+Swift.swift in Sources */,
 				5E8EE1FC20FDCCE200DB1F9B /* CompanyLoginRequestDetectorTests.swift in Sources */,
+				169E55F62518FF810092CD53 /* EventProcessingPerformanceTests.swift in Sources */,
 				54ADA7631E3B3D8E00B90C7D /* IntegrationTest+Encryption.swift in Sources */,
 				F991CE161CB55512004D8465 /* ZMUser+Testing.m in Sources */,
 				5E2C354D21A806A80034F1EE /* MockBackgroundActivityManager.swift in Sources */,

--- a/WireSyncEngine.xcodeproj/xcshareddata/xcbaselines/3E1860C2191A649D000FE027.xcbaseline/8C2DC110-E573-497C-922A-2C909350F73B.plist
+++ b/WireSyncEngine.xcodeproj/xcshareddata/xcbaselines/3E1860C2191A649D000FE027.xcbaseline/8C2DC110-E573-497C-922A-2C909350F73B.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>EventProcessingTests</key>
+		<dict>
+			<key>testTextEventProcessingPerformance_InLargeGroups()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/WireSyncEngine.xcodeproj/xcshareddata/xcbaselines/3E1860C2191A649D000FE027.xcbaseline/Info.plist
+++ b/WireSyncEngine.xcodeproj/xcshareddata/xcbaselines/3E1860C2191A649D000FE027.xcbaseline/Info.plist
@@ -78,6 +78,37 @@
 				<string>com.apple.platform.iphonesimulator</string>
 			</dict>
 		</dict>
+		<key>8C2DC110-E573-497C-922A-2C909350F73B</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>100</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>Quad-Core Intel Core i7</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>2800</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>8</integer>
+				<key>modelCode</key>
+				<string>MacBookPro14,3</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>4</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>x86_64</string>
+			<key>targetDevice</key>
+			<dict>
+				<key>modelCode</key>
+				<string>iPhone10,4</string>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.iphonesimulator</string>
+			</dict>
+		</dict>
 		<key>8C3EECB1-57FB-4A02-BBC3-1B30E7A54C38</key>
 		<dict>
 			<key>localComputer</key>

--- a/WireSyncEngine.xcodeproj/xcshareddata/xcschemes/WireSyncEngine.xcscheme
+++ b/WireSyncEngine.xcodeproj/xcshareddata/xcschemes/WireSyncEngine.xcscheme
@@ -66,6 +66,9 @@
                   Identifier = "AvailabilityTests">
                </Test>
                <Test
+                  Identifier = "EventProcessingPerformanceTests">
+               </Test>
+               <Test
                   Identifier = "SessionManagerTests/testThatSessionManagerSetsUpAPNSEnvironmentOnLaunch()">
                </Test>
             </SkippedTests>


### PR DESCRIPTION
## What's new in this PR?

Add performance tests for event processing in order to better profile and evaluate performance improvements. 

NOTE: The tests are disabled in the suite since they are quite slow to run.