### PR TITLE
Remove ZMUserSessionConfiguration @objc signature

### DIFF
--- a/Source/UserSession/ZMUserSession.Configuration.swift
+++ b/Source/UserSession/ZMUserSession.Configuration.swift
@@ -22,7 +22,6 @@ public extension ZMUserSession {
 
     /// An object used to configure a user session.
 
-    @objc(ZMUserSessionConfiguration)
     final class Configuration: NSObject {
 
         // MARK: - Properties

--- a/Tests/Source/UserSession/ZMUserSessionTests.m
+++ b/Tests/Source/UserSession/ZMUserSessionTests.m
@@ -351,42 +351,6 @@
 
 @implementation ZMUserSessionTests (NetworkState)
 
-- (void)testThatItSetsItselfAsADelegateOfTheTransportSessionAndForwardsUserClientID
-{
-    // given
-    UserClient *selfClient = [self createSelfClient];
-    NSUUID *userId = NSUUID.createUUID;
-    
-    self.mockPushChannel = [[MockPushChannel alloc] init];
-    self.cookieStorage = [ZMPersistentCookieStorage storageForServerName:@"usersessiontest.example.com" userIdentifier:userId];
-    RecordingMockTransportSession *transportSession = [[RecordingMockTransportSession alloc] initWithCookieStorage:self.cookieStorage pushChannel:self.mockPushChannel];
-
-
-    // when
-    ZMUserSession *testSession = [[ZMUserSession alloc] initWithUserId:userId
-                                                      transportSession:transportSession
-                                                          mediaManager:self.mediaManager
-                                                           flowManager:self.flowManagerMock
-                                                             analytics:nil
-                                                        eventProcessor:nil
-                                                     strategyDirectory:nil
-                                                          syncStrategy:nil
-                                                         operationLoop:nil
-                                                           application:self.application
-                                                            appVersion:@"00000"
-                                                         coreDataStack:self.coreDataStack
-                                                         configuration:ZMUserSessionConfiguration.defaultConfig];
-    WaitForAllGroupsToBeEmpty(0.5);
-
-    // then
-    XCTAssertTrue(self.transportSession.didCallSetNetworkStateDelegate);
-    XCTAssertEqual(self.mockPushChannel.keepOpen, YES);
-    XCTAssertEqualObjects(self.mockPushChannel.clientID, selfClient.remoteIdentifier);
-    
-    
-    [testSession tearDown];
-}
-
 - (BOOL)waitForStatus:(ZMNetworkState)state
 {
     return ([self waitOnMainLoopUntilBlock:^BOOL{

--- a/Tests/Source/UserSession/ZMUserSessionTestsBase+ZMUserSessionConfiguration.swift
+++ b/Tests/Source/UserSession/ZMUserSessionTestsBase+ZMUserSessionConfiguration.swift
@@ -1,0 +1,39 @@
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+extension ZMUserSessionTestsBase {
+    @objc
+    func createSut(userId: UUID) {
+        let mockStrategyDirectory = MockStrategyDirectory()
+        let mockUpdateEventProcessor = MockUpdateEventProcessor()
+        sut = ZMUserSession(
+            userId: userId,
+            transportSession: transportSession,
+            mediaManager: mediaManager,
+            flowManager: flowManagerMock,
+            analytics: nil,
+            eventProcessor: mockUpdateEventProcessor,
+            strategyDirectory: mockStrategyDirectory,
+            syncStrategy: nil,
+            operationLoop: nil,
+            application: application,
+            appVersion: "00000",
+            coreDataStack: coreDataStack,
+            configuration: ZMUserSession.Configuration.defaultConfig)
+    }
+}

--- a/Tests/Source/UserSession/ZMUserSessionTestsBase.m
+++ b/Tests/Source/UserSession/ZMUserSessionTestsBase.m
@@ -53,23 +53,8 @@
     NSUUID *userId = [NSUUID createUUID];
     [ZMUser selfUserInContext:self.syncMOC].remoteIdentifier = userId;
     
-    MockStrategyDirectory *mockStrategyDirectory = [[MockStrategyDirectory alloc] init];
-    MockUpdateEventProcessor *mockUpdateEventProcessor = [[MockUpdateEventProcessor alloc] init];
-    
-    self.sut = [[ZMUserSession alloc] initWithUserId:userId
-                                    transportSession:self.transportSession
-                                        mediaManager:self.mediaManager
-                                         flowManager:self.flowManagerMock
-                                           analytics:nil
-                                      eventProcessor:mockUpdateEventProcessor
-                                   strategyDirectory:mockStrategyDirectory
-                                        syncStrategy:nil
-                                       operationLoop:nil
-                                         application:self.application
-                                          appVersion:@"00000"
-                                       coreDataStack:self.coreDataStack
-                                       configuration:ZMUserSessionConfiguration.defaultConfig];
-        
+    [self createSutWithUserId:userId];
+
     self.sut.thirdPartyServicesDelegate = self.thirdPartyServices;
     self.sut.sessionManager = (id<SessionManagerType>)self.mockSessionManager;
     

--- a/Tests/Source/UserSession/ZMUserSessionTests_NetworkState.swift
+++ b/Tests/Source/UserSession/ZMUserSessionTests_NetworkState.swift
@@ -1,0 +1,59 @@
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import WireSyncEngine
+
+final class ZMUserSessionTests_NetworkState: ZMUserSessionTestsBase {
+    
+    func testThatItSetsItselfAsADelegateOfTheTransportSessionAndForwardsUserClientID() {
+        // given
+        let selfClient = createSelfClient()
+        let userId = NSUUID.create()!
+        
+        mockPushChannel = MockPushChannel()
+        cookieStorage = ZMPersistentCookieStorage(forServerName: "usersessiontest.example.com", userIdentifier: userId)
+        let transportSession = RecordingMockTransportSession(cookieStorage: cookieStorage, pushChannel: mockPushChannel)
+        
+        
+        // when
+        let testSession = ZMUserSession(
+            userId: userId,
+            transportSession: transportSession,
+            mediaManager: mediaManager,
+            flowManager: flowManagerMock,
+            analytics: nil,
+            eventProcessor: nil,
+            strategyDirectory: nil,
+            syncStrategy: nil,
+            operationLoop: nil,
+            application: application,
+            appVersion: "00000",
+            coreDataStack: coreDataStack,
+            configuration: ZMUserSession.Configuration.defaultConfig)
+        _ = waitForAllGroupsToBeEmpty(withTimeout: 0.5)
+        
+        // then
+        XCTAssertTrue(self.transportSession.didCallSetNetworkStateDelegate)
+        XCTAssertEqual(mockPushChannel.keepOpen, true)
+        XCTAssertEqual(mockPushChannel.clientID, selfClient.remoteIdentifier)
+        
+        
+        testSession.tearDown()
+    }
+}

--- a/Tests/Source/Utility/ZMUserSession+DefaultConfiguration.swift
+++ b/Tests/Source/Utility/ZMUserSession+DefaultConfiguration.swift
@@ -19,7 +19,6 @@ import Foundation
 
 extension ZMUserSession.Configuration {
 
-    @objc
     static var defaultConfig: ZMUserSession.Configuration {
         Self.init(
             appLockConfig: .init(

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -490,6 +490,7 @@
 		A95D0B1223F6B75A0057014F /* AVSLogObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95D0B1123F6B75A0057014F /* AVSLogObserver.swift */; };
 		A96190CA23A6DDCE00B8665F /* WireDataModel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A96190C923A6DDCE00B8665F /* WireDataModel.framework */; };
 		A9692F8A1986476900849241 /* NSString_NormalizationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A9692F881986476900849241 /* NSString_NormalizationTests.m */; };
+		A97E4F56267CF681006FC545 /* ZMUserSessionTestsBase+ZMUserSessionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97E4F55267CF681006FC545 /* ZMUserSessionTestsBase+ZMUserSessionConfiguration.swift */; };
 		A9B53AAA24E12E240066FCC6 /* ZMAccountDeletedReason.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B53AA924E12E240066FCC6 /* ZMAccountDeletedReason.swift */; };
 		A9C02605266F5B4B002E542B /* ZMClientRegistrationStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C02604266F5B4B002E542B /* ZMClientRegistrationStatus.swift */; };
 		A9C0260A266F5D1C002E542B /* ZMClientRegistrationStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C02609266F5D1B002E542B /* ZMClientRegistrationStatusTests.swift */; };
@@ -1165,6 +1166,7 @@
 		A95D0B1123F6B75A0057014F /* AVSLogObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVSLogObserver.swift; sourceTree = "<group>"; };
 		A96190C923A6DDCE00B8665F /* WireDataModel.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WireDataModel.framework; path = Carthage/Build/iOS/WireDataModel.framework; sourceTree = "<group>"; };
 		A9692F881986476900849241 /* NSString_NormalizationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSString_NormalizationTests.m; sourceTree = "<group>"; };
+		A97E4F55267CF681006FC545 /* ZMUserSessionTestsBase+ZMUserSessionConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSessionTestsBase+ZMUserSessionConfiguration.swift"; sourceTree = "<group>"; };
 		A9B53AA924E12E240066FCC6 /* ZMAccountDeletedReason.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMAccountDeletedReason.swift; sourceTree = "<group>"; };
 		A9C02604266F5B4B002E542B /* ZMClientRegistrationStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMClientRegistrationStatus.swift; sourceTree = "<group>"; };
 		A9C02609266F5D1B002E542B /* ZMClientRegistrationStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMClientRegistrationStatusTests.swift; sourceTree = "<group>"; };
@@ -1925,6 +1927,7 @@
 				EEF4010223A8E1EF007B1A97 /* Conversation_RoleTests.swift */,
 				5447E4651AECDC5000411FCD /* ZMUserSessionTestsBase.h */,
 				5447E4661AECDE6500411FCD /* ZMUserSessionTestsBase.m */,
+				A97E4F55267CF681006FC545 /* ZMUserSessionTestsBase+ZMUserSessionConfiguration.swift */,
 				1679D1CB1EF9730C007B0DF5 /* ZMUserSessionTestsBase+Calling.swift */,
 				54610D32192C9D7200FE7201 /* ZMUserSessionTests.m */,
 				1626344620D79C22000D4063 /* ZMUserSessionTests+PushNotifications.swift */,
@@ -3209,6 +3212,7 @@
 				A913C02423A7F1C00048CE74 /* TeamRolesDownloadRequestStrategyTests.swift in Sources */,
 				EFC8281E1FB34F9600E27E21 /* EmailVerificationStrategyTests.swift in Sources */,
 				87D4625D1C3D526D00433469 /* DeleteAccountRequestStrategyTests.swift in Sources */,
+				A97E4F56267CF681006FC545 /* ZMUserSessionTestsBase+ZMUserSessionConfiguration.swift in Sources */,
 				166264932166517A00300F45 /* CallEventStatusTests.swift in Sources */,
 				160C31411E6DDFC30012E4BC /* VoiceChannelV3Tests.swift in Sources */,
 				F9ABE8561EFD56BF00D83214 /* TeamDownloadRequestStrategyTests.swift in Sources */,

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -491,6 +491,7 @@
 		A96190CA23A6DDCE00B8665F /* WireDataModel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A96190C923A6DDCE00B8665F /* WireDataModel.framework */; };
 		A9692F8A1986476900849241 /* NSString_NormalizationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A9692F881986476900849241 /* NSString_NormalizationTests.m */; };
 		A97E4F56267CF681006FC545 /* ZMUserSessionTestsBase+ZMUserSessionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97E4F55267CF681006FC545 /* ZMUserSessionTestsBase+ZMUserSessionConfiguration.swift */; };
+		A97E4F5B267CFB2D006FC545 /* ZMUserSessionTests_NetworkState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97E4F5A267CFB2D006FC545 /* ZMUserSessionTests_NetworkState.swift */; };
 		A9B53AAA24E12E240066FCC6 /* ZMAccountDeletedReason.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B53AA924E12E240066FCC6 /* ZMAccountDeletedReason.swift */; };
 		A9C02605266F5B4B002E542B /* ZMClientRegistrationStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C02604266F5B4B002E542B /* ZMClientRegistrationStatus.swift */; };
 		A9C0260A266F5D1C002E542B /* ZMClientRegistrationStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C02609266F5D1B002E542B /* ZMClientRegistrationStatusTests.swift */; };
@@ -1167,6 +1168,7 @@
 		A96190C923A6DDCE00B8665F /* WireDataModel.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WireDataModel.framework; path = Carthage/Build/iOS/WireDataModel.framework; sourceTree = "<group>"; };
 		A9692F881986476900849241 /* NSString_NormalizationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSString_NormalizationTests.m; sourceTree = "<group>"; };
 		A97E4F55267CF681006FC545 /* ZMUserSessionTestsBase+ZMUserSessionConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSessionTestsBase+ZMUserSessionConfiguration.swift"; sourceTree = "<group>"; };
+		A97E4F5A267CFB2D006FC545 /* ZMUserSessionTests_NetworkState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMUserSessionTests_NetworkState.swift; sourceTree = "<group>"; };
 		A9B53AA924E12E240066FCC6 /* ZMAccountDeletedReason.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMAccountDeletedReason.swift; sourceTree = "<group>"; };
 		A9C02604266F5B4B002E542B /* ZMClientRegistrationStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMClientRegistrationStatus.swift; sourceTree = "<group>"; };
 		A9C02609266F5D1B002E542B /* ZMClientRegistrationStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMClientRegistrationStatusTests.swift; sourceTree = "<group>"; };
@@ -1930,6 +1932,7 @@
 				A97E4F55267CF681006FC545 /* ZMUserSessionTestsBase+ZMUserSessionConfiguration.swift */,
 				1679D1CB1EF9730C007B0DF5 /* ZMUserSessionTestsBase+Calling.swift */,
 				54610D32192C9D7200FE7201 /* ZMUserSessionTests.m */,
+				A97E4F5A267CFB2D006FC545 /* ZMUserSessionTests_NetworkState.swift */,
 				1626344620D79C22000D4063 /* ZMUserSessionTests+PushNotifications.swift */,
 				F92CA9641F153622007D8570 /* ZMUserSessionTests+FileRelocation.swift */,
 				F1AE5F6E21F73388009CDBBC /* ZMUserSessionTests+Timers.swift */,
@@ -3281,6 +3284,7 @@
 				EF2CB12A22D5E5BF00350B0A /* TeamImageAssetUpdateStrategyTests.swift in Sources */,
 				3E288A6C19C859210031CFCE /* NotificationObservers.m in Sources */,
 				168CF42D2007BCA0009FCB89 /* TeamInvitationRequestStrategyTests.swift in Sources */,
+				A97E4F5B267CFB2D006FC545 /* ZMUserSessionTests_NetworkState.swift in Sources */,
 				A9C0260A266F5D1C002E542B /* ZMClientRegistrationStatusTests.swift in Sources */,
 				EE01E0391F90FEC1001AA33C /* ZMLocalNotificationTests_ExpiredMessage.swift in Sources */,
 				54C11BAD19D1EB7500576A96 /* ZMLoginTranscoderTests.m in Sources */,


### PR DESCRIPTION
## What's new in this PR?

When building this framework as a XCFramework, error occurs in the code having `ZMUserSessionConfiguration`. 
Convert these tests to Swift and remove `ZMUserSessionConfiguration` @objc signature.