### PR TITLE
Parse join conversation deep link

### DIFF
--- a/Source/DeepLink/URL+DeepLink.swift
+++ b/Source/DeepLink/URL+DeepLink.swift
@@ -22,5 +22,6 @@ extension URL {
     enum DeepLink {
         static let user = "user"
         static let conversation = "conversation"
+        static let conversationJoin = "conversation-join"
     }
 }

--- a/Source/SessionManager/URLActions.swift
+++ b/Source/SessionManager/URLActions.swift
@@ -29,6 +29,9 @@ public enum URLAction: Equatable {
     /// Start the SSO login flow
     case startCompanyLogin(code: UUID)
 
+    /// Join a public conversation
+    case joinConversation(key: String, code: String)
+
     /// Navigate to a conversation
     case openConversation(id: UUID)
 
@@ -47,7 +50,8 @@ public enum URLAction: Equatable {
 
     public var requiresAuthentication: Bool {
         switch self {
-        case .openConversation,
+        case .joinConversation,
+             .openConversation,
              .openUserProfile,
              .connectBot:
              return true
@@ -57,7 +61,8 @@ public enum URLAction: Equatable {
 
     public var opensDeepLink: Bool {
         switch self {
-        case .openConversation,
+        case .joinConversation,
+             .openConversation,
              .openUserProfile:
             return true
         default: return false
@@ -89,6 +94,16 @@ extension URLAction {
             } else {
                 throw DeepLinkRequestError.invalidUserLink
             }
+
+        case URL.DeepLink.conversationJoin:
+            guard
+                let key = components.query(for: URLQueryItem.Key.conversationKey),
+                let code = components.query(for: URLQueryItem.Key.conversationCode)
+            else {
+                throw DeepLinkRequestError.malformedLink
+            }
+
+            self = .joinConversation(key: key, code: code)
             
         case URL.DeepLink.conversation:
             if let lastComponent = url.pathComponents.last,
@@ -172,4 +187,11 @@ extension URLAction {
         return storedToken.matches(identifier: token)
     }
     
+}
+
+private extension URLQueryItem.Key {
+
+    static let conversationKey = "key"
+    static let conversationCode = "code"
+
 }

--- a/Source/UserSession/URLActionProcessors/DeepLinkURLActionProcessor.swift
+++ b/Source/UserSession/URLActionProcessors/DeepLinkURLActionProcessor.swift
@@ -30,6 +30,14 @@ class DeepLinkURLActionProcessor: URLActionProcessor {
     
     func process(urlAction: URLAction, delegate: PresentationDelegate?) {
         switch urlAction {
+        case let .joinConversation(key: key, code: code):
+            delegate?.shouldPerformAction(urlAction) { shouldJoin in
+                defer { delegate?.completedURLAction(urlAction) }
+                guard shouldJoin else { return }
+                // TODO: Make the join request
+                // TODO: On success, open conversation
+                // TODO: On fail, inform delegate
+            }
             
         case .openConversation(let id):
             guard let conversation = ZMConversation(remoteID: id, createIfNeeded: false, in: uiMOC) else {
@@ -38,17 +46,19 @@ class DeepLinkURLActionProcessor: URLActionProcessor {
             }
             
             delegate?.showConversation(conversation, at: nil)
+            delegate?.completedURLAction(urlAction)
+
         case .openUserProfile(let id):
             if let user = ZMUser(remoteID: id, createIfNeeded: false, in: uiMOC) {
                 delegate?.showUserProfile(user: user)
             } else {
                 delegate?.showConnectionRequest(userId: id)
             }
+
+            delegate?.completedURLAction(urlAction)
             
         default:
-            break
+            delegate?.completedURLAction(urlAction)
         }
-        
-        delegate?.completedURLAction(urlAction)
     }
 }

--- a/Tests/Source/SessionManager/URLActionTests.swift
+++ b/Tests/Source/SessionManager/URLActionTests.swift
@@ -59,6 +59,19 @@ class URLActionTests: ZMTBaseTest {
     }
     
     // MARK: - Deep link
+
+    func testThatItParsesJoinConversationLink() throws {
+        // given
+        let key = "KpvjjQSDgp9aniYGUXqi"
+        let code = "L6NrwRNGgsc1ekCVJoBp"
+        let url = URL(string: "wire://conversation-join/?key=\(key)&code=\(code)")!
+
+        // when
+        let action = try URLAction(url: url)
+
+        // then
+        XCTAssertEqual(action, URLAction.joinConversation(key: key, code: code))
+    }
     
     func testThatItParsesOpenConversationLink() throws {
         // given
@@ -85,6 +98,18 @@ class URLActionTests: ZMTBaseTest {
         
         // then
         XCTAssertEqual(action, URLAction.openUserProfile(id: uuid))
+    }
+
+    func testThatItDiscardsInvalidJoinConversationLink() throws {
+        // given
+        let key = "KpvjjQSDgp9aniYGUXqi"
+        let url = URL(string: "wire://conversation-join/?key=\(key)")!
+
+        // when
+        XCTAssertThrowsError(try URLAction(url: url)) { (error) in
+            // then
+            XCTAssertEqual(error as? DeepLinkRequestError, .malformedLink)
+        }
     }
     
     func testThatItDiscardsInvalidOpenUserProfileLink() {


### PR DESCRIPTION
## What's new in this PR?

- Introduce a new url action `joinConversation` which will be used to join a conversation with a key and a code.
- Extend the `DeepLinkURLActionProcessor` to handle this new deep link. It currently just asks for user confirmation. 
- Added unit tests for parsing the new deep link.