### PR TITLE
[Refactor] active speaker state

### DIFF
--- a/Source/Calling/AVSActiveSpeakerChange.swift
+++ b/Source/Calling/AVSActiveSpeakerChange.swift
@@ -49,4 +49,8 @@ extension AVSActiveSpeakersChange.ActiveSpeaker {
     var client: AVSClient {
         AVSClient(userId: userId, clientId: clientId)
     }
+    
+    var audioLevels: AudioLevels {
+        return AudioLevels(instantaneous: audioLevelNow, smoothed: audioLevel)
+    }
 }

--- a/Source/Calling/AVSActiveSpeakerChange.swift
+++ b/Source/Calling/AVSActiveSpeakerChange.swift
@@ -49,8 +49,4 @@ extension AVSActiveSpeakersChange.ActiveSpeaker {
     var client: AVSClient {
         AVSClient(userId: userId, clientId: clientId)
     }
-    
-    var audioLevels: AudioLevels {
-        return AudioLevels(instantaneous: audioLevelNow, smoothed: audioLevel)
-    }
 }

--- a/Source/Calling/CallParticipantsListKind.swift
+++ b/Source/Calling/CallParticipantsListKind.swift
@@ -36,7 +36,7 @@ extension CallParticipantsListKind {
         switch self {
         case .all where activeSpeaker.audioLevelNow > 0,
              .smoothedActiveSpeakers where activeSpeaker.audioLevel > 0:
-            return .active(audioLevels: activeSpeaker.audioLevels)
+            return .active(audioLevelNow: activeSpeaker.audioLevelNow)
         default:
             return .inactive
         }

--- a/Source/Calling/CallParticipantsListKind.swift
+++ b/Source/Calling/CallParticipantsListKind.swift
@@ -32,7 +32,7 @@ public enum CallParticipantsListKind {
 
 extension CallParticipantsListKind {
 
-    func stateOf(activeSpeaker: AVSActiveSpeakersChange.ActiveSpeaker) -> ActiveSpeakerState {
+    func state(ofActiveSpeaker activeSpeaker: AVSActiveSpeakersChange.ActiveSpeaker) -> ActiveSpeakerState {
         switch self {
         case .all where activeSpeaker.audioLevelNow > 0,
              .smoothedActiveSpeakers where activeSpeaker.audioLevel > 0:

--- a/Source/Calling/CallParticipantsListKind.swift
+++ b/Source/Calling/CallParticipantsListKind.swift
@@ -31,13 +31,14 @@ public enum CallParticipantsListKind {
 }
 
 extension CallParticipantsListKind {
-    
-    func isActive(activeSpeaker: AVSActiveSpeakersChange.ActiveSpeaker) -> Bool {
+
+    func stateOf(activeSpeaker: AVSActiveSpeakersChange.ActiveSpeaker) -> ActiveSpeakerState {
         switch self {
-        case .all:
-            return activeSpeaker.audioLevelNow > 0
-        case .smoothedActiveSpeakers:
-            return activeSpeaker.audioLevel > 0
+        case .all where activeSpeaker.audioLevelNow > 0,
+             .smoothedActiveSpeakers where activeSpeaker.audioLevel > 0:
+            return .active(audioLevels: activeSpeaker.audioLevels)
+        default:
+            return .inactive
         }
     }
 

--- a/Source/Calling/CallState.swift
+++ b/Source/Calling/CallState.swift
@@ -152,27 +152,9 @@ public enum MicrophoneState: Int32, Codable {
 
 public enum ActiveSpeakerState: Equatable {
     /// Participant is an active speaker
-    case active(audioLevels: AudioLevels)
+    case active(audioLevelNow: Int)
     /// Participant is not an active speaker
     case inactive
-    
-    var audioLevels: AudioLevels? {
-        switch self {
-        case .active(audioLevels: let audioLevels):
-            return audioLevels
-        default:
-            return nil
-        }
-    }
-}
-
-/**
- * The audio levels of an active speaker
- */
-
-public struct AudioLevels: Equatable {
-    let instantaneous: Int
-    let smoothed: Int
 }
 
 /**

--- a/Source/Calling/CallState.swift
+++ b/Source/Calling/CallState.swift
@@ -31,7 +31,7 @@ public struct CallParticipant: Hashable {
     public let clientId: String
     public let userId: UUID
     public let state: CallParticipantState
-    public let isActiveSpeaker: Bool
+    public let activeSpeakerState: ActiveSpeakerState
         
     /// convenience init method for ZMUser
     /// - Parameters:
@@ -41,12 +41,12 @@ public struct CallParticipant: Hashable {
     public init(user: ZMUser,
                 clientId: String,
                 state: CallParticipantState,
-                isActiveSpeaker: Bool) {
+                activeSpeakerState: ActiveSpeakerState) {
         self.user = user
         self.clientId = clientId
         self.userId = user.remoteIdentifier
         self.state = state
-        self.isActiveSpeaker = isActiveSpeaker
+        self.activeSpeakerState = activeSpeakerState
     }
 
     /// Init with separated user and user id to allow CallParticipant to be Hashable even though user is not Hashable
@@ -59,17 +59,17 @@ public struct CallParticipant: Hashable {
                 userId: UUID,
                 clientId: String,
                 state: CallParticipantState,
-                isActiveSpeaker: Bool) {
+                activeSpeakerState: ActiveSpeakerState) {
         self.user = user
         self.clientId = clientId
         self.userId = userId
         self.state = state
-        self.isActiveSpeaker = isActiveSpeaker
+        self.activeSpeakerState = activeSpeakerState
     }
 
-    init?(member: AVSCallMember, isActiveSpeaker: Bool = false, context: NSManagedObjectContext) {
+    init?(member: AVSCallMember, activeSpeakerState: ActiveSpeakerState = .inactive, context: NSManagedObjectContext) {
         guard let user = ZMUser(remoteID: member.client.userId, createIfNeeded: false, in: context) else { return nil }
-        self.init(user: user, userId: user.remoteIdentifier, clientId: member.client.clientId, state: member.callParticipantState, isActiveSpeaker: isActiveSpeaker)
+        self.init(user: user, userId: user.remoteIdentifier, clientId: member.client.clientId, state: member.callParticipantState, activeSpeakerState: activeSpeakerState)
     }
 
     // MARK: - Hashable
@@ -144,6 +144,35 @@ public enum MicrophoneState: Int32, Codable {
     case unmuted = 0
     /// Sender is muted
     case muted = 1
+}
+
+/**
+ * The speaking activity state of a participant in the call.
+ */
+
+public enum ActiveSpeakerState: Equatable {
+    /// Participant is an active speaker
+    case active(audioLevels: AudioLevels)
+    /// Participant is not an active speaker
+    case inactive
+    
+    var audioLevels: AudioLevels? {
+        switch self {
+        case .active(audioLevels: let audioLevels):
+            return audioLevels
+        default:
+            return nil
+        }
+    }
+}
+
+/**
+ * The audio levels of an active speaker
+ */
+
+public struct AudioLevels: Equatable {
+    let instantaneous: Int
+    let smoothed: Int
 }
 
 /**

--- a/Source/Calling/CallState.swift
+++ b/Source/Calling/CallState.swift
@@ -150,7 +150,7 @@ public enum MicrophoneState: Int32, Codable {
  * The speaking activity state of a participant in the call.
  */
 
-public enum ActiveSpeakerState: Equatable {
+public enum ActiveSpeakerState: Hashable {
     /// Participant is an active speaker
     case active(audioLevelNow: Int)
     /// Participant is not an active speaker

--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -349,7 +349,7 @@ extension WireCallCenterV3 {
             var activeSpeakerState: ActiveSpeakerState = .inactive
             
             if let activeSpeaker = activeSpeakers.first(where: { $0.client == member.client }) {
-                activeSpeakerState = kind.stateOf(activeSpeaker: activeSpeaker)
+                activeSpeakerState = kind.state(ofActiveSpeaker: activeSpeaker)
             }
             
             if kind == .smoothedActiveSpeakers && activeSpeakerState == .inactive {

--- a/Source/Calling/WireCallCenterV3.swift
+++ b/Source/Calling/WireCallCenterV3.swift
@@ -345,7 +345,7 @@ extension WireCallCenterV3 {
 
         let activeSpeakers = self.activeSpeakers(conversationId: conversationId, limitedBy: limit)
         
-        let participants: [CallParticipant] = callMembers.compactMap { member in
+        return callMembers.compactMap { member in
             var activeSpeakerState: ActiveSpeakerState = .inactive
             
             if let activeSpeaker = activeSpeakers.first(where: { $0.client == member.client }) {
@@ -357,15 +357,6 @@ extension WireCallCenterV3 {
             }
             
             return CallParticipant(member: member, activeSpeakerState: activeSpeakerState, context: context)
-        }
-        
-        guard kind == .smoothedActiveSpeakers else {
-            return participants
-        }
-        
-        // Sort smoothed active speakers by activity level
-        return participants.sorted { p1, p2 in
-            p1.activeSpeakerState.audioLevels?.smoothed > p2.activeSpeakerState.audioLevels?.smoothed
         }
     }
     

--- a/Tests/Source/Calling/CallParticipantTests.swift
+++ b/Tests/Source/Calling/CallParticipantTests.swift
@@ -39,8 +39,8 @@ final class CallParticipantTests: MessagingTest {
     func testThatHashIsSameWithDifferentState() {
         
         //GIVEN & WHEN
-        let callParticipant1 = CallParticipant(user: otherUser, clientId: otherUserClientID, state: .connecting, isActiveSpeaker: false)
-        let callParticipant2 = CallParticipant(user: otherUser, clientId: otherUserClientID, state: .unconnected, isActiveSpeaker: false)
+        let callParticipant1 = CallParticipant(user: otherUser, clientId: otherUserClientID, state: .connecting, activeSpeakerState: .inactive)
+        let callParticipant2 = CallParticipant(user: otherUser, clientId: otherUserClientID, state: .unconnected, activeSpeakerState: .inactive)
 
         //THEN
         XCTAssertEqual(callParticipant1.hashValue, callParticipant2.hashValue)

--- a/Tests/Source/Calling/CallParticipantsKindTests.swift
+++ b/Tests/Source/Calling/CallParticipantsKindTests.swift
@@ -48,19 +48,31 @@ class CallParticipantsKindTests: XCTestCase {
     }
     
     func testThat_RealTimeActiveSpeaker_IsActive_WhenCase_All() {
-        XCTAssertTrue(CallParticipantsListKind.all.isActive(activeSpeaker: realTimeActiveSpeaker))
+        XCTAssertEqual(
+            CallParticipantsListKind.all.stateOf(activeSpeaker: realTimeActiveSpeaker),
+            .active(audioLevelNow: 100)
+        )
     }
     
-    func testThat_RealTimeActiveSpeaker_IsNotActive_WhenCase_SmoothedActiveSpeakers() {
-        XCTAssertFalse(CallParticipantsListKind.smoothedActiveSpeakers.isActive(activeSpeaker: realTimeActiveSpeaker))
+    func testThat_RealTimeActiveSpeaker_IsInactive_WhenCase_SmoothedActiveSpeakers() {
+        XCTAssertEqual(
+            CallParticipantsListKind.smoothedActiveSpeakers.stateOf(activeSpeaker: realTimeActiveSpeaker),
+            .inactive
+        )
     }
     
-    func testThat_SmoothedActiveSpeaker_IsNotActive_WhenCase_All() {
-        XCTAssertFalse(CallParticipantsListKind.all.isActive(activeSpeaker: smoothedActiveSpeaker))
+    func testThat_SmoothedActiveSpeaker_IsInactive_WhenCase_All() {
+        XCTAssertEqual(
+            CallParticipantsListKind.all.stateOf(activeSpeaker: smoothedActiveSpeaker),
+            .inactive
+        )
     }
     
     func testThat_SmoothedActiveSpeaker_IsActive_WhenCase_SmoothedActiveSpeakers() {
-        XCTAssertTrue(CallParticipantsListKind.smoothedActiveSpeakers.isActive(activeSpeaker: smoothedActiveSpeaker))
+        XCTAssertEqual(
+            CallParticipantsListKind.smoothedActiveSpeakers.stateOf(activeSpeaker: smoothedActiveSpeaker),
+            .active(audioLevelNow: 0)
+        )
     }
 
 }

--- a/Tests/Source/Calling/CallParticipantsKindTests.swift
+++ b/Tests/Source/Calling/CallParticipantsKindTests.swift
@@ -49,29 +49,29 @@ class CallParticipantsKindTests: XCTestCase {
     
     func testThat_RealTimeActiveSpeaker_IsActive_WhenCase_All() {
         XCTAssertEqual(
-            CallParticipantsListKind.all.stateOf(activeSpeaker: realTimeActiveSpeaker),
-            .active(audioLevelNow: 100)
+            CallParticipantsListKind.all.state(ofActiveSpeaker: realTimeActiveSpeaker),
+            ActiveSpeakerState.active(audioLevelNow: 100)
         )
     }
     
     func testThat_RealTimeActiveSpeaker_IsInactive_WhenCase_SmoothedActiveSpeakers() {
         XCTAssertEqual(
-            CallParticipantsListKind.smoothedActiveSpeakers.stateOf(activeSpeaker: realTimeActiveSpeaker),
-            .inactive
+            CallParticipantsListKind.smoothedActiveSpeakers.state(ofActiveSpeaker: realTimeActiveSpeaker),
+            ActiveSpeakerState.inactive
         )
     }
     
     func testThat_SmoothedActiveSpeaker_IsInactive_WhenCase_All() {
         XCTAssertEqual(
-            CallParticipantsListKind.all.stateOf(activeSpeaker: smoothedActiveSpeaker),
-            .inactive
+            CallParticipantsListKind.all.state(ofActiveSpeaker: smoothedActiveSpeaker),
+            ActiveSpeakerState.inactive
         )
     }
     
     func testThat_SmoothedActiveSpeaker_IsActive_WhenCase_SmoothedActiveSpeakers() {
         XCTAssertEqual(
-            CallParticipantsListKind.smoothedActiveSpeakers.stateOf(activeSpeaker: smoothedActiveSpeaker),
-            .active(audioLevelNow: 0)
+            CallParticipantsListKind.smoothedActiveSpeakers.state(ofActiveSpeaker: smoothedActiveSpeaker),
+            ActiveSpeakerState.active(audioLevelNow: 0)
         )
     }
 

--- a/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -1100,7 +1100,7 @@ extension WireCallCenterV3Tests {
 
         // then
         let actual = sut.callParticipants(conversationId: oneOnOneConversationID, kind: .all)
-        let expected = [CallParticipant(user: otherUser, clientId: otherUserClientID, state: .connecting, isActiveSpeaker: false)]
+        let expected = [CallParticipant(user: otherUser, clientId: otherUserClientID, state: .connecting, activeSpeakerState: .inactive)]
         XCTAssertEqual(actual, expected)
     }
 
@@ -1125,7 +1125,7 @@ extension WireCallCenterV3Tests {
         
         // then
         let actual = sut.callParticipants(conversationId: oneOnOneConversationID, kind: .all)
-        let expected = [CallParticipant(user: otherUser, clientId: otherUserClientID, state: .connecting, isActiveSpeaker: false)]
+        let expected = [CallParticipant(user: otherUser, clientId: otherUserClientID, state: .connecting, activeSpeakerState: .inactive)]
         XCTAssertEqual(actual, expected)
     }
 
@@ -1137,7 +1137,7 @@ extension WireCallCenterV3Tests {
 
         // then
         let actual = sut.callParticipants(conversationId: groupConversationID, kind: .all)
-        let expected = [CallParticipant(user: otherUser, clientId: otherUserClientID, state: .connecting, isActiveSpeaker: false)]
+        let expected = [CallParticipant(user: otherUser, clientId: otherUserClientID, state: .connecting, activeSpeakerState: .inactive)]
         XCTAssertEqual(actual, expected)
     }
 
@@ -1154,7 +1154,7 @@ extension WireCallCenterV3Tests {
 
         // then
         var actual = sut.callParticipants(conversationId: groupConversationID, kind: .all)
-        var expected = [CallParticipant(user: otherUser, clientId: otherUserClientID, state: .connecting, isActiveSpeaker: false)]
+        var expected = [CallParticipant(user: otherUser, clientId: otherUserClientID, state: .connecting, activeSpeakerState: .inactive)]
         XCTAssertEqual(actual, expected)
 
         // when
@@ -1163,7 +1163,7 @@ extension WireCallCenterV3Tests {
 
         // then
         actual = sut.callParticipants(conversationId: groupConversationID, kind: .all)
-        expected = [CallParticipant(user: otherUser, clientId: otherUserClientID, state: .connected(videoState: .stopped, microphoneState: .unmuted), isActiveSpeaker: false)]
+        expected = [CallParticipant(user: otherUser, clientId: otherUserClientID, state: .connected(videoState: .stopped, microphoneState: .unmuted), activeSpeakerState: .inactive)]
         XCTAssertEqual(actual, expected)
     }
 }
@@ -1366,7 +1366,12 @@ extension WireCallCenterV3Tests {
         let participants = sut.callParticipants(conversationId: conversationId, kind: participantsKind, activeSpeakersLimit: limit)
         
         // THEN
-        let activeSpeakersAmount = participants.filter { $0.isActiveSpeaker }.count
+        let activeSpeakersAmount = participants.filter {
+            guard case .active = $0.activeSpeakerState else {
+                return false
+            }
+            return true
+        }.count
         assertionBlock?(participants, activeSpeakersAmount)
     }
     


### PR DESCRIPTION
## What's new in this PR?

Updated the `CallParticipant`'s property `isActiveSpeaker: Bool` into `activeSpeakerState: ActiveSpeakerState`.

This allow the `.active` case of `ActiveSpeakerState` enum to carry an associated value for the instantaneous audio level, which should be used to pulse the participant's microphone / show the active speaker frame.