### PR TITLE
[Feature] Handling error messages when adding new conversation

### DIFF
--- a/Source/UserSession/NotificationInContext+UserSession.swift
+++ b/Source/UserSession/NotificationInContext+UserSession.swift
@@ -114,6 +114,18 @@ extension ZMConversation {
     func typingDidChange(conversation: ZMConversation, typingUsers: [UserType])
 }
 
+// MARK: Add conversation
+@objc extension ZMConversation {
+
+    public static let conversationMissingLegalHoldConsent = Notification.Name(rawValue: "ZMConversationMissingLegalHoldConsentNotification")
+
+    @objc(notifyMissingLegalHoldConsentInContext:)
+    public static func notifyMissingLegalHoldConsent(context: NSManagedObjectContext) {
+        NotificationInContext(name: conversationMissingLegalHoldConsent, context: context.notificationContext).post()
+    }
+
+}
+
 // MARK: - Connection limit reached
 @objc public protocol ZMConnectionFailureObserver: NSObjectProtocol {
     

--- a/Source/UserSession/NotificationInContext+UserSession.swift
+++ b/Source/UserSession/NotificationInContext+UserSession.swift
@@ -117,11 +117,11 @@ extension ZMConversation {
 // MARK: Add conversation
 @objc extension ZMConversation {
 
-    public static let conversationMissingLegalHoldConsent = Notification.Name(rawValue: "ZMConversationMissingLegalHoldConsentNotification")
+    public static let missingLegalHoldConsentNotificationName = Notification.Name(rawValue: "ZMConversationMissingLegalHoldConsentNotification")
 
     @objc(notifyMissingLegalHoldConsentInContext:)
     public static func notifyMissingLegalHoldConsent(context: NSManagedObjectContext) {
-        NotificationInContext(name: conversationMissingLegalHoldConsent, context: context.notificationContext).post()
+        NotificationInContext(name: missingLegalHoldConsentNotificationName, context: context.notificationContext).post()
     }
 
 }


### PR DESCRIPTION
## What's new in this PR?

BE will add error code `412` in response to posting a new conversation if there is a legal hold policy conflict.
When we receive this error code, we should notify the UI project and display an alert with a message.

TODO: I haven't added any tests, but if you don't mind I'll add them later