### PR TITLE
fix: Payload typo for 2FA for Login SQSERVICES-1417

### DIFF
--- a/Source/Synchronization/Transcoders/ZMLoginTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMLoginTranscoder.m
@@ -101,6 +101,7 @@ NSTimeInterval DefaultPendingValidationLoginAttemptInterval = 5;
         [self.loginWithPhoneNumberSync readyForNextRequestIfNotBusy];
         return [self.loginWithPhoneNumberSync nextRequest];
     }
+    
     if(authenticationStatus.currentPhase == ZMAuthenticationPhaseLoginWithEmail) {
         [self.timedDownstreamSync readyForNextRequestIfNotBusy];
         request = [self.timedDownstreamSync nextRequest];
@@ -145,7 +146,7 @@ NSTimeInterval DefaultPendingValidationLoginAttemptInterval = 5;
     if (credentials.emailVerificationCode != nil && credentials.email != nil && credentials.password != nil) {
        payload[@"email"] = credentials.email;
        payload[@"password"] = credentials.password;
-       payload[@"verification-code"]  = credentials.emailVerificationCode;
+       payload[@"verification_code"]  = credentials.emailVerificationCode;
     }
     else if (credentials.email != nil && credentials.password != nil) {
         payload[@"email"] = credentials.email;

--- a/Source/Synchronization/Transcoders/ZMLoginTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMLoginTranscoder.m
@@ -101,7 +101,6 @@ NSTimeInterval DefaultPendingValidationLoginAttemptInterval = 5;
         [self.loginWithPhoneNumberSync readyForNextRequestIfNotBusy];
         return [self.loginWithPhoneNumberSync nextRequest];
     }
-    
     if(authenticationStatus.currentPhase == ZMAuthenticationPhaseLoginWithEmail) {
         [self.timedDownstreamSync readyForNextRequestIfNotBusy];
         request = [self.timedDownstreamSync nextRequest];

--- a/Tests/Source/Synchronization/Transcoders/ZMLoginTranscoderTests.m
+++ b/Tests/Source/Synchronization/Transcoders/ZMLoginTranscoderTests.m
@@ -247,7 +247,7 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
     // GIVEN
     NSDictionary *payload = @{@"email": self.testEmailCredentialsWithVerificationCode.email,
                               @"password": self.testEmailCredentialsWithVerificationCode.password,
-                              @"verification-code": self.testEmailCredentialsWithVerificationCode.emailVerificationCode,
+                              @"verification_code": self.testEmailCredentialsWithVerificationCode.emailVerificationCode,
                               @"label": CookieLabel.current.value};
     ZMTransportRequest *expectedRequest = [[ZMTransportRequest alloc] initWithPath:ZMLoginURL method:ZMMethodPOST payload:payload authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken];
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1417" title="SQSERVICES-1417" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />SQSERVICES-1417</a>  SE: Fix typo in the payload for the verification code (2FA)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Fix a typo related to the payload for the 2FA for login. 

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
