### PR TITLE
feat: load session using async SQSERVICES-1111

### DIFF
--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -673,6 +673,23 @@ public final class SessionManager: NSObject, SessionManagerType {
         processPendingURLActionRequiresAuthentication()
     }
 
+    @available(iOS 13, *)
+    func withSession(for account: Account) async throws -> ZMUserSession {
+        log.debug("Request to load session for \(account)")
+
+        return try await withCheckedThrowingContinuation { continuation in
+            withSession(for: account) { result in
+                switch result {
+                case let .success(session):
+                    continuation.resume(returning: session)
+
+                case let .failure(error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
     // Loads user session for @c account given and executes the @c action block.
     func withSession(
         for account: Account,

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -1679,6 +1679,27 @@ class MockForegroundNotificationResponder: NSObject, ForegroundNotificationRespo
         return true
     }
 }
+
+extension SessionManagerTests {
+
+    @available(iOS 13, *)
+    func testThatItLoadsUserSession() async throws {
+        // GIVEN
+        let sessionManager = try XCTUnwrap(self.sessionManager)
+        let account = createAccount()
+
+        XCTAssertNil(sessionManager.backgroundUserSessions[account.userIdentifier])
+
+        // WHEN
+        let session = try await sessionManager.withSession(for: account)
+
+        // THEN
+        XCTAssertNotNil(session.managedObjectContext)
+        XCTAssertNotNil(sessionManager.backgroundUserSessions[account.userIdentifier])
+    }
+
+}
+
 extension SessionManager {
 
     func withSession(

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -1679,3 +1679,21 @@ class MockForegroundNotificationResponder: NSObject, ForegroundNotificationRespo
         return true
     }
 }
+extension SessionManager {
+
+    func withSession(
+        for account: Account,
+        perform completion: @escaping (ZMUserSession) -> Void
+    ) {
+        withSession(for: account) { (result: Swift.Result<ZMUserSession, SessionLoadingError>) in
+            switch result {
+            case let .success(session):
+                completion(session)
+
+            case .failure:
+                fatalError()
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1111" title="SQSERVICES-1111" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />SQSERVICES-1111</a>  [iOS] Notification extension: Handle call notifications
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

In order to successfully process call events fetched from the notification service extension, we must report incoming calls to CallKit by the end of the PushKit method [pushRegistry(_:didReceiveIncomingPushWith:for:completion:)](https://developer.apple.com/documentation/pushkit/pkpushregistrydelegate/2875784-pushregistry), otherwise iOS will terminate the app. See [Apple docs](https://developer.apple.com/documentation/callkit/sending_end-to-end_encrypted_voip_calls) for more detail.

This is not currently possible because our normal flow to process call events from push payloads is inherently asynchronous:. For instance, we must load the user session for a given account, which we will only receive via a completion handler.

Once we have the user session however, we can then gain access to the `WireCallCenter` and proceed to report an incoming call to CallKit.

This PR will help facilitate "synchronous" loading of the user session by leveraging the async / await language features of Swift. We do this by creating an "async" version of `withSession` which uses a continuation to wait for the completion handlers of the existing `withSession` method to be called.

For this to work, the completion handler of `withSession` must be called in every code path out of the method, which I found was not the case when there was a database error. For this reason I converted the argument of the completion handler to contain a result of either the user session or an error.

I updated the code for this change, but didn't focus on handling the new error.

### Testing

#### How to Test

I added a test to ensure that loading the session works.


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
