### PR TITLE
Revert "[Fix] Disable observation system during quick sync (#1314)"

### DIFF
--- a/Source/UserSession/ZMUserSession.swift
+++ b/Source/UserSession/ZMUserSession.swift
@@ -459,7 +459,6 @@ extension ZMUserSession: ZMSyncStateDelegate {
     
     public func didStartQuickSync() {
         managedObjectContext.performGroupedBlock { [weak self] in
-            self?.notificationDispatcher.isDisabled = true
             self?.isPerformingSync = true
             self?.updateNetworkState()
         }
@@ -471,9 +470,7 @@ extension ZMUserSession: ZMSyncStateDelegate {
         syncStrategy.processAllEventsInBuffer()
         let hasMoreEventsToProcess = syncStrategy.processEventsAfterFinishingQuickSync()
         
-
         managedObjectContext.performGroupedBlock { [weak self] in
-            self?.notificationDispatcher.isDisabled = hasMoreEventsToProcess
             self?.isPerformingSync = hasMoreEventsToProcess
             self?.updateNetworkState()
             self?.notifyThirdPartyServices()

--- a/Tests/Source/UserSession/ZMUserSessionTests+Syncing.swift
+++ b/Tests/Source/UserSession/ZMUserSessionTests+Syncing.swift
@@ -118,22 +118,6 @@ class ZMUserSessionTests_Syncing: ZMUserSessionTestsBase {
     
     // MARK: Quick Sync
 
-    func testThatObserverSystemIsDisabledDuringQuickSync() {
-        // when
-        sut.didStartQuickSync()
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-
-        // then
-        XCTAssertTrue(sut.notificationDispatcher.isDisabled)
-
-        // when
-        sut.didFinishQuickSync()
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-
-        // then
-        XCTAssertFalse(sut.notificationDispatcher.isDisabled)
-    }
-
     func testThatPerformingSyncIsFinishedAfterQuickSync() {
         
         // given


### PR DESCRIPTION
## What's new in this PR?

This reverts commit f92188f068ad30fb8941dd019f2ae12e73cea76e because the observation system was getting stuck in a disabled state after the quick sync finished.