### PR TITLE
feat: Add verification_code parameter to the register client request SQSERVICES-1177

### DIFF
--- a/Source/Synchronization/Strategies/UserClientRequestFactory.swift
+++ b/Source/Synchronization/Strategies/UserClientRequestFactory.swift
@@ -14,7 +14,7 @@
 // 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
+//
 
 import Foundation
 import WireCryptobox

--- a/Source/Synchronization/Strategies/UserClientRequestFactory.swift
+++ b/Source/Synchronization/Strategies/UserClientRequestFactory.swift
@@ -63,6 +63,10 @@ public final class UserClientRequestFactory {
             payload["password"] = password
         }
 
+        if let verificationCode = credentials?.emailVerificationCode {
+            payload["verification_code"] = verificationCode
+        }
+
         let request = ZMTransportRequest(path: "/clients", method: ZMTransportRequestMethod.methodPOST, payload: payload as ZMTransportData)
         request.add(storeMaxRangeID(client, maxRangeID: preKeysRangeMax))
         request.add(storeAPSSignalingKeys(client, signalingKeys: signalingKeys))

--- a/Source/Synchronization/Strategies/UserClientRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/UserClientRequestStrategy.swift
@@ -309,7 +309,9 @@ public final class UserClientRequestStrategy: ZMObjectSyncStrategy, ZMObjectStra
                     }
                 case "too-many-clients":
                     errorCode = .canNotRegisterMoreClients
-                case "invalid-credentials":
+                case "invalid-credentials",
+                    "code-authentication-failed",
+                    "code-authentication-required":
                     errorCode = .invalidCredentials
                 default:
                     break

--- a/Tests/Source/E2EE/UserClientRequestFactoryTests.swift
+++ b/Tests/Source/E2EE/UserClientRequestFactoryTests.swift
@@ -118,8 +118,10 @@ class UserClientRequestFactoryTests: MessagingTest {
         let payload = try XCTUnwrap(transportRequest.payload?.asDictionary() as? [String: NSObject])
 
         XCTAssertEqual(transportRequest.path, "/clients")
-        guard let password = payload["password"] as? String, password == credentials.password else { return XCTFail("Payload should contain password") }
-        guard let password = payload["verification_code"] as? String, password == credentials.emailVerificationCode else { return XCTFail("Payload should contain verification code") }
+        let password = try XCTUnwrap(payload["password"] as? String)
+        XCTAssertEqual(password, credentials.password)
+        let verificationCode = try XCTUnwrap(payload["verification_code"] as? String)
+        XCTAssertEqual(verificationCode, credentials.emailVerificationCode)
         XCTAssertEqual(transportRequest.method, ZMTransportRequestMethod.methodPOST)
     }
 

--- a/Tests/Source/E2EE/UserClientRequestFactoryTests.swift
+++ b/Tests/Source/E2EE/UserClientRequestFactoryTests.swift
@@ -114,8 +114,8 @@ class UserClientRequestFactoryTests: MessagingTest {
         }
 
         // then
-        guard let transportRequest = request.transportRequest else { return XCTFail("Should return non nil request") }
-        guard let payload = transportRequest.payload?.asDictionary() as? [String: NSObject] else { return XCTFail("Request should contain payload") }
+        let transportRequest = try XCTUnwrap(request.transportRequest)
+        let payload = try XCTUnwrap(transportRequest.payload?.asDictionary() as? [String: NSObject])
 
         XCTAssertEqual(transportRequest.path, "/clients")
         guard let password = payload["password"] as? String, password == credentials.password else { return XCTFail("Payload should contain password") }

--- a/Tests/Source/E2EE/UserClientRequestFactoryTests.swift
+++ b/Tests/Source/E2EE/UserClientRequestFactoryTests.swift
@@ -97,12 +97,11 @@ class UserClientRequestFactoryTests: MessagingTest {
         XCTAssertNotNil(apnsKeysPayload["mackey"], "Payload should contain apns mac key")
     }
 
-    func testThatItCreatesRegistrationRequestWithEmailVerificationCodeCorrectly() {
+    func testThatItCreatesRegistrationRequestWithEmailVerificationCodeCorrectly() throws {
         // given
-        let email = "some@example.com"
-        let password = "gfsgdfgdfgdfgdfg"
-        let verificationCode = "123456"
-        let credentials = ZMEmailCredentials(email: email, password: password, emailVerificationCode: verificationCode)
+        let credentials = ZMEmailCredentials(email: "some@example.com",
+                                             password: "gfsgdfgdfgdfgdfg",
+                                             emailVerificationCode: "123456")
 
         let client = UserClient.insertNewObject(in: self.syncMOC)
         client.remoteIdentifier = "\(client.objectID)"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1177" title="SQSERVICES-1177" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />SQSERVICES-1177</a>  [iOS] 2nd auth factor for "add client"
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

If 2nd auth factor is enabled, we should send an additional optional field verification-code to the POST /clients endpoint.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
