### PR TITLE
fix: Continue using voip pushes for iOS 12

### DIFF
--- a/Source/SessionManager/SessionManager+Push.swift
+++ b/Source/SessionManager/SessionManager+Push.swift
@@ -146,15 +146,15 @@ extension SessionManager: PKPushRegistryDelegate {
     public func updatePushToken(for session: ZMUserSession) {
         session.managedObjectContext.performGroupedBlock { [weak session] in
             // Refresh the tokens if needed
-            if self.configuration.useLegacyPushNotifications {
+            if #available(iOS 13.0, *), !self.configuration.useLegacyPushNotifications {
+                pushLog.safePublic("creating standard push token")
+                self.application.registerForRemoteNotifications()
+            } else {
                 if let token = self.pushRegistry.pushToken(for: .voIP) {
                     pushLog.safePublic("creating voip push token")
                     let pushToken = PushToken.createVOIPToken(from: token)
                     session?.setPushToken(pushToken)
                 }
-            } else {
-                pushLog.safePublic("creating standard push token")
-                self.application.registerForRemoteNotifications()
             }
         }
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The notification filtering entitlement (used in conjunction with the notification extension) is only supported from iOS 13.3

### Solutions

Continue using voip pushes for iOS 12 and add extra check for iOS version when updating or creating push tokens.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
