### PR TITLE
fix: Add "action" as part of the payload regarding 2FA for login SQSERVICES-1416

### DIFF
--- a/Source/Synchronization/Transcoders/ZMLoginCodeRequestTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMLoginCodeRequestTranscoder.m
@@ -73,7 +73,9 @@
     if (sync == self.emailVerificationCodeRequestSync) {
         ZMTransportRequest *emailVerficationCodeRequest = [[ZMTransportRequest alloc] initWithPath:@"/verification-code/send"
                                                                                             method:ZMMethodPOST
-                                                                                           payload:@{@"email": self.authenticationStatus.loginEmailThatNeedsAValidationCode}
+                                                                                           payload:@{@"email": self.authenticationStatus.loginEmailThatNeedsAValidationCode,
+                                                                                                     @"action": @"login"
+                                                                                                   }
                                                                                     authentication:ZMTransportRequestAuthNone];
         return emailVerficationCodeRequest;
     } else if (sync == self.phoneVerificationCodeRequestSync) {

--- a/Tests/Source/Synchronization/Transcoders/ZMLoginCodeRequestTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMLoginCodeRequestTranscoderTests.m
@@ -80,9 +80,10 @@
 -(void)testThatItReturnsExpectedRequestWhenThereIsEmailThatNeedsVerificationCode
 {
     NSString *email = @"test@wire.com";
+    NSString *loginAction = @"login";
     [self.authenticationStatus prepareForRequestingEmailVerificationCodeForLogin:email];
 
-    ZMTransportRequest *expectedRequest = [[ZMTransportRequest alloc] initWithPath:@"/verification-code/send" method:ZMMethodPOST payload:@{@"email": email} authentication:ZMTransportRequestAuthNone];
+    ZMTransportRequest *expectedRequest = [[ZMTransportRequest alloc] initWithPath:@"/verification-code/send" method:ZMMethodPOST payload:@{@"email": email, @"action": loginAction} authentication:ZMTransportRequestAuthNone];
 
     ZMTransportRequest *request = [self.sut nextRequest];
     XCTAssertEqualObjects(request, expectedRequest);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1416" title="SQSERVICES-1416" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />SQSERVICES-1416</a>  SE: Add "action" as part of the payload
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we add action as part of the payload regarding 2FA for login. This is needed so the request can work as expected. If it's missing we're getting an error back.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
