### PR TITLE
Fix: change voice channel protocol member firstDegradedUser type form ZMUser to usertype

### DIFF
--- a/Source/Calling/VoiceChannel.swift
+++ b/Source/Calling/VoiceChannel.swift
@@ -61,7 +61,7 @@ public protocol CallProperties : NSObjectProtocol {
 
     var isConferenceCall: Bool { get }
 
-    var firstDegradedUser: ZMUser? { get }
+    var firstDegradedUser: UserType? { get }
     
     func setVideoCaptureDevice(_ device: CaptureDevice) throws
 }

--- a/Source/Calling/VoiceChannelV3.swift
+++ b/Source/Calling/VoiceChannelV3.swift
@@ -123,7 +123,7 @@ public class VoiceChannelV3 : NSObject, VoiceChannel {
         return callCenter.isConferenceCall(conversationId: remoteIdentifier)
     }
 
-    public var firstDegradedUser: ZMUser? {
+    public var firstDegradedUser: UserType? {
         guard
             let conversationId = conversation?.remoteIdentifier,
             let degradedUser = callCenter?.degradedUser(conversationId: conversationId)

--- a/Tests/Source/Calling/VoiceChannelV3Tests.swift
+++ b/Tests/Source/Calling/VoiceChannelV3Tests.swift
@@ -102,7 +102,7 @@ class VoiceChannelV3Tests : MessagingTest {
         ]
         
         // When / Then
-        XCTAssert(sut.firstDegradedUser == user)
+        XCTAssert(sut.firstDegradedUser as? ZMUser == user)
     }
     
     func testThatItReturnsNil_IfNoDegradedUser() {


### PR DESCRIPTION
## What's new in this PR?

Change the `firstDegradedUser` type to protocol type `Usertype` for UI project easier to mock.