### PR TITLE
[Refactor]: SessionManagerDelegate: improve sessionManagerDidFailToLogin method usage

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -40,10 +40,7 @@ public typealias LaunchOptions = [UIApplication.LaunchOptionsKey : Any]
 }
 
 @objc public protocol SessionManagerDelegate : SessionActivationObserver {
-    func sessionManagerDidFailToLogin(error: Error)
-    func sessionManagerDidFailToFetchUserIdentifier()
-    func sessionManagerDidFailLoadSession(error: Error)
-    func sessionManagerDidFailToRegisterClient(error: Error)
+    func sessionManagerDidFailToLogin(error: Error?)
     func sessionManagerWillLogout(error : Error?, userSessionCanBeTornDown: (() -> Void)?)
     func sessionManagerWillOpenAccount(_ account: Account,
                                        from selectedAccount: Account?,
@@ -458,7 +455,7 @@ public final class SessionManager : NSObject, SessionManagerType {
                 completion: { [weak self] userIdentifier in
                     guard let strongSelf = self, let userIdentifier = userIdentifier else {
                         self?.createUnauthenticatedSession()
-                        self?.delegate?.sessionManagerDidFailToFetchUserIdentifier()
+                        self?.delegate?.sessionManagerDidFailToLogin(error: nil)
                         return
                     }
                     let account = strongSelf.migrateAccount(with: userIdentifier)
@@ -635,7 +632,7 @@ public final class SessionManager : NSObject, SessionManagerType {
                 guard account == accountManager.selectedAccount else { return }
                 let error = NSError(code: .accessTokenExpired,
                                     userInfo: account.loginCredentials?.dictionaryRepresentation)
-                delegate?.sessionManagerDidFailLoadSession(error: error)
+                delegate?.sessionManagerDidFailToLogin(error: error)
             }
             
             return
@@ -1071,7 +1068,7 @@ extension SessionManager: PostLoginAuthenticationObserver {
         
         let account = accountManager.account(with: accountId)
         guard account == accountManager.selectedAccount else { return }
-        delegate?.sessionManagerDidFailToRegisterClient(error: error)
+        delegate?.sessionManagerDidFailToLogin(error: error)
     }
     
     public func authenticationInvalidated(_ error: NSError, accountId: UUID) {

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -631,6 +631,8 @@ public final class SessionManager : NSObject, SessionManagerType {
                 delete(account: account, reason: .sessionExpired)
             } else {
                 createUnauthenticatedSession(accountId: account.userIdentifier)
+                
+                guard account == accountManager.selectedAccount else { return }
                 let error = NSError(code: .accessTokenExpired,
                                     userInfo: account.loginCredentials?.dictionaryRepresentation)
                 delegate?.sessionManagerDidFailLoadSession(error: error)
@@ -1066,7 +1068,9 @@ extension SessionManager: PostLoginAuthenticationObserver {
         if unauthenticatedSession == nil || unauthenticatedSession?.accountId != accountId {
             createUnauthenticatedSession(accountId: accountId)
         }
-                
+        
+        let account = accountManager.account(with: accountId)
+        guard account == accountManager.selectedAccount else { return }
         delegate?.sessionManagerDidFailToRegisterClient(error: error)
     }
     
@@ -1094,6 +1098,9 @@ extension SessionManager: PostLoginAuthenticationObserver {
             if unauthenticatedSession == nil {
                 createUnauthenticatedSession(accountId: accountId)
             }
+            
+            let account = accountManager.account(with: accountId)
+            guard account == accountManager.selectedAccount else { return }
             delegate?.sessionManagerDidFailToLogin(error: error)
         }
     }

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -39,7 +39,7 @@ public typealias LaunchOptions = [UIApplication.LaunchOptionsKey : Any]
     func sessionManagerDidReportDatabaseLockChange(isLocked: Bool)
 }
 
-@objc public protocol SessionManagerDelegate : SessionActivationObserver {
+@objc public protocol SessionManagerDelegate: SessionActivationObserver {
     func sessionManagerDidFailToLogin(error: Error?)
     func sessionManagerWillLogout(error : Error?, userSessionCanBeTornDown: (() -> Void)?)
     func sessionManagerWillOpenAccount(_ account: Account,
@@ -629,7 +629,6 @@ public final class SessionManager : NSObject, SessionManagerType {
             } else {
                 createUnauthenticatedSession(accountId: account.userIdentifier)
                 
-                guard account == accountManager.selectedAccount else { return }
                 let error = NSError(code: .accessTokenExpired,
                                     userInfo: account.loginCredentials?.dictionaryRepresentation)
                 delegate?.sessionManagerDidFailToLogin(error: error)

--- a/Tests/Source/Integration/IntegrationTest.swift
+++ b/Tests/Source/Integration/IntegrationTest.swift
@@ -628,9 +628,19 @@ extension IntegrationTest {
 
 extension IntegrationTest: SessionManagerDelegate {
     
-    public func sessionManagerDidFailToLogin(account: Account?,
-                                      from selectedAccount: Account?,
-                                      error: Error) {
+    public func sessionManagerDidFailToLogin(error: Error) {
+        // no op
+    }
+    
+    public func sessionManagerDidFailToFetchUserIdentifier() {
+        // no op
+    }
+    
+    public func sessionManagerDidFailLoadSession(error: Error) {
+        // no op
+    }
+    
+    public func sessionManagerDidFailToRegisterClient(error: Error) {
         // no op
     }
     

--- a/Tests/Source/Integration/IntegrationTest.swift
+++ b/Tests/Source/Integration/IntegrationTest.swift
@@ -628,19 +628,7 @@ extension IntegrationTest {
 
 extension IntegrationTest: SessionManagerDelegate {
     
-    public func sessionManagerDidFailToLogin(error: Error) {
-        // no op
-    }
-    
-    public func sessionManagerDidFailToFetchUserIdentifier() {
-        // no op
-    }
-    
-    public func sessionManagerDidFailLoadSession(error: Error) {
-        // no op
-    }
-    
-    public func sessionManagerDidFailToRegisterClient(error: Error) {
+    public func sessionManagerDidFailToLogin(error: Error?) {
         // no op
     }
     

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -83,7 +83,7 @@ final class SessionManagerTests: IntegrationTest {
         
         // then
         XCTAssertNil(delegate.userSession)
-        XCTAssertTrue(delegate.sessionManagerDidFailToLoginIsCalled)
+        XCTAssertTrue(delegate.sessionManagerDidFailToFetchUserIdentifierIsCalled)
         XCTAssertNotNil(sut?.unauthenticatedSession)
         withExtendedLifetime(token) {
             XCTAssertEqual([], observer.createdUserSession)
@@ -1479,11 +1479,23 @@ class SessionManagerTestDelegate: SessionManagerDelegate {
         userSessionCanBeTornDown?()
     }
     
-    var sessionManagerDidFailToLoginIsCalled: Bool = false
-    func sessionManagerDidFailToLogin(account: Account?,
-                                      from selectedAccount: Account?,
-                                      error: Error) {
-        sessionManagerDidFailToLoginIsCalled = true
+
+    func sessionManagerDidFailToLogin(error: Error) {
+        // no op
+    }
+    
+    var sessionManagerDidFailToFetchUserIdentifierIsCalled: Bool = false
+    func sessionManagerDidFailToFetchUserIdentifier() {
+        sessionManagerDidFailToFetchUserIdentifierIsCalled = true
+    }
+    
+    
+    func sessionManagerDidFailLoadSession(error: Error) {
+        // no op
+    }
+    
+    func sessionManagerDidFailToRegisterClient(error: Error) {
+        // no op
     }
     
     func sessionManagerWillOpenAccount(_ account: Account,

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -83,7 +83,7 @@ final class SessionManagerTests: IntegrationTest {
         
         // then
         XCTAssertNil(delegate.userSession)
-        XCTAssertTrue(delegate.sessionManagerDidFailToFetchUserIdentifierIsCalled)
+        XCTAssertTrue(delegate.sessionManagerDidFailToLogin)
         XCTAssertNotNil(sut?.unauthenticatedSession)
         withExtendedLifetime(token) {
             XCTAssertEqual([], observer.createdUserSession)
@@ -1479,23 +1479,9 @@ class SessionManagerTestDelegate: SessionManagerDelegate {
         userSessionCanBeTornDown?()
     }
     
-
-    func sessionManagerDidFailToLogin(error: Error) {
-        // no op
-    }
-    
-    var sessionManagerDidFailToFetchUserIdentifierIsCalled: Bool = false
-    func sessionManagerDidFailToFetchUserIdentifier() {
-        sessionManagerDidFailToFetchUserIdentifierIsCalled = true
-    }
-    
-    
-    func sessionManagerDidFailLoadSession(error: Error) {
-        // no op
-    }
-    
-    func sessionManagerDidFailToRegisterClient(error: Error) {
-        // no op
+    var sessionManagerDidFailToLogin: Bool = false
+    func sessionManagerDidFailToLogin(error: Error?) {
+        sessionManagerDidFailToLogin = true
     }
     
     func sessionManagerWillOpenAccount(_ account: Account,


### PR DESCRIPTION
## What's new in this PR?

the method of the `SessionManagerDelegate` (in the new version it is not there anymore)

```swift
func sessionManagerDidFailToLogin(account: Account?,
                                      from selectedAccount: Account?,
                                      error: Error)
```

 is currently called in situations which is unexpected, this means that we have been forced to add filtering logic in the `UI` to disregard these situations.

### Solutions

adding where necessary

```swift
let account = accountManager.account(with: accountId)
guard account == accountManager.selectedAccount else { return }
```

we ensure that the `sessionManagerDidFailToLogin` it is now called when it necessary and we don't need anymore to pass to the `UI` the `account: Account?` and the `selectedAccount: Account?`.

## Dependencies

JIRA: [SQCORE-215](https://wearezeta.atlassian.net/browse/SQCORE-215)