### PR TITLE
fix(mls): not able to fetch backend keys

### DIFF
--- a/Source/UserSession/ZMUserSession.swift
+++ b/Source/UserSession/ZMUserSession.swift
@@ -261,8 +261,6 @@ public class ZMUserSession: NSObject {
 
         appLockController.delegate = self
 
-        setupMLSControllerIfNeeded(coreCryptoSetup: coreCryptoSetup)
-
         configureCaches()
 
         syncManagedObjectContext.performGroupedBlockAndWait {
@@ -278,6 +276,10 @@ public class ZMUserSession: NSObject {
                                                        contextProvider: self,
                                                        callNotificationStyleProvider: self)
         }
+
+        // This should happen after the request strategies are created b/c
+        // it needs to make network requests upon initialization.
+        setupMLSControllerIfNeeded(coreCryptoSetup: coreCryptoSetup)
 
         updateEventProcessor!.eventConsumers = self.strategyDirectory!.eventConsumers
         registerForCalculateBadgeCountNotification()


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sometimes the client is unable to fetch the backend mls keys.

### Causes

Fetching the keys happens in the initializer of the `MLSController`. It uses an action to make the network request. Typically an action handler picks up the action and schedules the request to the backend, but this isn't always happening because the action handler may not exist yet. This is because the request strategies are set up after setting up the MLS controller.

### Solutions

Set up the mls controller after the request strategies.

### Testing

#### Test Coverage

- tested manually


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
