### PR TITLE
[Feature] Support creating fake one-to-one conversation with a federated user

### DIFF
--- a/Source/Data Model/ZMUser+FederatedConnection.swift
+++ b/Source/Data Model/ZMUser+FederatedConnection.swift
@@ -1,0 +1,50 @@
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension UserType {
+
+
+    /// Create fake one-to-one connection with a federated user.
+    ///
+    /// NOTE this is a temporary method for creating a conversation with federated users, it should
+    /// be deleted before this is merged into develop.
+    public func createFederatedOneToOne(in userSession: ZMUserSession) -> ZMConversation? {
+        return materialize(in: userSession.viewContext)?.createFederatedOneToOne()
+    }
+
+}
+
+extension ZMUser {
+
+    /// Create fake one-to-one connection with a federated user.
+    ///
+    /// NOTE this is a temporary method for creating a conversation with federated users, it should
+    /// be deleted before this is merged into develop.
+    func createFederatedOneToOne() -> ZMConversation? {
+        let selfUser = ZMUser.selfUser(in: managedObjectContext!)
+        let otherUser = self
+        let conversation = ZMConversation.insertGroupConversation(moc: managedObjectContext!,
+                                                                  participants: [selfUser, otherUser],
+                                                                  name: otherUser.name)
+
+        return conversation
+    }
+
+}

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -257,6 +257,7 @@
 		16AD86B81F7292EB00E4C797 /* TypingChange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16AD86B71F7292EB00E4C797 /* TypingChange.swift */; };
 		16C22BA41BF4D5D7007099D9 /* NSError+ZMUserSessionInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 3E05F254192A50CC00F22D80 /* NSError+ZMUserSessionInternal.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		16C4BDA020A309CD00BCDB17 /* CallParticipantSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C4BD9F20A309CD00BCDB17 /* CallParticipantSnapshot.swift */; };
+		16CD6A272681BA9000B9A73A /* ZMUser+FederatedConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CD6A262681BA9000B9A73A /* ZMUser+FederatedConnection.swift */; };
 		16D0A119234B999600A83F87 /* LabelUpstreamRequestStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D0A118234B999600A83F87 /* LabelUpstreamRequestStrategyTests.swift */; };
 		16D0A11D234C8CD700A83F87 /* LabelUpstreamRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D0A11C234C8CD700A83F87 /* LabelUpstreamRequestStrategy.swift */; };
 		16D3FCDF1E365ABC0052A535 /* CallStateObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D3FCDE1E365ABC0052A535 /* CallStateObserverTests.swift */; };
@@ -875,6 +876,7 @@
 		16A86B8322A7E57100A674F8 /* ConversationTests+LegalHold.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationTests+LegalHold.swift"; sourceTree = "<group>"; };
 		16AD86B71F7292EB00E4C797 /* TypingChange.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypingChange.swift; sourceTree = "<group>"; };
 		16C4BD9F20A309CD00BCDB17 /* CallParticipantSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallParticipantSnapshot.swift; sourceTree = "<group>"; };
+		16CD6A262681BA9000B9A73A /* ZMUser+FederatedConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUser+FederatedConnection.swift"; sourceTree = "<group>"; };
 		16D0A118234B999600A83F87 /* LabelUpstreamRequestStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelUpstreamRequestStrategyTests.swift; sourceTree = "<group>"; };
 		16D0A11C234C8CD700A83F87 /* LabelUpstreamRequestStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelUpstreamRequestStrategy.swift; sourceTree = "<group>"; };
 		16D1383A1FD6A6F4001B4411 /* AvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailabilityTests.swift; sourceTree = "<group>"; };
@@ -1696,6 +1698,7 @@
 				EEF4010023A8DFC6007B1A97 /* Conversation+Role.swift */,
 				EE1DEBC223D5F1920087EE1F /* Conversation+TypingUsers.swift */,
 				878ACB4720AEFB980016E68A /* ZMUser+Consent.swift */,
+				16CD6A262681BA9000B9A73A /* ZMUser+FederatedConnection.swift */,
 			);
 			path = "Data Model";
 			sourceTree = "<group>";
@@ -3420,6 +3423,7 @@
 				878ACB4820AEFB980016E68A /* ZMUser+Consent.swift in Sources */,
 				F1C51FE71FB49660009C2269 /* RegistrationStatus.swift in Sources */,
 				5E8EE1FA20FDC7D700DB1F9B /* Pasteboard.swift in Sources */,
+				16CD6A272681BA9000B9A73A /* ZMUser+FederatedConnection.swift in Sources */,
 				874A16922052BEC5001C6760 /* UserExpirationObserver.swift in Sources */,
 				8751DA061F66BFA6000D308B /* ZMUserSession+Push.swift in Sources */,
 				EEEA75FA1F8A6142006D1070 /* ZMLocalNotification+ExpiredMessages.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

Support creating fake one-to-one conversation with a federated user. 

## Notes

This code will be removed before this feature is shipped and is only implemented to unlock some user flows during testing.
