### PR TITLE
[Fix] Perform the request from viewContext

### DIFF
--- a/Source/Data Model/Conversation+Join.swift
+++ b/Source/Data Model/Conversation+Join.swift
@@ -66,7 +66,7 @@ extension ZMConversation {
         let syncContext = contextProvider.syncContext
         let viewContext = contextProvider.viewContext
 
-        request.add(ZMCompletionHandler(on: syncContext, block: { response in
+        request.add(ZMCompletionHandler(on: viewContext, block: { response in
             switch response.httpStatus {
             case 200:
                 guard let payload = response.payload,

--- a/Source/Data Model/Conversation+Join.swift
+++ b/Source/Data Model/Conversation+Join.swift
@@ -54,7 +54,7 @@ extension ZMConversation {
     ///   - transportSession: session to handle requests
     ///   - eventProcessor: update event processor
     ///   - contextProvider: context provider
-    ///   - completion: called when the user joines the conversation or when it fails. If the completion is a success, it is run in the main thread
+    ///   - completion: called on the main thread when the user joins the conversation or when it fails. If the completion is a success, it is run in the main thread
     public static func join(key: String,
                             code: String,
                             transportSession: TransportSessionType,


### PR DESCRIPTION
## What's new in this PR?

### Issues
The crash in the UI when receiving an error message.

### Causes
`completion(.failure(error))` was called from syncContext. The completion handler triggers a delegate method that displays a popup with an error message.


### Solutions
Perform the request from `viewContext`.
