### PR TITLE
chore: Drop forceVoipSession IC - 59 

### DIFF
--- a/Source/Calling/VoiceChannel.swift
+++ b/Source/Calling/VoiceChannel.swift
@@ -33,7 +33,7 @@ public enum CaptureDevice: Int {
     }
 }
 
-public protocol VoiceChannel: AnyObject, CallProperties, CallActions, CallActionsInternal, CallObservers {
+public protocol VoiceChannel: CallProperties, CallActions, CallActionsInternal, CallObservers {
 
     init(conversation: ZMConversation)
 

--- a/Source/Data Model/Conversation+MessageDestructionTimeout.swift
+++ b/Source/Data Model/Conversation+MessageDestructionTimeout.swift
@@ -49,8 +49,7 @@ extension ZMConversation {
     public func setMessageDestructionTimeout(
         _ timeout: MessageDestructionTimeoutValue,
         in userSession: ZMUserSession, _
-        completion: @escaping (VoidResult) -> Void)
-    {
+        completion: @escaping (VoidResult) -> Void) {
         guard let apiVersion = APIVersion.current else {
             return completion(.failure(WirelessLinkError.unknown))
         }

--- a/Source/Synchronization/Strategies/CallingRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/CallingRequestStrategy.swift
@@ -86,7 +86,6 @@ public final class CallingRequestStrategy: AbstractRequestStrategy, ZMSingleRequ
                       clientDiscoverySync.nextRequest(for: apiVersion) ??
                       messageSync.nextRequest(for: apiVersion)
 
-        request?.forceToVoipSession()
         return request
     }
 

--- a/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
+++ b/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
@@ -264,7 +264,7 @@ NSUInteger const ZMMissingUpdateEventsTranscoderListPageSize = 500;
         ZMTransportRequest *request = [self.listPaginator nextRequestForAPIVersion:apiVersion];
 
         if (self.isFetchingStreamForAPNS && nil != request) {
-            [request forceToVoipSession];
+            
             [self.notificationsTracker registerStartStreamFetching];
             [request addCompletionHandler:[ZMCompletionHandler handlerOnGroupQueue:self.managedObjectContext block:^(__unused ZMTransportResponse * _Nonnull response) {
                 [self.notificationsTracker registerFinishStreamFetching];


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we drop the forceVoipSession because it has been deprecated.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
