### PR TITLE
[Fix] Close the event persistence store when the EventProcessor deinits

### DIFF
--- a/Source/Synchronization/EventProcessor.swift
+++ b/Source/Synchronization/EventProcessor.swift
@@ -64,7 +64,10 @@ class EventProcessor: UpdateEventProcessor {
         self.eventDecoder = EventDecoder(eventMOC: eventContext, syncMOC: syncContext)
         self.eventProcessingTracker = eventProcessingTracker
         self.eventBuffer = ZMUpdateEventsBuffer(updateEventProcessor: self)
-        
+    }
+
+    deinit {
+        eventContext.tearDownEventMOC()
     }
     
     // MARK: Methods


### PR DESCRIPTION
## What's new in this PR?

### Issues

Tests were logging the data store was deleted while Core Data was having an open file descriptor attached to it.

### Causes

We weren't closing the persistence store when shutting down a user session. This can lead to data loss as we experienced in https://github.com/wireapp/wire-ios-data-model/pull/1071

### Solutions

Close the persistence store on deinit.

## Notes

See also https://github.com/wireapp/wire-ios-data-model/pull/1149
