### PR TITLE
fix: can't login to deep-linked backend FS-799

### DIFF
--- a/Source/SessionManager/BackendEnvironmentProvider+Reachability.swift
+++ b/Source/SessionManager/BackendEnvironmentProvider+Reachability.swift
@@ -1,0 +1,29 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension BackendEnvironmentProvider {
+
+    var reachability: ZMReachability {
+        let serverNames = [backendURL, backendWSURL].compactMap(\.host)
+        let group = ZMSDispatchGroup(dispatchGroup: DispatchGroup(), label: "Reachability")!
+        return ZMReachability(serverNames: serverNames, group: group)
+    }
+
+}

--- a/Source/SessionManager/SessionFactories.swift
+++ b/Source/SessionManager/SessionFactories.swift
@@ -93,25 +93,34 @@ open class UnauthenticatedSessionFactory {
         }
     }
 
-    var reachability: ReachabilityProvider
+    var reachability: ReachabilityProvider & TearDownCapable
     let appVersion: String
 
-    init(appVersion: String,
-         environment: BackendEnvironmentProvider,
-         reachability: ReachabilityProvider) {
+    init(
+      appVersion: String,
+      environment: BackendEnvironmentProvider,
+      reachability: ReachabilityProvider & TearDownCapable
+    ) {
         self.environment = environment
         self.reachability = reachability
         self.appVersion = appVersion
     }
 
-    func session(delegate: UnauthenticatedSessionDelegate,
-                 authenticationStatusDelegate: ZMAuthenticationStatusDelegate) -> UnauthenticatedSession {
-        let transportSession = UnauthenticatedTransportSession(environment: environment,
-                                                               reachability: reachability,
-                                                               applicationVersion: appVersion)
-        return UnauthenticatedSession(transportSession: transportSession,
-                                      reachability: reachability,
-                                      delegate: delegate,
-                                      authenticationStatusDelegate: authenticationStatusDelegate)
+    func session(
+      delegate: UnauthenticatedSessionDelegate,
+      authenticationStatusDelegate: ZMAuthenticationStatusDelegate
+    ) -> UnauthenticatedSession {
+        let transportSession = UnauthenticatedTransportSession(
+          environment: environment,
+          reachability: reachability,
+          applicationVersion: appVersion
+        )
+
+      return UnauthenticatedSession(
+        transportSession: transportSession,
+        reachability: reachability,
+        delegate: delegate,
+        authenticationStatusDelegate: authenticationStatusDelegate
+      )
     }
 }

--- a/Source/SessionManager/SessionFactories.swift
+++ b/Source/SessionManager/SessionFactories.swift
@@ -26,8 +26,14 @@ open class AuthenticatedSessionFactory {
     let flowManager: FlowManagerType
     var analytics: AnalyticsType?
     let application: ZMApplication
-    var environment: BackendEnvironmentProvider
-    let reachability: ReachabilityProvider & TearDownCapable
+
+    var environment: BackendEnvironmentProvider {
+        didSet {
+            reachability = environment.reachability
+        }
+    }
+
+    var reachability: ReachabilityProvider & TearDownCapable
 
     public init(
         appVersion: String,
@@ -81,8 +87,13 @@ open class AuthenticatedSessionFactory {
 
 open class UnauthenticatedSessionFactory {
 
-    var environment: BackendEnvironmentProvider
-    let reachability: ReachabilityProvider
+    var environment: BackendEnvironmentProvider {
+        didSet {
+            reachability = environment.reachability
+        }
+    }
+
+    var reachability: ReachabilityProvider
     let appVersion: String
 
     init(appVersion: String,

--- a/Source/SessionManager/SessionManager+ServerConnection.swift
+++ b/Source/SessionManager/SessionManager+ServerConnection.swift
@@ -19,20 +19,11 @@
 import Foundation
 
 @objc
-public protocol ServerConnectionObserver {
-
-    @objc(serverConnectionDidChange:)
-    func serverConnection(didChange serverConnection: ServerConnection)
-
-}
-
-@objc
 public protocol ServerConnection {
 
     var isMobileConnection: Bool { get }
     var isOffline: Bool { get }
 
-    func addServerConnectionObserver(_ observer: ServerConnectionObserver) -> Any
 }
 
 extension SessionManager {
@@ -53,13 +44,5 @@ extension SessionManager: ServerConnection {
         return reachability.isMobileConnection
     }
 
-    /// Add observer of server connection. Returns a token for de-registering the observer.
-    public func addServerConnectionObserver(_ observer: ServerConnectionObserver) -> Any {
-
-        return reachability.addReachabilityObserver(on: .main) { [weak self, weak observer] _ in
-            guard let `self` = self else { return }
-            observer?.serverConnection(didChange: self)
-        }
-    }
 
 }

--- a/Source/SessionManager/SessionManager+ServerConnection.swift
+++ b/Source/SessionManager/SessionManager+ServerConnection.swift
@@ -44,5 +44,4 @@ extension SessionManager: ServerConnection {
         return reachability.isMobileConnection
     }
 
-
 }

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -236,7 +236,7 @@ public final class SessionManager: NSObject, SessionManagerType {
     var deleteAccountToken: Any?
     var callCenterObserverToken: Any?
     var blacklistVerificator: ZMBlacklistVerificator?
-    let reachability: ReachabilityProvider & TearDownCapable
+    var reachability: ReachabilityProvider & TearDownCapable
     var pushRegistry: PushRegistry
     let notificationsTracker: NotificationsTracker?
     let configuration: SessionManagerConfiguration
@@ -253,6 +253,7 @@ public final class SessionManager: NSObject, SessionManagerType {
         didSet {
             authenticatedSessionFactory.environment = environment
             unauthenticatedSessionFactory.environment = environment
+            reachability = environment.reachability
 
             // We need a new resolver for the new backend environment.
             apiVersionResolver = createAPIVersionResolver()
@@ -307,11 +308,8 @@ public final class SessionManager: NSObject, SessionManagerType {
         detector: JailbreakDetectorProtocol = JailbreakDetector(),
         requiredPushTokenType: PushToken.TokenType
     ) {
-        let group = ZMSDispatchGroup(dispatchGroup: DispatchGroup(), label: "Session manager reachability")!
         let flowManager = FlowManager(mediaManager: mediaManager)
-
-        let serverNames = [environment.backendURL, environment.backendWSURL].compactMap { $0.host }
-        let reachability = ZMReachability(serverNames: serverNames, group: group)
+        let reachability = environment.reachability
 
         let unauthenticatedSessionFactory = UnauthenticatedSessionFactory(
             appVersion: appVersion,

--- a/Tests/Source/Integration/IntegrationTest.swift
+++ b/Tests/Source/Integration/IntegrationTest.swift
@@ -63,7 +63,7 @@ final class MockUnauthenticatedSessionFactory: UnauthenticatedSessionFactory {
 
     init(transportSession: UnauthenticatedTransportSessionProtocol,
          environment: BackendEnvironmentProvider,
-         reachability: ReachabilityProvider) {
+         reachability: ReachabilityProvider & TearDownCapable) {
         self.transportSession = transportSession
         super.init(appVersion: "1.0", environment: environment, reachability: reachability)
     }

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -519,6 +519,7 @@
 		EE38DDEE280437E500D4983D /* BlacklistReason.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE38DDED280437E500D4983D /* BlacklistReason.swift */; };
 		EE419B58256FEA3D004618E2 /* ZMUserSession.Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE419B57256FEA3D004618E2 /* ZMUserSession.Configuration.swift */; };
 		EE458B0B27CCD58800F04038 /* ZMOperationLoop+APIVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE458B0A27CCD58800F04038 /* ZMOperationLoop+APIVersion.swift */; };
+		EE5AAF3A2874E8C70018FA01 /* BackendEnvironmentProvider+Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5AAF392874E8C70018FA01 /* BackendEnvironmentProvider+Reachability.swift */; };
 		EE5BF6351F8F907C00B49D06 /* ZMLocalNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5BF6341F8F907C00B49D06 /* ZMLocalNotificationTests.swift */; };
 		EE5FEF0521E8948F00E24F7F /* ZMUserSession+DarwinNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5FEF0421E8948F00E24F7F /* ZMUserSession+DarwinNotificationCenter.swift */; };
 		EE6654642445D4EE00CBF8D3 /* MockAddressBook.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6654632445D4EE00CBF8D3 /* MockAddressBook.swift */; };
@@ -1191,6 +1192,7 @@
 		EE38DDED280437E500D4983D /* BlacklistReason.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlacklistReason.swift; sourceTree = "<group>"; };
 		EE419B57256FEA3D004618E2 /* ZMUserSession.Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMUserSession.Configuration.swift; sourceTree = "<group>"; };
 		EE458B0A27CCD58800F04038 /* ZMOperationLoop+APIVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMOperationLoop+APIVersion.swift"; sourceTree = "<group>"; };
+		EE5AAF392874E8C70018FA01 /* BackendEnvironmentProvider+Reachability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BackendEnvironmentProvider+Reachability.swift"; sourceTree = "<group>"; };
 		EE5BF6341F8F907C00B49D06 /* ZMLocalNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ZMLocalNotificationTests.swift; path = Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests.swift; sourceTree = SOURCE_ROOT; };
 		EE5FEF0421E8948F00E24F7F /* ZMUserSession+DarwinNotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSession+DarwinNotificationCenter.swift"; sourceTree = "<group>"; };
 		EE6654632445D4EE00CBF8D3 /* MockAddressBook.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockAddressBook.swift; sourceTree = "<group>"; };
@@ -2489,6 +2491,7 @@
 				54131BCD25C7FFCA00CE2CA2 /* SessionManager+AuthenticationStatusDelegate.swift */,
 				161ACB2323F432CC00ABFF33 /* SessionManager+URLActions.swift */,
 				BF2ADA011F41A450000980E8 /* BackendEnvironmentProvider+Cookie.swift */,
+				EE5AAF392874E8C70018FA01 /* BackendEnvironmentProvider+Reachability.swift */,
 				7CD279832338B74600E638CD /* SessionManagerConfiguration.swift */,
 				7CD279852338E31D00E638CD /* SessionManager+Authentication.swift */,
 				7CD279872338E52000E638CD /* ProcessInfo+SystemBootTime.swift */,
@@ -3348,6 +3351,7 @@
 				165BB94C2004D6490077EFD5 /* SessionManager+UserActivity.swift in Sources */,
 				165D3A151E1D3EF30052E654 /* WireCallCenterV3.swift in Sources */,
 				554FEE2122AFF20600B1A8A1 /* ZMUserSession+LegalHold.swift in Sources */,
+				EE5AAF3A2874E8C70018FA01 /* BackendEnvironmentProvider+Reachability.swift in Sources */,
 				1634958B1F0254CB004E80DB /* SessionManager+ServerConnection.swift in Sources */,
 				54034F381BB1A6D900F4ED62 /* ZMUserSession+Logs.swift in Sources */,
 				549816471A432BC800A7CE2E /* ZMSyncStrategy.m in Sources */,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-799" title="FS-799" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-799</a>  Cannot login with deeplinked backend
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When switching a backend via deep link, then logging in with valid credentials an alert is shown stating that is issues with the network.

### Causes 

When logging in, there is a reachability check to see if the server is reachable. This was failing because the reachability object was still configured to the previous backend environment, which in this case was unreachable.

### Solutions

When the backend environment changes, then the reachability helper must be recreated and configured with the new server names. 

### Testing

Tested manually

### Notes 

This is a somewhat simple solution to unblock a delivery. I think though that we need to prevent this problem occurring by coupling the reachability logic closely to the backend environment, so that the environment owns the reachability object and we don't need to keep two separate objects in sync. I'll address this in another PR.


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
