### PR TITLE
fix: crash when unarchiving NotificationUserInfo SQSERVICES-1107

### DIFF
--- a/Source/Synchronization/ZMHotFixDirectory+Swift.swift
+++ b/Source/Synchronization/ZMHotFixDirectory+Swift.swift
@@ -275,9 +275,8 @@ import WireRequestStrategy
     }
 
 
-    public static func mapNotificationUserInfoClassName() {
+    public static func mapNotificationUserInfoClassName(_ context: NSManagedObjectContext) {
         NSKeyedUnarchiver.setClass(WireRequestStrategy.NotificationUserInfo.self,
                                    forClassName: "WireSyncEngine.NotificationUserInfo")
-        
     }
 }

--- a/Source/Synchronization/ZMHotFixDirectory+Swift.swift
+++ b/Source/Synchronization/ZMHotFixDirectory+Swift.swift
@@ -17,6 +17,7 @@
 // 
 
 import Foundation
+import WireRequestStrategy
 
 @objc extension ZMHotFixDirectory {
 
@@ -271,5 +272,12 @@ import Foundation
         }
 
         context.saveOrRollback()
+    }
+
+
+    public static func mapNotificationUserInfoClassName() {
+        NSKeyedUnarchiver.setClass(WireRequestStrategy.NotificationUserInfo.self,
+                                   forClassName: "WireSyncEngine.NotificationUserInfo")
+        
     }
 }

--- a/Source/Synchronization/ZMHotFixDirectory.m
+++ b/Source/Synchronization/ZMHotFixDirectory.m
@@ -233,7 +233,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"HotFix";
                     [ZMHotFixPatch
                      patchWithVersion:@"414.0.0"
                      patchCode:^(NSManagedObjectContext *context) {
-                        [ZMHotFixDirectory mapNotificationUserInfoClassName];
+                        [ZMHotFixDirectory mapNotificationUserInfoClassName:context];
                      }],
                     ];
     });

--- a/Source/Synchronization/ZMHotFixDirectory.m
+++ b/Source/Synchronization/ZMHotFixDirectory.m
@@ -224,6 +224,17 @@ static NSString* ZMLogTag ZM_UNUSED = @"HotFix";
                         [ZMHotFixDirectory refetchSelfUser:context];
                         [ZMHotFixDirectory refetchUsers:context];
                      }],
+
+                    /// `NotificationUserInfo` was moved from sync engine to request strategy. Instances of this class were
+                    /// being archived in `ZMLocalNotificationSet`, previously as "WireSyncEngine.NotificationUserInfo".
+                    /// When the app was upgraded, it would try to unarchive these objects as "WireRequestStrategy.NotificationUser.Info",
+                    /// leading to a crash. This patch maps the class name so that `NSKeyedUnarchiver` can successfully unarchive
+                    /// the persisted notifications.
+                    [ZMHotFixPatch
+                     patchWithVersion:@"414.0.0"
+                     patchCode:^(NSManagedObjectContext *context) {
+                        [ZMHotFixDirectory mapNotificationUserInfoClassName];
+                     }],
                     ];
     });
     return patches;


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When updating the app from before https://github.com/wireapp/wire-ios-sync-engine/pull/1620 to after, the app would crash.

### Causes

`NotificationUserInfo` was moved from sync engine to request strategy. Instances of this class were archived and persisted in the `ZMLocalNotificatonSet`. When the app was updated, it tried to unarchive the notifications, but the key had changed implicitly from `WireSyncEngine.NotificationUserInfo` to `WireRequestStrategy.NotificationUserInfo`. This caused a crash.

### Solutions

Add a hot fix patch that adds a mapping of the class name so that `NSKeyedUnarchiver` can understand how to unarchive old objects.

### Testing

Added a test for the hot fix patch.


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
