### PR TITLE
[Fix] Failed testThatItPostsNotification_WhenLogoutRequestSucceeds test

### DIFF
--- a/Tests/Source/UserSession/ZMUserSessionTestsBase.m
+++ b/Tests/Source/UserSession/ZMUserSessionTestsBase.m
@@ -99,6 +99,7 @@
     [[self.operationLoop stub] tearDown];
     
     self.storeProvider = [[MockLocalStoreProvider alloc] initWithSharedContainerDirectory:self.sharedContainerURL userIdentifier:self.userIdentifier contextDirectory:self.contextDirectory];
+    [ZMUser selfUserInContext:self.syncMOC].remoteIdentifier = [NSUUID createUUID];
     
     self.sut = [[ZMUserSession alloc] initWithTransportSession:self.transportSession
                                                   mediaManager:self.mediaManager


### PR DESCRIPTION
## What's new in this PR?

### Issues
There's a failed `testThatItPostsNotification_WhenLogoutRequestSucceeds` test.


### Causes
In the `ZMUserSession` initialiser, we create a selfUser in `uiMoc` without the `remoteIdentifier` that is causing the test to fail.


### Solutions
Create a `selfUser` before initialise the userSession in `ZMUserSessionTestsBase`.
