### PR TITLE
fix: SwiftLint warnings related to `(for_where)`

### DIFF
--- a/Source/SessionManager/JailbreakDetector.swift
+++ b/Source/SessionManager/JailbreakDetector.swift
@@ -76,10 +76,8 @@ public final class JailbreakDetector: NSObject, JailbreakDetectorProtocol {
             "/Applications/blackra1n.app"
         ]
 
-        for path in paths {
-            if fm.fileExists(atPath: path) {
-                return true
-            }
+        for path in paths where fm.fileExists(atPath: path) {
+            return true
         }
 
         return false
@@ -133,10 +131,8 @@ public final class JailbreakDetector: NSObject, JailbreakDetectorProtocol {
                                               "sileo://package",
                                               "sileo://source"]
 
-        for url in jailbrokenStoresURLs {
-            if UIApplication.shared.canOpenURL(URL(string: url)!) {
-                return true
-            }
+        for url in jailbrokenStoresURLs where UIApplication.shared.canOpenURL(URL(string: url)!) {
+            return true
         }
         return false
     }

--- a/Source/Synchronization/Strategies/UserProfileUpdateRequestStrategy.swift
+++ b/Source/Synchronization/Strategies/UserProfileUpdateRequestStrategy.swift
@@ -275,10 +275,8 @@ public class UserProfileUpdateRequestStrategy: AbstractRequestStrategy, ZMSingle
         }
 
         let existingHandles = Set(usersPayload.compactMap { $0["handle"] as? String })
-        for handle in possibleHandles {
-            if !existingHandles.contains(handle) {
-                return handle
-            }
+        for handle in possibleHandles where !existingHandles.contains(handle) {
+            return handle
         }
         return nil
     }

--- a/Tests/Source/MockAddressBook.swift
+++ b/Tests/Source/MockAddressBook.swift
@@ -41,10 +41,8 @@ class MockAddressBook: WireSyncEngine.AddressBook, WireSyncEngine.AddressBookAcc
     /// Enumerates the contacts, invoking the block for each contact.
     /// If the block returns false, it will stop enumerating them.
     func enumerateRawContacts(block: @escaping (WireSyncEngine.ContactRecord) -> (Bool)) {
-        for contact in self.contacts {
-            if !block(contact) {
+        for contact in self.contacts where !block(contact) {
                 return
-            }
         }
         let infiniteContact = MockAddressBookContact(firstName: "johnny infinite",
                                                      emailAddresses: ["johnny.infinite@example.com"],


### PR DESCRIPTION
For Where Violation: `where` clauses are preferred over a single `if` inside a `for`. (for_where)

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we fix SwiftLint warnings related to `(for_where)`

- For Where Violation: `where` clauses are preferred over a single `if` inside a `for`. (for_where)

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
