### PR TITLE
[Refactoring]: SwitchingAccountRouter Tests

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -42,7 +42,7 @@ public typealias LaunchOptions = [UIApplication.LaunchOptionsKey : Any]
 @objc public protocol SessionManagerDelegate : SessionActivationObserver {
     func sessionManagerDidFailToLogin(account: Account?,
                                       from selectedAccount: Account?,
-                                      error : Error)
+                                      error: Error)
     func sessionManagerWillLogout(error : Error?, userSessionCanBeTornDown: (() -> Void)?)
     func sessionManagerWillOpenAccount(_ account: Account,
                                        from selectedAccount: Account?,
@@ -100,8 +100,7 @@ public protocol SessionManagerType: class {
 
 @objc
 public protocol SessionManagerSwitchingDelegate: class {
-    func sessionManagerConfirmSwitchingAccount(activeUserSession: ZMUserSession,
-                                               completion: @escaping (Bool) -> Void)
+    func confirmSwitchingAccount(completion: @escaping (Bool) -> Void)
 }
 
 @objc
@@ -1300,14 +1299,15 @@ extension SessionManager {
     public func confirmSwitchingAccount(completion: @escaping ()->Void) {
         guard
             let switchingDelegate = switchingDelegate,
-            let activeUserSession = activeUserSession
+            let activeUserSession = activeUserSession,
+            activeUserSession.isCallOngoing
         else {
             return completion()
         }
         
-        switchingDelegate.sessionManagerConfirmSwitchingAccount(activeUserSession: activeUserSession,
-                                                                completion: { confirmed in
+        switchingDelegate.confirmSwitchingAccount(completion: { confirmed in
             if confirmed {
+                activeUserSession.callCenter?.endAllCalls()
                 completion()
             }
         })

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -100,7 +100,8 @@ public protocol SessionManagerType: class {
 
 @objc
 public protocol SessionManagerSwitchingDelegate: class {
-    func confirmSwitchingAccount(completion: @escaping (Bool)->Void)
+    func sessionManagerConfirmSwitchingAccount(activeUserSession: ZMUserSession,
+                                               completion: @escaping (Bool) -> Void)
 }
 
 @objc
@@ -1297,15 +1298,20 @@ extension SessionManager {
 extension SessionManager {
     
     public func confirmSwitchingAccount(completion: @escaping ()->Void) {
-        guard let switchingDelegate = switchingDelegate else { return completion() }
+        guard
+            let switchingDelegate = switchingDelegate,
+            let activeUserSession = activeUserSession
+        else {
+            return completion()
+        }
         
-        switchingDelegate.confirmSwitchingAccount(completion: { (confirmed) in
+        switchingDelegate.sessionManagerConfirmSwitchingAccount(activeUserSession: activeUserSession,
+                                                                completion: { confirmed in
             if confirmed {
                 completion()
             }
         })
     }
-    
 }
 
 // MARK: - AVS Logging

--- a/Source/UserSession/ZMUserSession+Calling.swift
+++ b/Source/UserSession/ZMUserSession+Calling.swift
@@ -35,6 +35,12 @@ public protocol CallNotificationStyleProvider: class {
         return sessionManager?.callNotificationStyle ?? .pushNotifications
     }
     
+    public var isCallOngoing: Bool {
+        guard let callCenter = callCenter else { return false }
+        
+        return !callCenter.activeCallConversations(in: self).isEmpty
+    }
+    
     internal var callKitManager : CallKitManager? {
         return sessionManager?.callKitManager
     }
@@ -60,5 +66,7 @@ public protocol CallNotificationStyleProvider: class {
             return managedObjectContext.zm_useConferenceCalling
         }
     }
+    
+    
     
 }

--- a/Tests/Source/Integration/IntegrationTest.swift
+++ b/Tests/Source/Integration/IntegrationTest.swift
@@ -630,7 +630,7 @@ extension IntegrationTest: SessionManagerDelegate {
     
     public func sessionManagerDidFailToLogin(account: Account?,
                                       from selectedAccount: Account?,
-                                      error : Error) {
+                                      error: Error) {
         // no op
     }
     

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -1386,7 +1386,6 @@ extension SessionManagerTests {
 
 // MARK: - Mocks
 class SessionManagerTestDelegate: SessionManagerDelegate {
-
     var onLogout: ((NSError?) -> Void)?
     func sessionManagerWillLogout(error: Error?, userSessionCanBeTornDown: (() -> Void)?) {
         onLogout?(error as NSError?)
@@ -1395,7 +1394,7 @@ class SessionManagerTestDelegate: SessionManagerDelegate {
     
     func sessionManagerDidFailToLogin(account: Account?,
                                       from selectedAccount: Account?,
-                                      error : Error) {
+                                      error: Error) {
         // no op
     }
     


### PR DESCRIPTION
## What's new in this PR?

## Context
When the user has an ongoing call and wants to switch the account a confirmation alert is presented. When the user confirm the alert the account is switched and all the calls are ended.

## Refactoring Logic
In order to have a better testability of the `SwitchingAccountRouter` (`wire-ios`) I moved from the `UI` all the task that should be performed directly in the sync-engine in a way that now the `UI` should take care to just show the alert when it is necessary. This means that:

1) All the checks if there are ongoing calls are mede in the `sync-engine`
2) If the switch is confirmed all the call are ended in the `sync-engine`