### PR TITLE
[Fix]  Name for for fake one-to-one conversations with federated users

### DIFF
--- a/Source/Data Model/ZMUser+FederatedConnection.swift
+++ b/Source/Data Model/ZMUser+FederatedConnection.swift
@@ -40,9 +40,10 @@ extension ZMUser {
     func createFederatedOneToOne() -> ZMConversation? {
         let selfUser = ZMUser.selfUser(in: managedObjectContext!)
         let otherUser = self
+        let name = [otherUser.name ?? "-", selfUser.name ?? "-"].sorted().joined(separator: ", ")
         let conversation = ZMConversation.insertGroupConversation(moc: managedObjectContext!,
                                                                   participants: [selfUser, otherUser],
-                                                                  name: otherUser.name)
+                                                                  name: name)
 
         return conversation
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

fake one-to-one conversations with federated users had always the name of the other user which doesn't make sense for the receiving end. 

### Solutions

Set both names as the conversation name.