### PR TITLE
[Fix] Indicate syncing while processing events

### DIFF
--- a/Source/UserSession/ZMUserSession.swift
+++ b/Source/UserSession/ZMUserSession.swift
@@ -482,6 +482,11 @@ extension ZMUserSession: ZMSyncStateDelegate {
     func processEvents() {
         guard let syncStrategy = syncStrategy else { return }
         
+        managedObjectContext.performGroupedBlock { [weak self] in
+            self?.isPerformingSync = true
+            self?.updateNetworkState()
+        }
+        
         let hasMoreEventsToProcess = syncStrategy.processEventsIfReady()
         
         managedObjectContext.performGroupedBlock { [weak self] in

--- a/Tests/Source/Integration/SlowSyncTests.m
+++ b/Tests/Source/Integration/SlowSyncTests.m
@@ -297,9 +297,9 @@
     XCTAssertTrue([self login]);
     
     // then
-    XCTAssertEqual(stateRecoder.stateChanges.count, 2u);
-    ZMNetworkState state1 = (ZMNetworkState)[stateRecoder.stateChanges.firstObject intValue];
-    ZMNetworkState state2 = (ZMNetworkState)[stateRecoder.stateChanges.lastObject intValue];
+    XCTAssertEqual(stateRecoder.stateChanges_objc.count, 2u);
+    ZMNetworkState state1 = (ZMNetworkState)[stateRecoder.stateChanges_objc.firstObject intValue];
+    ZMNetworkState state2 = (ZMNetworkState)[stateRecoder.stateChanges_objc.lastObject intValue];
 
     XCTAssertEqual(state1, ZMNetworkStateOnlineSynchronizing);
     XCTAssertEqual(state2, ZMNetworkStateOnline);

--- a/Tests/Source/UserSession/NetworkStateRecorder.swift
+++ b/Tests/Source/UserSession/NetworkStateRecorder.swift
@@ -21,10 +21,25 @@ import Foundation
 @objcMembers
 public class NetworkStateRecorder : NSObject, ZMNetworkAvailabilityObserver {
     
-    var stateChanges : [NSNumber] = []
+    var stateChanges: [ZMNetworkState] = []
+    var stateChanges_objc: [NSNumber] {
+        stateChanges.map { NSNumber(value: $0.rawValue) }
+    }
+    
+    var observerToken: Any?
+    
+    public override init() {
+        super.init()
+    }
+    
+    init(userSession: ZMUserSession) {
+        super.init()
+        
+        observerToken = ZMNetworkAvailabilityChangeNotification.addNetworkAvailabilityObserver(self, userSession: userSession)
+    }
     
     public func didChangeAvailability(newState: ZMNetworkState) {
-        stateChanges.append(NSNumber(value: newState.rawValue))
+        stateChanges.append(newState)
     }
     
 }

--- a/Tests/Source/UserSession/ZMUserSessionTests+Syncing.swift
+++ b/Tests/Source/UserSession/ZMUserSessionTests+Syncing.swift
@@ -23,7 +23,7 @@ class ZMUserSessionTests_Syncing: ZMUserSessionTestsBase {
     
     // MARK: Helpers
     
-    class InitialSyncObserver : NSObject, ZMInitialSyncCompletionObserver {
+    class InitialSyncObserver: NSObject, ZMInitialSyncCompletionObserver {
         
         var didNotify : Bool = false
         var initialSyncToken : Any?
@@ -37,7 +37,6 @@ class ZMUserSessionTests_Syncing: ZMUserSessionTestsBase {
             didNotify = true
         }
     }
-    
     
     // MARK: Slow Sync
     
@@ -130,6 +129,26 @@ class ZMUserSessionTests_Syncing: ZMUserSessionTestsBase {
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // then
+        XCTAssertFalse(sut.isPerformingSync)
+    }
+    
+    // MARK: Process events
+    
+    func testThatItNotifiesOnlineSynchronzingWhileProcessingEvents() {
+        
+        // given
+        sut.didReceiveData()
+        sut.didFinishSlowSync()
+        sut.didFinishQuickSync()
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        let networkStateRecorder = NetworkStateRecorder(userSession: sut)
+        
+        // when
+        sut.processEvents()
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        // then
+        XCTAssertEqual(networkStateRecorder.stateChanges, [.onlineSynchronizing, .online])
         XCTAssertFalse(sut.isPerformingSync)
     }
     

--- a/Tests/Source/UserSession/ZMUserSessionTests.m
+++ b/Tests/Source/UserSession/ZMUserSessionTests.m
@@ -637,8 +637,8 @@
     
     // then
     WaitForAllGroupsToBeEmpty(0.5);
-    XCTAssertEqual(stateRecorder.stateChanges.count, 1u);
-    XCTAssertEqual((ZMNetworkState)[stateRecorder.stateChanges.firstObject intValue], ZMNetworkStateOnlineSynchronizing);
+    XCTAssertEqual(stateRecorder.stateChanges_objc.count, 1u);
+    XCTAssertEqual((ZMNetworkState)[stateRecorder.stateChanges_objc.firstObject intValue], ZMNetworkStateOnlineSynchronizing);
     
     // after
     token = nil;
@@ -655,7 +655,7 @@
     
     // then
     WaitForAllGroupsToBeEmpty(0.5);
-    XCTAssertEqual(stateRecorder.stateChanges.count, 0u);
+    XCTAssertEqual(stateRecorder.stateChanges_objc.count, 0u);
     
     // after
     token = nil;
@@ -673,8 +673,8 @@
     
     // then
     WaitForAllGroupsToBeEmpty(0.5);
-    XCTAssertEqual(stateRecorder.stateChanges.count, 1u);
-    XCTAssertEqual((ZMNetworkState)[stateRecorder.stateChanges.firstObject intValue], ZMNetworkStateOffline);
+    XCTAssertEqual(stateRecorder.stateChanges_objc.count, 1u);
+    XCTAssertEqual((ZMNetworkState)[stateRecorder.stateChanges_objc.firstObject intValue], ZMNetworkStateOffline);
     
     // after
     token = nil;
@@ -693,7 +693,7 @@
     
     // then
     WaitForAllGroupsToBeEmpty(0.5);
-    XCTAssertEqual(stateRecorder.stateChanges.count, 0u);
+    XCTAssertEqual(stateRecorder.stateChanges_objc.count, 0u);
     
     // after
     token = nil;


### PR DESCRIPTION
## What's new in this PR?

### Issues

Syncing indicator isn't shown when processing events received in the background.

### Causes

The syncing indicator is only shown when we perform the quick sync but we are now processing previously received events before the quick sync. If many events have been accumulating this processing can take a few seconds.

### Solutions

Indicate that we are syncing before processing previously received events.