### PR TITLE
[Fix] Failed tests that were affected by adding new requests to QuickSync

### DIFF
--- a/Tests/Source/Integration/PushChannelTests.swift
+++ b/Tests/Source/Integration/PushChannelTests.swift
@@ -116,9 +116,10 @@ class PushChannelTests: IntegrationTest {
         _ = waitForAllGroupsToBeEmpty(withTimeout: 0.5)
         
         // THEN
-        let expectedLastRequest = "/notifications?size=\(ZMMissingUpdateEventsTranscoderListPageSize)&since=\(messageAddLastNotificationID?.transportString() ?? "")&client=\(userSession?.selfUserClient?.remoteIdentifier ?? "")"
+        let expectedRequest = "/notifications?size=\(ZMMissingUpdateEventsTranscoderListPageSize)&since=\(messageAddLastNotificationID?.transportString() ?? "")&client=\(userSession?.selfUserClient?.remoteIdentifier ?? "")"
 
-        XCTAssertTrue(mockTransportSession.receivedRequests().contains(where: { $0.path == expectedLastRequest } ))
+        let targetRequests = mockTransportSession.receivedRequests().filter { $0.path == expectedRequest }
+        XCTAssertEqual(targetRequests.count, 1)
     }
 
 }

--- a/Tests/Source/Integration/PushChannelTests.swift
+++ b/Tests/Source/Integration/PushChannelTests.swift
@@ -118,17 +118,7 @@ class PushChannelTests: IntegrationTest {
         // THEN
         let expectedLastRequest = "/notifications?size=\(ZMMissingUpdateEventsTranscoderListPageSize)&since=\(messageAddLastNotificationID?.transportString() ?? "")&client=\(userSession?.selfUserClient?.remoteIdentifier ?? "")"
 
-        /// Requests to fetch feature configs have been added to QuickSync, that should be excluded
-        let requestsWithoutFeatureConfigs = removeFeatureConfigRequest(from: mockTransportSession.receivedRequests())
-        XCTAssertEqual(requestsWithoutFeatureConfigs.last?.path , expectedLastRequest)
+        XCTAssertTrue(mockTransportSession.receivedRequests().contains(where: { $0.path == expectedLastRequest } ))
     }
 
-    private func removeFeatureConfigRequest(from: [ZMTransportRequest]) -> [ZMTransportRequest] {
-
-            return mockTransportSession.receivedRequests().filter { (request) -> Bool in
-                let paths = Feature.Name.allCases.map { "/feature-configs/\($0)" }
-                return !paths.contains(request.path)
-            }
-
-        }
 }

--- a/Tests/Source/Integration/PushChannelTests.swift
+++ b/Tests/Source/Integration/PushChannelTests.swift
@@ -117,6 +117,18 @@ class PushChannelTests: IntegrationTest {
         
         // THEN
         let expectedLastRequest = "/notifications?size=\(ZMMissingUpdateEventsTranscoderListPageSize)&since=\(messageAddLastNotificationID?.transportString() ?? "")&client=\(userSession?.selfUserClient?.remoteIdentifier ?? "")"
-        XCTAssertEqual(mockTransportSession.receivedRequests().last?.path , expectedLastRequest)
+
+        /// Requests to fetch feature configs have been added to QuickSync, that should be excluded
+        let requestsWithoutFeatureConfigs = removeFeatureConfigRequest(from: mockTransportSession.receivedRequests())
+        XCTAssertEqual(requestsWithoutFeatureConfigs.last?.path , expectedLastRequest)
     }
+
+    private func removeFeatureConfigRequest(from: [ZMTransportRequest]) -> [ZMTransportRequest] {
+
+            return mockTransportSession.receivedRequests().filter { (request) -> Bool in
+                let paths = Feature.Name.allCases.map { "/feature-configs/\($0)" }
+                return !paths.contains(request.path)
+            }
+
+        }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues
Failed `testThatItFetchesLastNotificationsFromBackendIgnoringTransientNotificationsID` test. 

### Causes
Requests to fetch feature configs have been added to QuickSync.

### Solutions
Exclude the fetch feature config requests from the expected result, as the test checks if there are transient notification in the given result.
