### PR TITLE
fix: For Where Violation: `where` clauses are preferred over a single `if` inside a `for`. (for_where)

### DIFF
--- a/Source/SessionManager/JailbreakDetector.swift
+++ b/Source/SessionManager/JailbreakDetector.swift
@@ -28,15 +28,15 @@ public final class JailbreakDetector: NSObject, JailbreakDetectorProtocol {
     private let fm = FileManager.default
 
     public func isJailbroken() -> Bool {
-        #if targetEnvironment(simulator)
+#if targetEnvironment(simulator)
         return false
-        #else
+#else
         return hasJailbrokenFiles ||
-            hasWriteablePaths ||
-            hasSymlinks ||
-            callsFork ||
-            canOpenJailbrokenStores
-        #endif
+        hasWriteablePaths ||
+        hasSymlinks ||
+        callsFork ||
+        canOpenJailbrokenStores
+#endif
     }
 
     private var hasJailbrokenFiles: Bool {
@@ -76,10 +76,8 @@ public final class JailbreakDetector: NSObject, JailbreakDetectorProtocol {
             "/Applications/blackra1n.app"
         ]
 
-        for path in paths {
-            if fm.fileExists(atPath: path) {
-                return true
-            }
+        for path in paths where fm.fileExists(atPath: path) {
+            return true
         }
 
         return false
@@ -110,8 +108,8 @@ public final class JailbreakDetector: NSObject, JailbreakDetectorProtocol {
 
         for link in symlinks {
             if fm.fileExists(atPath: link),
-                let attributes = try? fm.attributesOfItem(atPath: link),
-                attributes[.type] as? String == "NSFileTypeSymbolicLink" {
+               let attributes = try? fm.attributesOfItem(atPath: link),
+               attributes[.type] as? String == "NSFileTypeSymbolicLink" {
                 return true
             }
         }
@@ -133,10 +131,8 @@ public final class JailbreakDetector: NSObject, JailbreakDetectorProtocol {
                                               "sileo://package",
                                               "sileo://source"]
 
-        for url in jailbrokenStoresURLs {
-            if UIApplication.shared.canOpenURL(URL(string: url)!) {
-                return true
-            }
+        for url in jailbrokenStoresURLs where UIApplication.shared.canOpenURL(URL(string: url)!) {
+            return true
         }
         return false
     }

--- a/Source/Synchronization/Strategies/UserProfileUpdateRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/UserProfileUpdateRequestStrategy.swift
@@ -275,10 +275,8 @@ public class UserProfileUpdateRequestStrategy: AbstractRequestStrategy, ZMSingle
         }
 
         let existingHandles = Set(usersPayload.compactMap { $0["handle"] as? String })
-        for handle in possibleHandles {
-            if !existingHandles.contains(handle) {
-                return handle
-            }
+        for handle in possibleHandles where !existingHandles.contains(handle) {
+            return handle
         }
         return nil
     }

--- a/Tests/Source/MockAddressBook.swift
+++ b/Tests/Source/MockAddressBook.swift
@@ -41,42 +41,41 @@ class MockAddressBook: WireSyncEngine.AddressBook, WireSyncEngine.AddressBookAcc
     /// Enumerates the contacts, invoking the block for each contact.
     /// If the block returns false, it will stop enumerating them.
     func enumerateRawContacts(block: @escaping (WireSyncEngine.ContactRecord) -> (Bool)) {
-        for contact in self.contacts {
-            if !block(contact) {
-                return
-            }
-        }
-        let infiniteContact = MockAddressBookContact(firstName: "johnny infinite",
-                                                     emailAddresses: ["johnny.infinite@example.com"],
-                                                     phoneNumbers: [])
-        while createInfiniteContacts {
-            if !block(infiniteContact) {
-                return
-            }
+        for contact in self.contacts where !block(contact) {
+            return
         }
     }
-
-    func rawContacts(matchingQuery: String) -> [WireSyncEngine.ContactRecord] {
-        guard matchingQuery != "" else {
-            return contacts
-        }
-        return contacts.filter { $0.firstName.lowercased().contains(matchingQuery.lowercased()) || $0.lastName.lowercased().contains(matchingQuery.lowercased()) }
-    }
-
-    /// Replace the content with a given number of random hashes
-    func fillWithContacts(_ number: UInt) {
-        self.contacts = (0..<number).map {
-            self.createContact(card: $0)
+    let infiniteContact = MockAddressBookContact(firstName: "johnny infinite",
+                                                 emailAddresses: ["johnny.infinite@example.com"],
+                                                 phoneNumbers: [])
+    while createInfiniteContacts {
+        if !block(infiniteContact) {
+            return
         }
     }
+}
 
-    /// Create a fake contact
-    func createContact(card: UInt) -> MockAddressBookContact {
-        return MockAddressBookContact(firstName: "tester \(card)", emailAddresses: ["tester_\(card)@example.com"], phoneNumbers: ["+155512300\(card % 10)"], identifier: "\(card)")
+func rawContacts(matchingQuery: String) -> [WireSyncEngine.ContactRecord] {
+    guard matchingQuery != "" else {
+        return contacts
     }
+    return contacts.filter { $0.firstName.lowercased().contains(matchingQuery.lowercased()) || $0.lastName.lowercased().contains(matchingQuery.lowercased()) }
+}
 
-    /// Generate an infinite number of contacts
-    var createInfiniteContacts = false
+/// Replace the content with a given number of random hashes
+func fillWithContacts(_ number: UInt) {
+    self.contacts = (0..<number).map {
+        self.createContact(card: $0)
+    }
+}
+
+/// Create a fake contact
+func createContact(card: UInt) -> MockAddressBookContact {
+    return MockAddressBookContact(firstName: "tester \(card)", emailAddresses: ["tester_\(card)@example.com"], phoneNumbers: ["+155512300\(card % 10)"], identifier: "\(card)")
+}
+
+/// Generate an infinite number of contacts
+var createInfiniteContacts = false
 }
 
 struct MockAddressBookContact: WireSyncEngine.ContactRecord {
@@ -99,7 +98,7 @@ struct MockAddressBookContact: WireSyncEngine.ContactRecord {
         self.localIdentifier = identifier ?? {
             MockAddressBookContact.incrementalLocalIdentifier.increment()
             return "\(MockAddressBookContact.incrementalLocalIdentifier.rawValue)"
-            }()
+        }()
     }
 
     var expectedHashes: [String] {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we fix the SwiftLint warning related to (for_where)

- For Where Violation: `where` clauses are preferred over a single `if` inside a `for`. (for_where)

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
