### PR TITLE
[Fix] Save the incoming call in the pendingCallKitCall property

### DIFF
--- a/Source/Calling/CallKitManager.swift
+++ b/Source/Calling/CallKitManager.swift
@@ -66,6 +66,7 @@ protocol CallKitManagerDelegate: class {
 @objc
 public class CallKitManager: NSObject {
     
+    public var pendingCallKitCall: (() -> Void)?
     fileprivate let provider: CXProvider
     fileprivate let callController: CXCallController
     fileprivate weak var delegate: CallKitManagerDelegate?
@@ -416,8 +417,10 @@ extension CallKitManager : CXProviderDelegate {
             action.fail()
         }
         
-        if call.conversation.voiceChannel?.join(video: false) != true {
-            action.fail()
+        pendingCallKitCall = {
+            if call.conversation.voiceChannel?.join(video: false) != true {
+                action.fail()
+            }
         }
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues
When the applock is enable and client accepts a call through CallKit, the client has no visual elements about the current call.

### Solutions
Store the incoming call in the `pendingCallKitCall` property and join the call when the client unlocks the app.

## Dependencies

https://wearezeta.atlassian.net/browse/ZIOS-13792