### PR TITLE
Fix: xcode13 warning - Using 'class' keyword to define a class-constrained protocol is deprecated; use 'AnyObject' instead

### DIFF
--- a/Source/Calling/CallCenterSupport.swift
+++ b/Source/Calling/CallCenterSupport.swift
@@ -64,7 +64,7 @@ public typealias CallConfigRequestCompletion = (String?, Int) -> Void
 
 /// An object that can perform requests on behalf of the call center.
 
-public protocol WireCallCenterTransport: class {
+public protocol WireCallCenterTransport: AnyObject {
 
     /// Sends a calling message.
     ///

--- a/Source/Calling/CallKitManager.swift
+++ b/Source/Calling/CallKitManager.swift
@@ -51,7 +51,7 @@ struct CallHandle: Hashable {
     }
 }
 
-protocol CallKitManagerDelegate: class {
+protocol CallKitManagerDelegate: AnyObject {
     
     /// Look a conversation where a call has or will take place
     

--- a/Source/Calling/MediaManager.swift
+++ b/Source/Calling/MediaManager.swift
@@ -20,7 +20,7 @@ import Foundation
 import avs
 
 @objc
-public protocol MediaManagerType: class {
+public protocol MediaManagerType: AnyObject {
  
     func setUiStartsAudio(_ enabled: Bool)
     func startAudio()

--- a/Source/Calling/VoiceChannel.swift
+++ b/Source/Calling/VoiceChannel.swift
@@ -33,7 +33,7 @@ public enum CaptureDevice : Int {
     }
 }
 
-public protocol VoiceChannel : class, CallProperties, CallActions, CallActionsInternal, CallObservers {
+public protocol VoiceChannel : AnyObject, CallProperties, CallActions, CallActionsInternal, CallObservers {
     
     init(conversation: ZMConversation)
     

--- a/Source/Calling/WireCallCenterV3+Notifications.swift
+++ b/Source/Calling/WireCallCenterV3+Notifications.swift
@@ -33,7 +33,7 @@ extension SelfPostingNotification {
 
 // MARK:- Network Quality observer
 
-public protocol NetworkQualityObserver : class {
+public protocol NetworkQualityObserver : AnyObject {
     func callCenterDidChange(networkQuality: NetworkQuality)
 }
 
@@ -47,7 +47,7 @@ struct WireCallCenterNetworkQualityNotification : SelfPostingNotification {
 
 // MARK:- CBR observer
 
-public protocol ConstantBitRateAudioObserver : class {
+public protocol ConstantBitRateAudioObserver : AnyObject {
     func callCenterDidChange(constantAudioBitRateAudioEnabled: Bool)
 }
 
@@ -59,7 +59,7 @@ struct WireCallCenterCBRNotification : SelfPostingNotification {
 
 // MARK:- Mute state observer
 
-public protocol MuteStateObserver : class {
+public protocol MuteStateObserver : AnyObject {
     func callCenterDidChange(muted: Bool)
 }
 
@@ -71,7 +71,7 @@ struct WireCallCenterMutedNotification : SelfPostingNotification {
 
 // MARK: - Conference calling unavailable observer
 
-public protocol ConferenceCallingUnavailableObserver: class {
+public protocol ConferenceCallingUnavailableObserver: AnyObject {
     func callCenterDidNotStartConferenceCall()
 }
 
@@ -81,7 +81,7 @@ struct WireCallCenterConferenceCallingUnavailableNotification: SelfPostingNotifi
 
 // MARK:- Active speakers observer
 
-public protocol ActiveSpeakersObserver : class {
+public protocol ActiveSpeakersObserver : AnyObject {
     func callCenterDidChangeActiveSpeakers()
 }
 
@@ -91,7 +91,7 @@ struct WireCallCenterActiveSpeakersNotification : SelfPostingNotification {
 
 // MARK:- Call state observer
 
-public protocol WireCallCenterCallStateObserver : class {
+public protocol WireCallCenterCallStateObserver : AnyObject {
     
     /**
      Called when the callState changes in a conversation
@@ -117,7 +117,7 @@ public struct WireCallCenterCallStateNotification : SelfPostingNotification {
 
 // MARK:- Missed call observer
 
-public protocol WireCallCenterMissedCallObserver : class {
+public protocol WireCallCenterMissedCallObserver : AnyObject {
     func callCenterMissedCall(conversation: ZMConversation, caller: UserType, timestamp: Date, video: Bool)
 }
 
@@ -133,7 +133,7 @@ public struct WireCallCenterMissedCallNotification : SelfPostingNotification {
 
 // MARK:- Received call observer
 
-public protocol WireCallCenterCallErrorObserver: class {
+public protocol WireCallCenterCallErrorObserver: AnyObject {
     func callCenterDidReceiveCallError(_ error: CallError, conversationId: UUID)
 }
 
@@ -148,7 +148,7 @@ public struct WireCallCenterCallErrorNotification: SelfPostingNotification {
 
 // MARK:- CallParticipantObserver
 
-public protocol WireCallCenterCallParticipantObserver : class {
+public protocol WireCallCenterCallParticipantObserver : AnyObject {
     
     /**
      Called when a participant of the call joins / leaves or when their call state changes
@@ -176,7 +176,7 @@ public struct WireCallCenterCallParticipantNotification : SelfPostingNotificatio
 // MARK:- VoiceGainObserver
 
 @objc
-public protocol VoiceGainObserver : class {
+public protocol VoiceGainObserver : AnyObject {
     func voiceGainDidChange(forParticipant participant: UserType, volume: Float)
 }
 

--- a/Source/Notifications/Push notifications/Helpers/UserNotificationCenter.swift
+++ b/Source/Notifications/Push notifications/Helpers/UserNotificationCenter.swift
@@ -25,7 +25,7 @@ import UserNotifications
  * mocking for unit tests.
  */
 
-public protocol UserNotificationCenter: class {
+public protocol UserNotificationCenter: AnyObject {
     
     /// The object that processes incoming notifications and actions.
     var delegate: UNUserNotificationCenterDelegate? { get set }

--- a/Source/Registration/Company/CompanyLoginRequester.swift
+++ b/Source/Registration/Company/CompanyLoginRequester.swift
@@ -55,7 +55,7 @@ extension URLQueryItem {
     }
 }
 
-@objc public protocol URLSessionProtocol: class {
+@objc public protocol URLSessionProtocol: AnyObject {
     @objc(dataTaskWithRequest:completionHandler:)
     func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask
 }
@@ -79,7 +79,7 @@ public enum ValidationError: Equatable {
     }
 }
 
-public protocol CompanyLoginRequesterDelegate: class {
+public protocol CompanyLoginRequesterDelegate: AnyObject {
 
     /**
      * The login requester asks the user to verify their identity on the given website.

--- a/Source/Registration/RegistrationStatus.swift
+++ b/Source/Registration/RegistrationStatus.swift
@@ -19,7 +19,7 @@
 import Foundation
 
 /// Used to signal changes to the registration state.
-public protocol RegistrationStatusDelegate: class {
+public protocol RegistrationStatusDelegate: AnyObject {
     /// The team was successfully created.
     func teamRegistered()
 
@@ -49,7 +49,7 @@ public protocol RegistrationStatusDelegate: class {
  * A protocol for objects that handle registration of users and teams.
  */
 
-protocol RegistrationStatusProtocol: class {
+protocol RegistrationStatusProtocol: AnyObject {
     /// The current registration phase.
     var phase: RegistrationPhase { get }
 

--- a/Source/SessionManager/PresentationDelegate.swift
+++ b/Source/SessionManager/PresentationDelegate.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-public protocol PresentationDelegate: class {
+public protocol PresentationDelegate: AnyObject {
     /// Called when a conversation at one particular message should be shown
     /// - parameter conversation: Conversation which will be performed.
     /// - parameter message: Message which the conversation will be opened at.

--- a/Source/SessionManager/SessionManager+AVS.swift
+++ b/Source/SessionManager/SessionManager+AVS.swift
@@ -21,7 +21,7 @@ import Foundation
 fileprivate let AVSLogMessageNotification = Notification.Name("AVSLogMessageNotification")
 
 @objc
-public protocol AVSLogger: class {
+public protocol AVSLogger: AnyObject {
     
     @objc(logMessage:)
     func log(message : String)

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -40,7 +40,7 @@ public extension Bundle {
     case callKit
 }
 
-public protocol SessionActivationObserver: class {
+public protocol SessionActivationObserver: AnyObject {
     func sessionManagerDidChangeActiveUserSession(userSession: ZMUserSession)
     func sessionManagerDidReportLockChange(forSession session: UserSessionAppLockInterface)
 }
@@ -60,7 +60,7 @@ public protocol SessionManagerDelegate: SessionActivationObserver {
 /// The public interface for the session manager.
 
 @objc
-public protocol SessionManagerType: class {
+public protocol SessionManagerType: AnyObject {
     
     var accountManager : AccountManager { get }
     
@@ -104,12 +104,12 @@ public protocol SessionManagerType: class {
 }
 
 @objc
-public protocol SessionManagerSwitchingDelegate: class {
+public protocol SessionManagerSwitchingDelegate: AnyObject {
     func confirmSwitchingAccount(completion: @escaping (Bool) -> Void)
 }
 
 @objc
-public protocol ForegroundNotificationResponder: class {
+public protocol ForegroundNotificationResponder: AnyObject {
     func shouldPresentNotification(with userInfo: NotificationUserInfo) -> Bool
 }
 
@@ -1209,7 +1209,7 @@ extension SessionManager {
 
 // MARK: - Session manager observer
 
-@objc public protocol SessionManagerCreatedSessionObserver: class {
+@objc public protocol SessionManagerCreatedSessionObserver: AnyObject {
     /// Invoked when the SessionManager creates a user session either by
     /// activating one or creating one in the background. No assumption should
     /// be made that the session is active.
@@ -1219,7 +1219,7 @@ extension SessionManager {
     func sessionManagerCreated(unauthenticatedSession: UnauthenticatedSession)
 }
 
-@objc public protocol SessionManagerDestroyedSessionObserver: class {
+@objc public protocol SessionManagerDestroyedSessionObserver: AnyObject {
     /// Invoked when the SessionManager tears down the user session associated
     /// with the accountId.
     func sessionManagerDestroyedUserSession(for accountId : UUID)

--- a/Source/Synchronization/EventProcessingTracker.swift
+++ b/Source/Synchronization/EventProcessingTracker.swift
@@ -19,7 +19,7 @@
 import Foundation
 import WireDataModel
 
-@objc public protocol EventProcessingTrackerProtocol: class {
+@objc public protocol EventProcessingTrackerProtocol: AnyObject {
     func registerEventProcessed()
     func registerDataInsertionPerformed(amount: UInt)
     func registerDataUpdatePerformed(amount: UInt)

--- a/Source/Synchronization/EventProcessor.swift
+++ b/Source/Synchronization/EventProcessor.swift
@@ -23,7 +23,7 @@ extension NSNotification.Name {
 }
 
 @objc
-public protocol UpdateEventProcessor: class {
+public protocol UpdateEventProcessor: AnyObject {
             
     @objc(storeUpdateEvents:ignoreBuffer:)
     func storeUpdateEvents(_ updateEvents: [ZMUpdateEvent], ignoreBuffer: Bool)

--- a/Source/Synchronization/Strategies/Asset Deletion/AssetDeletionStatus.swift
+++ b/Source/Synchronization/Strategies/Asset Deletion/AssetDeletionStatus.swift
@@ -20,7 +20,7 @@ import Foundation
 
 private let log = ZMSLog(tag: "AssetDeletion")
 
-@objc public protocol AssetDeletionIdentifierProviderType: class {
+@objc public protocol AssetDeletionIdentifierProviderType: AnyObject {
     func nextIdentifierToDelete() -> String?
     func didDelete(identifier: String)
     func didFailToDelete(identifier: String)

--- a/Source/Synchronization/Strategies/Asset Deletion/DeletableAssetIdentifierProvider.swift
+++ b/Source/Synchronization/Strategies/Asset Deletion/DeletableAssetIdentifierProvider.swift
@@ -16,7 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-@objc public protocol DeletableAssetIdentifierProvider: class {
+@objc public protocol DeletableAssetIdentifierProvider: AnyObject {
     var assetIdentifiersToBeDeleted: Set<String> { get set }
 }
 

--- a/Source/UnauthenticatedSession/URLActionProcessors/CompanyLoginURLActionProcessor.swift
+++ b/Source/UnauthenticatedSession/URLActionProcessors/CompanyLoginURLActionProcessor.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-protocol CompanyLoginURLActionProcessorDelegate: class {
+protocol CompanyLoginURLActionProcessorDelegate: AnyObject {
     
     var isAllowedToCreateNewAccount: Bool { get }
     

--- a/Source/UnauthenticatedSession/UnauthenticatedSession.swift
+++ b/Source/UnauthenticatedSession/UnauthenticatedSession.swift
@@ -19,7 +19,7 @@
 import Foundation
 import WireUtilities
 
-public protocol UnauthenticatedSessionDelegate: class {
+public protocol UnauthenticatedSessionDelegate: AnyObject {
     /// Update credentials for the corresponding user session. Returns true if the credentials were accepted.
     func session(session: UnauthenticatedSession, updatedCredentials credentials: ZMCredentials)  -> Bool
     func session(session: UnauthenticatedSession, updatedProfileImage imageData: Data)
@@ -28,7 +28,7 @@ public protocol UnauthenticatedSessionDelegate: class {
     func sessionIsAllowedToCreateNewAccount(_ session: UnauthenticatedSession) -> Bool
 }
 
-@objc public protocol UserInfoParser: class {
+@objc public protocol UserInfoParser: AnyObject {
     @objc(accountExistsLocallyFromUserInfo:)
     func accountExistsLocally(from userInfo: UserInfo) -> Bool
     @objc(upgradeToAuthenticatedSessionWithUserInfo:)

--- a/Source/UserSession/OperationStatus.swift
+++ b/Source/UserSession/OperationStatus.swift
@@ -25,7 +25,7 @@ public typealias BackgroundTaskHandler = (_ taskResult: BackgroundTaskResult) ->
 private let zmLog = ZMSLog(tag: "OperationStatus")
 
 @objc(ZMOperationStatusDelegate)
-public protocol OperationStatusDelegate : class {
+public protocol OperationStatusDelegate : AnyObject {
     
     @objc(operationStatusDidChangeState:)
     func operationStatus(didChangeState state: SyncEngineOperationState)

--- a/Source/UserSession/UserProfileImageUpdateStatus.swift
+++ b/Source/UserSession/UserProfileImageUpdateStatus.swift
@@ -25,11 +25,11 @@ internal enum UserProfileImageUpdateError: Error {
     case uploadFailed(Error)
 }
 
-internal protocol UserProfileImageUpdateStateDelegate: class {
+internal protocol UserProfileImageUpdateStateDelegate: AnyObject {
     func failed(withError: UserProfileImageUpdateError)
 }
 
-internal protocol UserProfileImageUploadStatusProtocol: class {
+internal protocol UserProfileImageUploadStatusProtocol: AnyObject {
     func hasAssetToDelete() -> Bool
     func consumeAssetToDelete() -> String?
     func consumeImage(for size: ProfileImageSize) -> Data?
@@ -38,12 +38,12 @@ internal protocol UserProfileImageUploadStatusProtocol: class {
     func uploadingFailed(imageSize: ProfileImageSize, error: Error)
 }
 
-@objc public protocol UserProfileImageUpdateProtocol: class {
+@objc public protocol UserProfileImageUpdateProtocol: AnyObject {
     @objc(updateImageWithImageData:)
     func updateImage(imageData: Data)
 }
 
-internal protocol UserProfileImageUploadStateChangeDelegate: class {
+internal protocol UserProfileImageUploadStateChangeDelegate: AnyObject {
     func didTransition(from oldState: UserProfileImageUpdateStatus.ProfileUpdateState, to currentState: UserProfileImageUpdateStatus.ProfileUpdateState)
     func didTransition(from oldState: UserProfileImageUpdateStatus.ImageState, to currentState: UserProfileImageUpdateStatus.ImageState, for size: ProfileImageSize)
 }

--- a/Source/UserSession/ZMUserSession+AppLock.swift
+++ b/Source/UserSession/ZMUserSession+AppLock.swift
@@ -66,7 +66,7 @@ public enum SessionLock {
 
 }
 
-protocol UserSessionAppLockDelegate: class {
+protocol UserSessionAppLockDelegate: AnyObject {
 
     func userSessionDidUnlock(_ session: ZMUserSession)
 

--- a/Source/UserSession/ZMUserSession+Calling.swift
+++ b/Source/UserSession/ZMUserSession+Calling.swift
@@ -19,7 +19,7 @@
 import Foundation
 
 @objc
-public protocol CallNotificationStyleProvider: class {
+public protocol CallNotificationStyleProvider: AnyObject {
     
     var callNotificationStyle: CallNotificationStyle { get }
     

--- a/Source/UserSession/ZMUserSession+EncryptionAtRest.swift
+++ b/Source/UserSession/ZMUserSession+EncryptionAtRest.swift
@@ -29,7 +29,7 @@ public protocol UserSessionEncryptionAtRestInterface {
     func registerDatabaseLockedHandler(_ handler: @escaping (_ isDatabaseLocked: Bool) -> Void) -> Any
 }
 
-protocol UserSessionEncryptionAtRestDelegate: class {
+protocol UserSessionEncryptionAtRestDelegate: AnyObject {
     
     func setEncryptionAtRest(enabled: Bool, account: Account, encryptionKeys: EncryptionKeys)
     

--- a/Source/Utility/Pasteboard.swift
+++ b/Source/Utility/Pasteboard.swift
@@ -22,7 +22,7 @@ import Foundation
  * An object that provides
  */
 
-public protocol Pasteboard: class {
+public protocol Pasteboard: AnyObject {
 
     /// The text copied by the user, if any.
     var text: String? { get }


### PR DESCRIPTION
## What's new in this PR?

Replace all protocol extends class with AnyObject