### PR TITLE
feat: remote mute support - SQCALL-336

### DIFF
--- a/Source/Calling/CallCenterSupport.swift
+++ b/Source/Calling/CallCenterSupport.swift
@@ -18,8 +18,6 @@
 
 import Foundation
 
-private let zmLog = ZMSLog(tag: "calling")
-
 /// An opaque OTR calling message.
 
 public typealias WireCallMessageToken = UnsafeMutableRawPointer

--- a/Source/Calling/CallCenterSupport.swift
+++ b/Source/Calling/CallCenterSupport.swift
@@ -64,7 +64,7 @@ extension CallEvent {
     var isRemoteMute: Bool {
         let content = try? decoder.decode(Content.self, from: data)
         zmLog.debug("call event: \(content?.type)")
-        return content?.type == "REMOTE_MUTE"
+        return content?.type == "REMOTEMUTE"
     }
 
     private struct Content: Codable {

--- a/Source/Calling/CallCenterSupport.swift
+++ b/Source/Calling/CallCenterSupport.swift
@@ -55,22 +55,6 @@ public struct CallEvent {
     let userId: AVSIdentifier
     let clientId: String
 
-    let decoder = JSONDecoder()
-
-}
-
-extension CallEvent {
-
-    var isRemoteMute: Bool {
-        let content = try? decoder.decode(Content.self, from: data)
-        zmLog.debug("call event: \(content?.type)")
-        return content?.type == "REMOTEMUTE"
-    }
-
-    private struct Content: Codable {
-        let type: String
-    }
-
 }
 
 // MARK: - Call center transport

--- a/Source/Calling/CallCenterSupport.swift
+++ b/Source/Calling/CallCenterSupport.swift
@@ -18,6 +18,8 @@
 
 import Foundation
 
+private let zmLog = ZMSLog(tag: "calling")
+
 /// An opaque OTR calling message.
 
 public typealias WireCallMessageToken = UnsafeMutableRawPointer
@@ -61,6 +63,7 @@ extension CallEvent {
 
     var isRemoteMute: Bool {
         let content = try? decoder.decode(Content.self, from: data)
+        zmLog.debug("call event: \(content?.type)")
         return content?.type == "REMOTE_MUTE"
     }
 

--- a/Source/Calling/CallCenterSupport.swift
+++ b/Source/Calling/CallCenterSupport.swift
@@ -53,6 +53,21 @@ public struct CallEvent {
     let userId: AVSIdentifier
     let clientId: String
 
+    let decoder = JSONDecoder()
+
+}
+
+extension CallEvent {
+
+    var isRemoteMute: Bool {
+        let content = try? decoder.decode(Content.self, from: data)
+        return content?.type == "REMOTE_MUTE"
+    }
+
+    private struct Content: Codable {
+        let type: String
+    }
+
 }
 
 // MARK: - Call center transport

--- a/Source/Calling/CallEventContent.swift
+++ b/Source/Calling/CallEventContent.swift
@@ -1,0 +1,35 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+struct CallEventContent: Codable {
+    let type: String
+
+    init?(from data: Data, with decoder: JSONDecoder) {
+        do {
+            self = try decoder.decode(Self.self, from: data)
+        } catch {
+            return nil
+        }
+    }
+
+    var isRemoteMute: Bool {
+        return type == "REMOTEMUTE"
+    }
+}

--- a/Source/Synchronization/Strategies/CallingRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/CallingRequestStrategy.swift
@@ -285,6 +285,12 @@ public final class CallingRequestStrategy: AbstractRequestStrategy, ZMSingleRequ
 
                 callEventStatus.scheduledCallEventForProcessing()
 
+                guard !callEvent.isRemoteMute else {
+                    callCenter?.muted = true
+                    zmLog.debug("muted remotely from calling message")
+                    return
+                }
+
                 callCenter?.processCallEvent(callEvent, completionHandler: { [weak self] in
                     self?.zmLog.debug("processed calling message")
                     self?.callEventStatus.finishedProcessingCallEvent()

--- a/Source/Synchronization/Strategies/CallingRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/CallingRequestStrategy.swift
@@ -27,7 +27,6 @@ public final class CallingRequestStrategy: AbstractRequestStrategy, ZMSingleRequ
 
     private let zmLog = ZMSLog(tag: "calling")
 
-    private var callCenter: WireCallCenterV3?
     private let messageSync: ProteusMessageSync<GenericMessageEntity>
     private let flowManager: FlowManagerType
     private let decoder = JSONDecoder()
@@ -41,6 +40,10 @@ public final class CallingRequestStrategy: AbstractRequestStrategy, ZMSingleRequ
     private var clientDiscoveryRequest: ClientDiscoveryRequest?
 
     private let ephemeralURLSession = URLSession(configuration: .ephemeral)
+
+    // MARK: - Internal Properties
+
+    var callCenter: WireCallCenterV3?
 
     // MARK: - Public Properties
 
@@ -265,38 +268,58 @@ public final class CallingRequestStrategy: AbstractRequestStrategy, ZMSingleRequ
 
                 self.zmLog.debug("received calling message, timestamp \(eventTimestamp), serverTimeDelta \(serverTimeDelta)")
 
-                let conversationId = AVSIdentifier(
-                    identifier: conversationUUID,
-                    domain: useFederationEndpoint ? event.conversationDomain : nil
-                )
-                let userId = AVSIdentifier(
-                    identifier: senderUUID,
-                    domain: useFederationEndpoint ? event.senderDomain : nil
-                )
+                let isRemoteMute = CallEventContent(from: payload, with: decoder)?.isRemoteMute ?? false
 
-                let callEvent = CallEvent(
-                    data: payload,
-                    currentTimestamp: Date().addingTimeInterval(serverTimeDelta),
-                    serverTimestamp: eventTimestamp,
-                    conversationId: conversationId,
-                    userId: userId,
-                    clientId: clientId
-                )
-
-                callEventStatus.scheduledCallEventForProcessing()
-
-                guard !callEvent.isRemoteMute else {
+                guard !isRemoteMute else {
                     callCenter?.muted = true
                     zmLog.debug("muted remotely from calling message")
                     return
                 }
 
-                callCenter?.processCallEvent(callEvent, completionHandler: { [weak self] in
-                    self?.zmLog.debug("processed calling message")
-                    self?.callEventStatus.finishedProcessingCallEvent()
-                })
+                processCallEvent(
+                    conversationUUID: conversationUUID,
+                    senderUUID: senderUUID,
+                    clientId: clientId,
+                    event: event,
+                    payload: payload,
+                    currentTimestamp: Date().addingTimeInterval(serverTimeDelta),
+                    eventTimestamp: eventTimestamp
+                )
             }
         }
+    }
+
+    private func processCallEvent(conversationUUID: UUID,
+                                  senderUUID: UUID,
+                                  clientId: String,
+                                  event: ZMUpdateEvent,
+                                  payload: Data,
+                                  currentTimestamp: Date,
+                                  eventTimestamp: Date) {
+        let conversationId = AVSIdentifier(
+            identifier: conversationUUID,
+            domain: useFederationEndpoint ? event.conversationDomain : nil
+        )
+        let userId = AVSIdentifier(
+            identifier: senderUUID,
+            domain: useFederationEndpoint ? event.senderDomain : nil
+        )
+
+        let callEvent = CallEvent(
+            data: payload,
+            currentTimestamp: currentTimestamp,
+            serverTimestamp: eventTimestamp,
+            conversationId: conversationId,
+            userId: userId,
+            clientId: clientId
+        )
+
+        callEventStatus.scheduledCallEventForProcessing()
+
+        callCenter?.processCallEvent(callEvent, completionHandler: { [weak self] in
+            self?.zmLog.debug("processed calling message")
+            self?.callEventStatus.finishedProcessingCallEvent()
+        })
     }
 
     public func processEvents(_ events: [ZMUpdateEvent], liveEvents: Bool, prefetchResult: ZMFetchRequestBatchResult?) {

--- a/Tests/Source/Calling/CallEventContentTests.swift
+++ b/Tests/Source/Calling/CallEventContentTests.swift
@@ -1,0 +1,55 @@
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import XCTest
+@testable import WireSyncEngine
+
+class CallEventContentTests: XCTestCase {
+
+    private let decoder = JSONDecoder()
+    private let remoteMute = "REMOTEMUTE"
+
+    private func eventData(type: String) -> Data {
+        try! JSONSerialization.data(withJSONObject: ["type": type], options: [])
+    }
+
+    func testThatItCanBeCreatedFromData() {
+        // GIVEN / WHEN
+        let sut = CallEventContent(from: eventData(type: remoteMute), with: decoder)
+
+        // THEN
+        XCTAssertEqual(sut?.type, remoteMute)
+    }
+
+    func testThatIsRemoteMute_IsTrue_WhenTypeIsRemoteMute() {
+        // GIVEN
+        let sut = CallEventContent(from: eventData(type: remoteMute), with: decoder)!
+
+        // WHEN / THEN
+        XCTAssertTrue(sut.isRemoteMute)
+    }
+
+    func testThatIsRemoteMute_IsFalse_WhenTypeIsNotRemoteMute() {
+        // GIVEN
+        let sut = CallEventContent(from: eventData(type: "SOME"), with: decoder)!
+
+        // WHEN / THEN
+        XCTAssertFalse(sut.isRemoteMute)
+    }
+}

--- a/Tests/Source/Synchronization/StoreUpdateEventTests.swift
+++ b/Tests/Source/Synchronization/StoreUpdateEventTests.swift
@@ -359,7 +359,7 @@ extension StoreUpdateEventTests {
 
             // when
             let convertedEvents = StoredUpdateEvent.eventsFromStoredEvents([storedEvent], encryptionKeys: nil)
-            
+
             // then
             XCTAssertTrue(convertedEvents.isEmpty)
         } else {

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -397,6 +397,7 @@
 		632A582025CC43DA00F0C4BD /* CallParticipantsListKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632A581F25CC43DA00F0C4BD /* CallParticipantsListKind.swift */; };
 		632A582225CD9DF900F0C4BD /* CallParticipantsKindTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632A582125CD9DF900F0C4BD /* CallParticipantsKindTests.swift */; };
 		633BBC5D27C3B93A00D8B1B0 /* CallEventContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 633BBC5C27C3B93A00D8B1B0 /* CallEventContent.swift */; };
+		633BBC6127C3C74B00D8B1B0 /* CallEventContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 633BBC5E27C3C39700D8B1B0 /* CallEventContentTests.swift */; };
 		634976E9268A185A00824A05 /* AVSVideoStreams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634976E8268A185A00824A05 /* AVSVideoStreams.swift */; };
 		634976F8268A200C00824A05 /* AVSClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634976F7268A200C00824A05 /* AVSClient.swift */; };
 		634976FD268A205A00824A05 /* AVSClientList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634976FC268A205A00824A05 /* AVSClientList.swift */; };
@@ -1041,6 +1042,7 @@
 		632A581F25CC43DA00F0C4BD /* CallParticipantsListKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallParticipantsListKind.swift; sourceTree = "<group>"; };
 		632A582125CD9DF900F0C4BD /* CallParticipantsKindTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallParticipantsKindTests.swift; sourceTree = "<group>"; };
 		633BBC5C27C3B93A00D8B1B0 /* CallEventContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallEventContent.swift; sourceTree = "<group>"; };
+		633BBC5E27C3C39700D8B1B0 /* CallEventContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallEventContentTests.swift; sourceTree = "<group>"; };
 		63495E4623FFF098002A7C59 /* ConversationTests+OTR.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationTests+OTR.swift"; sourceTree = "<group>"; };
 		634976E8268A185A00824A05 /* AVSVideoStreams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVSVideoStreams.swift; sourceTree = "<group>"; };
 		634976F7268A200C00824A05 /* AVSClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVSClient.swift; sourceTree = "<group>"; };
@@ -1733,6 +1735,7 @@
 				63A8F575276B7B3100513750 /* AVSClientTests.swift */,
 				63A1100D27A026010041E14E /* ZMConversation+AVSIdentifierTests.swift */,
 				63A1100F27A028540041E14E /* ZMUser+AVSIdentifierTests.swift */,
+				633BBC5E27C3C39700D8B1B0 /* CallEventContentTests.swift */,
 			);
 			path = Calling;
 			sourceTree = "<group>";
@@ -3236,6 +3239,7 @@
 				F9410F681DE4BE42007451FF /* PushTokenStrategyTests.swift in Sources */,
 				F9ABE8571EFD56BF00D83214 /* TeamDownloadRequestStrategy+EventsTests.swift in Sources */,
 				85D85EAFA1CB6E457D14E3B7 /* MockEntity2.m in Sources */,
+				633BBC6127C3C74B00D8B1B0 /* CallEventContentTests.swift in Sources */,
 				166D18A6230EC418001288CD /* MockMediaManager.swift in Sources */,
 				09914E531BD6613D00C10BF8 /* ZMDecodedAPSMessageTest.m in Sources */,
 				6349771E268B7C4300824A05 /* AVSVideoStreamsTest.swift in Sources */,

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -396,6 +396,7 @@
 		5EFE9C17212AB945007932A6 /* RegistrationPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EFE9C16212AB945007932A6 /* RegistrationPhase.swift */; };
 		632A582025CC43DA00F0C4BD /* CallParticipantsListKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632A581F25CC43DA00F0C4BD /* CallParticipantsListKind.swift */; };
 		632A582225CD9DF900F0C4BD /* CallParticipantsKindTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632A582125CD9DF900F0C4BD /* CallParticipantsKindTests.swift */; };
+		633BBC5D27C3B93A00D8B1B0 /* CallEventContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 633BBC5C27C3B93A00D8B1B0 /* CallEventContent.swift */; };
 		634976E9268A185A00824A05 /* AVSVideoStreams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634976E8268A185A00824A05 /* AVSVideoStreams.swift */; };
 		634976F8268A200C00824A05 /* AVSClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634976F7268A200C00824A05 /* AVSClient.swift */; };
 		634976FD268A205A00824A05 /* AVSClientList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634976FC268A205A00824A05 /* AVSClientList.swift */; };
@@ -1039,6 +1040,7 @@
 		5EFE9C16212AB945007932A6 /* RegistrationPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationPhase.swift; sourceTree = "<group>"; };
 		632A581F25CC43DA00F0C4BD /* CallParticipantsListKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallParticipantsListKind.swift; sourceTree = "<group>"; };
 		632A582125CD9DF900F0C4BD /* CallParticipantsKindTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallParticipantsKindTests.swift; sourceTree = "<group>"; };
+		633BBC5C27C3B93A00D8B1B0 /* CallEventContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallEventContent.swift; sourceTree = "<group>"; };
 		63495E4623FFF098002A7C59 /* ConversationTests+OTR.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationTests+OTR.swift"; sourceTree = "<group>"; };
 		634976E8268A185A00824A05 /* AVSVideoStreams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVSVideoStreams.swift; sourceTree = "<group>"; };
 		634976F7268A200C00824A05 /* AVSClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVSClient.swift; sourceTree = "<group>"; };
@@ -1696,6 +1698,7 @@
 				5EC2C58E2137F5EE00C6CE35 /* CallClosedReason.swift */,
 				7C5482D9225380160055F1AB /* CallReceivedResult.swift */,
 				5E8BB8A12147F89000EEA64B /* CallCenterSupport.swift */,
+				633BBC5C27C3B93A00D8B1B0 /* CallEventContent.swift */,
 				165D3A141E1D3EF30052E654 /* WireCallCenterV3.swift */,
 				639290A6252DEDB400046171 /* WireCallCenterV3+Degradation.swift */,
 				5EC2C592213827BF00C6CE35 /* WireCallCenterV3+Events.swift */,
@@ -3401,6 +3404,7 @@
 				0640C26D26EA0B5C0057AF80 /* NSManagedObjectContext+Packaging.swift in Sources */,
 				F1C51FE71FB49660009C2269 /* RegistrationStatus.swift in Sources */,
 				5E8EE1FA20FDC7D700DB1F9B /* Pasteboard.swift in Sources */,
+				633BBC5D27C3B93A00D8B1B0 /* CallEventContent.swift in Sources */,
 				16CD6A272681BA9000B9A73A /* ZMUser+FederatedConnection.swift in Sources */,
 				874A16922052BEC5001C6760 /* UserExpirationObserver.swift in Sources */,
 				8751DA061F66BFA6000D308B /* ZMUserSession+Push.swift in Sources */,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQCALL-336" title="SQCALL-336" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />SQCALL-336</a>  [iOS] PARTICIPANT - Remote mute support for participant
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We need to implement support for remote mute

### Solutions

Before processing call events and forwarding them to AVS, we decode the event data and check if the type of the event is a remote mute event. If it is, we mute the user instead of sending the call event to AVS.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
