### PR TITLE
[Refactor] SessionManager account migration

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -454,9 +454,12 @@ public final class SessionManager : NSObject, SessionManagerType {
                 in: sharedContainerURL,
                 migration: { [weak self] in self?.delegate?.sessionManagerWillMigrateAccount() },
                 completion: { [weak self] userIdentifier in
-                    guard let `self` = self, let userIdentifier = userIdentifier else { return }
-                    let account = self.migrateAccount(with: userIdentifier)
-                    self.selectInitialAccount(account, launchOptions: launchOptions)
+                    guard let strongSelf = self, let userIdentifier = userIdentifier else {
+                        self?.createUnauthenticatedSession()
+                        return
+                    }
+                    let account = strongSelf.migrateAccount(with: userIdentifier)
+                    self?.selectInitialAccount(account, launchOptions: launchOptions)
             })
         }
     }

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -47,8 +47,7 @@ public typealias LaunchOptions = [UIApplication.LaunchOptionsKey : Any]
     func sessionManagerWillOpenAccount(_ account: Account,
                                        from selectedAccount: Account?,
                                        userSessionCanBeTornDown: @escaping () -> Void)
-    func sessionManagerWillMigrateAccount(_ account: Account)
-    func sessionManagerWillMigrateLegacyAccount()
+    func sessionManagerWillMigrateAccount()
     func sessionManagerDidBlacklistCurrentVersion()
     func sessionManagerDidBlacklistJailbrokenDevice()
 }
@@ -453,7 +452,7 @@ public final class SessionManager : NSObject, SessionManagerType {
             // In order to do so we open the old database and get the user identifier.
             LocalStoreProvider.fetchUserIDFromLegacyStore(
                 in: sharedContainerURL,
-                migration: { [weak self] in self?.delegate?.sessionManagerWillMigrateLegacyAccount() },
+                migration: { [weak self] in self?.delegate?.sessionManagerWillMigrateAccount() },
                 completion: { [weak self] userIdentifier in
                     guard let `self` = self, let userIdentifier = userIdentifier else { return }
                     let account = self.migrateAccount(with: userIdentifier)
@@ -686,7 +685,7 @@ public final class SessionManager : NSObject, SessionManagerType {
                     dispatchGroup: self.dispatchGroup,
                     migration: { [weak self] in
                         if notifyAboutMigration {
-                            self?.delegate?.sessionManagerWillMigrateAccount(account)
+                            self?.delegate?.sessionManagerWillMigrateAccount()
                         }
                     },
                     completion: { provider in

--- a/Tests/Source/Integration/IntegrationTest.swift
+++ b/Tests/Source/Integration/IntegrationTest.swift
@@ -651,12 +651,8 @@ extension IntegrationTest: SessionManagerDelegate {
     public func sessionManagerDidReportDatabaseLockChange(isLocked: Bool) {
         // no-op
     }
-    
-    public func sessionManagerWillMigrateLegacyAccount() {
-        // no-op
-    }
-    
-    public func sessionManagerWillMigrateAccount(_ account: Account) {
+        
+    public func sessionManagerWillMigrateAccount() {
         // no-op
     }
     

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -1424,12 +1424,8 @@ class SessionManagerTestDelegate: SessionManagerDelegate {
     }
     
     var startedMigrationCalled = false
-    func sessionManagerWillMigrateAccount(_ account: Account) {
+    func sessionManagerWillMigrateAccount() {
         startedMigrationCalled = true
-    }
-    
-    func sessionManagerWillMigrateLegacyAccount() {
-        // no op
     }
 
 }


### PR DESCRIPTION
## What's new in this PR?

UI currently has logic for determining if a call `sessionManagerWillMigrateAccount()` should display the migration screen or not. It's better to have this logic inside the SessionManager.

Changes:
- Only call `sessionManagerWillMigrateAccount()` when we load a session which will become the active session. That is don't call it when loading a session for processing a push notification.
- Make the `Account` parameter non-optional in the session loading methods
- Delete the `sessionManagerWillMigrateLegacyAccount` delegate method, use `sessionManagerWillMigrateAccount` use instead.

## Notes

This PR is part of a series refactoring necessary to enable migrations to and from EAR.