### PR TITLE
[Fix] Do not check the file extension

### DIFF
--- a/Source/SessionManager/SessionManager+Backup.swift
+++ b/Source/SessionManager/SessionManager+Backup.swift
@@ -93,9 +93,6 @@ extension SessionManager {
         }
 
         guard let userId = unauthenticatedSession?.authenticationStatus.authenticatedUserIdentifier else { return completion(.failure(BackupError.notAuthenticated)) }
-
-        // Verify the imported file has the correct file extension.
-        guard location.pathExtension == BackupMetadata.fileExtension else { return completion(.failure(BackupError.invalidFileExtension)) }
         
         SessionManager.workerQueue.async(group: dispatchGroup) { [weak self] in
             guard let `self` = self else { return }

--- a/Source/SessionManager/SessionManager+Backup.swift
+++ b/Source/SessionManager/SessionManager+Backup.swift
@@ -94,6 +94,9 @@ extension SessionManager {
 
         guard let userId = unauthenticatedSession?.authenticationStatus.authenticatedUserIdentifier else { return completion(.failure(BackupError.notAuthenticated)) }
         
+        // Verify the imported file has the correct file extension.
+        guard FileExtensions.allCases.contains(where: { $0.rawValue == location.pathExtension }) else { return completion(.failure(BackupError.invalidFileExtension)) }
+        
         SessionManager.workerQueue.async(group: dispatchGroup) { [weak self] in
             guard let `self` = self else { return }
             let decryptedURL = SessionManager.temporaryURL(for: location)
@@ -167,11 +170,16 @@ extension SessionManager {
 
 // MARK: - Compressed Filename
 
+fileprivate enum FileExtensions: String, CaseIterable {
+    case fileExtensionUnderscore = "ios_wbu"
+    case fileExtensionHyphen = "ios-wbu"
+}
+
 fileprivate extension BackupMetadata {
     
     static let nameAppName = "Wire"
     static let nameFileName = "Backup"
-    static let fileExtension = "ios_wbu"
+    static let fileExtension = FileExtensions.fileExtensionUnderscore.rawValue
 
     private static let formatter: DateFormatter = {
        let formatter = DateFormatter()

--- a/Source/SessionManager/SessionManager+Backup.swift
+++ b/Source/SessionManager/SessionManager+Backup.swift
@@ -95,7 +95,7 @@ extension SessionManager {
         guard let userId = unauthenticatedSession?.authenticationStatus.authenticatedUserIdentifier else { return completion(.failure(BackupError.notAuthenticated)) }
         
         // Verify the imported file has the correct file extension.
-        guard FileExtensions.allCases.contains(where: { $0.rawValue == location.pathExtension }) else { return completion(.failure(BackupError.invalidFileExtension)) }
+        guard BackupFileExtensions.allCases.contains(where: { $0.rawValue == location.pathExtension }) else { return completion(.failure(BackupError.invalidFileExtension)) }
         
         SessionManager.workerQueue.async(group: dispatchGroup) { [weak self] in
             guard let `self` = self else { return }
@@ -170,7 +170,8 @@ extension SessionManager {
 
 // MARK: - Compressed Filename
 
-fileprivate enum FileExtensions: String, CaseIterable {
+/// There are some external apps that users can use to transfer backup files, which can modify their attachments and change the underscore with a dash. For this reason, we accept 2 types of file extensions to restore conversations.
+fileprivate enum BackupFileExtensions: String, CaseIterable {
     case fileExtensionUnderscore = "ios_wbu"
     case fileExtensionHyphen = "ios-wbu"
 }
@@ -179,7 +180,7 @@ fileprivate extension BackupMetadata {
     
     static let nameAppName = "Wire"
     static let nameFileName = "Backup"
-    static let fileExtension = FileExtensions.fileExtensionUnderscore.rawValue
+    static let fileExtension = BackupFileExtensions.fileExtensionUnderscore.rawValue
 
     private static let formatter: DateFormatter = {
        let formatter = DateFormatter()

--- a/Source/SessionManager/SessionManager+Backup.swift
+++ b/Source/SessionManager/SessionManager+Backup.swift
@@ -172,15 +172,15 @@ extension SessionManager {
 
 /// There are some external apps that users can use to transfer backup files, which can modify their attachments and change the underscore with a dash. For this reason, we accept 2 types of file extensions to restore conversations.
 fileprivate enum BackupFileExtensions: String, CaseIterable {
-    case fileExtensionUnderscore = "ios_wbu"
-    case fileExtensionHyphen = "ios-wbu"
+    case fileExtensionWithUnderscore = "ios_wbu"
+    case fileExtensionWithHyphen = "ios-wbu"
 }
 
 fileprivate extension BackupMetadata {
     
     static let nameAppName = "Wire"
     static let nameFileName = "Backup"
-    static let fileExtension = BackupFileExtensions.fileExtensionUnderscore.rawValue
+    static let fileExtension = BackupFileExtensions.fileExtensionWithUnderscore.rawValue
 
     private static let formatter: DateFormatter = {
        let formatter = DateFormatter()

--- a/Tests/Source/SessionManager/SessionManagerTests+Backup.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests+Backup.swift
@@ -141,6 +141,30 @@ class SessionManagerTests_Backup: IntegrationTest {
         XCTAssertEqual(result.error as? SessionManager.BackupError, .invalidFileExtension)
     }
     
+    func testThatItCanRestoreFileWithAHyphenInTheFileExtension() throws {
+        // Given
+        XCTAssert(login())
+        
+        let backupResult = backupActiveAcount(password: name)
+        guard let url = backupResult.value else { return XCTFail("\(backupResult.error!)") }
+        
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd"
+        let fileExtensionWithHyphen = "Wire-\(self.selfUser!.handle!)-Backup_\(formatter.string(from: .init())).ios-wbu"
+        
+        let fm = FileManager.default
+        try fm.createDirectory(atPath: backupURL.path, withIntermediateDirectories: true, attributes: nil)
+        let dataURL = backupURL.appendingPathComponent(fileExtensionWithHyphen)
+        try? fm.copyItem(at: url, to: dataURL)
+        
+        // When
+        XCTAssertEqual(dataURL.lastPathComponent, fileExtensionWithHyphen)
+        let result = restoreAcount(password: name, from: dataURL)
+        
+        // Then
+        XCTAssertNil(result.error, "\(result.error!)")
+    }
+    
     func testThatItReturnsAnErrorWhenImportingFileWithWrongPassword() throws {
         // Given
         XCTAssert(login())


### PR DESCRIPTION
## What's new in this PR?

### Issues
When you sent a backup file through the email, the Gmail app changes the file extension.(xxx.ios_wbu to xxx.ios-wbu).

### Causes
There is the Gmail app issue.
https://support.google.com/mail/thread/15716995?hl=en

### Solutions
Do not check the file extension and accept both file extensions.

## Dependencies

wireapp/wire-ios/pull/4634