### PR TITLE
fix: SwiftLint legacy_random warnings

### DIFF
--- a/Source/Data Model/Conversation+MessageDestructionTimeout.swift
+++ b/Source/Data Model/Conversation+MessageDestructionTimeout.swift
@@ -49,8 +49,8 @@ extension ZMConversation {
     public func setMessageDestructionTimeout(
         _ timeout: MessageDestructionTimeoutValue,
         in userSession: ZMUserSession, _
-        completion: @escaping (VoidResult) -> Void)
-    {
+        completion: @escaping (VoidResult) -> Void) {
+
         guard let apiVersion = APIVersion.current else {
             return completion(.failure(WirelessLinkError.unknown))
         }

--- a/Source/Registration/RandomHandleGenerator.swift
+++ b/Source/Registration/RandomHandleGenerator.swift
@@ -86,7 +86,7 @@ extension String {
 
     /// Returns a string composed of random digits
     fileprivate static func random(numberOfDigits: Int) -> String {
-        return (0..<numberOfDigits).map { _ in "\(arc4random_uniform(10))" }
+        return (0..<numberOfDigits).map { _ in "\(Int.random(in: 0..<10))" }
         .joined(separator: "")
     }
 }
@@ -119,7 +119,7 @@ extension Array {
             return self.first
         }
 
-        let index = Int(arc4random_uniform(UInt32(self.count)))
+        let index = Int.random(in: 0..<self.count)
         return self[index]
     }
 }

--- a/Source/UserSession/ZMUserSession.swift
+++ b/Source/UserSession/ZMUserSession.swift
@@ -408,7 +408,7 @@ public class ZMUserSession: NSObject {
 
     private func enableBackgroundFetch() {
         // We enable background fetch by setting the minimum interval to something different from UIApplicationBackgroundFetchIntervalNever
-        application.setMinimumBackgroundFetchInterval(10.0 * 60.0 + Double(arc4random_uniform(5 * 60)))
+        application.setMinimumBackgroundFetchInterval(10.0 * 60.0 + Double.random(in: 0..<300))
     }
 
     private func notifyUserAboutChangesInAvailabilityBehaviourIfNeeded() {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Fix SwiftLint warnings related to legacy random

- Legacy Random Violation: Prefer using type.random(in:) over legacy functions. (legacy_random)

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
