### PR TITLE
[Refactor] Add SessionManagerConfiguration option to enable EAR by default

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -1013,6 +1013,7 @@ extension SessionManager: UnauthenticatedSessionDelegate {
             let registered = session.authenticationStatus.completedRegistration || session.registrationStatus.completedRegistration
             let emailCredentials = session.authenticationStatus.emailCredentials()
             
+            userSession.encryptMessagesAtRest = self.configuration.encryptionAtRestEnabledByDefault
             userSession.syncManagedObjectContext.performGroupedBlock {
                 userSession.setEmailCredentials(emailCredentials)
                 userSession.syncManagedObjectContext.registeredOnThisDevice = registered

--- a/Source/SessionManager/SessionManagerConfiguration.swift
+++ b/Source/SessionManager/SessionManagerConfiguration.swift
@@ -62,6 +62,11 @@ public class SessionManagerConfiguration: NSObject, NSCopying, Codable {
     ///
     /// The default value of this property is `nil`, i.e. threshold is ignored
     public var failedPasswordThresholdBeforeWipe: Int?
+    
+    /// The `encryptionAtRestEnabledByDefault` configures if the encryption at rest will be enabled by default for all sessions.
+    ///
+    /// The default value of this property is `false`
+    public var encryptionAtRestEnabledByDefault: Bool
 
     // MARK: - Init
     
@@ -71,7 +76,8 @@ public class SessionManagerConfiguration: NSObject, NSCopying, Codable {
                 wipeOnJailbreakOrRoot: Bool = false,
                 messageRetentionInterval: TimeInterval? = nil,
                 authenticateAfterReboot: Bool = false,
-                failedPasswordThresholdBeforeWipe: Int? = nil) {
+                failedPasswordThresholdBeforeWipe: Int? = nil,
+                encryptionAtRestIsEnabledByDefault: Bool = false) {
         self.wipeOnCookieInvalid = wipeOnCookieInvalid
         self.blacklistDownloadInterval = blacklistDownloadInterval
         self.blockOnJailbreakOrRoot = blockOnJailbreakOrRoot
@@ -79,6 +85,7 @@ public class SessionManagerConfiguration: NSObject, NSCopying, Codable {
         self.messageRetentionInterval = messageRetentionInterval
         self.authenticateAfterReboot = authenticateAfterReboot
         self.failedPasswordThresholdBeforeWipe = failedPasswordThresholdBeforeWipe
+        self.encryptionAtRestEnabledByDefault = encryptionAtRestIsEnabledByDefault
     }
 
     required public init(from decoder: Decoder) throws {
@@ -90,6 +97,7 @@ public class SessionManagerConfiguration: NSObject, NSCopying, Codable {
         messageRetentionInterval = try container.decodeIfPresent(TimeInterval.self, forKey: .messageRetentionInterval)
         authenticateAfterReboot = try container.decode(Bool.self, forKey: .authenticateAfterReboot)
         failedPasswordThresholdBeforeWipe = try container.decodeIfPresent(Int.self, forKey: .failedPasswordThresholdBeforeWipe)
+        encryptionAtRestEnabledByDefault = try container.decode(Bool.self, forKey: .encryptionAtRestEnabledByDefault)
     }
 
     // MARK: - Methods
@@ -101,7 +109,8 @@ public class SessionManagerConfiguration: NSObject, NSCopying, Codable {
                                                wipeOnJailbreakOrRoot: wipeOnJailbreakOrRoot,
                                                messageRetentionInterval: messageRetentionInterval,
                                                authenticateAfterReboot: authenticateAfterReboot,
-                                               failedPasswordThresholdBeforeWipe: failedPasswordThresholdBeforeWipe)
+                                               failedPasswordThresholdBeforeWipe: failedPasswordThresholdBeforeWipe,
+                                               encryptionAtRestIsEnabledByDefault: encryptionAtRestEnabledByDefault)
         
         return copy
     }
@@ -132,6 +141,7 @@ extension SessionManagerConfiguration {
         case messageRetentionInterval
         case authenticateAfterReboot
         case failedPasswordThresholdBeforeWipe
+        case encryptionAtRestEnabledByDefault
     }
 
 }

--- a/Tests/Source/SessionManager/SessionManagerConfigurationTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerConfigurationTests.swift
@@ -33,6 +33,7 @@ class SessionManagerConfigurationTests: XCTestCase {
             "authenticateAfterReboot": false,
             "useBiometricsOrAccountPassword": true,
             "messageRetentionInterval": 3600,
+            "encryptionAtRestEnabledByDefault": false,
         }
 
         """
@@ -51,6 +52,7 @@ class SessionManagerConfigurationTests: XCTestCase {
         XCTAssertEqual(result.messageRetentionInterval, 3600)
         XCTAssertEqual(result.authenticateAfterReboot, false)
         XCTAssertEqual(result.failedPasswordThresholdBeforeWipe, nil)
+        XCTAssertEqual(result.encryptionAtRestEnabledByDefault, false)
     }
 
 }

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -517,6 +517,27 @@ class SessionManagerTests_AuthenticationFailure: IntegrationTest {
     
 }
 
+class SessionManagerTests_EncryptionAtRestIsEnabledByDefault_Option: IntegrationTest {
+    
+    override func setUp() {
+        super.setUp()
+        createSelfUserAndConversation()
+    }
+    
+    override var sessionManagerConfiguration: SessionManagerConfiguration {
+        return SessionManagerConfiguration(encryptionAtRestIsEnabledByDefault: true)
+    }
+    
+    func testThatEncryptionAtRestIsEnabled_OnActiveUserSession() {
+        // given
+        XCTAssertTrue(login())
+        
+        // then
+        XCTAssertTrue(sessionManager!.activeUserSession!.encryptMessagesAtRest)
+    }
+    
+}
+
 class SessionManagerTests_PasswordVerificationFailure_With_DeleteAccountAfterThreshold: IntegrationTest {
     private var threshold: Int? = 2
     override func setUp() {


### PR DESCRIPTION
## What's new in this PR?

Add SessionManagerConfiguration option to enable EAR by default.

This change is necessary because when I introduce EAR migration I don't want to perform a migration EAR is enabled by default. That would require me to add new public API to the `ZMUserSession` which could easily be miss-used, I there decided move all of the EAR by default logic to SE.

## Notes

This PR is part of a series refactoring necessary to enable migrations to and from EAR.
