### PR TITLE
[Fix] call degradation logic

### DIFF
--- a/Source/Calling/CallParticipantSnapshot.swift
+++ b/Source/Calling/CallParticipantSnapshot.swift
@@ -54,10 +54,17 @@ class CallParticipantsSnapshot {
             userVerifiedMap[zmuser] = userIsVerified
 
             if userWasVerified && !userIsVerified {
-                callCenter.callDidDegrade(conversationId: conversationId, degradedUser: zmuser)
+                guard let selfUser = selfUser else { return }
+                let degradedUser = selfUser.isTrusted ? zmuser : selfUser
+                callCenter.callDidDegrade(conversationId: conversationId, degradedUser: degradedUser)
                 break
             }
         }
+    }
+
+    private var selfUser: ZMUser? {
+        guard let moc = callCenter.uiMOC else { return nil }
+        return ZMUser.selfUser(in: moc)
     }
 
     /// Worst network quality of all the participants.

--- a/Source/Calling/CallParticipantSnapshot.swift
+++ b/Source/Calling/CallParticipantSnapshot.swift
@@ -38,22 +38,22 @@ class CallParticipantsSnapshot {
 
     private var participants = [CallParticipant]() {
         didSet {
-            updateUserTrustMap()
+            updateUserVerifiedMap()
             notifyChange()
         }
     }
 
-    private var userTrustMap = [ZMUser: Bool]()
+    private var userVerifiedMap = [ZMUser: Bool]()
 
-    private func updateUserTrustMap() {
+    private func updateUserVerifiedMap() {
         for user in participants.map(\.user) {
             let zmuser = user as! ZMUser
-            let userWasTrusted = userTrustMap[zmuser] ?? false
-            let userIsTrusted = zmuser.isTrusted
+            let userWasVerified = userVerifiedMap[zmuser] ?? false
+            let userIsVerified = zmuser.isVerified
 
-            userTrustMap[zmuser] = userIsTrusted
+            userVerifiedMap[zmuser] = userIsVerified
 
-            if userWasTrusted && !userIsTrusted {
+            if userWasVerified && !userIsVerified {
                 callCenter.callDidDegrade(conversationId: conversationId, degradedUser: zmuser)
                 break
             }

--- a/Tests/Source/Calling/CallParticipantsSnapshotTests.swift
+++ b/Tests/Source/Calling/CallParticipantsSnapshotTests.swift
@@ -31,6 +31,12 @@ class CallParticipantsSnapshotTests: MessagingTest {
     private var aliceDesktop: AVSClient!
     private var bobIphone: AVSClient!
     private var bobDesktop: AVSClient!
+    private var conversationId = UUID()
+    private var selfUser: ZMUser!
+    private var user2: ZMUser!
+    private var selfClient: UserClient!
+    private var client1: UserClient!
+    private var client2: UserClient!
 
     override func setUp() {
         super.setUp()
@@ -53,11 +59,16 @@ class CallParticipantsSnapshotTests: MessagingTest {
     override func tearDown() {
         mockFlowManager = nil
         mockWireCallCenterV3 = nil
+        selfUser = nil
+        selfClient = nil
+        user2 = nil
+        client1 = nil
+        client2 = nil
         super.tearDown()
     }
 
     private func createSut(members: [AVSCallMember]) -> Sut {
-        return Sut(conversationId: UUID(), members: members, callCenter: mockWireCallCenterV3)
+        return Sut(conversationId: conversationId, members: members, callCenter: mockWireCallCenterV3)
     }
 
     // MARK: - Duplicates
@@ -219,6 +230,93 @@ class CallParticipantsSnapshotTests: MessagingTest {
         XCTAssertEqual(sut.members.array, [updatedMember1, member2])
     }
 
+    // MARK: - Call Degradation
+
+    func testThat_ItDegradesCallSecurity_WithCorrectUser_WhenUserBecomesUnverified() {
+        // Given / When
+        setupCallSnapshot()
+        setupUsersAndClients()
+        setupDegradationTest(degradedClient: client2)
+
+        // Then
+        XCTAssertTrue(mockWireCallCenterV3.mockAVSWrapper.didCallEndCall)
+        XCTAssertEqual(mockWireCallCenterV3.callSnapshots[conversationId]!.degradedUser, user2)
+    }
+
+    func testThat_ItDegradesCallSecurity_WithSelfUser_WhenSelfUserBecomesUnverified() {
+        // Given
+        setupCallSnapshot()
+        setupUsersAndClients()
+        setupDegradationTest(degradedClient: client1)
+
+        // Then
+        XCTAssertTrue(mockWireCallCenterV3.mockAVSWrapper.didCallEndCall)
+        XCTAssertEqual(mockWireCallCenterV3.callSnapshots[conversationId]!.degradedUser, selfUser)
+    }
+
+    func setupCallSnapshot() {
+        mockWireCallCenterV3.callSnapshots[conversationId] = CallSnapshot(
+            callParticipants: CallParticipantsSnapshot(conversationId: conversationId, members: [], callCenter: mockWireCallCenterV3),
+            callState: .established,
+            callStarter: aliceIphone.userId,
+            isVideo: false,
+            isGroup: true,
+            isConstantBitRate: false,
+            videoState: .stopped,
+            networkQuality: .normal,
+            isConferenceCall: true,
+            degradedUser: nil,
+            activeSpeakers: [],
+            videoGridPresentationMode: .allVideoStreams,
+            conversationObserverToken: nil
+        )
+    }
+
+    private func setupUsersAndClients() {
+        performPretendingUiMocIsSyncMoc {
+            self.selfUser = ZMUser.selfUser(in: self.uiMOC)
+            self.selfUser.remoteIdentifier = self.aliceIphone.userId
+
+            self.selfClient = UserClient.insertNewObject(in: self.uiMOC)
+            self.selfClient.user = self.selfUser
+            self.selfClient.remoteIdentifier = self.aliceIphone.clientId
+            self.uiMOC.setPersistentStoreMetadata(self.selfClient.remoteIdentifier, key: "PersistedClientId")
+
+            self.client1 = UserClient.insertNewObject(in: self.uiMOC)
+            self.client1.user = self.selfUser
+            self.client1.remoteIdentifier = self.aliceDesktop.clientId
+
+            self.user2 = ZMUser(remoteID: self.bobIphone.userId, createIfNeeded: true, in: self.uiMOC)
+
+            self.client2 = UserClient.insertNewObject(in: self.uiMOC)
+            self.client2.user = self.user2
+            self.client2.remoteIdentifier = self.bobIphone.clientId
+
+            self.uiMOC.saveOrRollback()
+        }
+
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.2))
+    }
+
+    private func setupDegradationTest(degradedClient: UserClient) {
+        // Given / When
+        let sut = createSut(members: [])
+
+        // trust clients
+        client2.trustClient(selfClient)
+        selfClient.trustClients([client1, client2])
+
+        // Create call members
+        let member1 = AVSCallMember(client: aliceIphone, microphoneState: .unmuted)
+        let member2 = AVSCallMember(client: bobIphone, microphoneState: .unmuted)
+
+        // setup participants list
+        sut.callParticipantsChanged(participants: [member1, member2])
+
+        // When
+        selfClient.ignoreClient(degradedClient)
+        sut.callParticipantsChanged(participants: [member1, member2])
+    }
 }
 
 private extension AVSCallMember {

--- a/Tests/Source/Calling/CallParticipantsSnapshotTests.swift
+++ b/Tests/Source/Calling/CallParticipantsSnapshotTests.swift
@@ -299,7 +299,7 @@ class CallParticipantsSnapshotTests: MessagingTest {
     }
 
     private func setupDegradationTest(degradedClient: UserClient) {
-        // Given / When
+        // Given
         let sut = createSut(members: [])
 
         // trust clients


### PR DESCRIPTION
## What's new in this PR?

### Issues

Sometimes an ongoing call will be terminated with the reason `.securityDegraded` although the user did not verify any participants beforehand.

### Causes

`isTrusted` evaluates to `true` when the evaluated user's clients list is empty

### Solutions

use `isVerified` instead of `isTrusted`

