### PR TITLE
refactor: separate call observation

### DIFF
--- a/Source/Calling/CallKitCall.swift
+++ b/Source/Calling/CallKitCall.swift
@@ -23,7 +23,6 @@ class CallKitCall {
     let id: UUID
     let handle: CallHandle
     let observer = CallObserver()
-    var isAVSReady = false
 
     init(
         id: UUID,
@@ -31,10 +30,6 @@ class CallKitCall {
     ) {
         self.id = id
         self.handle = handle
-    }
-
-    func markAsReady() {
-        isAVSReady = true
     }
 
 }

--- a/Source/Calling/CallKitCallRegister.swift
+++ b/Source/Calling/CallKitCallRegister.swift
@@ -24,6 +24,16 @@ class CallKitCallRegister {
 
     private var storage = [UUID: CallKitCall]()
 
+    // MARK: - Life cycle
+
+    init() {
+        persistStorage()
+    }
+
+    deinit {
+        persistStorage()
+    }
+
     // MARK: - Persistence
 
     private func persistStorage() {

--- a/Source/Calling/CallKitManager.swift
+++ b/Source/Calling/CallKitManager.swift
@@ -25,7 +25,15 @@ protocol CallKitManagerDelegate: AnyObject {
 
     /// Look a conversation where a call has or will take place
 
-    func lookupConversation(by handle: CallHandle, completionHandler: @escaping (Result<ZMConversation>) -> Void)
+    func lookupConversation(
+        by handle: CallHandle,
+        completionHandler: @escaping (Result<ZMConversation>) -> Void
+    )
+
+    func lookupConversationAndSync(
+        by handle: CallHandle,
+        completionHandler: @escaping (Result<ZMConversation>) -> Void
+    )
 
     /// End all active calls in all user sessions
 
@@ -37,6 +45,9 @@ protocol CallKitManagerDelegate: AnyObject {
 public class CallKitManager: NSObject {
 
     // MARK: - Properties
+
+    private let application: ZMApplication
+    private let requirePushTokenType: PushToken.TokenType
 
     private let provider: CXProvider
     private let callController: CXCallController
@@ -54,18 +65,28 @@ public class CallKitManager: NSObject {
 
     // MARK: - Life cycle
 
-    public convenience init(mediaManager: MediaManagerType) {
+    public convenience init(
+        application: ZMApplication,
+        requiredPushTokenType: PushToken.TokenType,
+        mediaManager: MediaManagerType
+    ) {
         self.init(
+            application: application,
+            requiredPushTokenType: requiredPushTokenType,
             mediaManager: mediaManager,
             delegate: nil
         )
     }
 
     convenience init(
+        application: ZMApplication,
+        requiredPushTokenType: PushToken.TokenType,
         mediaManager: MediaManagerType,
         delegate: CallKitManagerDelegate?
     ) {
         self.init(
+            application: application,
+            requiredPushTokenType: requiredPushTokenType,
             provider: CXProvider(configuration: CallKitManager.providerConfiguration),
             callController: CXCallController(queue: DispatchQueue.main),
             mediaManager: mediaManager,
@@ -74,11 +95,15 @@ public class CallKitManager: NSObject {
     }
 
     init(
+        application: ZMApplication,
+        requiredPushTokenType: PushToken.TokenType,
         provider: CXProvider,
         callController: CXCallController,
         mediaManager: MediaManagerType?,
         delegate: CallKitManagerDelegate? = nil
     ) {
+        self.application = application
+        self.requirePushTokenType = requiredPushTokenType
         self.provider = provider
         self.callController = callController
         self.mediaManager = mediaManager
@@ -454,7 +479,7 @@ public class CallKitManager: NSObject {
         Self.logger.trace("report call ended")
 
         let associatedCalls = callRegister.allCalls.filter {
-            $0.handle == conversation.callHandle && $0.isAVSReady
+            $0.handle == conversation.callHandle
         }
 
         for call in associatedCalls {
@@ -561,7 +586,7 @@ extension CallKitManager: CXProviderDelegate {
             return
         }
 
-        delegate.lookupConversation(by: call.handle) { [weak self] result in
+        delegate.lookupConversationAndSync(by: call.handle) { [weak self] result in
             guard let `self` = self else {
                 action.fail()
                 return
@@ -572,37 +597,21 @@ extension CallKitManager: CXProviderDelegate {
                 call.observer.startObservingChanges(in: conversation)
 
                 call.observer.onEstablished = {
-                    Self.logger.error("success: perform answer call action")
+                    Self.logger.info("success: perform answer call action")
                     action.fulfill()
                 }
 
                 call.observer.onFailedToJoin = {
+                    Self.logger.error("fail: perform answer call action: failed to join")
                     action.fail()
                 }
 
-                if call.isAVSReady {
-                    Self.logger.info("perform answer call action: AVS already processed incoming call event, joining...")
-                    self.mediaManager?.setupAudioDevice()
+                Self.logger.info("joining the call...")
+                self.mediaManager?.setupAudioDevice()
 
-                    if conversation.voiceChannel?.join(video: false) != true {
-                        Self.logger.error("fail: perform answer call action: couldn't join call")
-                        action.fail()
-                    }
-                } else {
-                    Self.logger.info("perform answer call action: AVS did not process incoming call event yet, fetching event...")
-
-                    call.observer.onIncoming = {
-                        Self.logger.info("joining the call...")
-                        self.mediaManager?.setupAudioDevice()
-
-                        if conversation.voiceChannel?.join(video: false) != true {
-                            Self.logger.error("fail: perform answer call action: couldn't join call")
-                            action.fail()
-                        }
-                    }
-
-                    Self.logger.info("requesting quick sync")
-                    NotificationCenter.default.post(name: .triggerQuickSync, object: nil)
+                if conversation.voiceChannel?.join(video: false) != true {
+                    Self.logger.error("fail: perform answer call action: couldn't join call")
+                    action.fail()
                 }
 
             case .failure(let error):
@@ -737,6 +746,18 @@ extension CallKitManager: CXProviderDelegate {
 
 extension CallKitManager: WireCallCenterCallStateObserver, WireCallCenterMissedCallObserver {
 
+    private var shouldHandleCallStates: Bool {
+        switch (requirePushTokenType, application.applicationState) {
+        case (.standard, .background):
+            // Processing call states in the background wiLl interfere with
+            // CallKit calls triggered from the NSE.
+            return false
+
+        default:
+            return true
+        }
+    }
+
     public func callCenterDidChange(
         callState: CallState,
         conversation: ZMConversation,
@@ -746,12 +767,15 @@ extension CallKitManager: WireCallCenterCallStateObserver, WireCallCenterMissedC
     ) {
         Self.logger.trace("received new call state: \(callState)")
 
+        // FIX: We need to handle some call states like when the call is terminated, but perhaps we should
+        // do that in the call observer.
+        guard shouldHandleCallStates else {
+            Self.logger.info("not handling call state: app state is \(String(describing: application.applicationState))")
+            return
+        }
+
         switch callState {
         case .incoming(let hasVideo, let shouldRing, degraded: _):
-            if var call = callRegister.lookupCall(by: conversation) {
-                call.markAsReady()
-            }
-
             if shouldRing {
                 Self.logger.info("should report an incoming call")
 
@@ -789,6 +813,7 @@ extension CallKitManager: WireCallCenterCallStateObserver, WireCallCenterMissedC
             )
 
         case .established, .establishedDataChannel:
+            // TODO: we'll need to move this to the other observer.
             // Users are join conferences in a muted state, so we want to make sure
             // that the CallKit mute state is in sync with the voice channel mute state.
             guard let voiceChannel = conversation.voiceChannel else { return }

--- a/Source/Calling/CallObserver.swift
+++ b/Source/Calling/CallObserver.swift
@@ -20,14 +20,16 @@ import Foundation
 
 class CallObserver: WireCallCenterCallStateObserver {
 
-    typealias Handler = () -> Void
+    typealias VoidHandler = () -> Void
+    typealias Handler<T> = (T) -> Void
 
     private var token: Any?
 
-    public var onIncoming: Handler?
-    public var onAnswered: Handler?
-    public var onEstablished: Handler?
-    public var onFailedToJoin: Handler?
+    public var onIncoming: VoidHandler?
+    public var onAnswered: VoidHandler?
+    public var onEstablished: VoidHandler?
+    public var onFailedToJoin: VoidHandler?
+    public var onTerminated: Handler<CallClosedReason>?
 
     public func startObservingChanges(in conversation: ZMConversation) {
         token = WireCallCenterV3.addCallStateObserver(
@@ -60,7 +62,7 @@ class CallObserver: WireCallCenterCallStateObserver {
                 onFailedToJoin?()
 
             default:
-                break
+                onTerminated?(reason)
             }
 
         default:

--- a/Source/Notifications/VoIPPushManager.swift
+++ b/Source/Notifications/VoIPPushManager.swift
@@ -69,11 +69,21 @@ public final class VoIPPushManager: NSObject, PKPushRegistryDelegate {
 
     // MARK: - Life cycle
 
-    public init(requiredPushTokenType: PushToken.TokenType) {
+    public init(
+        application: ZMApplication,
+        requiredPushTokenType: PushToken.TokenType
+    ) {
         Self.logger.trace("init")
         self.requiredPushTokenType = requiredPushTokenType
-        callKitManager = CallKitManager(mediaManager: AVSMediaManager.sharedInstance())
+
+        callKitManager = CallKitManager(
+            application: application,
+            requiredPushTokenType: requiredPushTokenType,
+            mediaManager: AVSMediaManager.sharedInstance()
+        )
+
         super.init()
+
         registry.delegate = self
     }
 

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -184,6 +184,8 @@ public protocol ForegroundNotificationResponder: AnyObject {
 @objcMembers
 public final class SessionManager: NSObject, SessionManagerType {
 
+    static let logger = Logger(subsystem: "VoIP Push", category: "SessionManager")
+
     public enum AccountError: Error {
         case accountLimitReached
     }

--- a/Source/Synchronization/ApplicationStatusDirectory.swift
+++ b/Source/Synchronization/ApplicationStatusDirectory.swift
@@ -102,4 +102,8 @@ public final class ApplicationStatusDirectory: NSObject, ApplicationStatus {
         syncStatus.forceSlowSync()
     }
 
+    public func requestQuickSync() {
+        syncStatus.forceQuickSync()
+    }
+
 }

--- a/Source/Synchronization/EventProcessor.swift
+++ b/Source/Synchronization/EventProcessor.swift
@@ -71,7 +71,9 @@ class EventProcessor: UpdateEventProcessor {
         eventBuffer?.processAllEventsInBuffer()
 
         if syncContext.encryptMessagesAtRest {
+            Self.logger.info("trying to get EAR keys")
             guard let encryptionKeys = syncContext.encryptionKeys else {
+                Self.logger.warning("failed to get EAR keys")
                 return true
             }
 

--- a/Source/UserSession/SyncStatus.swift
+++ b/Source/UserSession/SyncStatus.swift
@@ -90,7 +90,7 @@ extension Notification.Name {
             object: nil,
             queue: nil
         ) { [weak self] _ in
-            self?.triggerQuickSync()
+            self?.forceQuickSync()
         }
     }
 
@@ -113,7 +113,7 @@ extension Notification.Name {
         syncStateDelegate.didStartSlowSync()
     }
 
-    func triggerQuickSync() {
+    public func forceQuickSync() {
         isForceQuickSync = true
         currentSyncPhase = .fetchingMissedEvents
         RequestAvailableNotification.notifyNewRequestsAvailable(self)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

If you accumulate unprocessed call events (e.g call start, call end, call start...), then attempt to answer an incoming call, the calls will be terminated.

### Causes

All unprocessed call events need to be processed before you can join a current call. Processing old events would trigger call state changes that would then terminated the current CallKit call.

### Solutions

- Disable call state observation when processing CallKit calls.
- Perform a quick sync before registering observation for the current call.
- There are some other little fixes included in this PR too.

### Testing

Manually tested.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
