### PR TITLE
fix: remove space in federated handle search query FS-454

### DIFF
--- a/Source/UserSession/Search/SearchRequest.swift
+++ b/Source/UserSession/Search/SearchRequest.swift
@@ -78,8 +78,9 @@ public struct SearchRequest {
 
     var handleAndDomain: (String, String)? {
         let components = query.split(separator: "@")
-            .map({ String($0).trimmingCharacters(in: .whitespaces).lowercased() })
-            .filter({ !$0.isEmpty })
+            .map { String($0).trimmingCharacters(in: .whitespaces).lowercased() }
+            .map { $0.replacingOccurrences(of: " ", with: "") }
+            .filter { !$0.isEmpty }
 
         guard
             let handle = components.element(atIndex: 0),

--- a/Source/UserSession/Search/SearchRequest.swift
+++ b/Source/UserSession/Search/SearchRequest.swift
@@ -78,8 +78,8 @@ public struct SearchRequest {
 
     var handleAndDomain: (String, String)? {
         let components = query.split(separator: "@")
-            .map { String($0).trimmingCharacters(in: .whitespaces).lowercased() }
-            .map { $0.replacingOccurrences(of: " ", with: "") }
+//            .map { String($0).trimmingCharacters(in: .whitespaces).lowercased() }
+            .map { String($0).replacingOccurrences(of: " ", with: "") }
             .filter { !$0.isEmpty }
 
         guard

--- a/Source/UserSession/Search/SearchRequest.swift
+++ b/Source/UserSession/Search/SearchRequest.swift
@@ -78,7 +78,6 @@ public struct SearchRequest {
 
     var handleAndDomain: (String, String)? {
         let components = query.split(separator: "@")
-//            .map { String($0).trimmingCharacters(in: .whitespaces).lowercased() }
             .map { String($0).replacingOccurrences(of: " ", with: "") }
             .filter { !$0.isEmpty }
 

--- a/Tests/Source/UserSession/SearchRequestTests.swift
+++ b/Tests/Source/UserSession/SearchRequestTests.swift
@@ -60,6 +60,9 @@ class SearchRequestTests: MessagingTest {
 
         // with leading whitespace
         try assertHandleAndDomain(from: " john@example.com ", handle: "john", domain: "example.com")
+
+        // with whitespace in the middle
+        try assertHandleAndDomain(from: " john@ example.com abc", handle: "john", domain: "example.comabc")
     }
 
     func testThatItDoesntParseHandleAndDomain_WhenQueryIsIncomplete() throws {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-454" title="FS-454" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-454</a>  [iOS] The app crashes on searching muhammadanta1@anta.wire.link abc in search UI field 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Remove whitespace in federated handle search