### PR TITLE
[Fix] Fix crash during integration tests

### DIFF
--- a/Tests/Source/Integration/IntegrationTest.swift
+++ b/Tests/Source/Integration/IntegrationTest.swift
@@ -193,11 +193,10 @@ extension IntegrationTest {
         groupConversationWithServiceUser = nil
         application = nil
         notificationCenter = nil
-        resetInMemoryDatabases()
-        deleteSharedContainerContent()
         sharedContainerDirectory = nil
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+        resetInMemoryDatabases()
+        deleteSharedContainerContent()
     }
     
     func resetInMemoryDatabases() {


### PR DESCRIPTION
## What's new in this PR?

### Issues

I was experience a crash while running the integration tests while the user session accessed its sync context during tear down and it was already `nil` causing an optional unwrapping crash.

### Causes

The storage stack is torn down in (`resetInMemoryDatabases()`) in `IntegrationTest.tearDown()` before the call to`XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))`, which means that if the user session was waiting for something to complete its managed objects contexts would already be gone by the time it is ready call its `tearDown()` method.

### Solutions

Reset the storage stack after `XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))`