### PR TITLE
[fix]: SQCORE-511 Logout is not working when switch account.

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -618,14 +618,14 @@ public final class SessionManager : NSObject, SessionManagerType {
             self.delegate?.sessionManagerDidChangeActiveUserSession(userSession: session)
             self.configureUserNotifications()
 
+            completion(session)
+            
             // If the user isn't logged in it's because they still need
             // to complete the login flow, which will be handle elsewhere.
             if session.isLoggedIn {            
                 self.delegate?.sessionManagerDidReportLockChange(forSession: session)
                 self.performPostUnlockActionsIfPossible(for: session)
             }
-            
-            completion(session)
         }
     }
 


### PR DESCRIPTION
## What's new in this PR?

for ore info about the issue see the bug ticket [here](https://wearezeta.atlassian.net/browse/SQCORE-511). Anyway this happens always, not just when the user has the maximum of the devices registered as written in the ticket.

### Causes

when we inform the `UI` with 

```swift
if session.isLoggedIn {            
      self.delegate?.sessionManagerDidReportLockChange(forSession: session)
}
```

we still didn't select the account. The account selection is done in the `completion(session)`

### Solutions

move the `completion(session)` before we inform the UI through the `delegate`. 

## Notes

I have tried many scenarios and it seems to work. Anyway it would be nice if who is reviewing this PR will think a bit if there is some edge cases on which this solution doesn't work.
