### PR TITLE
feat: Modify `ZMLoginCodeRequestTranscoder` to support 2FA for login SQSERVICES-1341

### DIFF
--- a/Source/Synchronization/Transcoders/ZMLoginCodeRequestTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMLoginCodeRequestTranscoder.m
@@ -48,6 +48,7 @@
         self.phoneVerificationCodeRequestSync = [[ZMSingleRequestSync alloc] initWithSingleRequestTranscoder:self groupQueue:groupQueue];
         self.emailVerificationCodeRequestSync = [[ZMSingleRequestSync alloc] initWithSingleRequestTranscoder:self groupQueue:groupQueue];
         [self.phoneVerificationCodeRequestSync readyForNextRequest];
+        [self.emailVerificationCodeRequestSync readyForNextRequest];
     }
     return self;
 }

--- a/Source/Synchronization/Transcoders/ZMLoginCodeRequestTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMLoginCodeRequestTranscoder.m
@@ -69,7 +69,7 @@
 - (ZMTransportRequest *)requestForSingleRequestSync:(__unused ZMSingleRequestSync *)sync;
 {
 
-    if (sync == _emailVerificationCodeRequestSync) {
+    if (sync == self.emailVerificationCodeRequestSync) {
         ZMTransportRequest *emailVerficationCodeRequest = [[ZMTransportRequest alloc] initWithPath:@"/verification-code/send"
                                                                         method:ZMMethodPOST
                                                                        payload:@{@"email": self.authenticationStatus.loginEmailThatNeedsAValidationCode}

--- a/Source/Synchronization/Transcoders/ZMLoginCodeRequestTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMLoginCodeRequestTranscoder.m
@@ -71,18 +71,20 @@
 
     if (sync == self.emailVerificationCodeRequestSync) {
         ZMTransportRequest *emailVerficationCodeRequest = [[ZMTransportRequest alloc] initWithPath:@"/verification-code/send"
-                                                                        method:ZMMethodPOST
-                                                                       payload:@{@"email": self.authenticationStatus.loginEmailThatNeedsAValidationCode}
-                                                                authentication:ZMTransportRequestAuthNone];
+                                                                                            method:ZMMethodPOST
+                                                                                           payload:@{@"email": self.authenticationStatus.loginEmailThatNeedsAValidationCode}
+                                                                                    authentication:ZMTransportRequestAuthNone];
         return emailVerficationCodeRequest;
-    } else {
+    } else if (sync == self.phoneVerificationCodeRequestSync) {
 
-    ZMTransportRequest *phoneVerificationCodeRequest = [[ZMTransportRequest alloc] initWithPath:@"/login/send"
-                                                                    method:ZMMethodPOST
-                                                                   payload:@{@"phone": self.authenticationStatus.loginPhoneNumberThatNeedsAValidationCode}
-                                                            authentication:ZMTransportRequestAuthNone];
-    return phoneVerificationCodeRequest;
+        ZMTransportRequest *phoneVerificationCodeRequest = [[ZMTransportRequest alloc] initWithPath:@"/login/send"
+                                                                                             method:ZMMethodPOST
+                                                                                            payload:@{@"phone": self.authenticationStatus.loginPhoneNumberThatNeedsAValidationCode}
+                                                                                     authentication:ZMTransportRequestAuthNone];
+        return phoneVerificationCodeRequest;
     }
+
+    return nil;
 }
 
 - (void)didReceiveResponse:(ZMTransportResponse *)response forSingleRequest:(__unused ZMSingleRequestSync *)sync

--- a/Source/Synchronization/Transcoders/ZMLoginTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMLoginTranscoder.m
@@ -150,7 +150,7 @@ NSTimeInterval DefaultPendingValidationLoginAttemptInterval = 5;
         payload[@"phone"] = credentials.phoneNumber;
         payload[@"code"] = credentials.phoneNumberVerificationCode;
     }
-    else if (credentials.email != nil && credentials.password != nil && credentials.emailVerificationCode != nil) {
+    else if (credentials.emailVerificationCode != nil && credentials.email != nil && credentials.password != nil) {
         payload[@"email"] = credentials.email;
         payload[@"password"] = credentials.password;
         payload[@"verification-code"]  = credentials.emailVerificationCode;

--- a/Source/Synchronization/Transcoders/ZMLoginTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMLoginTranscoder.m
@@ -150,6 +150,10 @@ NSTimeInterval DefaultPendingValidationLoginAttemptInterval = 5;
         payload[@"phone"] = credentials.phoneNumber;
         payload[@"code"] = credentials.phoneNumberVerificationCode;
     }
+    else if (credentials.email != nil && credentials.emailVerificationCode != nil) {
+        payload[@"email"] = credentials.email;
+        payload[@"verification-code"]  =credentials.emailVerificationCode;
+    }
     else {
         return nil;
     }

--- a/Source/Synchronization/Transcoders/ZMLoginTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMLoginTranscoder.m
@@ -142,18 +142,18 @@ NSTimeInterval DefaultPendingValidationLoginAttemptInterval = 5;
         return nil;
     }
     NSMutableDictionary *payload = [NSMutableDictionary dictionary];
-    if (credentials.email != nil && credentials.password != nil) {
+    if (credentials.emailVerificationCode != nil && credentials.email != nil && credentials.password != nil) {
+       payload[@"email"] = credentials.email;
+       payload[@"password"] = credentials.password;
+       payload[@"verification-code"]  = credentials.emailVerificationCode;
+    }
+    else if (credentials.email != nil && credentials.password != nil) {
         payload[@"email"] = credentials.email;
         payload[@"password"] = credentials.password;
     }
     else if (credentials.phoneNumber != nil && credentials.phoneNumberVerificationCode != nil) {
         payload[@"phone"] = credentials.phoneNumber;
         payload[@"code"] = credentials.phoneNumberVerificationCode;
-    }
-    else if (credentials.emailVerificationCode != nil && credentials.email != nil && credentials.password != nil) {
-        payload[@"email"] = credentials.email;
-        payload[@"password"] = credentials.password;
-        payload[@"verification-code"]  = credentials.emailVerificationCode;
     }
     else {
         return nil;

--- a/Source/Synchronization/Transcoders/ZMLoginTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMLoginTranscoder.m
@@ -150,9 +150,10 @@ NSTimeInterval DefaultPendingValidationLoginAttemptInterval = 5;
         payload[@"phone"] = credentials.phoneNumber;
         payload[@"code"] = credentials.phoneNumberVerificationCode;
     }
-    else if (credentials.email != nil && credentials.emailVerificationCode != nil) {
+    else if (credentials.email != nil && credentials.password != nil && credentials.emailVerificationCode != nil) {
         payload[@"email"] = credentials.email;
-        payload[@"verification-code"]  =credentials.emailVerificationCode;
+        payload[@"password"] = credentials.password;
+        payload[@"verification-code"]  = credentials.emailVerificationCode;
     }
     else {
         return nil;

--- a/Tests/Source/Synchronization/Transcoders/ZMLoginCodeRequestTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMLoginCodeRequestTranscoderTests.m
@@ -77,6 +77,17 @@
     XCTAssertEqualObjects(request, expectedRequest);
 }
 
+-(void)testThatItReturnsExpectedRequestWhenThereIsEmailVerificationCode
+{
+    NSString *email = @"test@wire.com";
+    [self.authenticationStatus prepareForRequestingEmailVerificationCodeForLogin:email];
+
+    ZMTransportRequest *expectedRequest = [[ZMTransportRequest alloc] initWithPath:@"/verification-code/send" method:ZMMethodPOST payload:@{@"email": email} authentication:ZMTransportRequestAuthNone];
+
+    ZMTransportRequest *request = [self.sut nextRequest];
+    XCTAssertEqualObjects(request, expectedRequest);
+}
+
 - (void)testThatItInformTheAuthCenterThatTheCodeWasReceived
 {
     // given

--- a/Tests/Source/Synchronization/Transcoders/ZMLoginCodeRequestTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMLoginCodeRequestTranscoderTests.m
@@ -77,7 +77,7 @@
     XCTAssertEqualObjects(request, expectedRequest);
 }
 
--(void)testThatItReturnsExpectedRequestWhenThereIsEmailVerificationCode
+-(void)testThatItReturnsExpectedRequestWhenThereIsEmailThatNeedsVerificationCode
 {
     NSString *email = @"test@wire.com";
     [self.authenticationStatus prepareForRequestingEmailVerificationCodeForLogin:email];

--- a/Tests/Source/Synchronization/Transcoders/ZMLoginTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMLoginTranscoderTests.m
@@ -1,20 +1,20 @@
-// 
+//
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
+//
 
 @import WireDataModel;
 
@@ -34,6 +34,7 @@
 
 static NSString * const TestEmail = @"bar@example.com";
 static NSString * const TestPassword = @"super-secure-password-sijovhjs987y";
+static NSString * const TestEmailVerificationCode = @"123456";
 
 static NSString * const TestPhoneNumber = @"+7123456789";
 static NSString * const TestPhoneCode = @"123456";
@@ -67,6 +68,7 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
 @property (nonatomic) id mockApplicationStatusDirectory;
 
 @property (nonatomic) ZMCredentials *testEmailCredentials;
+@property (nonatomic) ZMCredentials *testEmailCredentialsWithVerificationCode;
 @property (nonatomic) ZMCredentials *testPhoneNumberCredentials;
 @property (nonatomic) NSTimeInterval originalLoginTimerInterval;
 @property (nonatomic) id mockLocale;
@@ -85,21 +87,23 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
     self.groupQueue = [[DispatchGroupQueue alloc] initWithQueue:dispatch_get_main_queue()];
     self.mockAuthenticationStatusDelegate = [[MockAuthenticationStatusDelegate alloc] init];
     self.originalLoginTimerInterval = DefaultPendingValidationLoginAttemptInterval;
-    
+
     self.authenticationStatus = [[ZMAuthenticationStatus alloc] initWithDelegate:self.mockAuthenticationStatusDelegate
-                                          groupQueue:self.groupQueue
-                                      userInfoParser:self.mockUserInfoParser];
+                                                                      groupQueue:self.groupQueue
+                                                                  userInfoParser:self.mockUserInfoParser];
 
     self.mockClientRegistrationStatus = [OCMockObject niceMockForClass:[ZMClientRegistrationStatus class]];
-    
+
     self.mockLocale = [OCMockObject niceMockForClass:[NSLocale class]];
     [[[self.mockLocale stub] andReturn:[NSLocale localeWithLocaleIdentifier:@"fr_FR"]] currentLocale];
 
 
     self.sut = [[ZMLoginTranscoder alloc] initWithGroupQueue:self.groupQueue
                                         authenticationStatus:self.authenticationStatus];
-    
+
     self.testEmailCredentials = [ZMEmailCredentials credentialsWithEmail:TestEmail password:TestPassword];
+    self.testEmailCredentialsWithVerificationCode = [ZMEmailCredentials credentialsWithEmail:TestEmail password:TestPassword emailVerificationCode:TestEmailVerificationCode];
+
     self.testPhoneNumberCredentials = [ZMPhoneCredentials credentialsWithPhoneNumber:TestPhoneNumber verificationCode:TestPhoneCode];
 }
 
@@ -119,13 +123,13 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
 {
     // given
     ZMLoginTranscoder *sut = [[ZMLoginTranscoder alloc] initWithGroupQueue:self.groupQueue authenticationStatus:self.authenticationStatus];
-    
+
     // then
     XCTAssertNotNil(sut.timedDownstreamSync);
     XCTAssertEqualObjects(sut.timedDownstreamSync.groupQueue, self.groupQueue);
     XCTAssertEqualObjects(sut.timedDownstreamSync.transcoder, sut);
     XCTAssertEqual(sut.timedDownstreamSync.timeInterval, 0);
-    
+
     // after
     [sut tearDown];
 }
@@ -134,10 +138,10 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
 {
     id mockAuthStatus = [OCMockObject partialMockForObject:self.authenticationStatus];
     [[[mockAuthStatus expect] andForwardToRealObject] loginSucceededWithResponse:OCMOCK_ANY];
-    
+
     // when
     block();
-    
+
     //then
     [mockAuthStatus verify];
 }
@@ -163,10 +167,10 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
         XCTAssertNil(error);
         notified = YES;
     }];
-    
+
     // when
     block();
-    
+
     //then
     XCTAssert(notified);
     token = nil;
@@ -182,10 +186,10 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
         XCTAssertEqual((ZMUserSessionErrorCode)error.code, code);
         notified = YES;
     }];
-    
+
     // when
     block();
-    
+
     //then
     XCTAssert(notified);
     token = nil;
@@ -199,7 +203,7 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
 {
     // when
     ZMTransportRequest *request = [self.sut nextRequest];
-    
+
     // then
     XCTAssertNil(request);
 }
@@ -212,12 +216,12 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
                               @"password": self.testEmailCredentials.password,
                               @"label": CookieLabel.current.value};
     ZMTransportRequest *expectedRequest = [[ZMTransportRequest alloc] initWithPath:ZMLoginURL method:ZMMethodPOST payload:payload authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken];
-    
+
     [self.authenticationStatus prepareForLoginWithCredentials:self.testEmailCredentials];
 
     // when
     ZMTransportRequest *request = [self.sut nextRequest];
-    
+
     // then
     XCTAssertEqualObjects(request, expectedRequest);
 }
@@ -230,10 +234,10 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
                               @"label": CookieLabel.current.value};
     ZMTransportRequest *expectedRequest = [[ZMTransportRequest alloc] initWithPath:ZMLoginURL method:ZMMethodPOST payload:payload authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken];
     [self.authenticationStatus prepareForLoginWithCredentials:self.testPhoneNumberCredentials];
-    
+
     // when
     ZMTransportRequest *request = [self.sut nextRequest];
-    
+
     // then
     XCTAssertEqualObjects(request, expectedRequest);
 }
@@ -242,7 +246,7 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
 {
     // when
     ZMTransportRequest *request = [self.sut nextRequest];
-    
+
     // then
     XCTAssertNil(request);
 }
@@ -251,10 +255,10 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
 {
     // given
     [self.authenticationStatus setAuthenticationCookieData:[@"foo" dataUsingEncoding:NSUTF8StringEncoding]];
-    
+
     // when
     ZMTransportRequest *request = [self.sut nextRequest];
-    
+
     // then
     XCTAssertNil(request);
 }
@@ -271,12 +275,12 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
     NSDictionary *content = @{@"access_token": @"61184561417968870ce708ed0c319206914bc56db444d01227a63f9b9849045f.1.1401213378.a.3bc5750a-b965-40f8-aff2-831e9b5ac2e9.846754296078244309",
                               @"expires_in": @604800,
                               @"token_type": @"Bearer"
-                              };
+    };
     [self.authenticationStatus prepareForLoginWithCredentials:[ZMEmailCredentials credentialsWithEmail:@"foo@example.com" password:@"12345678"]];
     ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:content HTTPStatus:200 transportSessionError:nil];
-    
+
     // when
-    
+
     [self expectAuthenticationSucceedAfter:^{
         [[self.sut nextRequest] completeWithResponse:response];
         WaitForAllGroupsToBeEmpty(0.5);
@@ -289,7 +293,7 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
     NSDictionary *content = @{@"access_token": @"61184561417968870ce708ed0c319206914bc56db444d01227a63f9b9849045f.1.1401213378.a.3bc5750a-b965-40f8-aff2-831e9b5ac2e9.846754296078244309",
                               @"expires_in": @604800,
                               @"token_type": @"Bearer"
-                              };
+    };
     [self.authenticationStatus prepareForLoginWithCredentials:[ZMPhoneCredentials credentialsWithPhoneNumber:@"+49123456789" verificationCode:@"123456"]];
     ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:content HTTPStatus:200 transportSessionError:nil];
 
@@ -308,9 +312,25 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
                               @"label":@"invalid-credentials"};
     [self.authenticationStatus prepareForLoginWithCredentials:[ZMEmailCredentials credentialsWithEmail:@"foo@example.com" password:@"12345678"]];
     ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:content HTTPStatus:403 transportSessionError:nil];
-    
+
     // when
     [self expectAuthenticationFailedWithError:ZMUserSessionInvalidCredentials after:^{
+        [[self.sut nextRequest] completeWithResponse:response];
+        WaitForAllGroupsToBeEmpty(0.5);
+    }];
+}
+
+-(void)testThatItCallsAuthenticationFailOnEmailVerficationCodeNeeded
+{
+    // GIVEN
+    NSDictionary *content = @{@"code":@403,
+                              @"message":@"Code Authentication Required",
+                              @"label":@"code-authentication-required"};
+    [self.authenticationStatus prepareForLoginWithCredentials:[ZMEmailCredentials credentialsWithEmail:@"foo@example.com" password:@"12345678"]];
+    ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:content HTTPStatus:403 transportSessionError:nil];
+
+    // WHEN
+    [self expectAuthenticationFailedWithError:ZMUserSessionAccountIsPendingVerification after:^{
         [[self.sut nextRequest] completeWithResponse:response];
         WaitForAllGroupsToBeEmpty(0.5);
     }];
@@ -322,10 +342,10 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
     NSDictionary *content = @{@"code":@403,
                               @"message":@"Invalid login credentials",
                               @"label":@"invalid-credentials"};
-    
+
     ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:content HTTPStatus:403 transportSessionError:nil];
     [self.authenticationStatus prepareForLoginWithCredentials:[ZMPhoneCredentials credentialsWithPhoneNumber:@"+4912345678" verificationCode:@"123456"]];
-    
+
     // when
     [self expectAuthenticationFailedWithError:ZMUserSessionInvalidCredentials after:^{
         [[self.sut nextRequest] completeWithResponse:response];
@@ -354,7 +374,7 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
                               @"label":@"pending-activation"};
     [self.authenticationStatus prepareForLoginWithCredentials:[ZMEmailCredentials credentialsWithEmail:@"foo@example.com" password:@"12345678"]];
     ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:content HTTPStatus:403 transportSessionError:nil];
-    
+
     // when
     [self expectAuthenticationFailedWithError:ZMUserSessionAccountIsPendingActivation after:^{
         [[self.sut nextRequest] completeWithResponse:response];
@@ -370,7 +390,7 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
                               @"label":@"suspended"};
     [self.authenticationStatus prepareForLoginWithCredentials:[ZMPhoneCredentials credentialsWithPhoneNumber:@"+4912345678" verificationCode:@"123456"]];
     ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:content HTTPStatus:403 transportSessionError:nil];
-    
+
     // when
     [self expectAuthenticationFailedWithError:ZMUserSessionAccountSuspended after:^{
         [[self.sut nextRequest] completeWithResponse:response];
@@ -387,7 +407,7 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
                               @"label":@"suspended"};
     [self.authenticationStatus prepareForLoginWithCredentials:[ZMEmailCredentials credentialsWithEmail:@"foo@example.com" password:@"12345678"]];
     ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:content HTTPStatus:403 transportSessionError:nil];
-    
+
     // when
     [self expectAuthenticationFailedWithError:ZMUserSessionAccountSuspended after:^{
         [[self.sut nextRequest] completeWithResponse:response];
@@ -418,16 +438,16 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
     NSDictionary *content = @{@"code":@403,
                               @"message":@"Invalid login credentials",
                               @"label":@"invalid-credentials"};
-    
+
     ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:content HTTPStatus:403 transportSessionError:nil];
     [self.authenticationStatus prepareForLoginWithCredentials:[ZMEmailCredentials credentialsWithEmail:@"foo@example.com" password:@"12345678"]];
-    
+
     // when
     [self expectAuthenticationFailedWithError:ZMUserSessionInvalidCredentials after:^{
         [[self.sut nextRequest] completeWithResponse:response];
         WaitForAllGroupsToBeEmpty(0.5);
     }];
-    
+
     // then
     XCTAssertEqual(self.authenticationStatus.currentPhase, ZMAuthenticationPhaseUnauthenticated);
     XCTAssertNil(self.authenticationStatus.loginCredentials);
@@ -442,13 +462,13 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
                               @"label":@"invalid-credentials"};
     [self.authenticationStatus prepareForLoginWithCredentials:[ZMPhoneCredentials credentialsWithPhoneNumber:@"+49123456789" verificationCode:@"12345678"]];
     ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:content HTTPStatus:403 transportSessionError:nil];
-    
+
     // when
     [self expectAuthenticationFailedWithError:ZMUserSessionInvalidCredentials after:^{
         [[self.sut nextRequest] completeWithResponse:response];
         WaitForAllGroupsToBeEmpty(0.5);
     }];
-    
+
     // then
     XCTAssertEqual(self.authenticationStatus.currentPhase, ZMAuthenticationPhaseUnauthenticated);
     XCTAssertNil(self.authenticationStatus.loginCredentials);
@@ -460,10 +480,10 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
     NSDictionary *content = @{@"access_token": @"61184561417968870ce708ed0c319206914bc56db444d01227a63f9b9849045f.1.1401213378.a.3bc5750a-b965-40f8-aff2-831e9b5ac2e9.846754296078244309",
                               @"expires_in": @604800,
                               @"token_type": @"Bearer"
-                              };
+    };
     [self.authenticationStatus prepareForLoginWithCredentials:[ZMPhoneCredentials credentialsWithPhoneNumber:@"+49123456789" verificationCode:@"12345678"]];
     ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:content HTTPStatus:200 transportSessionError:nil];
-    
+
     // when
     [self expectAuthenticationSucceedAfter:^{
         [[self.sut nextRequest] completeWithResponse:response];
@@ -472,7 +492,7 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
         [self.authenticationStatus setAuthenticationCookieData:[@"foo" dataUsingEncoding:NSUTF8StringEncoding]];
         WaitForAllGroupsToBeEmpty(0.5);
     }];
-    
+
     // then
     XCTAssertEqual(self.authenticationStatus.currentPhase, ZMAuthenticationPhaseAuthenticated);
     XCTAssertNotNil(self.authenticationStatus.loginCredentials);
@@ -485,10 +505,10 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
     NSDictionary *content = @{@"access_token": @"61184561417968870ce708ed0c319206914bc56db444d01227a63f9b9849045f.1.1401213378.a.3bc5750a-b965-40f8-aff2-831e9b5ac2e9.846754296078244309",
                               @"expires_in": @604800,
                               @"token_type": @"Bearer"
-                              };
+    };
     [self.authenticationStatus prepareForLoginWithCredentials:[ZMEmailCredentials credentialsWithEmail:@"foo@example.com" password:@"12345678"]];
     ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:content HTTPStatus:200 transportSessionError:nil];
-    
+
     // when
     [self expectAuthenticationSucceedAfter:^{
         [[self.sut nextRequest] completeWithResponse:response];
@@ -497,7 +517,7 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
         [self.authenticationStatus setAuthenticationCookieData:[@"foo" dataUsingEncoding:NSUTF8StringEncoding]];
         WaitForAllGroupsToBeEmpty(0.5);
     }];
-    
+
     // then
     XCTAssertEqual(self.authenticationStatus.currentPhase, ZMAuthenticationPhaseAuthenticated);
     XCTAssertNotNil(self.authenticationStatus.loginCredentials);

--- a/Tests/Source/Synchronization/Transcoders/ZMLoginTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMLoginTranscoderTests.m
@@ -242,6 +242,24 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
     XCTAssertEqualObjects(request, expectedRequest);
 }
 
+- (void)testThatItGeneratesALoginRequestWhenTheUserSessionHasCredentialsWithEmailVerificationCodeAndWeAreNotLoggedIn
+{
+    // GIVEN
+    NSDictionary *payload = @{@"email": self.testEmailCredentialsWithVerificationCode.email,
+                              @"password": self.testEmailCredentialsWithVerificationCode.password,
+                              @"verification-code": self.testEmailCredentialsWithVerificationCode.emailVerificationCode,
+                              @"label": CookieLabel.current.value};
+    ZMTransportRequest *expectedRequest = [[ZMTransportRequest alloc] initWithPath:ZMLoginURL method:ZMMethodPOST payload:payload authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken];
+
+    [self.authenticationStatus prepareForLoginWithCredentials:self.testEmailCredentialsWithVerificationCode];
+
+    // WHEN
+    ZMTransportRequest *request = [self.sut nextRequest];
+
+    // THEN
+    XCTAssertEqualObjects(request, expectedRequest);
+}
+
 - (void)testThatItDoesNotGenerateALoginRequestWhenTheUserSessionHasNoCredentials
 {
     // when

--- a/Tests/Source/UserSession/ZMAuthenticationStatusTests.m
+++ b/Tests/Source/UserSession/ZMAuthenticationStatusTests.m
@@ -83,6 +83,7 @@
     
     XCTAssertNil(self.sut.registrationPhoneNumberThatNeedsAValidationCode);
     XCTAssertNil(self.sut.loginPhoneNumberThatNeedsAValidationCode);
+    XCTAssertNil(self.sut.loginEmailThatNeedsAValidationCode);
     XCTAssertNil(self.sut.loginCredentials);
     XCTAssertNil(self.sut.registrationPhoneValidationCredentials);
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1341" title="SQSERVICES-1341" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />SQSERVICES-1341</a>  [iOS] SE: modify ZMLoginCodeRequestTranscoder
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we modify the `ZMLoginCodeRequestTranscoder` to support Two Factor Authentication for Login. More specifically:

- Renamed `codeRequestSync` to `phoneVerificationCodeRequestSync`
- Added a new property `emailVerificationCodeRequestSync`
- in nextRequest we add an if check for the `current phase`
- In `requestForSingleRequestSync` method we do a check for which sync we do have and based on that we return the appropriate request.
- Added tests

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
