### PR TITLE
[Fix] Delete encryption keys when migrating away from EAR

### DIFF
--- a/Source/SessionManager/SessionManager+EncryptionAtRest.swift
+++ b/Source/SessionManager/SessionManager+EncryptionAtRest.swift
@@ -36,6 +36,7 @@ extension SessionManager: UserSessionEncryptionAtRestDelegate {
                                                     try context.enableEncryptionAtRest(encryptionKeys: encryptionKeys)
                                                 } else {
                                                     try context.disableEncryptionAtRest(encryptionKeys: encryptionKeys)
+                                                    try EncryptionKeys.deleteKeys(for: account)
                                                 }
             }) { result in
                 switch result {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Messages are not received after migrating away from EAR

### Causes

EncryptionKeys are not deleted from key chain after migrating away from EAR.

### Solutions

Delete encryption keys from keychain 