### PR TITLE
[Fix] Crash after tearing down user session quickly

### DIFF
--- a/Source/SessionManager/SessionManager+Push.swift
+++ b/Source/SessionManager/SessionManager+Push.swift
@@ -144,10 +144,10 @@ extension SessionManager: PKPushRegistryDelegate {
     }
     
     public func updatePushToken(for session: ZMUserSession) {
-        session.managedObjectContext.performGroupedBlock {
+        session.managedObjectContext.performGroupedBlock { [weak session] in
             // Refresh the tokens if needed
             if let token = self.pushRegistry.pushToken(for: .voIP) {
-                session.setPushKitToken(token)
+                session?.setPushKitToken(token)
             }
         }
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

App sometimes crash if the user session is shutdown quickly after it started.

### Causes

When the user session is started we asynchronously update the push token. If the user session shut down before this asynchronous call is performed `setPushKitToken()` will be called on the torn down  user session where the managed object contexts have deallocated, which will cause a nil unwrapping crash.

### Solutions

Hold a weak reference to the user session so that we don't call `setPushKitToken()` if it has been shutdown.