### PR TITLE
[Feature] Handling error messages when requesting new connections

### DIFF
--- a/Source/Synchronization/Transcoders/ZMConnectionTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMConnectionTranscoder.m
@@ -165,9 +165,23 @@ NSUInteger ZMConnectionTranscoderPageSize = 90;
                     [self.managedObjectContext enqueueDelayedSave];
                 }
             }
-            
             [self.managedObjectContext.zm_userInterfaceContext performGroupedBlock:^{
-                [ZMConnectionLimitNotification notifyInContext:self.managedObjectContext];
+                [ZMConnectionLimitNotification notifyLimitReachedInContext:self.managedObjectContext];
+            }];
+        }
+
+        if (response.HTTPStatus == 412 && [[response payloadLabel] isEqualToString:@"missing-legalhold-consent"])
+        {
+            if (conversationID != nil) {
+                ZMConversation *syncConversation = [self.managedObjectContext objectRegisteredForID:conversationID];
+                if (syncConversation != nil) {
+                    [self.managedObjectContext deleteObject:syncConversation];
+                    [self.managedObjectContext enqueueDelayedSave];
+                }
+            }
+
+            [self.managedObjectContext.zm_userInterfaceContext performGroupedBlock:^{
+                [ZMConnectionLimitNotification notifyMissingLegalHoldConsentInContext:self.managedObjectContext ];
             }];
         }
     }];

--- a/Source/Synchronization/Transcoders/ZMConnectionTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMConnectionTranscoder.m
@@ -166,7 +166,7 @@ NSUInteger ZMConnectionTranscoderPageSize = 90;
                 }
             }
             [self.managedObjectContext.zm_userInterfaceContext performGroupedBlock:^{
-                [ZMConnectionLimitNotification notifyLimitReachedInContext:self.managedObjectContext];
+                [ZMConnectionNotification notifyLimitReachedInContext:self.managedObjectContext];
             }];
         }
 
@@ -181,7 +181,7 @@ NSUInteger ZMConnectionTranscoderPageSize = 90;
             }
 
             [self.managedObjectContext.zm_userInterfaceContext performGroupedBlock:^{
-                [ZMConnectionLimitNotification notifyMissingLegalHoldConsentInContext:self.managedObjectContext ];
+                [ZMConnectionNotification notifyMissingLegalHoldConsentInContext:self.managedObjectContext ];
             }];
         }
     }];

--- a/Source/UserSession/NotificationInContext+UserSession.swift
+++ b/Source/UserSession/NotificationInContext+UserSession.swift
@@ -115,7 +115,7 @@ extension ZMConversation {
 }
 
 // MARK: - Connection limit reached
-@objc public protocol ZMConnectionLimitObserver: NSObjectProtocol {
+@objc public protocol ZMConnectionFailureObserver: NSObjectProtocol {
     
     func connectionLimitReached()
     func missingConnectionLegalHoldConsent()
@@ -127,14 +127,14 @@ extension ZMConversation {
     public static let limitReached = Notification.Name(rawValue: "ZMConnectionLimitReachedNotification")
     public static let missingLegalHoldConsent = Notification.Name(rawValue: "ZMConnectionMissingLegalHoldConsentNotification")
     
-    public static func addConnectionLimitObserver(_ observer: ZMConnectionLimitObserver, context: NSManagedObjectContext) -> Any {
+    public static func addConnectionLimitObserver(_ observer: ZMConnectionFailureObserver, context: NSManagedObjectContext) -> Any {
         return NotificationInContext.addObserver(name: self.limitReached, context: context.notificationContext) {
             [weak observer] _ in
             observer?.connectionLimitReached()
         }
     }
 
-    public static func addConnectionMissingLegalHoldConsentObserver(_ observer: ZMConnectionLimitObserver, context: NSManagedObjectContext) -> Any {
+    public static func addConnectionMissingLegalHoldConsentObserver(_ observer: ZMConnectionFailureObserver, context: NSManagedObjectContext) -> Any {
         return NotificationInContext.addObserver(name: self.missingLegalHoldConsent, context: context.notificationContext) {
             [weak observer] _ in
             observer?.missingConnectionLegalHoldConsent()

--- a/Source/UserSession/NotificationInContext+UserSession.swift
+++ b/Source/UserSession/NotificationInContext+UserSession.swift
@@ -124,8 +124,8 @@ extension ZMConversation {
 
 @objcMembers public class ZMConnectionLimitNotification : NSObject {
 
-    private static let limitReached = Notification.Name(rawValue: "ZMConnectionLimitReachedNotification")
-    private static let missingLegalHoldConsent = Notification.Name(rawValue: "ZMConnectionMissingLegalHoldConsentNotification")
+    public static let limitReached = Notification.Name(rawValue: "ZMConnectionLimitReachedNotification")
+    public static let missingLegalHoldConsent = Notification.Name(rawValue: "ZMConnectionMissingLegalHoldConsentNotification")
     
     public static func addConnectionLimitObserver(_ observer: ZMConnectionLimitObserver, context: NSManagedObjectContext) -> Any {
         return NotificationInContext.addObserver(name: self.limitReached, context: context.notificationContext) {

--- a/Source/UserSession/NotificationInContext+UserSession.swift
+++ b/Source/UserSession/NotificationInContext+UserSession.swift
@@ -118,23 +118,37 @@ extension ZMConversation {
 @objc public protocol ZMConnectionLimitObserver: NSObjectProtocol {
     
     func connectionLimitReached()
+    func missingConnectionLegalHoldConsent()
 }
 
 
 @objcMembers public class ZMConnectionLimitNotification : NSObject {
 
-    private static let name = Notification.Name(rawValue: "ZMConnectionLimitReachedNotification")
+    private static let limitReached = Notification.Name(rawValue: "ZMConnectionLimitReachedNotification")
+    private static let missingLegalHoldConsent = Notification.Name(rawValue: "ZMConnectionMissingLegalHoldConsentNotification")
     
     public static func addConnectionLimitObserver(_ observer: ZMConnectionLimitObserver, context: NSManagedObjectContext) -> Any {
-        return NotificationInContext.addObserver(name: self.name, context: context.notificationContext) {
+        return NotificationInContext.addObserver(name: self.limitReached, context: context.notificationContext) {
             [weak observer] _ in
             observer?.connectionLimitReached()
         }
     }
+
+    public static func addConnectionMissingLegalHoldConsentObserver(_ observer: ZMConnectionLimitObserver, context: NSManagedObjectContext) -> Any {
+        return NotificationInContext.addObserver(name: self.missingLegalHoldConsent, context: context.notificationContext) {
+            [weak observer] _ in
+            observer?.missingConnectionLegalHoldConsent()
+        }
+    }
     
-    @objc(notifyInContext:)
-    public static func notify(context: NSManagedObjectContext) {
-        NotificationInContext(name: self.name, context: context.notificationContext).post()
+    @objc(notifyLimitReachedInContext:)
+    public static func notifyLimitReached(context: NSManagedObjectContext) {
+        NotificationInContext(name: limitReached, context: context.notificationContext).post()
+    }
+
+    @objc(notifyMissingLegalHoldConsentInContext:)
+    public static func notifyMissingLegalHoldConsent(context: NSManagedObjectContext) {
+        NotificationInContext(name: missingLegalHoldConsent, context: context.notificationContext).post()
     }
 }
 

--- a/Source/UserSession/NotificationInContext+UserSession.swift
+++ b/Source/UserSession/NotificationInContext+UserSession.swift
@@ -122,7 +122,7 @@ extension ZMConversation {
 }
 
 
-@objcMembers public class ZMConnectionLimitNotification : NSObject {
+@objcMembers public class ZMConnectionNotification : NSObject {
 
     public static let limitReached = Notification.Name(rawValue: "ZMConnectionLimitReachedNotification")
     public static let missingLegalHoldConsent = Notification.Name(rawValue: "ZMConnectionMissingLegalHoldConsentNotification")

--- a/Tests/Source/Data Model/ServiceUserTests.swift
+++ b/Tests/Source/Data Model/ServiceUserTests.swift
@@ -52,6 +52,8 @@ final class DummyServiceUser: NSObject, ServiceUser {
     var teamName: String? = nil
     
     var isBlocked: Bool = false
+
+    var blockState: ZMBlockState = .none
     
     var isExpired: Bool = false
     

--- a/Tests/Source/Integration/ConnectionTests.m
+++ b/Tests/Source/Integration/ConnectionTests.m
@@ -52,10 +52,10 @@
     self = [super init];
     if  (self) {
         self.reachedConnectionLimit = NO;
-        self.connectionLimitObserverToken = [ZMConnectionLimitNotification addConnectionLimitObserver:self context:moc];
+        self.connectionLimitObserverToken = [ZMConnectionNotification addConnectionLimitObserver:self context:moc];
 
         self.missingLegalHoldConsent = NO;
-        self.missingConnectionLegalHoldConsentToken = [ZMConnectionLimitNotification addConnectionMissingLegalHoldConsentObserver:self context:moc];
+        self.missingConnectionLegalHoldConsentToken = [ZMConnectionNotification addConnectionMissingLegalHoldConsentObserver:self context:moc];
     }
     return self;
 }

--- a/Tests/Source/Integration/ConnectionTests.m
+++ b/Tests/Source/Integration/ConnectionTests.m
@@ -28,7 +28,7 @@
 // TestObserver
 ///
 
-@interface MockConnectionLimitObserver : NSObject <ZMConnectionLimitObserver>
+@interface MockConnectionLimitObserver : NSObject <ZMConnectionFailureObserver>
 
 @property (nonatomic) id connectionLimitObserverToken;
 @property (nonatomic) id missingConnectionLegalHoldConsentToken;

--- a/Tests/Source/Integration/ConnectionTests.m
+++ b/Tests/Source/Integration/ConnectionTests.m
@@ -31,7 +31,9 @@
 @interface MockConnectionLimitObserver : NSObject <ZMConnectionLimitObserver>
 
 @property (nonatomic) id connectionLimitObserverToken;
+@property (nonatomic) id missingConnectionLegalHoldConsentToken;
 @property (nonatomic) BOOL reachedConnectionLimit;
+@property (nonatomic) BOOL missingLegalHoldConsent;
 
 @end
 
@@ -42,11 +44,18 @@
     self.reachedConnectionLimit = YES;
 }
 
+- (void)missingConnectionLegalHoldConsent {
+    self.missingLegalHoldConsent = YES;
+}
+
 - (instancetype)initWithManagedObjectContext:(NSManagedObjectContext *)moc {
     self = [super init];
     if  (self) {
         self.reachedConnectionLimit = NO;
         self.connectionLimitObserverToken = [ZMConnectionLimitNotification addConnectionLimitObserver:self context:moc];
+
+        self.missingLegalHoldConsent = NO;
+        self.missingConnectionLegalHoldConsentToken = [ZMConnectionLimitNotification addConnectionMissingLegalHoldConsentObserver:self context:moc];
     }
     return self;
 }
@@ -1011,6 +1020,61 @@
     
     // then
     XCTAssertTrue(observer.reachedConnectionLimit);
+}
+
+#pragma mark - MissingLegalHoldConsent
+
+- (ZMCustomResponseGeneratorBlock)responseBlockForMissingLegalHoldConsent;
+{
+    return ^ZMTransportResponse *(ZMTransportRequest *request) {
+        if (![request.path hasPrefix:@"/connections"] || (request.method == ZMMethodGET)) {
+            return nil;
+        }
+        NSDictionary *payload = @{@"label": @"missing-legalhold-consent"};
+        return [[ZMTransportResponse alloc] initWithPayload:payload HTTPStatus:412 transportSessionError:nil headers:nil];
+    };
+
+}
+
+- (void)testThatItDeletesTheConversationWhenConnectionIsRejectedByBackend_MissingLegalHoldConsent
+{
+    // given
+    NSString *searchUserName = @"Karl McUser";
+    [self createUserWithName:searchUserName uuid:NSUUID.createUUID];
+
+    self.mockTransportSession.responseGeneratorBlock = self.responseBlockForMissingLegalHoldConsent;
+
+    XCTAssertTrue([self login]);
+    ZMConversationList *conversations = [ZMConversationList conversationsInUserSession:self.userSession];
+    NSUInteger beforeInsertingCount = conversations.count;
+
+    // when
+    [self searchAndConnectToUserWithName:searchUserName searchQuery:@"McUser"];
+    [self.mockTransportSession waitForAllRequestsToCompleteWithTimeout:0.5];
+
+    // then
+    XCTAssertEqual(conversations.count, beforeInsertingCount);
+}
+
+- (void)testThatItNotifiesObserversAboutMissingLegalHoldConsentWhenInsertingAnObject
+{
+    // given
+    NSString *searchUserName = @"Karl McUser";
+    NSUUID *userID = [NSUUID createUUID];
+    [self createUserWithName:searchUserName uuid:userID];
+
+    self.mockTransportSession.responseGeneratorBlock = self.responseBlockForMissingLegalHoldConsent;
+
+    XCTAssertTrue([self login]);
+    MockConnectionLimitObserver *observer = [[MockConnectionLimitObserver alloc] initWithManagedObjectContext:self.userSession.managedObjectContext];
+    XCTAssertFalse(observer.missingLegalHoldConsent);
+
+    // when
+    [self searchAndConnectToUserWithName:searchUserName searchQuery:@"McUser"];
+    [self.mockTransportSession waitForAllRequestsToCompleteWithTimeout:0.5];
+
+    // then
+    XCTAssertTrue(observer.missingLegalHoldConsent);
 }
 
 - (void)testThatItResetsTheConversationWhenAConnectionStatusChangeFromPendingToAcceptedIsRejectedByTheBackend


### PR DESCRIPTION
## What's new in this PR?

BE will add `error code 412` in response to posting a new connection if it's a legal hold policy conflict.
When we receive this error code, we should notify the UI project and display an alert with a message.