### PR TITLE
Fix: integration test linker error

### DIFF
--- a/Tests/Source/Integration/IntegrationTest.h
+++ b/Tests/Source/Integration/IntegrationTest.h
@@ -33,7 +33,6 @@
 @class SearchDirectory;
 @class PushRegistryMock;
 @class UserNotificationCenterMock;
-@class SessionManagerConfiguration;
 @class MockJailbreakDetector;
 @class MockEnvironment;
 @class MockMediaManager;
@@ -55,7 +54,6 @@
 @property (nonatomic, readonly) BOOL useRealKeychain;
 @property (nonatomic, nullable) SearchDirectory *sharedSearchDirectory;
 @property (nonatomic, nullable) UserNotificationCenterMock *notificationCenter;
-@property (nonatomic, readonly, nonnull) SessionManagerConfiguration *sessionManagerConfiguration;
 @property (nonatomic, nullable) MockJailbreakDetector *jailbreakDetector;
 @property (nonatomic, nullable) MockLoginDelegate *mockLoginDelegete;
 

--- a/Tests/Source/Integration/IntegrationTest.m
+++ b/Tests/Source/Integration/IntegrationTest.m
@@ -54,11 +54,6 @@
     [super tearDown];
 }
 
-
-- (SessionManagerConfiguration *)sessionManagerConfiguration {
-    return [SessionManagerConfiguration defaultConfiguration];
-}
-
 - (BOOL)useInMemoryStore
 {
     return YES;

--- a/Tests/Source/Integration/IntegrationTest.swift
+++ b/Tests/Source/Integration/IntegrationTest.swift
@@ -78,6 +78,9 @@ final class MockUnauthenticatedSessionFactory: UnauthenticatedSessionFactory {
 
 
 extension IntegrationTest {
+    var sessionManagerConfiguration: SessionManagerConfiguration {
+        return SessionManagerConfiguration.defaultConfiguration
+    }
     
     static let SelfUserEmail = "myself@user.example.com"
     static let SelfUserPassword = "fgf0934';$@#%"


### PR DESCRIPTION
## What's new in this PR?

Prevent using `SessionManagerConfiguration` in objc code to prevent linker error