### PR TITLE
[Fix]: Inform the UI when an UnauthenticatedSession is created

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -456,6 +456,11 @@ public final class SessionManager : NSObject, SessionManagerType {
                 completion: { [weak self] userIdentifier in
                     guard let strongSelf = self, let userIdentifier = userIdentifier else {
                         self?.createUnauthenticatedSession()
+                        let userInfo = self?.accountManager.selectedAccount?.loginCredentials?.dictionaryRepresentation
+                        let error = NSError(code: .accessTokenExpired, userInfo: userInfo)
+                        self?.delegate?.sessionManagerDidFailToLogin(account: self?.accountManager.selectedAccount,
+                                                                     from: self?.accountManager.selectedAccount,
+                                                                     error: error)
                         return
                     }
                     let account = strongSelf.migrateAccount(with: userIdentifier)

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -456,10 +456,9 @@ public final class SessionManager : NSObject, SessionManagerType {
                 completion: { [weak self] userIdentifier in
                     guard let strongSelf = self, let userIdentifier = userIdentifier else {
                         self?.createUnauthenticatedSession()
-                        let userInfo = self?.accountManager.selectedAccount?.loginCredentials?.dictionaryRepresentation
-                        let error = NSError(code: .accessTokenExpired, userInfo: userInfo)
-                        self?.delegate?.sessionManagerDidFailToLogin(account: self?.accountManager.selectedAccount,
-                                                                     from: self?.accountManager.selectedAccount,
+                        let error = NSError(code: .accessTokenExpired, userInfo: nil)
+                        self?.delegate?.sessionManagerDidFailToLogin(account: nil,
+                                                                     from: nil,
                                                                      error: error)
                         return
                     }

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -82,6 +82,7 @@ final class SessionManagerTests: IntegrationTest {
         
         // then
         XCTAssertNil(delegate.userSession)
+        XCTAssertTrue(delegate.sessionManagerDidFailToLoginIsCalled)
         XCTAssertNotNil(sut?.unauthenticatedSession)
         withExtendedLifetime(token) {
             XCTAssertEqual([], observer.createdUserSession)
@@ -1413,10 +1414,11 @@ class SessionManagerTestDelegate: SessionManagerDelegate {
         userSessionCanBeTornDown?()
     }
     
+    var sessionManagerDidFailToLoginIsCalled: Bool = false
     func sessionManagerDidFailToLogin(account: Account?,
                                       from selectedAccount: Account?,
                                       error: Error) {
-        // no op
+        sessionManagerDidFailToLoginIsCalled = true
     }
     
     func sessionManagerWillOpenAccount(_ account: Account,


### PR DESCRIPTION
## What's new in this PR?

### Issues

At the app launch when the user was unauthenticated the app remain stuck 

### Causes

Some changes were made and the `UI` was was not informed anymore by the `SessionManager` that the unauthenticated session was created and the `AppState` didn't change

### Solutions

Even if we noticed that the old solution to inform the UI when an UnauthenticatedSession is created smells a bit, the fastest solution to solve the issue is using the same approach and now the UI is informed using the  `sessionManagerDidFailToLogin` delegate method of the `SessionManager` and the `AppState` changes.
