### PR TITLE
[Chore] Add logs for when scheduling a notification succeeds / fails

### DIFF
--- a/Source/Notifications/Push notifications/LocalNotificationDispatcher.swift
+++ b/Source/Notifications/Push notifications/LocalNotificationDispatcher.swift
@@ -52,7 +52,14 @@ import UserNotifications
     func scheduleLocalNotification(_ note: ZMLocalNotification) {
         Logging.push.safePublic("Scheduling local notification with id=\(note.id)")
         
-        notificationCenter.add(note.request, withCompletionHandler: nil)
+        notificationCenter.add(note.request, withCompletionHandler: { error in
+            if let error = error {
+                Logging.push.safePublic("Error scheduling local notification")
+                Logging.push.error("Scheduling Error: \(error)")
+            } else {
+                Logging.push.safePublic("Succesfully scheduled local notification")
+            }
+        })
     }
 
     /// Determines if the notification content should be hidden as reflected in the store

--- a/Source/Notifications/Push notifications/LocalNotificationDispatcher.swift
+++ b/Source/Notifications/Push notifications/LocalNotificationDispatcher.swift
@@ -57,7 +57,7 @@ import UserNotifications
                 Logging.push.safePublic("Error scheduling local notification")
                 Logging.push.error("Scheduling Error: \(error)")
             } else {
-                Logging.push.safePublic("Succesfully scheduled local notification")
+                Logging.push.safePublic("Successfully scheduled local notification")
             }
         })
     }


### PR DESCRIPTION
## What's new in this PR?

I've observed that scheduled notifications are sometimes not displayed. To investigate this further I'm adding logs for when scheduling a notification succeeds / fails.