### PR TITLE
remove state from CallParticipant hash

### DIFF
--- a/Source/Calling/CallState.swift
+++ b/Source/Calling/CallState.swift
@@ -76,7 +76,6 @@ public struct CallParticipant: Hashable {
     }
 
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(state)
         hasher.combine(userId)
         hasher.combine(clientId)
     }

--- a/Tests/Source/Calling/CallParticipantTests.swift
+++ b/Tests/Source/Calling/CallParticipantTests.swift
@@ -1,0 +1,48 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+final class CallParticipantTests: MessagingTest {
+    var otherUser: ZMUser!
+    let otherUserID : UUID = UUID()
+    let otherUserClientID = UUID().transportString()
+
+    override func setUp() {
+        super.setUp()
+        
+        otherUser = ZMUser.insertNewObject(in: uiMOC)
+        otherUser.remoteIdentifier = otherUserID
+    }
+    
+    override func tearDown() {
+        otherUser = nil
+        
+        super.tearDown()
+    }
+
+    func testThatHashIsSameWithDifferentState() {
+        
+        //GIVEN & WHEN
+        let callParticipant1 = CallParticipant(user: otherUser, clientId: otherUserClientID, state: .connecting)
+        let callParticipant2 = CallParticipant(user: otherUser, clientId: otherUserClientID, state: .unconnected)
+
+        //THEN
+        XCTAssertEqual(callParticipant1.hashValue, callParticipant2.hashValue)
+    }
+}

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -405,6 +405,7 @@
 		87D003FF1BB5810D00472E06 /* APSSignalingKeyStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D003FE1BB5810D00472E06 /* APSSignalingKeyStoreTests.swift */; };
 		87D2555921D6275800D03789 /* BuildTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D2555821D6275800D03789 /* BuildTypeTests.swift */; };
 		87D4625D1C3D526D00433469 /* DeleteAccountRequestStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D4625C1C3D526D00433469 /* DeleteAccountRequestStrategyTests.swift */; };
+		A901FE9B258B562F003EAF5C /* CallParticipantTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A901FE9A258B562F003EAF5C /* CallParticipantTests.swift */; };
 		A907771A192E33A500141F13 /* SlowSyncTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 85D85D997334755E841D13EA /* SlowSyncTests.m */; };
 		A913C02223A7EDFB0048CE74 /* TeamRolesDownloadRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A913C02123A7EDFA0048CE74 /* TeamRolesDownloadRequestStrategy.swift */; };
 		A913C02423A7F1C00048CE74 /* TeamRolesDownloadRequestStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A913C02323A7F1C00048CE74 /* TeamRolesDownloadRequestStrategyTests.swift */; };
@@ -1072,6 +1073,7 @@
 		87D2555821D6275800D03789 /* BuildTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildTypeTests.swift; sourceTree = "<group>"; };
 		87D4625C1C3D526D00433469 /* DeleteAccountRequestStrategyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeleteAccountRequestStrategyTests.swift; sourceTree = "<group>"; };
 		87DF28C61F680495007E1702 /* PushDispatcherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushDispatcherTests.swift; sourceTree = "<group>"; };
+		A901FE9A258B562F003EAF5C /* CallParticipantTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallParticipantTests.swift; sourceTree = "<group>"; };
 		A913C02123A7EDFA0048CE74 /* TeamRolesDownloadRequestStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamRolesDownloadRequestStrategy.swift; sourceTree = "<group>"; };
 		A913C02323A7F1C00048CE74 /* TeamRolesDownloadRequestStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamRolesDownloadRequestStrategyTests.swift; sourceTree = "<group>"; };
 		A938BDC723A7964100D4C208 /* ConversationRoleDownstreamRequestStrategy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConversationRoleDownstreamRequestStrategy.swift; sourceTree = "<group>"; };
@@ -1624,6 +1626,7 @@
 				5E8BB8A3214912D100EEA64B /* AVSBridgingTests.swift */,
 				166D18A5230EC418001288CD /* MockMediaManager.swift */,
 				639290A3252CA53100046171 /* CallSnapshotTestFixture.swift */,
+				A901FE9A258B562F003EAF5C /* CallParticipantTests.swift */,
 			);
 			path = Calling;
 			sourceTree = "<group>";
@@ -2994,6 +2997,7 @@
 				F9DAC54F1C2035660001F11E /* ConversationStatusStrategyTests.swift in Sources */,
 				164C29A31ECF437E0026562A /* SearchRequestTests.swift in Sources */,
 				168CF42F2007BCD9009FCB89 /* TeamInvitationStatusTests.swift in Sources */,
+				A901FE9B258B562F003EAF5C /* CallParticipantTests.swift in Sources */,
 				874A174A205812B6001C6760 /* ZMUserSessionTests.swift in Sources */,
 				7CE017172317D72A00144905 /* ZMCredentialsTests.swift in Sources */,
 				63F65F03246D5A9600534A69 /* PushChannelTests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

After https://github.com/wireapp/wire-ios-sync-engine/pull/1358 is merged, UI tests failed

### Causes

`state` is added to the hash calculation, which is not included before.

### Solutions

Remove the unnecessary hash components and make a test to describe this requirement.