### PR TITLE
[Fix] Update capabilities for new clients

### DIFF
--- a/Source/Synchronization/ZMHotFixDirectory.m
+++ b/Source/Synchronization/ZMHotFixDirectory.m
@@ -209,7 +209,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"HotFix";
                      }],
                     /// We need to set implicit legalhold consent capability for the SelfClient
                     [ZMHotFixPatch
-                     patchWithVersion:@"381.0.0"
+                     patchWithVersion:@"381.1.0"
                      patchCode:^(NSManagedObjectContext *context){
                          [ZMHotFixDirectory updateClientCapabilities:context];
                      }],

--- a/Source/Synchronization/ZMHotFixDirectory.m
+++ b/Source/Synchronization/ZMHotFixDirectory.m
@@ -209,7 +209,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"HotFix";
                      }],
                     /// We need to set implicit legalhold consent capability for the SelfClient
                     [ZMHotFixPatch
-                     patchWithVersion:@"381.1.0"
+                     patchWithVersion:@"381.0.1"
                      patchCode:^(NSManagedObjectContext *context){
                          [ZMHotFixDirectory updateClientCapabilities:context];
                      }],

--- a/Source/UserSession/ZMUserSession.swift
+++ b/Source/UserSession/ZMUserSession.swift
@@ -557,6 +557,7 @@ extension ZMUserSession: ZMSyncStateDelegate {
         // The push token can only be registered after client registration
         transportSession.pushChannel.clientID = userClient.remoteIdentifier
         registerCurrentPushToken()
+        UserClient.triggerSelfClientCapabilityUpdate(syncContext)
         
         managedObjectContext.performGroupedBlock { [weak self] in
             guard let accountId = self?.managedObjectContext.selfUserId else {

--- a/Tests/Source/Integration/SlowSyncTests.m
+++ b/Tests/Source/Integration/SlowSyncTests.m
@@ -203,13 +203,18 @@
             [mutableRequests removeObject:request];
             clientRegistrationCallCount++;
         }
+
+        if ([request.path containsString:@"clients"] && request.method == ZMMethodPUT) {
+            [mutableRequests removeObject:request];
+            clientRegistrationCallCount++;
+        }
         
         if ([request.path hasPrefix:@"/notifications?size=500"]) {
             [mutableRequests removeObject:request];
             notificationStreamCallCount++;
         }
     }];
-    XCTAssertEqual(clientRegistrationCallCount, 1u);
+    XCTAssertEqual(clientRegistrationCallCount, 2u);
     XCTAssertEqual(notificationStreamCallCount, 1u);
     
     AssertArraysContainsSameObjects(expectedRequests, mutableRequests);

--- a/Tests/Source/Synchronization/ZMHotFixTests.swift
+++ b/Tests/Source/Synchronization/ZMHotFixTests.swift
@@ -191,7 +191,7 @@ class ZMHotFixTests_Integration: MessagingTest {
             // WHEN
             let sut = ZMHotFix(syncMOC: self.syncMOC)
             self.performIgnoringZMLogError {
-                sut!.applyPatches(forCurrentVersion: "381.1.0")
+                sut!.applyPatches(forCurrentVersion: "381.0.1")
             }
         }
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))

--- a/Tests/Source/Synchronization/ZMHotFixTests.swift
+++ b/Tests/Source/Synchronization/ZMHotFixTests.swift
@@ -191,7 +191,7 @@ class ZMHotFixTests_Integration: MessagingTest {
             // WHEN
             let sut = ZMHotFix(syncMOC: self.syncMOC)
             self.performIgnoringZMLogError {
-                sut!.applyPatches(forCurrentVersion: "381.0.0")
+                sut!.applyPatches(forCurrentVersion: "381.1.0")
             }
         }
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))


### PR DESCRIPTION
## What's new in this PR?

- Update capabilities `"capabilities": ["legalhold-implicit-consent"]` after registration for all new clients
- Change a HotFixPatch version