### PR TITLE
fix: Fix warnings and errors for multiple SwiftLint rules by removing them from the disabled list

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -9,7 +9,6 @@ disabled_rules:
     - type_name
     - todo
     - large_tuple
-    - unused_setter_value
     - notification_center_detachment
     - discarded_notification_center_observer
     - cyclomatic_complexity

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -25,7 +25,6 @@ disabled_rules:
     - function_parameter_count
     - xctfail_message
     - compiler_protocol_init
-    - reduce_boolean
     
 included:
     - Source

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -26,7 +26,6 @@ disabled_rules:
     - xctfail_message
     - compiler_protocol_init
     - reduce_boolean
-    - shorthand_operator
     
 included:
     - Source

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -14,7 +14,6 @@ disabled_rules:
     - discarded_notification_center_observer
     - cyclomatic_complexity
     - closure_parameter_position
-    - statement_position
     - weak_delegate
     - inclusive_language
     - class_delegate_protocol

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -2,7 +2,6 @@ disabled_rules:
     - function_body_length
     - type_body_length
     - file_length
-    - generic_type_name
     - force_cast
     - force_try
     - identifier_name
@@ -10,7 +9,6 @@ disabled_rules:
     - todo
     - large_tuple
     - notification_center_detachment
-    - discarded_notification_center_observer
     - cyclomatic_complexity
     - closure_parameter_position
     - weak_delegate

--- a/Source/Calling/CallKitManager.swift
+++ b/Source/Calling/CallKitManager.swift
@@ -174,8 +174,7 @@ extension CallKitManager {
         if let audioCallIntent = intent as? INStartAudioCallIntent {
             contacts = audioCallIntent.contacts
             video = false
-        }
-        else if let videoCallIntent = intent as? INStartVideoCallIntent {
+        } else if let videoCallIntent = intent as? INStartVideoCallIntent {
             contacts = videoCallIntent.contacts
             video = true
         }
@@ -342,11 +341,9 @@ fileprivate extension Date {
     func clamp(between fromDate: Date, and toDate: Date) -> Date {
         if timeIntervalSinceReferenceDate < fromDate.timeIntervalSinceReferenceDate {
             return fromDate
-        }
-        else if timeIntervalSinceReferenceDate > toDate.timeIntervalSinceReferenceDate {
+        } else if timeIntervalSinceReferenceDate > toDate.timeIntervalSinceReferenceDate {
             return toDate
-        }
-        else {
+        } else {
             return self
         }
     }

--- a/Source/Calling/SystemMessageCallObserver.swift
+++ b/Source/Calling/SystemMessageCallObserver.swift
@@ -51,8 +51,7 @@ final class CallSystemMessageGenerator: NSObject {
             let duration = -connectDate.timeIntervalSinceNow
             log.info("Appending performed call message: \(duration), \(caller.name ?? ""), \"\(conversation.displayName)\"")
             systemMessage =  conversation.appendPerformedCallMessage(with: duration, caller: caller)
-        }
-        else {
+        } else {
             if caller.isSelfUser {
                 log.info("Appending performed call message: \(caller.name ?? ""), \"\(conversation.displayName)\"")
                 systemMessage =  conversation.appendPerformedCallMessage(with: 0, caller: caller)

--- a/Source/Calling/WireCallCenterV3+Events.swift
+++ b/Source/Calling/WireCallCenterV3+Events.swift
@@ -350,8 +350,7 @@ extension WireCallCenterV3 {
                     self.callSnapshots[conversationId] = call.updateActiveSpeakers(change.activeSpeakers)
                     WireCallCenterActiveSpeakersNotification().post(in: $0.notificationContext)
                 }
-            }
-            catch {
+            } catch {
                 zmLog.safePublic("Cannot decode active speakers change JSON")
             }
         }

--- a/Source/Data Model/Conversation+AccessMode.swift
+++ b/Source/Data Model/Conversation+AccessMode.swift
@@ -61,11 +61,9 @@ extension ZMConversation {
             if response.httpStatus == 200,
                 let uri = response.payload?.asDictionary()?[ZMConversation.TransportKey.uri] as? String {
                 completion(.success(uri))
-            }
-            else if response.httpStatus == 404 {
+            } else if response.httpStatus == 404 {
                 completion(.success(nil))
-            }
-            else {
+            } else {
                 let error = WirelessLinkError(response: response) ?? .unknown
                 zmLog.debug("Error fetching wireless link: \(error)")
                 completion(.failure(error))
@@ -91,8 +89,7 @@ extension ZMConversation {
                     self.createWirelessLink(in: userSession, completion)
                 }
             }
-        }
-        else {
+        } else {
             createWirelessLink(in: userSession, completion)
         }
     }
@@ -117,13 +114,11 @@ extension ZMConversation {
                         userSession.updateEventProcessor?.storeAndProcessUpdateEvents([event], ignoreBuffer: true)
                     }
                 }
-            }
-            else if response.httpStatus == 200,
+            } else if response.httpStatus == 200,
                 let payload = response.payload?.asDictionary(),
                 let uri = payload[ZMConversation.TransportKey.uri] as? String {
                 completion(.success(uri))
-            }
-            else {
+            } else {
                 let error = WirelessLinkError(response: response) ?? .unknown
                 zmLog.error("Error creating wireless link: \(error)")
                 completion(.failure(error))

--- a/Source/Data Model/Conversation+MessageDestructionTimeout.swift
+++ b/Source/Data Model/Conversation+MessageDestructionTimeout.swift
@@ -81,8 +81,7 @@ private struct MessageDestructionTimeoutRequestFactory {
         let payload: [AnyHashable: Any?]
         if timeout == 0 {
             payload = ["message_timer": nil]
-        }
-        else {
+        } else {
             // Backend expects the timer to be in miliseconds, we store it in seconds.
             let timeoutInMS: Int64 = Int64(timeout) * 1000
             payload = ["message_timer": timeoutInMS]

--- a/Source/E2EE/APSSignalingKeysStore.swift
+++ b/Source/E2EE/APSSignalingKeysStore.swift
@@ -46,8 +46,7 @@ public final class APSSignalingKeysStore: NSObject {
             self.verificationKey = verificationKey
             self.decryptionKey = decryptionKey
             self.apsDecoder = ZMAPSMessageDecoder(encryptionKey: decryptionKey, macKey: verificationKey)
-        }
-        else {
+        } else {
             return nil
         }
     }

--- a/Source/Notifications/Push notifications/LocalNotificationDispatcher.swift
+++ b/Source/Notifications/Push notifications/LocalNotificationDispatcher.swift
@@ -191,8 +191,7 @@ extension LocalNotificationDispatcher {
         if genericMessage.hasDeleted {
             let deleted = genericMessage.deleted.messageID
             idToDelete = UUID(uuidString: deleted)
-        }
-        else if genericMessage.hasHidden {
+        } else if genericMessage.hasHidden {
             let hidden = genericMessage.hidden.messageID
             idToDelete = UUID(uuidString: hidden)
         }

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -385,8 +385,7 @@ public final class SessionManager: NSObject, SessionManagerType {
             if let selectedAccount = accountManager.selectedAccount {
                 log.debug("Default account: \(selectedAccount.userIdentifier)")
             }
-        }
-        else {
+        } else {
             log.debug("No known accounts.")
         }
 
@@ -644,8 +643,7 @@ public final class SessionManager: NSObject, SessionManagerType {
                 completion(session)
                 onWorkDone()
                 group?.leave()
-            }
-            else {
+            } else {
                 let coreDataStack = CoreDataStack(account: account,
                                                   applicationContainer: self.sharedContainerURL,
                                                   dispatchGroup: self.dispatchGroup)
@@ -680,8 +678,7 @@ public final class SessionManager: NSObject, SessionManagerType {
 
         do {
             try FileManager.default.removeItem(at: CoreDataStack.accountDataFolder(accountIdentifier: accountID, applicationContainer: sharedContainerURL))
-        }
-        catch let error {
+        } catch let error {
             log.error("Impossible to delete the acccount \(account): \(error)")
         }
     }

--- a/Source/Synchronization/Strategies/RegistationCredentialVerificationStrategy.swift
+++ b/Source/Synchronization/Strategies/RegistationCredentialVerificationStrategy.swift
@@ -55,8 +55,7 @@ extension RegistationCredentialVerificationStrategy: ZMSingleRequestTranscoder {
     func didReceive(_ response: ZMTransportResponse, forSingleRequest sync: ZMSingleRequestSync) {
         if response.result == .success {
             registrationStatus.success()
-        }
-        else {
+        } else {
             let error: NSError
 
             switch registrationStatus.phase {

--- a/Source/Synchronization/Strategies/UserClientRequestFactory.swift
+++ b/Source/Synchronization/Strategies/UserClientRequestFactory.swift
@@ -114,8 +114,7 @@ public final class UserClientRequestFactory {
                 ["key": $0.prekey, "id": NSNumber(value: $0.id)]
             }
             return (preKeysPayloadData, preKeys.last!.id)
-        }
-        catch {
+        } catch {
             throw UserClientRequestError.noPreKeys
         }
     }
@@ -194,8 +193,7 @@ public final class UserClientRequestFactory {
                 "email": email,
                 "password": password
             ]
-        }
-        else {
+        } else {
             payload = [:]
         }
 

--- a/Source/Synchronization/Strategies/UserClientRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/UserClientRequestStrategy.swift
@@ -169,8 +169,7 @@ public final class UserClientRequestStrategy: ZMObjectSyncStrategy, ZMObjectStra
             case _ where keys.contains(ZMUserClientMarkedToDeleteKey):
                 if clientUpdateStatus.currentPhase == ClientUpdatePhase.deletingClients {
                     request = requestsFactory.deleteClientRequest(managedObject, credentials: clientUpdateStatus.credentials)
-                }
-                else {
+                } else {
                     fatal("No email credentials in memory")
                 }
             case _ where keys.contains(ZMUserClientNeedsToUpdateSignalingKeysKey):
@@ -189,8 +188,7 @@ public final class UserClientRequestStrategy: ZMObjectSyncStrategy, ZMObjectStra
             }
 
             return request
-        }
-        else {
+        } else {
             fatal("Called requestForUpdatingObject() on \(managedObject) to sync keys: \(keys)")
         }
     }
@@ -236,8 +234,7 @@ public final class UserClientRequestStrategy: ZMObjectSyncStrategy, ZMObjectStra
             }
             (managedObject as? UserClient)?.needsToUpdateCapabilities = false
             return false
-        }
-        else if keysToParse.contains(ZMUserClientMarkedToDeleteKey) {
+        } else if keysToParse.contains(ZMUserClientMarkedToDeleteKey) {
             let error = self.errorFromFailedDeleteResponse(response)
             if error.code == ClientUpdateError.clientToDeleteNotFound.rawValue {
                 self.managedObjectContext?.delete(managedObject)
@@ -245,8 +242,7 @@ public final class UserClientRequestStrategy: ZMObjectSyncStrategy, ZMObjectStra
             }
             clientUpdateStatus?.failedToDeleteClient(managedObject as! UserClient, error: error)
             return false
-        }
-        else {
+        } else {
             // first we try to register without password (credentials can be there, but they can not contain password)
             // if there is no password in credentials but it's required, we will recieve error from backend and only then will ask for password
             let error = errorFromFailedInsertResponse(response)
@@ -274,8 +270,7 @@ public final class UserClientRequestStrategy: ZMObjectSyncStrategy, ZMObjectStra
             guard let moc = self.managedObjectContext else { return }
             _ = UserClient.createOrUpdateSelfUserClient(payload, context: moc)
             clientRegistrationStatus?.didRegister(client)
-        }
-        else {
+        } else {
             fatal("Called updateInsertedObject() on \(managedObject.safeForLoggingDescription)")
         }
     }
@@ -309,8 +304,7 @@ public final class UserClientRequestStrategy: ZMObjectSyncStrategy, ZMObjectStra
                 case "missing-auth":
                     if let emailAddress = ZMUser.selfUser(in: moc).emailAddress, !emailAddress.isEmpty {
                         errorCode = .needsPasswordToRegisterClient
-                    }
-                    else {
+                    } else {
                         errorCode = .invalidCredentials
                     }
                 case "too-many-clients":
@@ -377,14 +371,11 @@ public final class UserClientRequestStrategy: ZMObjectSyncStrategy, ZMObjectStra
 
         if keysToParse.contains(ZMUserClientMarkedToDeleteKey) {
             return processResponseForDeletingClients(managedObject, requestUserInfo: requestUserInfo, responsePayload: response.payload)
-        }
-        else if keysToParse.contains(ZMUserClientNumberOfKeysRemainingKey) {
+        } else if keysToParse.contains(ZMUserClientNumberOfKeysRemainingKey) {
             (managedObject as! UserClient).numberOfKeysRemaining += Int32(requestsFactory.keyCount)
-        }
-        else if keysToParse.contains(ZMUserClientNeedsToUpdateSignalingKeysKey) {
+        } else if keysToParse.contains(ZMUserClientNeedsToUpdateSignalingKeysKey) {
             didRetryRegisteringSignalingKeys = false
-        }
-        else if keysToParse.contains(ZMUserClientNeedsToUpdateCapabilitiesKey) {
+        } else if keysToParse.contains(ZMUserClientNeedsToUpdateCapabilitiesKey) {
             didRetryUpdatingCapabilities = false
         }
 

--- a/Source/UserSession/ClientUpdateStatus.swift
+++ b/Source/UserSession/ClientUpdateStatus.swift
@@ -100,12 +100,10 @@ public enum ClientUpdateError: NSInteger {
                 do {
                     excludingSelfClient = try filterSelfClientIfValid(excludingSelfClient)
                     ZMClientUpdateNotification.notifyFetchingClientsCompleted(userClients: excludingSelfClient, context: syncManagedObjectContext)
-                }
-                catch let error as NSError {
+                } catch let error as NSError {
                     ZMClientUpdateNotification.notifyFetchingClientsDidFail(error: error, context: syncManagedObjectContext)
                 }
-            }
-            else {
+            } else {
                 ZMClientUpdateNotification.notifyFetchingClientsCompleted(userClients: clients, context: syncManagedObjectContext)
             }
         }
@@ -162,8 +160,7 @@ public enum ClientUpdateError: NSInteger {
                 // however if it happens and there is no other client to delete we should notify that all clients where deleted
                 internalCredentials = nil
                 ZMClientUpdateNotification.notifyDeletionCompleted(remainingClients: selfUserClientsExcludingSelfClient, context: syncManagedObjectContext)
-            }
-            else if  errorCode == .invalidCredentials {
+            } else if  errorCode == .invalidCredentials {
                 isWaitingToDeleteClients = false
                 internalCredentials = nil
                 ZMClientUpdateNotification.notifyDeletionFailed(error: error, context: syncManagedObjectContext)

--- a/Source/UserSession/FileRelocator.swift
+++ b/Source/UserSession/FileRelocator.swift
@@ -52,13 +52,11 @@ extension ZMUserSession {
                 zmLog.debug("Moving non-assigned Cache folder from \(oldLocation) to \(newLocation)")
                 do {
                     try fm.moveItem(at: oldLocation, to: newLocation)
-                }
-                catch let error {
+                } catch let error {
                     zmLog.error("Failed to move non-assigned Cache folder from \(oldLocation) to \(newLocation) - \(error)")
                     do {
                         try fm.removeItem(at: oldLocation)
-                    }
-                    catch let anError {
+                    } catch let anError {
                         fatal("Could not remove unassigned cache folder at \(oldLocation) - \(anError)")
                     }
                 }

--- a/Source/UserSession/ZMUserSession+Push.swift
+++ b/Source/UserSession/ZMUserSession+Push.swift
@@ -74,8 +74,7 @@ struct PushTokenMetadata {
     var transportType: String {
         if isSandbox {
             return "APNS_VOIP_SANDBOX"
-        }
-        else {
+        } else {
             return "APNS_VOIP"
         }
     }

--- a/Tests/Source/Calling/CallKitManagerTests.swift
+++ b/Tests/Source/Calling/CallKitManagerTests.swift
@@ -90,10 +90,10 @@ class MockCallKitCallController: CXCallController {
     public let mockCallObserver = MockCallObserver()
 
     public override func request(_ transaction: CXTransaction, completion: @escaping (Error?) -> Void) {
-        timesRequestTransactionCalled = timesRequestTransactionCalled + 1
+        timesRequestTransactionCalled += 1
         requestedTransactions.append(transaction)
         if mockErrorCount >= 1 {
-            mockErrorCount = mockErrorCount-1
+            mockErrorCount -= 1
             completion(mockTransactionErrorCode)
         } else {
             completion(.none)

--- a/Tests/Source/Calling/CallKitManagerTests.swift
+++ b/Tests/Source/Calling/CallKitManagerTests.swift
@@ -599,8 +599,7 @@ class CallKitManagerTest: DatabaseTest {
 
         if isVideo {
             intent = INStartVideoCallIntent(contacts: contacts)
-        }
-        else {
+        } else {
             intent = INStartAudioCallIntent(contacts: contacts)
         }
 

--- a/Tests/Source/E2EE/UserClientRequestFactoryTests.swift
+++ b/Tests/Source/E2EE/UserClientRequestFactoryTests.swift
@@ -238,8 +238,7 @@ class UserClientRequestFactoryTests: MessagingTest {
         // when
         do {
             _ = try sut.updateClientPreKeysRequest(client)
-        }
-        catch let error {
+        } catch let error {
             XCTAssertNotNil(error, "Should not return request if client does not have remoteIdentifier")
         }
 

--- a/Tests/Source/Integration/ConversationTests+Ephemeral.swift
+++ b/Tests/Source/Integration/ConversationTests+Ephemeral.swift
@@ -187,8 +187,7 @@ extension ConversationTests_Ephemeral {
                     let deleteMessage = message.underlyingMessage, deleteMessage.hasDeleted,
                 deleteMessage.deleted.messageID == ephemeral.nonce!.transportString() {
                 return true
-            }
-            else {
+            } else {
                 return false
             }
         })) != nil

--- a/Tests/Source/Synchronization/EventDecoderTests.swift
+++ b/Tests/Source/Synchronization/EventDecoderTests.swift
@@ -145,8 +145,7 @@ extension EventDecoderTest {
                 } else if callCount == 1 {
                     XCTAssertTrue(events.contains(event3))
                     XCTAssertTrue(events.contains(event4))
-                }
-                else {
+                } else {
                     XCTFail("called too often")
                 }
                 callCount += 1

--- a/Tests/Source/Synchronization/SynchronizationMocks.swift
+++ b/Tests/Source/Synchronization/SynchronizationMocks.swift
@@ -175,8 +175,7 @@ class SpyUserClientKeyStore: UserClientKeysStore {
         if self.failToGeneratePreKeys {
             let error = NSError(domain: "cryptobox.error", code: 0, userInfo: ["reason": "using fake store with simulated fail"])
             throw error
-        }
-        else {
+        } else {
             let keys = try! super.generateMoreKeys(count, start: start)
             lastGeneratedKeys = keys
             return keys
@@ -187,8 +186,7 @@ class SpyUserClientKeyStore: UserClientKeysStore {
         if self.failToGenerateLastPreKey {
             let error = NSError(domain: "cryptobox.error", code: 0, userInfo: ["reason": "using fake store with simulated fail"])
             throw error
-        }
-        else {
+        } else {
             lastGeneratedLastPrekey = try! super.lastPreKey()
             return lastGeneratedLastPrekey!
         }

--- a/Tests/Source/Synchronization/SynchronizationMocks.swift
+++ b/Tests/Source/Synchronization/SynchronizationMocks.swift
@@ -55,7 +55,7 @@ public class MockApplicationStatus: NSObject, ApplicationStatus, ClientRegistrat
 
     /// Notify that the current client was deleted remotely
     public func didDetectCurrentClientDeletion() {
-        deletionCalls = deletionCalls+1
+        deletionCalls += 1
     }
 
     /// Returns true if the client is registered

--- a/Tests/Source/Synchronization/ZMConversationAccessModeTests.swift
+++ b/Tests/Source/Synchronization/ZMConversationAccessModeTests.swift
@@ -126,14 +126,12 @@ public class ZMConversationAccessModeTests: MessagingTest {
         let conversation = ZMConversation.insertGroupConversation(moc: self.uiMOC, participants: [], name: "Test Conversation")!
         if options.hasRemoteId {
             conversation.remoteIdentifier = UUID()
-        }
-        else {
+        } else {
             conversation.remoteIdentifier = nil
         }
         if options.isGroup {
             conversation.conversationType = .group
-        }
-        else {
+        } else {
             conversation.conversationType = .invalid
         }
 

--- a/Tests/Source/UserSession/ZMUserSessionTests+EncryptionAtRest.swift
+++ b/Tests/Source/UserSession/ZMUserSessionTests+EncryptionAtRest.swift
@@ -74,7 +74,7 @@ class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
     }
 
     // MARK: - Database migration
- 
+
     // @SF.Storage @TSFI.UserInterface @S0.1 @S0.2
     func testThatDelegateIsCalled_WhenEncryptionAtRestIsEnabled() throws {
         // given


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

1. With this PR I started to remove rules from the disabled rules list and fixed the errors and warnings that popped up. More specifically I fixed warnings and errors for the rules below:

- **Statement Position Violation**: Else and catch should be on the same line, one space after the previous declaration. `(statement_position)`
- **Shorthand Operator Violation**: Prefer shorthand operators (+=, -=, *=, /=) over doing the operation and assigning. `(shorthand_operator)`

2. In addition to that I removed a bunch of rules from the list since they didn't trigger any warnings and errors by being enabled. These rules are:

- **Reduce Boolean**: Prefer using .allSatisfy() or .contains() over reduce(true) or reduce(false) `(reduce_boolean)`
- **Unused Setter Value**: Setter value is not used. `(unused_setter_value)`
- **Generic Type Name**: Generic type name should only contain alphanumeric characters, start with an uppercase character and span between 1 and 20 characters in length. `(generic_type_name)`
- **Discarded Notification Center Observer**: When registering for a notification using a block, the opaque observer that is returned should be stored so it can be removed later. `(discarded_notification_center_observer)`

















----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
