### PR TITLE
Fix: remove LoginCredentials.dictionaryRepresentation @objc signature

### DIFF
--- a/Source/Synchronization/Strategies/UserClientRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/UserClientRequestStrategy.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
+// Copyright (C) 2021 Wire Swiss GmbH
 // 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/Source/Synchronization/Strategies/UserClientRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/UserClientRequestStrategy.swift
@@ -252,7 +252,7 @@ public final class UserClientRequestStrategy: ZMObjectSyncStrategy, ZMObjectStra
         else {
             //first we try to register without password (credentials can be there, but they can not contain password)
             //if there is no password in credentials but it's required, we will recieve error from backend and only then will ask for password
-            let error = self.errorFromFailedInsertResponse(response)
+            let error = errorFromFailedInsertResponse(response)
             if error.code == Int(ZMUserSessionErrorCode.canNotRegisterMoreClients.rawValue) {
                 clientUpdateStatus?.needsToFetchClients(andVerifySelfClient: false)
             }

--- a/Source/UserSession/PreLoginAuthenticationNotification.swift
+++ b/Source/UserSession/PreLoginAuthenticationNotification.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2017 Wire Swiss GmbH
+// Copyright (C) 2021 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/Source/UserSession/PreLoginAuthenticationNotification.swift
+++ b/Source/UserSession/PreLoginAuthenticationNotification.swift
@@ -34,7 +34,7 @@ extension ZMUser {
 extension LoginCredentials {
 
     /// This will be used to set user info on the NSError
-    @objc public var dictionaryRepresentation: [String: Any] {
+    public var dictionaryRepresentation: [String: Any] {
         var userInfo: [String: Any] = [:]
         userInfo[ZMUserLoginCredentialsKey] = self
         userInfo[ZMUserHasPasswordKey] = hasPassword

--- a/Source/UserSession/ZMClientRegistrationStatus.h
+++ b/Source/UserSession/ZMClientRegistrationStatus.h
@@ -64,7 +64,7 @@ extern NSString *const ZMPersistedClientIdKey;
 
 - (void)didFetchSelfUser;
 - (void)didRegisterClient:(UserClient *)client;
-- (void)didFailToRegisterClient:(NSError *)error;
+//- (void)didFailToRegisterClient:(NSError *)error;
 
 - (void)didDetectCurrentClientDeletion;
 - (BOOL)clientIsReadyForRequests;
@@ -74,5 +74,10 @@ extern NSString *const ZMPersistedClientIdKey;
 @property (nonatomic, readonly) ZMPersistentCookieStorage *cookieStorage;
 @property (nonatomic, readonly) ZMClientRegistrationPhase currentPhase;
 @property (nonatomic) ZMEmailCredentials *emailCredentials;
+
+@property (nonatomic) NSManagedObjectContext *managedObjectContext;
+@property (nonatomic, weak) id <ZMClientRegistrationStatusDelegate> registrationStatusDelegate;
+@property (nonatomic) BOOL needsToCheckCredentials;
+@property (nonatomic) BOOL isWaitingForUserClients;
 
 @end

--- a/Source/UserSession/ZMClientRegistrationStatus.h
+++ b/Source/UserSession/ZMClientRegistrationStatus.h
@@ -64,7 +64,6 @@ extern NSString *const ZMPersistedClientIdKey;
 
 - (void)didFetchSelfUser;
 - (void)didRegisterClient:(UserClient *)client;
-//- (void)didFailToRegisterClient:(NSError *)error;
 
 - (void)didDetectCurrentClientDeletion;
 - (BOOL)clientIsReadyForRequests;

--- a/Source/UserSession/ZMClientRegistrationStatus.m
+++ b/Source/UserSession/ZMClientRegistrationStatus.m
@@ -301,39 +301,6 @@ static NSString *ZMLogTag ZM_UNUSED = @"Authentication";
     }
 }
 
-//- (void)didFailToRegisterClient:(NSError *)error
-//{
-//    ZMLogDebug(@"%@", NSStringFromSelector(_cmd));
-//    //we should not reset login state for client registration errors
-//    if (error.code != ZMUserSessionNeedsPasswordToRegisterClient &&
-//        error.code != ZMUserSessionNeedsToRegisterEmailToRegisterClient &&
-//        error.code != ZMUserSessionCanNotRegisterMoreClients)
-//    {
-//        self.emailCredentials = nil;
-//    }
-//    
-//    if (error.code == ZMUserSessionNeedsPasswordToRegisterClient) {
-//        // help the user by providing the email associated with this account
-//        error = [NSError errorWithDomain:error.domain code:error.code userInfo:[ZMUser selfUserInContext:self.managedObjectContext].loginCredentials.dictionaryRepresentation];
-//    }
-//    
-//    if (error.code == ZMUserSessionNeedsPasswordToRegisterClient ||
-//        error.code == ZMUserSessionInvalidCredentials)
-//    {
-//        // set this label to block additional requests while we are waiting for the user to (re-)enter the password
-//        self.needsToCheckCredentials = YES;
-//    }
-//    
-//    if (error.code == ZMUserSessionCanNotRegisterMoreClients) {
-//        // Wait and fetch the clients before sending the error
-//        self.isWaitingForUserClients = YES;
-//        [ZMRequestAvailableNotification notifyNewRequestsAvailable:self];
-//    }
-//    else {
-//        [self.registrationStatusDelegate didFailToRegisterSelfUserClient:error];
-//    }
-//}
-
 - (void)notifyEmailIsNecessary
 {
     NSError *emailMissingError = [[NSError alloc] initWithDomain:NSError.ZMUserSessionErrorDomain

--- a/Source/UserSession/ZMClientRegistrationStatus.m
+++ b/Source/UserSession/ZMClientRegistrationStatus.m
@@ -377,16 +377,6 @@ static NSString *ZMLogTag ZM_UNUSED = @"Authentication";
     [self.managedObjectContext saveOrRollback];
 }
 
-//- (void)invalidateCookieAndNotify
-//{
-//    self.emailCredentials = nil;
-//    [self.cookieStorage deleteKeychainItems];
-//
-//    ZMUser *selfUser = [ZMUser selfUserInContext:self.managedObjectContext];
-//    NSError *outError = [NSError userSessionErrorWithErrorCode:ZMUserSessionClientDeletedRemotely userInfo:selfUser.loginCredentials.dictionaryRepresentation];
-//    [self.registrationStatusDelegate didDeleteSelfUserClient:outError];
-//}
-
 - (void)didDeleteClient
 {
     if (self.isWaitingForClientsToBeDeleted) {

--- a/Source/UserSession/ZMClientRegistrationStatus.m
+++ b/Source/UserSession/ZMClientRegistrationStatus.m
@@ -32,14 +32,10 @@ static NSString *ZMLogTag ZM_UNUSED = @"Authentication";
 
 @interface ZMClientRegistrationStatus ()
 
-@property (nonatomic) NSManagedObjectContext *managedObjectContext;
 @property (nonatomic) BOOL isWaitingForClientsToBeDeleted;
-@property (nonatomic) BOOL isWaitingForUserClients;
 @property (nonatomic) BOOL isWaitingForCredentials;
-@property (nonatomic) BOOL needsToCheckCredentials;
 @property (nonatomic) BOOL needsToVerifySelfClient;
 
-@property (nonatomic, weak) id <ZMClientRegistrationStatusDelegate> registrationStatusDelegate;
 @property (nonatomic) ZMPersistentCookieStorage *cookieStorage;
 
 @property (nonatomic) id clientUpdateToken;
@@ -305,38 +301,38 @@ static NSString *ZMLogTag ZM_UNUSED = @"Authentication";
     }
 }
 
-- (void)didFailToRegisterClient:(NSError *)error
-{
-    ZMLogDebug(@"%@", NSStringFromSelector(_cmd));
-    //we should not reset login state for client registration errors
-    if (error.code != ZMUserSessionNeedsPasswordToRegisterClient &&
-        error.code != ZMUserSessionNeedsToRegisterEmailToRegisterClient &&
-        error.code != ZMUserSessionCanNotRegisterMoreClients)
-    {
-        self.emailCredentials = nil;
-    }
-    
-    if (error.code == ZMUserSessionNeedsPasswordToRegisterClient) {
-        // help the user by providing the email associated with this account
-        error = [NSError errorWithDomain:error.domain code:error.code userInfo:[ZMUser selfUserInContext:self.managedObjectContext].loginCredentials.dictionaryRepresentation];
-    }
-    
-    if (error.code == ZMUserSessionNeedsPasswordToRegisterClient ||
-        error.code == ZMUserSessionInvalidCredentials)
-    {
-        // set this label to block additional requests while we are waiting for the user to (re-)enter the password
-        self.needsToCheckCredentials = YES;
-    }
-    
-    if (error.code == ZMUserSessionCanNotRegisterMoreClients) {
-        // Wait and fetch the clients before sending the error
-        self.isWaitingForUserClients = YES;
-        [ZMRequestAvailableNotification notifyNewRequestsAvailable:self];
-    }
-    else {
-        [self.registrationStatusDelegate didFailToRegisterSelfUserClient:error];
-    }
-}
+//- (void)didFailToRegisterClient:(NSError *)error
+//{
+//    ZMLogDebug(@"%@", NSStringFromSelector(_cmd));
+//    //we should not reset login state for client registration errors
+//    if (error.code != ZMUserSessionNeedsPasswordToRegisterClient &&
+//        error.code != ZMUserSessionNeedsToRegisterEmailToRegisterClient &&
+//        error.code != ZMUserSessionCanNotRegisterMoreClients)
+//    {
+//        self.emailCredentials = nil;
+//    }
+//    
+//    if (error.code == ZMUserSessionNeedsPasswordToRegisterClient) {
+//        // help the user by providing the email associated with this account
+//        error = [NSError errorWithDomain:error.domain code:error.code userInfo:[ZMUser selfUserInContext:self.managedObjectContext].loginCredentials.dictionaryRepresentation];
+//    }
+//    
+//    if (error.code == ZMUserSessionNeedsPasswordToRegisterClient ||
+//        error.code == ZMUserSessionInvalidCredentials)
+//    {
+//        // set this label to block additional requests while we are waiting for the user to (re-)enter the password
+//        self.needsToCheckCredentials = YES;
+//    }
+//    
+//    if (error.code == ZMUserSessionCanNotRegisterMoreClients) {
+//        // Wait and fetch the clients before sending the error
+//        self.isWaitingForUserClients = YES;
+//        [ZMRequestAvailableNotification notifyNewRequestsAvailable:self];
+//    }
+//    else {
+//        [self.registrationStatusDelegate didFailToRegisterSelfUserClient:error];
+//    }
+//}
 
 - (void)notifyEmailIsNecessary
 {
@@ -414,15 +410,15 @@ static NSString *ZMLogTag ZM_UNUSED = @"Authentication";
     [self.managedObjectContext saveOrRollback];
 }
 
-- (void)invalidateCookieAndNotify
-{
-    self.emailCredentials = nil;
-    [self.cookieStorage deleteKeychainItems];
-
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.managedObjectContext];
-    NSError *outError = [NSError userSessionErrorWithErrorCode:ZMUserSessionClientDeletedRemotely userInfo:selfUser.loginCredentials.dictionaryRepresentation];
-    [self.registrationStatusDelegate didDeleteSelfUserClient:outError];
-}
+//- (void)invalidateCookieAndNotify
+//{
+//    self.emailCredentials = nil;
+//    [self.cookieStorage deleteKeychainItems];
+//
+//    ZMUser *selfUser = [ZMUser selfUserInContext:self.managedObjectContext];
+//    NSError *outError = [NSError userSessionErrorWithErrorCode:ZMUserSessionClientDeletedRemotely userInfo:selfUser.loginCredentials.dictionaryRepresentation];
+//    [self.registrationStatusDelegate didDeleteSelfUserClient:outError];
+//}
 
 - (void)didDeleteClient
 {

--- a/Source/UserSession/ZMClientRegistrationStatus.swift
+++ b/Source/UserSession/ZMClientRegistrationStatus.swift
@@ -1,0 +1,54 @@
+//
+//  ZMClientRegistrationStatus.swift
+//  WireSyncEngine-ios
+//
+//  Created by Bill, Yiu Por Chan on 03.06.21.
+//  Copyright © 2021 Zeta Project Gmbh. All rights reserved.
+//
+
+import Foundation
+
+extension ZMClientRegistrationStatus {
+    func didFail(toRegisterClient error: NSError?) {
+        var error = error
+        ///TODO:
+//        ZMLogDebug("%@", NSStringFromSelector(#function))
+        //we should not reset login state for client registration errors
+        
+        
+        
+        if let errorCode = error?.code,
+           errorCode != ZMUserSessionErrorCode.needsPasswordToRegisterClient.rawValue && errorCode != ZMUserSessionErrorCode.needsToRegisterEmailToRegisterClient.rawValue && errorCode != ZMUserSessionErrorCode.canNotRegisterMoreClients.rawValue {
+            emailCredentials = nil
+        }
+
+        if let errorCode = error?.code,
+           errorCode == ZMUserSessionErrorCode.needsPasswordToRegisterClient.rawValue {
+            // help the user by providing the email associated with this account
+            error = NSError(domain: (error as NSError?)?.domain ?? "", code: errorCode, userInfo: ZMUser.selfUser(in: managedObjectContext).loginCredentials.dictionaryRepresentation)
+        }
+
+        if let errorCode = error?.code, errorCode == ZMUserSessionErrorCode.needsPasswordToRegisterClient.rawValue || errorCode == ZMUserSessionErrorCode.invalidCredentials.rawValue {
+            // set this label to block additional requests while we are waiting for the user to (re-)enter the password
+            needsToCheckCredentials = true
+        }
+
+        if let errorCode = error?.code, errorCode == ZMUserSessionErrorCode.canNotRegisterMoreClients.rawValue {
+            // Wait and fetch the clients before sending the error
+            isWaitingForUserClients = true
+            RequestAvailableNotification.notifyNewRequestsAvailable(self)
+        } else {
+            registrationStatusDelegate.didFailToRegisterSelfUserClient(error: error)
+        }
+    }
+    
+    @objc
+    public func invalidateCookieAndNotify() {
+        emailCredentials = nil
+        cookieStorage.deleteKeychainItems()
+
+        let selfUser = ZMUser.selfUser(in: managedObjectContext)
+        let outError = NSError.userSessionErrorWith(ZMUserSessionErrorCode.clientDeletedRemotely, userInfo: selfUser.loginCredentials.dictionaryRepresentation)
+        registrationStatusDelegate.didDeleteSelfUserClient(error: outError)
+    }
+}

--- a/Source/UserSession/ZMClientRegistrationStatus.swift
+++ b/Source/UserSession/ZMClientRegistrationStatus.swift
@@ -8,14 +8,13 @@
 
 import Foundation
 
+private let zmLog = ZMSLog(tag: "ZMClientRegistrationStatus")
+
 extension ZMClientRegistrationStatus {
     func didFail(toRegisterClient error: NSError?) {
         var error = error
-        ///TODO:
-//        ZMLogDebug("%@", NSStringFromSelector(#function))
         //we should not reset login state for client registration errors
-        
-        
+        zmLog.debug(#function)
         
         if let errorCode = error?.code,
            errorCode != ZMUserSessionErrorCode.needsPasswordToRegisterClient.rawValue && errorCode != ZMUserSessionErrorCode.needsToRegisterEmailToRegisterClient.rawValue && errorCode != ZMUserSessionErrorCode.canNotRegisterMoreClients.rawValue {
@@ -28,12 +27,14 @@ extension ZMClientRegistrationStatus {
             error = NSError(domain: (error as NSError?)?.domain ?? "", code: errorCode, userInfo: ZMUser.selfUser(in: managedObjectContext).loginCredentials.dictionaryRepresentation)
         }
 
-        if let errorCode = error?.code, errorCode == ZMUserSessionErrorCode.needsPasswordToRegisterClient.rawValue || errorCode == ZMUserSessionErrorCode.invalidCredentials.rawValue {
+        if let errorCode = error?.code,
+           errorCode == ZMUserSessionErrorCode.needsPasswordToRegisterClient.rawValue || errorCode == ZMUserSessionErrorCode.invalidCredentials.rawValue {
             // set this label to block additional requests while we are waiting for the user to (re-)enter the password
             needsToCheckCredentials = true
         }
 
-        if let errorCode = error?.code, errorCode == ZMUserSessionErrorCode.canNotRegisterMoreClients.rawValue {
+        if let errorCode = error?.code,
+           errorCode == ZMUserSessionErrorCode.canNotRegisterMoreClients.rawValue {
             // Wait and fetch the clients before sending the error
             isWaitingForUserClients = true
             RequestAvailableNotification.notifyNewRequestsAvailable(self)

--- a/Source/UserSession/ZMClientRegistrationStatus.swift
+++ b/Source/UserSession/ZMClientRegistrationStatus.swift
@@ -24,9 +24,9 @@ extension ZMClientRegistrationStatus {
     @objc(didFailToRegisterClient:)
     public func didFail(toRegisterClient error: NSError?) {
         var error = error
+        //we should not reset login state for client registration errors
         zmLog.debug(#function)
         
-        //we should not reset login state for client registration errors
         if let errorCode = error?.code,
            errorCode != ZMUserSessionErrorCode.needsPasswordToRegisterClient.rawValue && errorCode != ZMUserSessionErrorCode.needsToRegisterEmailToRegisterClient.rawValue && errorCode != ZMUserSessionErrorCode.canNotRegisterMoreClients.rawValue {
             emailCredentials = nil
@@ -35,7 +35,7 @@ extension ZMClientRegistrationStatus {
         if let errorCode = error?.code,
            errorCode == ZMUserSessionErrorCode.needsPasswordToRegisterClient.rawValue {
             // help the user by providing the email associated with this account
-            error = NSError(domain: error?.domain ?? "", code: errorCode, userInfo: ZMUser.selfUser(in: managedObjectContext).loginCredentials.dictionaryRepresentation)
+            error = NSError(domain: (error as NSError?)?.domain ?? "", code: errorCode, userInfo: ZMUser.selfUser(in: managedObjectContext).loginCredentials.dictionaryRepresentation)
         }
 
         if let errorCode = error?.code,

--- a/Source/UserSession/ZMClientRegistrationStatus.swift
+++ b/Source/UserSession/ZMClientRegistrationStatus.swift
@@ -37,12 +37,12 @@ extension ZMClientRegistrationStatus {
             errorForDelegate = NSError(domain: error.domain, code: error.code, userInfo: ZMUser.selfUser(in: managedObjectContext).loginCredentials.dictionaryRepresentation)
         }
 
-        if error.code == ZMUserSessionErrorCode.needsPasswordToRegisterClient.rawValue || error.code == ZMUserSessionErrorCode.invalidCredentials.rawValue {
+        if errorForDelegate.code == ZMUserSessionErrorCode.needsPasswordToRegisterClient.rawValue || errorForDelegate.code == ZMUserSessionErrorCode.invalidCredentials.rawValue {
             // set this label to block additional requests while we are waiting for the user to (re-)enter the password
             needsToCheckCredentials = true
         }
 
-        if error.code == ZMUserSessionErrorCode.canNotRegisterMoreClients.rawValue {
+        if errorForDelegate.code == ZMUserSessionErrorCode.canNotRegisterMoreClients.rawValue {
             // Wait and fetch the clients before sending the error
             isWaitingForUserClients = true
             RequestAvailableNotification.notifyNewRequestsAvailable(self)

--- a/Source/UserSession/ZMClientRegistrationStatus.swift
+++ b/Source/UserSession/ZMClientRegistrationStatus.swift
@@ -50,7 +50,7 @@ extension ZMClientRegistrationStatus {
             isWaitingForUserClients = true
             RequestAvailableNotification.notifyNewRequestsAvailable(self)
         } else {
-            registrationStatusDelegate.didFailToRegisterSelfUserClient(error: error)
+            registrationStatusDelegate?.didFailToRegisterSelfUserClient(error: error)
         }
     }
     
@@ -61,6 +61,6 @@ extension ZMClientRegistrationStatus {
 
         let selfUser = ZMUser.selfUser(in: managedObjectContext)
         let outError = NSError.userSessionErrorWith(ZMUserSessionErrorCode.clientDeletedRemotely, userInfo: selfUser.loginCredentials.dictionaryRepresentation)
-        registrationStatusDelegate.didDeleteSelfUserClient(error: outError)
+        registrationStatusDelegate?.didDeleteSelfUserClient(error: outError)
     }
 }

--- a/Source/UserSession/ZMClientRegistrationStatus.swift
+++ b/Source/UserSession/ZMClientRegistrationStatus.swift
@@ -22,30 +22,27 @@ private let zmLog = ZMSLog(tag: "ZMClientRegistrationStatus")
 
 extension ZMClientRegistrationStatus {
     @objc(didFailToRegisterClient:)
-    public func didFail(toRegisterClient error: NSError?) {
-        var error = error
-        //we should not reset login state for client registration errors
+    public func didFail(toRegisterClient error: NSError) {
         zmLog.debug(#function)
         
-        if let errorCode = error?.code,
-           errorCode != ZMUserSessionErrorCode.needsPasswordToRegisterClient.rawValue && errorCode != ZMUserSessionErrorCode.needsToRegisterEmailToRegisterClient.rawValue && errorCode != ZMUserSessionErrorCode.canNotRegisterMoreClients.rawValue {
+        var error: NSError = error
+
+        //we should not reset login state for client registration errors
+        if error.code != ZMUserSessionErrorCode.needsPasswordToRegisterClient.rawValue && error.code != ZMUserSessionErrorCode.needsToRegisterEmailToRegisterClient.rawValue && error.code != ZMUserSessionErrorCode.canNotRegisterMoreClients.rawValue {
             emailCredentials = nil
         }
-
-        if let errorCode = error?.code,
-           errorCode == ZMUserSessionErrorCode.needsPasswordToRegisterClient.rawValue {
+        
+        if error.code == ZMUserSessionErrorCode.needsPasswordToRegisterClient.rawValue {
             // help the user by providing the email associated with this account
-            error = NSError(domain: (error as NSError?)?.domain ?? "", code: errorCode, userInfo: ZMUser.selfUser(in: managedObjectContext).loginCredentials.dictionaryRepresentation)
+            error = NSError(domain: error.domain, code: error.code, userInfo: ZMUser.selfUser(in: managedObjectContext).loginCredentials.dictionaryRepresentation)
         }
 
-        if let errorCode = error?.code,
-           errorCode == ZMUserSessionErrorCode.needsPasswordToRegisterClient.rawValue || errorCode == ZMUserSessionErrorCode.invalidCredentials.rawValue {
+        if error.code == ZMUserSessionErrorCode.needsPasswordToRegisterClient.rawValue || error.code == ZMUserSessionErrorCode.invalidCredentials.rawValue {
             // set this label to block additional requests while we are waiting for the user to (re-)enter the password
             needsToCheckCredentials = true
         }
 
-        if let errorCode = error?.code,
-           errorCode == ZMUserSessionErrorCode.canNotRegisterMoreClients.rawValue {
+        if error.code == ZMUserSessionErrorCode.canNotRegisterMoreClients.rawValue {
             // Wait and fetch the clients before sending the error
             isWaitingForUserClients = true
             RequestAvailableNotification.notifyNewRequestsAvailable(self)

--- a/Source/UserSession/ZMClientRegistrationStatus.swift
+++ b/Source/UserSession/ZMClientRegistrationStatus.swift
@@ -1,9 +1,19 @@
 //
-//  ZMClientRegistrationStatus.swift
-//  WireSyncEngine-ios
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
 //
-//  Created by Bill, Yiu Por Chan on 03.06.21.
-//  Copyright © 2021 Zeta Project Gmbh. All rights reserved.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
 import Foundation
@@ -11,7 +21,8 @@ import Foundation
 private let zmLog = ZMSLog(tag: "ZMClientRegistrationStatus")
 
 extension ZMClientRegistrationStatus {
-    func didFail(toRegisterClient error: NSError?) {
+    @objc(didFailToRegisterClient:)
+    public func didFail(toRegisterClient error: NSError?) {
         var error = error
         //we should not reset login state for client registration errors
         zmLog.debug(#function)

--- a/Tests/Source/UserSession/ZMClientRegistrationStatusTests.h
+++ b/Tests/Source/UserSession/ZMClientRegistrationStatusTests.h
@@ -1,29 +1,27 @@
-// 
+//
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
-// 
+// Copyright (C) 2021 Wire Swiss GmbH
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
+//
 
+@interface ZMClientRegistrationStatusTests : MessagingTest
 
-#import <WireSyncEngine/WireSyncEngine.h>
-#import "MessagingTest.h"
-#import "ObjectTranscoderTests.h"
-#import "ZMUserSessionTestsBase.h"
-#import "MessagingTest+EventFactory.h"
-#import "ConversationTestsBase.h"
-#import "CallKitDelegateTests+Mocking.h"
-#import "IntegrationTest.h"
-#import "APNSTestsBase.h"
-#import "ZMClientRegistrationStatusTests.h"
+@property (nonatomic) ZMClientRegistrationStatus *sut;
+@property (nonatomic) id mockCookieStorage;
+@property (nonatomic) id mockClientRegistrationDelegate;
+@property (nonatomic) id sessionToken;
+
+- (NSError *)tooManyClientsError;
+@end

--- a/Tests/Source/UserSession/ZMClientRegistrationStatusTests.m
+++ b/Tests/Source/UserSession/ZMClientRegistrationStatusTests.m
@@ -55,16 +55,6 @@
 @end
 
 
-@interface ZMClientRegistrationStatusTests : MessagingTest
-
-@property (nonatomic) ZMClientRegistrationStatus *sut;
-@property (nonatomic) id mockCookieStorage;
-@property (nonatomic) id mockClientRegistrationDelegate;
-@property (nonatomic) id sessionToken;
-@end
-
-
-
 @implementation ZMClientRegistrationStatusTests
 
 - (void)setUp {
@@ -155,19 +145,6 @@
     
     // then
     XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseRegistered);
-}
-
-- (void)testThatItReturns_FetchingClients_WhenReceivingAnErrorWithTooManyClients
-{
-    // given
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
-    selfUser.remoteIdentifier = [NSUUID UUID];
-    
-    // when
-    [self.sut didFailToRegisterClient:[self tooManyClientsError]];
-    
-    // then
-    XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseFetchingClients);
 }
 
 - (void)testThatItReturns_WaitingForDeletion_AfterUserSelectedClientToDelete

--- a/Tests/Source/UserSession/ZMClientRegistrationStatusTests.swift
+++ b/Tests/Source/UserSession/ZMClientRegistrationStatusTests.swift
@@ -1,29 +1,34 @@
-// 
+//
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
-// 
+// Copyright (C) 2021 Wire Swiss GmbH
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
+//
 
+import XCTest
+@testable import WireSyncEngine
 
-#import <WireSyncEngine/WireSyncEngine.h>
-#import "MessagingTest.h"
-#import "ObjectTranscoderTests.h"
-#import "ZMUserSessionTestsBase.h"
-#import "MessagingTest+EventFactory.h"
-#import "ConversationTestsBase.h"
-#import "CallKitDelegateTests+Mocking.h"
-#import "IntegrationTest.h"
-#import "APNSTestsBase.h"
-#import "ZMClientRegistrationStatusTests.h"
+extension ZMClientRegistrationStatusTests {
+    func testThatItReturns_FetchingClients_WhenReceivingAnErrorWithTooManyClients() {
+        // given
+        let selfUser = ZMUser.selfUser(in: syncMOC)
+        selfUser.remoteIdentifier = UUID()
+
+        // when
+        sut.didFail(toRegisterClient: tooManyClientsError() as NSError?)
+
+        // then
+        XCTAssertEqual(sut.currentPhase, ZMClientRegistrationPhase.fetchingClients)
+    }
+}

--- a/Tests/Source/UserSession/ZMClientRegistrationStatusTests.swift
+++ b/Tests/Source/UserSession/ZMClientRegistrationStatusTests.swift
@@ -26,7 +26,7 @@ extension ZMClientRegistrationStatusTests {
         selfUser.remoteIdentifier = UUID()
 
         // when
-        sut.didFail(toRegisterClient: tooManyClientsError() as NSError?)
+        sut.didFail(toRegisterClient: tooManyClientsError()! as NSError)
 
         // then
         XCTAssertEqual(sut.currentPhase, ZMClientRegistrationPhase.fetchingClients)

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -492,6 +492,7 @@
 		A9692F8A1986476900849241 /* NSString_NormalizationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A9692F881986476900849241 /* NSString_NormalizationTests.m */; };
 		A9B53AAA24E12E240066FCC6 /* ZMAccountDeletedReason.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B53AA924E12E240066FCC6 /* ZMAccountDeletedReason.swift */; };
 		A9C02605266F5B4B002E542B /* ZMClientRegistrationStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C02604266F5B4B002E542B /* ZMClientRegistrationStatus.swift */; };
+		A9C0260A266F5D1C002E542B /* ZMClientRegistrationStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C02609266F5D1B002E542B /* ZMClientRegistrationStatusTests.swift */; };
 		AF6415A41C9C17FF00A535F5 /* EncryptedBase64EncondedExternalMessageTestFixture.txt in Resources */ = {isa = PBXBuildFile; fileRef = AF6415A01C9C151700A535F5 /* EncryptedBase64EncondedExternalMessageTestFixture.txt */; };
 		AF6415A51C9C180200A535F5 /* ExternalMessageTextFixture.txt in Resources */ = {isa = PBXBuildFile; fileRef = AF6415A11C9C151700A535F5 /* ExternalMessageTextFixture.txt */; };
 		BF00441B1C737CE9007A6EA4 /* PushNotificationStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF00441A1C737CE9007A6EA4 /* PushNotificationStatus.swift */; };
@@ -1166,6 +1167,8 @@
 		A9692F881986476900849241 /* NSString_NormalizationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSString_NormalizationTests.m; sourceTree = "<group>"; };
 		A9B53AA924E12E240066FCC6 /* ZMAccountDeletedReason.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMAccountDeletedReason.swift; sourceTree = "<group>"; };
 		A9C02604266F5B4B002E542B /* ZMClientRegistrationStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMClientRegistrationStatus.swift; sourceTree = "<group>"; };
+		A9C02609266F5D1B002E542B /* ZMClientRegistrationStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMClientRegistrationStatusTests.swift; sourceTree = "<group>"; };
+		A9C02611266F5DB8002E542B /* ZMClientRegistrationStatusTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ZMClientRegistrationStatusTests.h; sourceTree = "<group>"; };
 		A9F269C6257800940021B99A /* UserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTests.swift; sourceTree = "<group>"; };
 		AF6415A01C9C151700A535F5 /* EncryptedBase64EncondedExternalMessageTestFixture.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = EncryptedBase64EncondedExternalMessageTestFixture.txt; sourceTree = "<group>"; };
 		AF6415A11C9C151700A535F5 /* ExternalMessageTextFixture.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ExternalMessageTextFixture.txt; sourceTree = "<group>"; };
@@ -1932,7 +1935,9 @@
 				0920C4D81B305FF500C55728 /* UserSessionGiphyRequestStateTests.swift */,
 				541228431AEE422C00D9ED1C /* ZMAuthenticationStatusTests.m */,
 				7CE017142317D07E00144905 /* ZMAuthenticationStatusTests.swift */,
+				A9C02611266F5DB8002E542B /* ZMClientRegistrationStatusTests.h */,
 				F99298581BE110490058D42F /* ZMClientRegistrationStatusTests.m */,
+				A9C02609266F5D1B002E542B /* ZMClientRegistrationStatusTests.swift */,
 				F9B171F71C0F00E700E6EEC6 /* ClientUpdateStatusTests.swift */,
 				54BFDF691BDA87D20034A3DB /* HistorySynchronizationStatusTests.swift */,
 				09B730941B3045E400A5CCC9 /* ProxiedRequestStatusTests.swift */,
@@ -3269,6 +3274,7 @@
 				EF2CB12A22D5E5BF00350B0A /* TeamImageAssetUpdateStrategyTests.swift in Sources */,
 				3E288A6C19C859210031CFCE /* NotificationObservers.m in Sources */,
 				168CF42D2007BCA0009FCB89 /* TeamInvitationRequestStrategyTests.swift in Sources */,
+				A9C0260A266F5D1C002E542B /* ZMClientRegistrationStatusTests.swift in Sources */,
 				EE01E0391F90FEC1001AA33C /* ZMLocalNotificationTests_ExpiredMessage.swift in Sources */,
 				54C11BAD19D1EB7500576A96 /* ZMLoginTranscoderTests.m in Sources */,
 				16AD86B81F7292EB00E4C797 /* TypingChange.swift in Sources */,

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -491,6 +491,7 @@
 		A96190CA23A6DDCE00B8665F /* WireDataModel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A96190C923A6DDCE00B8665F /* WireDataModel.framework */; };
 		A9692F8A1986476900849241 /* NSString_NormalizationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A9692F881986476900849241 /* NSString_NormalizationTests.m */; };
 		A9B53AAA24E12E240066FCC6 /* ZMAccountDeletedReason.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B53AA924E12E240066FCC6 /* ZMAccountDeletedReason.swift */; };
+		A9C02605266F5B4B002E542B /* ZMClientRegistrationStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C02604266F5B4B002E542B /* ZMClientRegistrationStatus.swift */; };
 		AF6415A41C9C17FF00A535F5 /* EncryptedBase64EncondedExternalMessageTestFixture.txt in Resources */ = {isa = PBXBuildFile; fileRef = AF6415A01C9C151700A535F5 /* EncryptedBase64EncondedExternalMessageTestFixture.txt */; };
 		AF6415A51C9C180200A535F5 /* ExternalMessageTextFixture.txt in Resources */ = {isa = PBXBuildFile; fileRef = AF6415A11C9C151700A535F5 /* ExternalMessageTextFixture.txt */; };
 		BF00441B1C737CE9007A6EA4 /* PushNotificationStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF00441A1C737CE9007A6EA4 /* PushNotificationStatus.swift */; };
@@ -1164,6 +1165,7 @@
 		A96190C923A6DDCE00B8665F /* WireDataModel.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WireDataModel.framework; path = Carthage/Build/iOS/WireDataModel.framework; sourceTree = "<group>"; };
 		A9692F881986476900849241 /* NSString_NormalizationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSString_NormalizationTests.m; sourceTree = "<group>"; };
 		A9B53AA924E12E240066FCC6 /* ZMAccountDeletedReason.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMAccountDeletedReason.swift; sourceTree = "<group>"; };
+		A9C02604266F5B4B002E542B /* ZMClientRegistrationStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMClientRegistrationStatus.swift; sourceTree = "<group>"; };
 		A9F269C6257800940021B99A /* UserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTests.swift; sourceTree = "<group>"; };
 		AF6415A01C9C151700A535F5 /* EncryptedBase64EncondedExternalMessageTestFixture.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = EncryptedBase64EncondedExternalMessageTestFixture.txt; sourceTree = "<group>"; };
 		AF6415A11C9C151700A535F5 /* ExternalMessageTextFixture.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ExternalMessageTextFixture.txt; sourceTree = "<group>"; };
@@ -2086,6 +2088,7 @@
 				F9FD16791BDFCDAD00725F5C /* ZMClientRegistrationStatus.h */,
 				F992985A1BE1404D0058D42F /* ZMClientRegistrationStatus+Internal.h */,
 				F9FD167A1BDFCDAD00725F5C /* ZMClientRegistrationStatus.m */,
+				A9C02604266F5B4B002E542B /* ZMClientRegistrationStatus.swift */,
 				54973A351DD48CAB007F8702 /* NSManagedObject+EncryptionContext.swift */,
 				163FB9982057E3F200E74F83 /* AuthenticationStatusProvider.swift */,
 				F9B171F51C0EF21100E6EEC6 /* ClientUpdateStatus.swift */,
@@ -3424,6 +3427,7 @@
 				EEEA75FA1F8A6142006D1070 /* ZMLocalNotification+ExpiredMessages.swift in Sources */,
 				547E5B5A1DDB67390038D936 /* UserProfileUpdateRequestStrategy.swift in Sources */,
 				54FF64291F73D00C00787EF2 /* NSManagedObjectContext+AuthenticationStatus.swift in Sources */,
+				A9C02605266F5B4B002E542B /* ZMClientRegistrationStatus.swift in Sources */,
 				BF735CFA1E70003D003BC61F /* SystemMessageCallObserver.swift in Sources */,
 				5458AF7F1F70219F00E45977 /* AccountDeletedObserver.swift in Sources */,
 				1645ECF82448A0A3007A82D6 /* Decodable+JSON.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

Remove @objc signature of `LoginCredentials.dictionaryRepresentation` for the requirement of XCFramework.
Convert `ZMClientRegistrationStatus.didFailToRegisterClient` to Swift since it calls the above function.
Convert `testThatItReturns_FetchingClients_WhenReceivingAnErrorWithTooManyClients` to Swift to prove that `ZMClientRegistrationStatus.didFailToRegisterClient` call be called with Swift code.