### PR TITLE
feat: (2FA) Prepare for requesting email verification code for login SQSERVICES-1377

### DIFF
--- a/Source/UnauthenticatedSession/UnauthenticatedSession+Login.swift
+++ b/Source/UnauthenticatedSession/UnauthenticatedSession+Login.swift
@@ -69,4 +69,22 @@ extension UnauthenticatedSession {
         }
         return true
     }
+
+    /// Requires an email verification code for login. Returns NO if the email address was invalid
+    @objc(requestEmailVerificationCodeForLogin:)
+    @discardableResult public func requestEmailVerificationCodeForLogin(email: String) -> Bool {
+        do {
+            var email: String? = email
+            _ = try ZMUser.validate(emailAddress: &email)
+        } catch {
+            return false
+        }
+
+        authenticationErrorIfNotReachable {
+            self.authenticationStatus.prepareForRequestingEmailVerificationCode(forLogin: email)
+            RequestAvailableNotification.notifyNewRequestsAvailable(nil)
+        }
+        return true
+
+    }
 }

--- a/Source/UnauthenticatedSession/ZMAuthenticationStatus.h
+++ b/Source/UnauthenticatedSession/ZMAuthenticationStatus.h
@@ -55,6 +55,7 @@ typedef NS_ENUM(NSUInteger, ZMAuthenticationPhase) {
     ZMAuthenticationPhaseLoginWithEmail,
     ZMAuthenticationPhaseWaitingToImportBackup,
     ZMAuthenticationPhaseRequestPhoneVerificationCodeForLogin,
+    ZMAuthenticationPhaseRequestEmailVerificationCodeForLogin,
     ZMAuthenticationPhaseVerifyPhone,
     ZMAuthenticationPhaseAuthenticated
 };
@@ -63,6 +64,7 @@ typedef NS_ENUM(NSUInteger, ZMAuthenticationPhase) {
 
 @property (nonatomic, readonly, copy) NSString *registrationPhoneNumberThatNeedsAValidationCode;
 @property (nonatomic, readonly, copy) NSString *loginPhoneNumberThatNeedsAValidationCode;
+@property (nonatomic, readonly, copy) NSString *loginEmailThatNeedsAValidationCode;
 
 @property (nonatomic, readonly) ZMCredentials *loginCredentials;
 @property (nonatomic, readonly) ZMPhoneCredentials *registrationPhoneValidationCredentials;
@@ -86,6 +88,7 @@ typedef NS_ENUM(NSUInteger, ZMAuthenticationPhase) {
 - (void)prepareForLoginWithCredentials:(ZMCredentials *)credentials;
 - (void)continueAfterBackupImportStep;
 - (void)prepareForRequestingPhoneVerificationCodeForLogin:(NSString *)phone;
+- (void)prepareForRequestingEmailVerificationCodeForLogin:(NSString *)email;
 
 - (void)didCompleteRequestForLoginCodeSuccessfully;
 - (void)didFailRequestForLoginCode:(NSError *)error;

--- a/Source/UnauthenticatedSession/ZMAuthenticationStatus.m
+++ b/Source/UnauthenticatedSession/ZMAuthenticationStatus.m
@@ -83,6 +83,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"Authentication";
     
     self.registrationPhoneNumberThatNeedsAValidationCode = nil;
     self.loginPhoneNumberThatNeedsAValidationCode = nil;
+    self.loginEmailThatNeedsAValidationCode = nil;
 
     self.internalLoginCredentials = nil;
     self.registrationPhoneValidationCredentials = nil;
@@ -131,6 +132,11 @@ static NSString* ZMLogTag ZM_UNUSED = @"Authentication";
     if(self.loginPhoneNumberThatNeedsAValidationCode != nil) {
         return ZMAuthenticationPhaseRequestPhoneVerificationCodeForLogin;
     }
+
+    if (self.loginEmailThatNeedsAValidationCode != nil) {
+        return ZMAuthenticationPhaseRequestEmailVerificationCodeForLogin;
+    }
+    
     return ZMAuthenticationPhaseUnauthenticated;
 }
 
@@ -212,6 +218,14 @@ static NSString* ZMLogTag ZM_UNUSED = @"Authentication";
     ZMLogDebug(@"%@", NSStringFromSelector(_cmd));
     [self resetLoginAndRegistrationStatus];
     self.loginPhoneNumberThatNeedsAValidationCode = [ZMPhoneNumberValidator validatePhoneNumber: phone];
+    ZMLogDebug(@"current phase: %lu", (unsigned long)self.currentPhase);
+}
+
+- (void)prepareForRequestingEmailVerificationCodeForLogin:(NSString *)email;
+{
+    ZMLogDebug(@"%@", NSStringFromSelector(_cmd));
+    [self resetLoginAndRegistrationStatus];
+    self.loginEmailThatNeedsAValidationCode = email;
     ZMLogDebug(@"current phase: %lu", (unsigned long)self.currentPhase);
 }
 

--- a/Source/UnauthenticatedSession/ZMAuthenticationStatus_Internal.h
+++ b/Source/UnauthenticatedSession/ZMAuthenticationStatus_Internal.h
@@ -25,6 +25,7 @@
 
 @property (nonatomic, copy) NSString *registrationPhoneNumberThatNeedsAValidationCode;
 @property (nonatomic, copy) NSString *loginPhoneNumberThatNeedsAValidationCode;
+@property (nonatomic, copy) NSString *loginEmailThatNeedsAValidationCode;
 
 @property (nonatomic) ZMCredentials *internalLoginCredentials;
 @property (nonatomic) ZMPhoneCredentials *registrationPhoneValidationCredentials;


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

In this PR we introduce a couple of new things and preparing stuff so 2FA can work during Login:

1. Introducing `requestEmailVerificationCodeForLogin` as a public method so we can use it in the UI Project
2. Added a new` ZMAuthenticationPhase` to the list -> `ZMAuthenticationPhaseRequestEmailVerificationCodeForLogin`
3. `prepareForRequestingEmailVerificationCodeForLogin` has been added to ZMAuthenticationStatus


Open Question: Not exactly sure what we can test atm since we didn't make any changes to the the ZMLoginCodeRequestTranscoder.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
