### PR TITLE
fix: resolve api version when switching backend FS-422

### DIFF
--- a/Source/SessionManager/SessionManager+APIVersionResolver.swift
+++ b/Source/SessionManager/SessionManager+APIVersionResolver.swift
@@ -21,7 +21,23 @@ import Foundation
 extension SessionManager: APIVersionResolverDelegate {
 
     public func resolveAPIVersion() {
-        apiVersionResolver.resolveAPIVersion()
+        if apiVersionResolver == nil {
+            apiVersionResolver = createAPIVersionResolver()
+        }
+
+        apiVersionResolver!.resolveAPIVersion()
+    }
+
+    func createAPIVersionResolver() -> APIVersionResolver {
+        let transportSession = UnauthenticatedTransportSession(
+            environment: environment,
+            reachability: reachability,
+            applicationVersion: appVersion
+        )
+
+        let apiVersionResolver = APIVersionResolver(transportSession: transportSession)
+        apiVersionResolver.delegate = self
+        return apiVersionResolver
     }
 
     func apiVersionResolverFailedToResolveVersion(reason: BlacklistReason) {

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -242,6 +242,10 @@ public final class SessionManager: NSObject, SessionManagerType {
         didSet {
             authenticatedSessionFactory.environment = environment
             unauthenticatedSessionFactory.environment = environment
+
+            // We need a new resolver for the new backend environment.
+            apiVersionResolver = createAPIVersionResolver()
+            resolveAPIVersion()
         }
     }
 
@@ -268,17 +272,7 @@ public final class SessionManager: NSObject, SessionManagerType {
 
     private static var avsLogObserver: AVSLogObserver?
 
-    lazy var apiVersionResolver: APIVersionResolver = {
-        let transportSession = UnauthenticatedTransportSession(
-            environment: environment,
-            reachability: reachability,
-            applicationVersion: appVersion
-        )
-
-        let apiVersionResolver = APIVersionResolver(transportSession: transportSession)
-        apiVersionResolver.delegate = self
-        return apiVersionResolver
-    }()
+    var apiVersionResolver: APIVersionResolver?
 
     public override init() {
         fatal("init() not implemented")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-422" title="FS-422" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-422</a>  [iOS] Clients need to know if the backend support federated endpoints or not
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The app wasn't functioning correctly when switching backends. For example, when switching to a federated backend, the app was acting as if it couldn't federate.

### Causes 

We only resolved the api version when the app first loads or comes to the foreground. When switching the backend via a deep link, we were not resolving the api version directly afterward.

### Solutions

Resolve the api version also after switching backends.

### Testing

Tested manually.

#### How to Test

- Install the app
- Switch backends via deep link (e.g to a federated backend)
- Verify that the app behaves as expected.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
