### PR TITLE
[Fix] Don't generate notifications for edit messages

### DIFF
--- a/Source/Notifications/Push notifications/Notification Types/LocalNotificationContentType.swift
+++ b/Source/Notifications/Push notifications/Notification Types/LocalNotificationContentType.swift
@@ -70,7 +70,7 @@ public enum LocalNotificationContentType: Equatable {
             let quotedMessageId = UUID(uuidString: textMessageData.quote.quotedMessageID)
             return ZMOTRMessage.fetch(withNonce: quotedMessageId, for: conversation, in: moc)
         }
-
+        
         switch message.content {
         case .location:
             self =  .location
@@ -82,21 +82,22 @@ public enum LocalNotificationContentType: Equatable {
             self = .image
 
         case .ephemeral:
-            if let textMessageData = message.textData {
+            if message.ephemeral.hasText {
+                let textMessageData = message.ephemeral.text
                 let quotedMessage = getQuotedMessage(textMessageData, conversation: conversation, in: moc)
                 self = .ephemeral(isMention: textMessageData.isMentioningSelf(selfUser), isReply: textMessageData.isQuotingSelf(quotedMessage))
             } else {
                 self = .ephemeral(isMention: false, isReply: false)
             }
 
-        case .text, .edited:
+        case .text:
             guard
                 let textMessageData = message.textData,
                 let text = message.textData?.content.removingExtremeCombiningCharacters, !text.isEmpty
             else {
                 return nil
             }
-
+            
             let quotedMessage = getQuotedMessage(textMessageData, conversation: conversation, in: moc)
             self = .text(text, isMention: textMessageData.isMentioningSelf(selfUser), isReply: textMessageData.isQuotingSelf(quotedMessage))
 

--- a/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_Message.swift
+++ b/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_Message.swift
@@ -669,23 +669,14 @@ extension ZMLocalNotificationTests_Message {
         let event = ZMUpdateEvent(fromEventStreamPayload: payload as ZMTransportData, uuid: UUID())!
         return ZMLocalNotification(event: event, conversation: message.conversation!, managedObjectContext: uiMOC)
     }
-
-    func bodyForEditNote(_ conversation: ZMConversation, sender: ZMUser, text: String) -> String {
-        let message = try! conversation.appendText(content: "Foo") as! ZMClientMessage
+    
+    func testThatItDoesntCreateANotificationForAnEditMessage() {
+        let message = try! oneOnOneConversation.appendText(content: "Foo") as! ZMClientMessage
         message.markAsSent()
-        let note = editNote(message, sender: sender, text: text)
-        XCTAssertNotNil(note)
-        return note!.body
+        let note = editNote(message, sender: sender, text: "Edited Text")
+        XCTAssertNil(note)
     }
-
-    func testThatItCreatesANotificationForAnEditMessage(){
-        XCTAssertEqual(bodyForEditNote(oneOnOneConversation, sender: sender, text: "Edited Text"), "Edited Text")
-        XCTAssertEqual(bodyForEditNote(groupConversation, sender: sender, text: "Edited Text"), "Super User: Edited Text")
-        XCTAssertEqual(bodyForEditNote(groupConversationWithoutUserDefinedName, sender: sender, text: "Edited Text"), "Super User: Edited Text")
-        XCTAssertEqual(bodyForEditNote(groupConversationWithoutName, sender: sender, text: "Edited Text"), "Super User in a conversation: Edited Text")
-        XCTAssertEqual(bodyForEditNote(invalidConversation, sender: sender, text: "Edited Text"), "Super User in a conversation: Edited Text")
-    }
-
+    
 }
 
 // MARK: - Categories


### PR DESCRIPTION
## What's new in this PR?

### Issues

Message edits is generating notifications and therefore also increases the badge count, which doesn't go away if the original message has already been read.

### Causes

After the encryption at rest refactoring we are increasing the badge count (unread count) when we are scheduling a notification if the message is of a type which should increase the unread count. This unread count will later be re-calculated when the actual message is inserted during the second phase of the event processing.

However for message edits we don't insert a new message but instead modify an existing message and therefore we also don't re-calculate the unread count, which means that unread count will stay until another message arrives in the conversation.

### Solutions

1. Re-calculate the unread count also when applying message edits.
2. Stop displaying notifications for message edits.
3. Don't increase the unread count for message edits

I've implemented solution 2 because: 
- It  will actually align us with the behaviour on the desktop app. 
- Since EAR we no longer remove the original notification when a message gets edited, which means that a message will show up multiple times in notification list.