### PR TITLE
fix: NotificationSettingsRegistrable protocol

### DIFF
--- a/Source/SessionManager/SessionManager+Push.swift
+++ b/Source/SessionManager/SessionManager+Push.swift
@@ -137,7 +137,7 @@ extension SessionManager: PKPushRegistryDelegate {
     // MARK: Helpers
     
     public func configureUserNotifications() {
-        guard application.shouldRegisterUserNotificationSettings ?? true else { return }
+        guard (application as? NotificationSettingsRegistrable)?.shouldRegisterUserNotificationSettings ?? true else { return }
         notificationCenter.setNotificationCategories(PushNotificationCategory.allCategories)
         notificationCenter.requestAuthorization(options: [.alert, .badge, .sound], completionHandler: { _, _ in })
         notificationCenter.delegate = self

--- a/Source/Utility/Application.swift
+++ b/Source/Utility/Application.swift
@@ -20,6 +20,11 @@ import Foundation
 import WireTransport
 import UIKit
 
+public protocol NotificationSettingsRegistrable {
+    /// To determine if notification settings should be registered
+    var shouldRegisterUserNotificationSettings : Bool { get }
+}
+
 /// An abstraction of the application (UIApplication, NSApplication)
 @objc public protocol ZMApplication : NSObjectProtocol {
     
@@ -28,10 +33,7 @@ import UIKit
     
     /// Badge count
     var applicationIconBadgeNumber : Int { get set }
-    
-    /// To determine if notification settings should be registered
-    @objc optional var shouldRegisterUserNotificationSettings : Bool { get }
-    
+        
     /// Register for remote notification
     func registerForRemoteNotifications()
     


### PR DESCRIPTION

## What's new in this PR?

### Issues

Compilation failed with Xcode 12 on CI machines

### Causes

Unknown (crashed with reason Segmentation fault 11)
But it seems that `shouldRegisterUserNotificationSettings` is an optional protocol method, which is not implemented in sync engine


### Solutions

Create `NotificationSettingsRegistrable` for `shouldRegisterUserNotificationSettings` method and make `WireApplication` in UI project conforms it.