### PR TITLE
chore: Remove deprecated INStartAudioCallIntent and INStartVideoCalIntent

### DIFF
--- a/Source/Calling/CallKitManager.swift
+++ b/Source/Calling/CallKitManager.swift
@@ -182,13 +182,14 @@ extension CallKitManager {
         var contacts: [INPerson]?
         var video = false
 
-        if let audioCallIntent = intent as? INStartAudioCallIntent {
+        if let audioCallIntent = intent as? INStartCallIntent {
             contacts = audioCallIntent.contacts
             video = false
-        } else if let videoCallIntent = intent as? INStartVideoCallIntent {
+        } else if let videoCallIntent = intent as? INStartCallIntent {
             contacts = videoCallIntent.contacts
             video = true
         }
+
 
         if let contacts = contacts {
             findConversationAssociated(with: contacts) { [weak self] (conversation) in

--- a/Source/Calling/CallKitManager.swift
+++ b/Source/Calling/CallKitManager.swift
@@ -182,12 +182,9 @@ extension CallKitManager {
         var contacts: [INPerson]?
         var video = false
 
-        if let audioCallIntent = intent as? INStartCallIntent {
-            contacts = audioCallIntent.contacts
-            video = audioCallIntent.callCapability == .audioCall
-        } else if let videoCallIntent = intent as? INStartCallIntent {
-            contacts = videoCallIntent.contacts
-            video = videoCallIntent.callCapability == .videoCall
+        if let startCallIntent = intent as? INStartCallIntent {
+          contacts = startCallIntent.contacts
+          video = startCallIntent.callCapability == .videoCall
         }
 
         if let contacts = contacts {

--- a/Source/Calling/CallKitManager.swift
+++ b/Source/Calling/CallKitManager.swift
@@ -190,7 +190,6 @@ extension CallKitManager {
             video = true
         }
 
-
         if let contacts = contacts {
             findConversationAssociated(with: contacts) { [weak self] (conversation) in
                 self?.requestStartCall(in: conversation, video: video)

--- a/Source/Calling/CallKitManager.swift
+++ b/Source/Calling/CallKitManager.swift
@@ -184,10 +184,10 @@ extension CallKitManager {
 
         if let audioCallIntent = intent as? INStartCallIntent {
             contacts = audioCallIntent.contacts
-            video = false
+            video = audioCallIntent.callCapability == .audioCall
         } else if let videoCallIntent = intent as? INStartCallIntent {
             contacts = videoCallIntent.contacts
-            video = true
+            video = videoCallIntent.callCapability == .videoCall
         }
 
         if let contacts = contacts {

--- a/Tests/Source/Calling/CallKitManagerTests.swift
+++ b/Tests/Source/Calling/CallKitManagerTests.swift
@@ -598,9 +598,9 @@ class CallKitManagerTest: DatabaseTest {
         let intent: INIntent
 
         if isVideo {
-            intent = INStartVideoCallIntent(contacts: contacts)
+            intent = INStartCallIntent(audioRoute: .speakerphoneAudioRoute, destinationType: .normal, contacts: contacts, recordTypeForRedialing: .unknown, callCapability: .videoCall)
         } else {
-            intent = INStartAudioCallIntent(contacts: contacts)
+            intent = INStartCallIntent(audioRoute: .speakerphoneAudioRoute, destinationType: .normal, contacts: contacts, recordTypeForRedialing: .unknown, callCapability: .audioCall)
         }
 
         let interaction = INInteraction(intent: intent, response: .none)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we drop INStartAudioCallIntent and INStartVideoCalIntent and replace it with INStartCalIntent.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
