### PR TITLE
Fix: xcode12 tests build issue

### DIFF
--- a/Tests/Source/E2EE/ConversationTests+OTR.m
+++ b/Tests/Source/E2EE/ConversationTests+OTR.m
@@ -1079,7 +1079,7 @@
     
     // (3) remove inserted client for user1
     {
-        [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *__unused session) {
+        [self.mockTransportSession performRemoteChanges:^(id<MockTransportSessionObjectCreation>  _Nonnull __strong __unused session) {
             [self.user1.clients removeObject:additionalUserClient];
         }];
         WaitForAllGroupsToBeEmpty(0.5);
@@ -1257,7 +1257,7 @@
     
     // when
     [self performIgnoringZMLogError:^{
-        [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> * __unused session) {
+        [self.mockTransportSession performRemoteChanges:^(id<MockTransportSessionObjectCreation>  _Nonnull __strong __unused session) {
             [self.selfToUser1Conversation insertOTRMessageFromClient:self.user1.clients.anyObject
                                                             toClient:self.selfUser.clients.anyObject
                                                                 data:[@"😱" dataUsingEncoding:NSUTF8StringEncoding]];
@@ -1296,7 +1296,7 @@
     
     // when
     [self performIgnoringZMLogError:^{
-        [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> * __unused session) {
+        [self.mockTransportSession performRemoteChanges:^(id<MockTransportSessionObjectCreation>  _Nonnull __strong __unused session) {
             [self.selfToUser1Conversation insertOTRMessageFromClient:self.user1.clients.anyObject
                                                             toClient:self.selfUser.clients.anyObject
                                                                 data:[@"😱" dataUsingEncoding:NSUTF8StringEncoding]];

--- a/Tests/Source/E2EE/ConversationTests+OTR.m
+++ b/Tests/Source/E2EE/ConversationTests+OTR.m
@@ -197,7 +197,7 @@
     XCTAssertTrue([self login]);
     
     //register other users clients
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         for(int i = 0; i < 7; ++i) {
             MockUser *user = [session insertUserWithName:[NSString stringWithFormat:@"TestUser %d", i+1]];
             user.email = [NSString stringWithFormat:@"user%d@example.com", i+1];
@@ -398,7 +398,7 @@
     WaitForAllGroupsToBeEmpty(0.5);
     
     // when
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         NOT_USED(session);
         [self.groupConversationWithOnlyConnected addUsersByUser:self.user1 addedUsers:@[self.user5]];
     }];
@@ -413,7 +413,7 @@
     XCTAssertEqual(conversation.securityLevel, ZMConversationSecurityLevelSecureWithIgnored);
     
     // when
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         MockConversation *selfToUser5Conversation = [session insertOneOnOneConversationWithSelfUser:self.selfUser otherUser:self.user5];
         selfToUser5Conversation.creator = self.selfUser;
         MockConnection *connectionSelfToUser5 = [session insertConnectionWithSelfUser:self.selfUser toUser:self.user5];
@@ -495,7 +495,7 @@
     [self makeConversationSecured:conversation];
     
     //when
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         [session registerClientForUser:self.user1];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
@@ -894,7 +894,7 @@
     // given
     XCTAssertTrue([self login]);
     
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         [session registerClientForUser:self.selfUser];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
@@ -950,7 +950,7 @@
     // given
     XCTAssertTrue([self login]);
     
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         [session registerClientForUser:self.selfUser];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
@@ -1050,7 +1050,7 @@
     __block MockUserClient *additionalUserClient;
     // (2) insert new client for user 1
     {
-        [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+        [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
             additionalUserClient = [session registerClientForUser:self.user1];
         }];
         WaitForAllGroupsToBeEmpty(0.5);
@@ -1111,7 +1111,7 @@
     // given
     XCTAssertTrue([self login]);
     
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         [session registerClientForUser:self.selfUser];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
@@ -1153,7 +1153,7 @@
     }];
     WaitForAllGroupsToBeEmpty(0.5);
     
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         // this creates an extra client for self user
         [session registerClientForUser:self.selfUser];
     }];
@@ -1209,7 +1209,7 @@
     ZMUser *user1 = [self userForMockUser:self.user1];
     
     // add additional client for user1 remotely
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         [session registerClientForUser:self.user1];
     }];
     WaitForAllGroupsToBeEmpty(0.5);

--- a/Tests/Source/Integration/APNSTests.m
+++ b/Tests/Source/Integration/APNSTests.m
@@ -41,7 +41,7 @@
     __block NSDictionary *conversationTransportData;
     
     __block NSString *convIdentifier;
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         MockConversation *conversation = [session insertGroupConversationWithSelfUser:self.selfUser otherUsers:@[self.user1]];
         conversationTransportData = (NSDictionary *)conversation.transportData;
         convIdentifier = conversation.identifier;
@@ -94,7 +94,7 @@
     __block NSDictionary *conversationTransportData;
     
     __block NSString *convIdentifier;
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         MockConversation *conversation = [session insertGroupConversationWithSelfUser:self.selfUser otherUsers:@[self.user1]];
         conversationTransportData = (NSDictionary *)conversation.transportData;
         convIdentifier = conversation.identifier;

--- a/Tests/Source/Integration/ClientManagementTests.m
+++ b/Tests/Source/Integration/ClientManagementTests.m
@@ -92,7 +92,7 @@
 
 - (void)insertTwoSelfClientsOnMockTransporSession
 {
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         MockUserClient *client1 = [session registerClientForUser:self.selfUser label:@"foobar" type:@"permanent" deviceClass:@"phone"];
         client1.time = [NSDate dateWithTimeIntervalSince1970:124535];
         client1.deviceClass = @"iPhone";
@@ -170,7 +170,7 @@
     
     // when
     __block MockUserClient *mockClient;
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         mockClient = [session registerClientForUser:self.selfUser];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
@@ -200,7 +200,7 @@
     XCTAssertEqual(conversation.securityLevel, ZMConversationSecurityLevelSecure);
     
     // when
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         [session registerClientForUser:self.selfUser];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
@@ -231,7 +231,7 @@
     XCTAssertEqual(conversation.securityLevel, ZMConversationSecurityLevelSecure);
     
     // when
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         [session registerClientForUser:self.selfUser];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
@@ -262,7 +262,7 @@
 
     UserClient *currentSelfClient = selfUser.selfClient;
     __block MockUserClient *mockClient;
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         mockClient = [session registerClientForUser:self.selfUser];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
@@ -272,7 +272,7 @@
     UserChangeObserver *observer = [[UserChangeObserver alloc] initWithUser:selfUser];
     
     // when
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         [session deleteUserClientWithIdentifier:mockClient.identifier forUser:self.selfUser];
     }];
     WaitForAllGroupsToBeEmpty(0.5);

--- a/Tests/Source/Integration/ConnectionTests.m
+++ b/Tests/Source/Integration/ConnectionTests.m
@@ -149,7 +149,7 @@
     NSUUID *userID = [NSUUID createUUID];
     [self createUserWithName:userName uuid:userID];
     
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         NOT_USED(session);
         NSFetchRequest *fetchRequest = [MockUser sortedFetchRequestWithPredicate:[NSPredicate predicateWithFormat:@"identifier == %@", userID.transportString]];
         NSArray *users = [self.mockTransportSession.managedObjectContext executeFetchRequestOrAssert:fetchRequest];
@@ -399,7 +399,7 @@
     
     // when we add connection requests from remote users to the selfuser
     {
-        [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+        [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
             [self addConnectionRequestInMockTransportsession:session forUser:mockUser1];
             [self addConnectionRequestInMockTransportsession:session forUser:mockUser2];
         }];
@@ -499,7 +499,7 @@
 
     __block MockUser *mockUser1;
     __block MockUser *mockUser2;
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         mockUser1 = [session insertUserWithName:userName1];
         mockUser1.handle = @"hans";
         XCTAssertNotNil(mockUser1.identifier);
@@ -558,7 +558,7 @@
 
     // when the remote users accept the connection requests
     {
-        [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+        [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
             [session remotelyAcceptConnectionToUser:mockUser1];
             [session remotelyAcceptConnectionToUser:mockUser2];
         }];
@@ -626,7 +626,7 @@
     NSString *userName1 = @"Hans Von Üser";
     
     __block MockUser *mockUser1;
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         mockUser1 = [session insertUserWithName:userName1];
         XCTAssertNotNil(mockUser1.identifier);
         mockUser1.email = @"";
@@ -663,7 +663,7 @@
     
     // when the remote users accept the connection requests
     {
-        [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+        [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
             [session remotelyAcceptConnectionToUser:mockUser1];
         }];
         WaitForAllGroupsToBeEmpty(0.5);
@@ -685,7 +685,7 @@
     NSString *userName1 = @"Hans Von Üser";
     
     __block MockUser *mockUser1;
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         mockUser1 = [session insertUserWithName:userName1];
         XCTAssertNotNil(mockUser1.identifier);
         mockUser1.email = @"";
@@ -720,7 +720,7 @@
     
     // when the remote users accept the connection requests
     {
-        [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+        [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
             [session remotelyAcceptConnectionToUser:mockUser1];
         }];
         WaitForAllGroupsToBeEmpty(0.5);
@@ -739,7 +739,7 @@
     NSString *userName1 = @"Hans Von Üser";
     
     __block MockUser *mockUser1;
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         mockUser1 = [session insertUserWithName:userName1];
         XCTAssertNotNil(mockUser1.identifier);
         mockUser1.email = @"foo@bar.example.com";
@@ -777,7 +777,7 @@
     
     // when the remote users accept the connection requests
     {
-        [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+        [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
             [session remotelyAcceptConnectionToUser:mockUser1];
         }];
         WaitForAllGroupsToBeEmpty(0.5);
@@ -822,7 +822,7 @@
     NSString *userName1 = @"Hans Von Üser";
     
     __block MockUser *mockUser1;
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         mockUser1 = [session insertUserWithName:userName1];
         XCTAssertNotNil(mockUser1.identifier);
         mockUser1.email = @"";
@@ -868,7 +868,7 @@
     NSString *userName1 = @"Hans Von Üser";
     
     __block MockUser *mockUser;
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         mockUser = [session insertUserWithName:userName1];
         XCTAssertNotNil(mockUser.identifier);
         mockUser.email = @"";
@@ -946,7 +946,7 @@
     XCTAssertEqual(ZMConnectionTranscoderPageSize, 2u);
     
     __block NSUInteger numberOfConnections;
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         for(int i = 0; i < 11; ++i) {
             MockUser *user = [session insertUserWithName:@"foo foo"];
             user.identifier = [NSUUID createUUID].transportString;

--- a/Tests/Source/Integration/ConversationTestsBase.h
+++ b/Tests/Source/Integration/ConversationTestsBase.h
@@ -29,9 +29,9 @@
 
 @interface ConversationTestsBase : IntegrationTest
 
-- (void)testThatItAppendsMessageToConversation:(MockConversation *)mockConversation
-                                     withBlock:(NSArray *(^)(MockTransportSession<MockTransportSessionObjectCreation> *session))appendMessages
-                                        verify:(void(^)(ZMConversation *))verifyConversation;
+//- (void)testThatItAppendsMessageToConversation:(MockConversation *)mockConversation
+//                                     withBlock:(NSArray *(^)(MockTransportSession<MockTransportSessionObjectCreation> *session))appendMessages
+//                                        verify:(void(^)(ZMConversation *))verifyConversation;
 
 - (void)testThatItSendsANotificationInConversation:(MockConversation *)mockConversation
                                     ignoreLastRead:(BOOL)ignoreLastRead

--- a/Tests/Source/Integration/ConversationTestsBase.m
+++ b/Tests/Source/Integration/ConversationTestsBase.m
@@ -267,6 +267,7 @@
     return hasAllMessages;
 }
 
+/*
 - (void)testThatItAppendsMessageToConversation:(MockConversation *)mockConversation
                                      withBlock:(NSArray *(^)(MockTransportSession<MockTransportSessionObjectCreation> *session))appendMessages
                                         verify:(void(^)(ZMConversation *))verifyConversation
@@ -301,6 +302,6 @@
     verifyConversation(conversation);
     
 }
-
+*/
 @end
 

--- a/Tests/Source/Integration/ConversationTestsBase.m
+++ b/Tests/Source/Integration/ConversationTestsBase.m
@@ -192,7 +192,7 @@
     ConversationChangeObserver *observer = [[ConversationChangeObserver alloc] initWithConversation:conversation];
     [observer clearNotifications];
     
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> * __unused session) {
+    [self.mockTransportSession performRemoteChanges:^(id<MockTransportSessionObjectCreation>  _Nonnull __strong __unused session) {
         createMessage();
     }];
     
@@ -245,7 +245,7 @@
     ConversationChangeObserver *observer = [[ConversationChangeObserver alloc] initWithConversation:conversation];
     [observer clearNotifications];
     
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> * __unused session) {
+    [self.mockTransportSession performRemoteChanges:^(id<MockTransportSessionObjectCreation>  _Nonnull __strong __unused session) {
         createMessage();
     }];
     
@@ -292,8 +292,8 @@
     };
     
     // when
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> * session) {
-        messsagesNonces = appendMessages(session);
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
+        messsagesNonces = appendMessages(((MockTransportSession *)session));
     }];
     XCTAssert([self waitForCustomExpectationsWithTimeout:0.5]);
     

--- a/Tests/Source/Integration/ConversationTestsBase.m
+++ b/Tests/Source/Integration/ConversationTestsBase.m
@@ -151,7 +151,7 @@
     [self createSelfUserAndConversation];
     [self createExtraUsersAndConversations];
 
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         
         NSDate *selfConversationDate = [NSDate dateWithTimeIntervalSince1970:1400157817];
         NSDate *connection1Date = [NSDate dateWithTimeInterval:500 sinceDate:selfConversationDate];

--- a/Tests/Source/Integration/ConversationsTests.m
+++ b/Tests/Source/Integration/ConversationsTests.m
@@ -228,7 +228,7 @@
     XCTAssertNotNil(groupConversation);
     
     // when
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         [self.groupConversation addUsersByUser:session.selfUser addedUsers:@[self.user4]];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
@@ -250,7 +250,7 @@
     XCTAssertTrue([groupConversation.localParticipants containsObject:user3]);
     
     // when
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         [self.groupConversation removeUsersByUser:session.selfUser removedUser:self.user3];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
@@ -273,7 +273,7 @@
     XCTAssertTrue([groupConversation.localParticipants containsObject:bot]);
     
     // when
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         [self.groupConversationWithServiceUser removeUsersByUser:session.selfUser removedUser:self.serviceUser];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
@@ -338,7 +338,7 @@
     XCTAssertTrue([self login]);
 
     __block MockConversation *groupConversation;
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         groupConversation = [session insertConversationWithCreator:self.user3 otherUsers:@[self.user1, self.user2] type:ZMTConversationTypeGroup];
         [groupConversation changeNameByUser:self.selfUser name:@"Group conversation 2"];
     }];
@@ -378,7 +378,7 @@
     ConversationListChangeObserver *convListener2 = [[ConversationListChangeObserver alloc] initWithConversationList:convList2];
     
     // when
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         NOT_USED(session);
         [session insertConversationWithSelfUser:self.selfUser creator:self.selfUser otherUsers:@[self.user1, self.user2] type:ZMTConversationTypeGroup];
     }];
@@ -445,7 +445,7 @@
     {
         // given
         NSDate *previousArchivedDate = [NSDate dateWithTimeIntervalSince1970:-1];
-        [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+        [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
             // set last read
             NOT_USED(session);
             self.groupConversation.otrArchived = NO;
@@ -714,7 +714,7 @@
     }
 
     // when
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         block(session);
     }];
     WaitForAllGroupsToBeEmpty(0.5);
@@ -797,7 +797,7 @@
     XCTAssertTrue(conversation.isArchived);
     
     // when
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         [session remotelyAcceptConnectionToUser:mockUser];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
@@ -843,7 +843,7 @@
     ZMConversationTranscoderListPageSize = 3;
     
     __block NSUInteger numberOfConversations;
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         for(int i = 0; i < 10; ++i) {
             [session insertGroupConversationWithSelfUser:self.selfUser otherUsers:@[self.user1, self.user2]];
         }

--- a/Tests/Source/Integration/ConversationsTests.m
+++ b/Tests/Source/Integration/ConversationsTests.m
@@ -23,8 +23,8 @@
 @import WireUtilities;
 @import WireTesting;
 
-#import "MessagingTest.h"
-#import "ZMConversationTranscoder+Internal.h"
+//#import "MessagingTest.h"
+//#import "ZMConversationTranscoder+Internal.h"
 #import <WireSyncEngine/WireSyncEngine-Swift.h>
 #import "ConversationTestsBase.h"
 #import "WireSyncEngine_iOS_Tests-Swift.h"
@@ -206,7 +206,7 @@
     ConversationChangeObserver *observer = [[ConversationChangeObserver alloc] initWithConversation:conversation];
     [observer clearNotifications];
     
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> * ZM_UNUSED session) {
+    [self.mockTransportSession performRemoteChanges:^(id<MockTransportSessionObjectCreation>  _Nonnull __strong __unused session) {
         [self.groupConversation changeNameByUser:self.user3 name:newConversationName];
     }];
     
@@ -229,7 +229,7 @@
     
     // when
     [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
-        [self.groupConversation addUsersByUser:session.selfUser addedUsers:@[self.user4]];
+        [self.groupConversation addUsersByUser:((MockTransportSession *)session).selfUser addedUsers:@[self.user4]];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
     
@@ -251,7 +251,7 @@
     
     // when
     [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
-        [self.groupConversation removeUsersByUser:session.selfUser removedUser:self.user3];
+        [self.groupConversation removeUsersByUser:((MockTransportSession *)session).selfUser removedUser:self.user3];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
     
@@ -274,7 +274,7 @@
     
     // when
     [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
-        [self.groupConversationWithServiceUser removeUsersByUser:session.selfUser removedUser:self.serviceUser];
+        [self.groupConversationWithServiceUser removeUsersByUser:((MockTransportSession *)session).selfUser removedUser:self.serviceUser];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
     
@@ -346,7 +346,7 @@
     
     ZMConversationList *conversationList = [ZMConversationList conversationsInUserSession:self.userSession];
     
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> ZM_UNUSED *session) {
+    [self.mockTransportSession performRemoteChanges:^(id<MockTransportSessionObjectCreation>  _Nonnull __strong __unused session) {
         [groupConversation addUsersByUser:self.user1 addedUsers:@[self.selfUser]];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
@@ -715,7 +715,7 @@
 
     // when
     [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
-        block(session);
+        block(((MockTransportSession<MockTransportSessionObjectCreation> *)session));
     }];
     WaitForAllGroupsToBeEmpty(0.5);
 

--- a/Tests/Source/Integration/LoginFlowTests.m
+++ b/Tests/Source/Integration/LoginFlowTests.m
@@ -83,7 +83,7 @@ extern NSTimeInterval DebugLoginFailureTimerOverride;
     // given
     NSString *email = @"expected@example.com";
     NSString *password = @"valid-password-837246";
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         NOT_USED(session);
         self.selfUser.name = @"Self User";
         self.selfUser.email = email;
@@ -111,7 +111,7 @@ extern NSTimeInterval DebugLoginFailureTimerOverride;
     // given
     NSString *email = @"expected@example.com";
     NSString *password = @"valid-password-837246";
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         NOT_USED(session);
         self.selfUser.name = @"Self User";
         self.selfUser.email = email;
@@ -145,7 +145,7 @@ extern NSTimeInterval DebugLoginFailureTimerOverride;
     // given
     NSString *phone = @"+4912345678900";
     NSString *code = self.mockTransportSession.phoneVerificationCodeForLogin;
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         NOT_USED(session);
         self.selfUser.phone = phone;
     }];
@@ -179,7 +179,7 @@ extern NSTimeInterval DebugLoginFailureTimerOverride;
     // given
     NSString *email = @"expected@example.com";
     NSString *password = @"valid-password-837246";
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         NOT_USED(session);
         self.selfUser.name = @"Self User";
         self.selfUser.email = email;
@@ -223,7 +223,7 @@ extern NSTimeInterval DebugLoginFailureTimerOverride;
     NSString *email = @"expected@example.com";
     NSString *password = @"valid-password-837246";
     __block MockUser *selfUser;
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         selfUser = [session insertUserWithName:@"Self User"];
         selfUser.email = email;
         selfUser.password = password;
@@ -252,7 +252,7 @@ extern NSTimeInterval DebugLoginFailureTimerOverride;
     NSString *email = @"expected@example.com";
     NSString *password = @"valid-password-837246";
     __block MockUser *selfUser;
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         selfUser = [session insertUserWithName:@"Self User"];
         selfUser.email = email;
         selfUser.password = password;
@@ -297,7 +297,7 @@ extern NSTimeInterval DebugLoginFailureTimerOverride;
     NSString *email = @"expected@example.com";
     NSString *password = @"valid-password-837246";
     __block MockUser *selfUser;
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         selfUser = [session insertUserWithName:@"Self User"];
         selfUser.email = email;
         selfUser.password = password;
@@ -407,7 +407,7 @@ extern NSTimeInterval DebugLoginFailureTimerOverride;
     // given
     NSString *phone = @"+4912345678900";
     NSString *code = self.mockTransportSession.phoneVerificationCodeForLogin;
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         NOT_USED(session);
         self.selfUser.phone = phone;
     }];
@@ -470,7 +470,7 @@ extern NSTimeInterval DebugLoginFailureTimerOverride;
 {
     // given
     NSString *phone = @"+4912345678900";
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         NOT_USED(session);
         self.selfUser.phone = phone;
     }];
@@ -536,7 +536,7 @@ extern NSTimeInterval DebugLoginFailureTimerOverride;
     
     self.selfUser.phone = phone;
     
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         [session whiteListPhone:phone];
         self.selfUser.email = nil;
         self.selfUser.password = nil;
@@ -555,7 +555,7 @@ extern NSTimeInterval DebugLoginFailureTimerOverride;
                 [self.userSession.userProfile requestSettingEmailAndPasswordWithCredentials:credentials error:nil];
             }];
             
-            [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+            [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
                 // simulate user click on email
                 NOT_USED(session);
                 self.selfUser.email = email;
@@ -603,7 +603,7 @@ extern NSTimeInterval DebugLoginFailureTimerOverride;
 
     self.selfUser.phone = phone;
     
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         [session whiteListPhone:phone];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
@@ -670,7 +670,7 @@ extern NSTimeInterval DebugLoginFailureTimerOverride;
     PostLoginAuthenticationNotificationRecorder *recorder = [[PostLoginAuthenticationNotificationRecorder alloc] initWithDispatchGroup:self.dispatchGroup];
     
     // when we delete self client
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         MockUserClient *selfClient = self.selfUser.clients.anyObject;
         [session deleteUserClientWithIdentifier:selfClient.identifier forUser:self.selfUser];
     }];
@@ -693,7 +693,7 @@ extern NSTimeInterval DebugLoginFailureTimerOverride;
     // given
     NSString *phone = @"+4912345678900";
     NSString *code = self.mockTransportSession.phoneVerificationCodeForLogin;
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         NOT_USED(session);
         self.selfUser.phone = phone;
     }];
@@ -746,7 +746,7 @@ extern NSTimeInterval DebugLoginFailureTimerOverride;
 {
     // given
     __block NSString *idToDelete;
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         MockUserClient *client = [session registerClientForUser:self.selfUser];
         idToDelete = client.identifier;
     }];

--- a/Tests/Source/Integration/SendAndReceiveMessagesTests.m
+++ b/Tests/Source/Integration/SendAndReceiveMessagesTests.m
@@ -414,9 +414,9 @@
     
     // when
     [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
-        [self.groupConversation changeNameByUser:session.selfUser name:newName];
+        [self.groupConversation changeNameByUser:((MockTransportSession *)session).selfUser name:newName];
         [self spinMainQueueWithTimeout:0.2];
-        [self.groupConversation addUsersByUser:session.selfUser addedUsers:@[self.user4]];
+        [self.groupConversation addUsersByUser:((MockTransportSession *)session).selfUser addedUsers:@[self.user4]];
     }];
     WaitForAllGroupsToBeEmpty(0.1);
     
@@ -483,13 +483,13 @@
     
     // when
     [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
-        [self.groupConversation changeNameByUser:session.selfUser name:newName1];
+        [self.groupConversation changeNameByUser:((MockTransportSession *)session).selfUser name:newName1];
     }];
     WaitForAllGroupsToBeEmpty(0.1);
     
     
     [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
-        [self.groupConversation changeNameByUser:session.selfUser name:newName2];
+        [self.groupConversation changeNameByUser:((MockTransportSession *)session).selfUser name:newName2];
     }];
     WaitForAllGroupsToBeEmpty(0.1);
     

--- a/Tests/Source/Integration/SendAndReceiveMessagesTests.m
+++ b/Tests/Source/Integration/SendAndReceiveMessagesTests.m
@@ -413,7 +413,7 @@
     XCTAssertNotEqual(groupConversation.displayName, newName);
     
     // when
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         [self.groupConversation changeNameByUser:session.selfUser name:newName];
         [self spinMainQueueWithTimeout:0.2];
         [self.groupConversation addUsersByUser:session.selfUser addedUsers:@[self.user4]];
@@ -482,13 +482,13 @@
     XCTAssertNotEqual(groupConversation.displayName, newName1);
     
     // when
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         [self.groupConversation changeNameByUser:session.selfUser name:newName1];
     }];
     WaitForAllGroupsToBeEmpty(0.1);
     
     
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         [self.groupConversation changeNameByUser:session.selfUser name:newName2];
     }];
     WaitForAllGroupsToBeEmpty(0.1);

--- a/Tests/Source/Integration/SlowSyncTests.m
+++ b/Tests/Source/Integration/SlowSyncTests.m
@@ -348,7 +348,7 @@
     [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         [session simulatePushChannelClosed];
         [session removeMemberWithUser:self.selfUser fromTeam:mockTeam];
-        [session saveAndCreatePushChannelEvents]; // clears the team.member-leave event from the push channel events
+        [(MockTransportSession *)session saveAndCreatePushChannelEvents]; // clears the team.member-leave event from the push channel events
         [session simulatePushChannelOpened];
     }];
     WaitForAllGroupsToBeEmpty(0.5);

--- a/Tests/Source/Integration/SlowSyncTests.m
+++ b/Tests/Source/Integration/SlowSyncTests.m
@@ -273,7 +273,7 @@
     };
     
     // when
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         [session simulatePushChannelClosed];
         [session simulatePushChannelOpened];
     }];
@@ -345,7 +345,7 @@
         return nil;
     };
     
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         [session simulatePushChannelClosed];
         [session removeMemberWithUser:self.selfUser fromTeam:mockTeam];
         [session saveAndCreatePushChannelEvents]; // clears the team.member-leave event from the push channel events

--- a/Tests/Source/Integration/UserProfileTests.m
+++ b/Tests/Source/Integration/UserProfileTests.m
@@ -358,14 +358,14 @@
     NSString *phone = @"+99123456789";
     NSString *code = self.mockTransportSession.phoneVerificationCodeForLogin;
     
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         self.selfUser.phone = phone;
         [session whiteListPhone:phone];
     }];
     
     BOOL success = [self loginWithCredentials:[ZMPhoneCredentials credentialsWithPhoneNumber:phone verificationCode:code] ignoreAuthenticationFailures:NO];
     
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         NOT_USED(session);
         self.selfUser.email = nil;
         self.selfUser.password = nil;
@@ -400,7 +400,7 @@
     [self.userSession.userProfile requestSettingEmailAndPasswordWithCredentials:credentials error:nil]; // <- STEP 1
     WaitForAllGroupsToBeEmpty(0.5);
     
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         // simulate user click on email
         NOT_USED(session);
         self.selfUser.email = email;
@@ -481,7 +481,7 @@
     [self.userSession.userProfile requestSettingEmailAndPasswordWithCredentials:credentials error:nil];
     WaitForAllGroupsToBeEmpty(5);
     
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         // simulate user click on email
         NOT_USED(session);
         self.selfUser.email = email;

--- a/Tests/Source/Integration/UserTests.m
+++ b/Tests/Source/Integration/UserTests.m
@@ -129,7 +129,7 @@
     // add new user to groupConversation remotely
     
     __block MockUser *extraUser;
-    [self.mockTransportSession performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
+    [self.mockTransportSession performRemoteChanges:^ (id<MockTransportSessionObjectCreation>  _Nonnull __strong session) {
         extraUser = [session insertUserWithName:@"Max Tester"];
         [self.groupConversation addUsersByUser:self.selfUser addedUsers:@[extraUser]];
         XCTAssertNotNil(extraUser.name);


### PR DESCRIPTION
## What's new in this PR?

### Issues

Test target has compoile error with Xcode 12.2

### Causes

`MockTransportSession<MockTransportSessionObjectCreation> *session` can not be casted.
### Solutions


## Dependencies

Fix the block's parameter.