### PR TITLE
[Feature] call degradation

### DIFF
--- a/Source/Calling/CallParticipantSnapshot.swift
+++ b/Source/Calling/CallParticipantSnapshot.swift
@@ -89,6 +89,7 @@ class CallParticipantsSnapshot {
 
         allParticipantsAreTrusted = members.array.lazy
             .map(\.client.clientId)
+            .filter({ $0 != selfClient.remoteIdentifier })
             .allSatisfy(trustedClients.contains)
     }
 

--- a/Source/Calling/CallSnapshot.swift
+++ b/Source/Calling/CallSnapshot.swift
@@ -32,7 +32,12 @@ struct CallSnapshot {
     let videoState: VideoState
     let networkQuality: NetworkQuality
     let isConferenceCall: Bool
+    let degradedUser: ZMUser?
     var conversationObserverToken : NSObjectProtocol?
+
+    var isDegradedCall: Bool {
+        return degradedUser != nil
+    }
 
     /**
      * Updates the snapshot with the new state of the call.
@@ -49,6 +54,7 @@ struct CallSnapshot {
                             videoState: videoState,
                             networkQuality: networkQuality,
                             isConferenceCall: isConferenceCall,
+                            degradedUser: degradedUser,
                             conversationObserverToken: conversationObserverToken)
     }
 
@@ -67,6 +73,7 @@ struct CallSnapshot {
                             videoState: videoState,
                             networkQuality: networkQuality,
                             isConferenceCall: isConferenceCall,
+                            degradedUser: degradedUser,
                             conversationObserverToken: conversationObserverToken)
     }
 
@@ -85,6 +92,7 @@ struct CallSnapshot {
                             videoState: videoState,
                             networkQuality: networkQuality,
                             isConferenceCall: isConferenceCall,
+                            degradedUser: degradedUser,
                             conversationObserverToken: conversationObserverToken)
     }
 
@@ -103,6 +111,30 @@ struct CallSnapshot {
                             videoState: videoState,
                             networkQuality: networkQuality,
                             isConferenceCall: isConferenceCall,
+                            degradedUser: degradedUser,
+                            conversationObserverToken: conversationObserverToken)
+    }
+
+    /**
+     * Updates the snapshot with the new degraded user.
+     *
+     * A user degrades the call if they were previously trusted by the self
+     * client and then joined the call with an unverified device.
+     * 
+     * - parameter degradedUser: The user who degraded the call.
+     */
+
+    func updateDegradedUser(_ degradedUser: ZMUser) -> CallSnapshot {
+        return CallSnapshot(callParticipants: callParticipants,
+                            callState: callState,
+                            callStarter: callStarter,
+                            isVideo: isVideo,
+                            isGroup: isGroup,
+                            isConstantBitRate: isConstantBitRate,
+                            videoState: videoState,
+                            networkQuality: networkQuality,
+                            isConferenceCall: isConferenceCall,
+                            degradedUser: degradedUser,
                             conversationObserverToken: conversationObserverToken)
     }
 

--- a/Source/Calling/VoiceChannel.swift
+++ b/Source/Calling/VoiceChannel.swift
@@ -60,6 +60,8 @@ public protocol CallProperties : NSObjectProtocol {
     var muted: Bool { get set }
 
     var isConferenceCall: Bool { get }
+
+    var firstDegradedUser: ZMUser? { get }
     
     func setVideoCaptureDevice(_ device: CaptureDevice) throws
 }

--- a/Source/Calling/VoiceChannelV3.swift
+++ b/Source/Calling/VoiceChannelV3.swift
@@ -180,12 +180,10 @@ extension VoiceChannelV3 : CallActionsInternal {
         var joined = false
         
         switch state {
-        case .incoming(video: _, shouldRing: _, degraded: let degraded):
-            if !degraded {
-                joined = callCenter?.answerCall(conversation: conversation, video: video) ?? false
-            }
+        case .incoming(video: _, shouldRing: _, degraded: _):
+            joined = callCenter?.answerCall(conversation: conversation, video: video) ?? false
         default:
-            joined = self.callCenter?.startCall(conversation: conversation, video: video) ?? false
+            joined = callCenter?.startCall(conversation: conversation, video: video) ?? false
         }
         
         return joined

--- a/Source/Calling/VoiceChannelV3.swift
+++ b/Source/Calling/VoiceChannelV3.swift
@@ -124,15 +124,16 @@ public class VoiceChannelV3 : NSObject, VoiceChannel {
     }
 
     public var firstDegradedUser: ZMUser? {
-        if let conversationId = conversation?.remoteIdentifier,
+        guard
+            let conversationId = conversation?.remoteIdentifier,
             let degradedUser = callCenter?.degradedUser(conversationId: conversationId)
-        {
-            return degradedUser
+        else {
+            return conversation?.localParticipants.first(where: {
+                !$0.isTrusted
+            })
         }
 
-        return conversation?.localParticipants.first(where: {
-            !$0.isTrusted
-        })
+        return degradedUser
     }
 
 }

--- a/Source/Calling/VoiceChannelV3.swift
+++ b/Source/Calling/VoiceChannelV3.swift
@@ -122,7 +122,19 @@ public class VoiceChannelV3 : NSObject, VoiceChannel {
 
         return callCenter.isConferenceCall(conversationId: remoteIdentifier)
     }
-    
+
+    public var firstDegradedUser: ZMUser? {
+        if let conversationId = conversation?.remoteIdentifier,
+            let degradedUser = callCenter?.degradedUser(conversationId: conversationId)
+        {
+            return degradedUser
+        }
+
+        return conversation?.localParticipants.first(where: {
+            !$0.isTrusted
+        })
+    }
+
 }
 
 extension VoiceChannelV3 : CallActions {

--- a/Source/Calling/WireCallCenterV3+Degradation.swift
+++ b/Source/Calling/WireCallCenterV3+Degradation.swift
@@ -1,0 +1,31 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension WireCallCenterV3 {
+    
+    func callDidDegrade(conversationId: UUID, degradedUser: ZMUser) {
+        closeCall(conversationId: conversationId, reason: .securityDegraded)
+        
+        if let previousSnapshot = callSnapshots[conversationId] {
+            callSnapshots[conversationId] = previousSnapshot.updateDegradedUser(degradedUser)
+        }
+    }
+    
+}

--- a/Source/Calling/WireCallCenterV3+Events.swift
+++ b/Source/Calling/WireCallCenterV3+Events.swift
@@ -326,6 +326,18 @@ extension WireCallCenterV3 {
     }
 }
 
+extension WireCallCenterV3 {
+
+    func callDidDegrade(conversationId: UUID, degradedUser: ZMUser) {
+        closeCall(conversationId: conversationId, reason: .securityDegraded)
+
+        if let previousSnapshot = callSnapshots[conversationId] {
+            callSnapshots[conversationId] = previousSnapshot.updateDegradedUser(degradedUser)
+        }
+    }
+    
+}
+
 private extension Set where Element == ZMUser {
 
     var avsClients: Set<AVSClient> {

--- a/Source/Calling/WireCallCenterV3+Events.swift
+++ b/Source/Calling/WireCallCenterV3+Events.swift
@@ -326,18 +326,6 @@ extension WireCallCenterV3 {
     }
 }
 
-extension WireCallCenterV3 {
-
-    func callDidDegrade(conversationId: UUID, degradedUser: ZMUser) {
-        closeCall(conversationId: conversationId, reason: .securityDegraded)
-
-        if let previousSnapshot = callSnapshots[conversationId] {
-            callSnapshots[conversationId] = previousSnapshot.updateDegradedUser(degradedUser)
-        }
-    }
-    
-}
-
 private extension Set where Element == ZMUser {
 
     var avsClients: Set<AVSClient> {

--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -187,6 +187,7 @@ extension WireCallCenterV3 {
             videoState: video ? .started : .stopped,
             networkQuality: .normal,
             isConferenceCall: isConferenceCall,
+            degradedUser: nil,
             conversationObserverToken: token
         )
     }
@@ -272,13 +273,14 @@ extension WireCallCenterV3 {
     /**
      * Determines the degradation of the conversation.
      * - parameter conversationId: The identifier of the conversation to check the state of.
-     * - returns: Whether the conversation has degraded security.
+     * - returns: Whether the conversation has degraded security or the call in the conversation has a degraded user.
      */
 
     public func isDegraded(conversationId: UUID) -> Bool {
         let conversation = ZMConversation(remoteID: conversationId, createIfNeeded: false, in: uiMOC!)
-        let degraded = conversation?.securityLevel == .secureWithIgnored
-        return degraded
+        let isConversationDegraded = conversation?.securityLevel == .secureWithIgnored
+        let isCallDegraded = callSnapshots[conversationId]?.isDegradedCall ?? false
+        return isConversationDegraded || isCallDegraded
     }
 
     /// Returns conversations with active calls.
@@ -310,6 +312,10 @@ extension WireCallCenterV3 {
 
     public func isConferenceCall(conversationId: UUID) -> Bool {
         return callSnapshots[conversationId]?.isConferenceCall ?? false
+    }
+
+    func degradedUser(conversationId: UUID) -> ZMUser? {
+        return callSnapshots[conversationId]?.degradedUser
     }
 
 }

--- a/Tests/Source/Calling/CallSnapshotTestFixture.swift
+++ b/Tests/Source/Calling/CallSnapshotTestFixture.swift
@@ -1,0 +1,47 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+@testable import WireSyncEngine
+
+struct CallSnapshotTestFixture {
+    static func degradedCallSnapshot(conversationId: UUID, user: ZMUser, callCenter: WireCallCenterV3) -> CallSnapshot {
+        
+        let callMember = AVSCallMember(client: AVSClient(userId: user.remoteIdentifier, clientId: UUID().transportString()))
+        
+        let callParticipantSnapshot = CallParticipantsSnapshot(
+            conversationId: conversationId,
+            members: [callMember],
+            callCenter: callCenter
+        )
+        
+        return CallSnapshot(
+            callParticipants: callParticipantSnapshot,
+            callState: .established,
+            callStarter: UUID(),
+            isVideo: false,
+            isGroup: true,
+            isConstantBitRate: false,
+            videoState: .stopped,
+            networkQuality: .normal,
+            isConferenceCall: true,
+            degradedUser: user,
+            conversationObserverToken: nil
+        )
+    }
+}

--- a/Tests/Source/Calling/VoiceChannelV3Tests.swift
+++ b/Tests/Source/Calling/VoiceChannelV3Tests.swift
@@ -17,8 +17,6 @@
 //
 
 import Foundation
-
-import Foundation
 @testable import WireSyncEngine
 
 class VoiceChannelV3Tests : MessagingTest {
@@ -72,17 +70,6 @@ class VoiceChannelV3Tests : MessagingTest {
         // then
         XCTAssertTrue(wireCallCenterMock!.didCallAnswerCall)
     }
-    
-    func testThatItDoesntAnswer_whenTheresAnIncomingDegradedCall() {
-        // given
-        wireCallCenterMock?.setMockCallState(.incoming(video: false, shouldRing: false, degraded: true), conversationId: conversation!.remoteIdentifier!, callerId: UUID(), isVideo: false)
-
-        // when
-        _ = sut.join(video: false)
-        
-        // then
-        XCTAssertFalse(wireCallCenterMock!.didCallAnswerCall)
-    }
 
     func testThatItForwardsNetworkQualityFromCallCenter() {
         // given
@@ -100,4 +87,25 @@ class VoiceChannelV3Tests : MessagingTest {
         XCTAssertEqual(sut.networkQuality, quality)
     }
 
+    func testThatItReturnsDegradedUser_IfSavedInCallCenter() {
+        // Given
+        let conversationId = conversation!.remoteIdentifier!
+        let user = ZMUser.insertNewObject(in: uiMOC)
+        user.remoteIdentifier = UUID()
+        
+        wireCallCenterMock?.callSnapshots = [
+            conversationId : CallSnapshotTestFixture.degradedCallSnapshot(
+                conversationId: conversationId,
+                user: user,
+                callCenter: wireCallCenterMock!
+            )
+        ]
+        
+        // When / Then
+        XCTAssert(sut.firstDegradedUser == user)
+    }
+    
+    func testThatItReturnsNil_IfNoDegradedUser() {
+        XCTAssert(sut.firstDegradedUser == nil)
+    }
 }

--- a/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -1181,3 +1181,35 @@ extension WireCallCenterV3Tests {
         }
     }
 }
+
+
+// MARK: - Call Degradation
+
+extension WireCallCenterV3Tests {
+    func testThatCallDidDegradeEndsCall() {
+        // When
+        sut.callDidDegrade(conversationId: UUID(), degradedUser: ZMUser.insertNewObject(in: uiMOC))
+        
+        // Then
+        XCTAssertTrue(mockAVSWrapper.didCallEndCall)
+    }
+    
+    func testThatCallDidDegradeUpdatesDegradedUser() {
+        // Given
+        let conversationId = groupConversation.remoteIdentifier!
+        
+        sut.callSnapshots = [
+            conversationId : CallSnapshotTestFixture.degradedCallSnapshot(
+                conversationId: conversationId,
+                user: otherUser,
+                callCenter: sut
+            )
+        ]
+        
+        // When
+        sut.callDidDegrade(conversationId: conversationId, degradedUser: otherUser)
+        
+        // Then
+        XCTAssertTrue(sut.callSnapshots[conversationId]?.isDegradedCall ?? false)
+    }
+}

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -343,6 +343,7 @@
 		636B716223ABE85D00B624D6 /* VerifyPasswordRequestStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636B716123ABE85D00B624D6 /* VerifyPasswordRequestStrategyTests.swift */; };
 		636B716823BF46EB00B624D6 /* ZMUserSession+VerifyPassword.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636B716723BF46EA00B624D6 /* ZMUserSession+VerifyPassword.swift */; };
 		6387932F23A2403300FD23CF /* VerifyPasswordRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6387932E23A2403300FD23CF /* VerifyPasswordRequestStrategy.swift */; };
+		639290A4252CA53200046171 /* CallSnapshotTestFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639290A3252CA53100046171 /* CallSnapshotTestFixture.swift */; };
 		63F65F03246D5A9600534A69 /* PushChannelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F65F02246D5A9600534A69 /* PushChannelTests.swift */; };
 		63F65F05246D972900534A69 /* ConversationTests+MessageEditing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F65F04246D972900534A69 /* ConversationTests+MessageEditing.swift */; };
 		63F65F1324729B4D00534A69 /* APNSTests+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F65F1224729B4C00534A69 /* APNSTests+Swift.swift */; };
@@ -1000,6 +1001,7 @@
 		636B716123ABE85D00B624D6 /* VerifyPasswordRequestStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifyPasswordRequestStrategyTests.swift; sourceTree = "<group>"; };
 		636B716723BF46EA00B624D6 /* ZMUserSession+VerifyPassword.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSession+VerifyPassword.swift"; sourceTree = "<group>"; };
 		6387932E23A2403300FD23CF /* VerifyPasswordRequestStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifyPasswordRequestStrategy.swift; sourceTree = "<group>"; };
+		639290A3252CA53100046171 /* CallSnapshotTestFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallSnapshotTestFixture.swift; sourceTree = "<group>"; };
 		63F65F02246D5A9600534A69 /* PushChannelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushChannelTests.swift; sourceTree = "<group>"; };
 		63F65F04246D972900534A69 /* ConversationTests+MessageEditing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationTests+MessageEditing.swift"; sourceTree = "<group>"; };
 		63F65F1224729B4C00534A69 /* APNSTests+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APNSTests+Swift.swift"; sourceTree = "<group>"; };
@@ -1613,6 +1615,7 @@
 				87B30C5B1FA756220054DFB1 /* FlowManagerTests.swift */,
 				5E8BB8A3214912D100EEA64B /* AVSBridgingTests.swift */,
 				166D18A5230EC418001288CD /* MockMediaManager.swift */,
+				639290A3252CA53100046171 /* CallSnapshotTestFixture.swift */,
 			);
 			path = Calling;
 			sourceTree = "<group>";
@@ -2917,6 +2920,7 @@
 				F9ABDF441CECC6C0008461B2 /* AccountStatusTests.swift in Sources */,
 				161927242459E09C00DDD9EB /* UserClientEventConsumerTests.swift in Sources */,
 				5447E4681AECDE6500411FCD /* ZMUserSessionTestsBase.m in Sources */,
+				639290A4252CA53200046171 /* CallSnapshotTestFixture.swift in Sources */,
 				87B30C5C1FA756220054DFB1 /* FlowManagerTests.swift in Sources */,
 				1626344720D79C22000D4063 /* ZMUserSessionTests+PushNotifications.swift in Sources */,
 				16D3FD021E3A5C0D0052A535 /* ZMConversationVoiceChannelRouterTests.swift in Sources */,

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -344,6 +344,7 @@
 		636B716823BF46EB00B624D6 /* ZMUserSession+VerifyPassword.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636B716723BF46EA00B624D6 /* ZMUserSession+VerifyPassword.swift */; };
 		6387932F23A2403300FD23CF /* VerifyPasswordRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6387932E23A2403300FD23CF /* VerifyPasswordRequestStrategy.swift */; };
 		639290A4252CA53200046171 /* CallSnapshotTestFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639290A3252CA53100046171 /* CallSnapshotTestFixture.swift */; };
+		639290A7252DEDB500046171 /* WireCallCenterV3+Degradation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639290A6252DEDB400046171 /* WireCallCenterV3+Degradation.swift */; };
 		63F65F03246D5A9600534A69 /* PushChannelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F65F02246D5A9600534A69 /* PushChannelTests.swift */; };
 		63F65F05246D972900534A69 /* ConversationTests+MessageEditing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F65F04246D972900534A69 /* ConversationTests+MessageEditing.swift */; };
 		63F65F1324729B4D00534A69 /* APNSTests+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F65F1224729B4C00534A69 /* APNSTests+Swift.swift */; };
@@ -1002,6 +1003,7 @@
 		636B716723BF46EA00B624D6 /* ZMUserSession+VerifyPassword.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSession+VerifyPassword.swift"; sourceTree = "<group>"; };
 		6387932E23A2403300FD23CF /* VerifyPasswordRequestStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifyPasswordRequestStrategy.swift; sourceTree = "<group>"; };
 		639290A3252CA53100046171 /* CallSnapshotTestFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallSnapshotTestFixture.swift; sourceTree = "<group>"; };
+		639290A6252DEDB400046171 /* WireCallCenterV3+Degradation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WireCallCenterV3+Degradation.swift"; sourceTree = "<group>"; };
 		63F65F02246D5A9600534A69 /* PushChannelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushChannelTests.swift; sourceTree = "<group>"; };
 		63F65F04246D972900534A69 /* ConversationTests+MessageEditing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationTests+MessageEditing.swift"; sourceTree = "<group>"; };
 		63F65F1224729B4C00534A69 /* APNSTests+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APNSTests+Swift.swift"; sourceTree = "<group>"; };
@@ -1592,6 +1594,7 @@
 				F90EC5A21E7BF1AC00A6779E /* AVSWrapper.swift */,
 				5E8BB8A12147F89000EEA64B /* CallCenterSupport.swift */,
 				165D3A141E1D3EF30052E654 /* WireCallCenterV3.swift */,
+				639290A6252DEDB400046171 /* WireCallCenterV3+Degradation.swift */,
 				5EC2C592213827BF00C6CE35 /* WireCallCenterV3+Events.swift */,
 				F9E577201E77EC6D0065EFE4 /* WireCallCenterV3+Notifications.swift */,
 				166A8BF21E015F3B00F5EEEA /* WireCallCenterV3Factory.swift */,
@@ -3205,6 +3208,7 @@
 				F1C1F3F01FCF18C5007273E3 /* NSError+Localized.swift in Sources */,
 				5467F1C41E0AE2EF008C1745 /* KeyValueStore.swift in Sources */,
 				5467F1C61E0AE421008C1745 /* KeyValueStore+AccessToken.swift in Sources */,
+				639290A7252DEDB500046171 /* WireCallCenterV3+Degradation.swift in Sources */,
 				8754B84A1F73C25400EC02AD /* ConversationListChangeInfo+UserSession.swift in Sources */,
 				8737D554209217BD00E5A4AF /* URLActions.swift in Sources */,
 				547E5B581DDB4B800038D936 /* UserProfileUpdateStatus.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

- New behaviour for dropping calls when a security degradation occurs.
- Allow a degraded incoming call to be joined

### New behaviour explained

#### Current behaviour 
Drop the call if the security level of **the conversation** degrades. 

Degradation may occur in following scenario:
_GIVEN_ **all conversation participants** are verified 
_WHEN_ one or more participants become unverified
_THEN_ conversation security degrades

#### New behaviour 
Drop the call if the security of **any call participant** degrades.

Degradation may occur in following scenario:
_GIVEN_ **any call participant** is verified 
_WHEN_ a verified participant becomes unverified
_THEN_ call security degrades

