### PR TITLE
feat(api-v3): add api migration mechanism + migrate access token FS-1237

### DIFF
--- a/Source/SessionManager/APIMigration/APIMigrationManager.swift
+++ b/Source/SessionManager/APIMigration/APIMigrationManager.swift
@@ -1,0 +1,135 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+protocol APIMigration {
+    func perform(with session: ZMUserSession, clientID: String) async throws
+    var version: APIVersion { get }
+}
+
+class APIMigrationManager {
+    let migrations: [APIMigration]
+
+    private let logger = Logging.apiMigration
+
+    init(migrations: [APIMigration]) {
+        self.migrations = migrations
+    }
+
+    func migrate(
+        session: ZMUserSession,
+        clientID: String,
+        from lastVersion: APIVersion,
+        to currentVersion: APIVersion
+    ) async {
+        guard lastVersion.rawValue < currentVersion.rawValue else {
+            return
+        }
+
+        logger.info("starting API migrations from api v\(lastVersion.rawValue) to v\(currentVersion.rawValue) for session with clientID \(String(describing: clientID))")
+
+        for migration in migrations.filter({
+            (lastVersion.rawValue+1..<currentVersion.rawValue+1).contains($0.version.rawValue)
+        }) {
+            do {
+                logger.info("starting migration (\(String(describing: migration))) for api v\(migration.version.rawValue)")
+                try await migration.perform(with: session, clientID: clientID)
+            } catch {
+                logger.warn("migration (\(String(describing: migration))) failed for session with clientID (\(String(describing: clientID)). error: \(String(describing: error))")
+            }
+        }
+    }
+
+    func migrateIfNeeded(sessions: [ZMUserSession], to apiVersion: APIVersion) async {
+
+        for session in sessions {
+
+            guard let clientID = clientId(for: session) else {
+                return
+            }
+
+            // TODO: David
+            // What if there is no last used API version, but we still need the migrations to be done?
+            // e.g: client with active session installs latest version of the app,
+            // has no last used version saved.
+            // previous version was v2, and current version is v3.
+            // we need the client to migrate the access token,
+            // but, since no last used version is recorded, we won't perform the migration.
+            //
+            // solution: maybe we can persist the last used version before resolving the api version?
+            // -> note that we may need to do that for all sessions
+            guard let lastUsedVersion = lastUsedAPIVersion(for: clientID) else {
+                persistLastUsedAPIVersion(for: clientID, apiVersion: apiVersion)
+                return
+            }
+
+            await migrate(
+                session: session,
+                clientID: clientID,
+                from: lastUsedVersion,
+                to: apiVersion
+            )
+            persistLastUsedAPIVersion(for: clientID, apiVersion: apiVersion)
+        }
+    }
+
+    private func clientId(for session: ZMUserSession) -> String? {
+        var clientID: String?
+
+        session.viewContext.performAndWait {
+            clientID = session.selfUserClient?.remoteIdentifier
+        }
+
+        return clientID
+    }
+
+    private func lastUsedAPIVersion(for clientID: String) -> APIVersion? {
+        return userDefaults(for: clientID).lastUsedAPIVersion
+    }
+
+    private func persistLastUsedAPIVersion(for clientID: String, apiVersion: APIVersion) {
+        logger.info("persisting last used API version (v\(apiVersion.rawValue)) for client (\(clientID))")
+        userDefaults(for: clientID).lastUsedAPIVersion = apiVersion
+    }
+
+    private func userDefaults(for clientID: String) -> UserDefaults {
+        return UserDefaults(suiteName: "com.wire.apiversion.\(clientID)")!
+    }
+
+}
+
+private extension UserDefaults {
+
+    private var lastUsedAPIVersionKey: String { "LastUsedAPIVersionKey" }
+
+    var lastUsedAPIVersion: APIVersion? {
+
+        get {
+            guard let value = object(forKey: lastUsedAPIVersionKey) as? Int32 else {
+                return nil
+            }
+
+            return APIVersion(rawValue: value)
+        }
+
+        set {
+            set(newValue?.rawValue, forKey: lastUsedAPIVersionKey)
+        }
+    }
+}

--- a/Source/SessionManager/APIMigration/APIMigrationManager.swift
+++ b/Source/SessionManager/APIMigration/APIMigrationManager.swift
@@ -114,8 +114,8 @@ class APIMigrationManager {
 
     // MARK: - Tests
 
-    func resetLastUsedAPIVersion(for clientID: String) {
-        userDefaults(for: clientID).lastUsedAPIVersion = nil
+    func removeDefaults(for clientID: String) {
+        UserDefaults.standard.removePersistentDomain(forName: "com.wire.apiversion.\(clientID)")
     }
 
 }

--- a/Source/SessionManager/APIMigration/APIMigrationManager.swift
+++ b/Source/SessionManager/APIMigration/APIMigrationManager.swift
@@ -89,6 +89,19 @@ class APIMigrationManager {
         }
     }
 
+    func lastUsedAPIVersion(for clientID: String) -> APIVersion? {
+        return userDefaults(for: clientID).lastUsedAPIVersion
+    }
+
+    func persistLastUsedAPIVersion(for clientID: String, apiVersion: APIVersion) {
+        logger.info("persisting last used API version (v\(apiVersion.rawValue)) for client (\(clientID))")
+        userDefaults(for: clientID).lastUsedAPIVersion = apiVersion
+    }
+
+    private func userDefaults(for clientID: String) -> UserDefaults {
+        return UserDefaults(suiteName: "com.wire.apiversion.\(clientID)")!
+    }
+
     private func clientId(for session: ZMUserSession) -> String? {
         var clientID: String?
 
@@ -99,17 +112,10 @@ class APIMigrationManager {
         return clientID
     }
 
-    private func lastUsedAPIVersion(for clientID: String) -> APIVersion? {
-        return userDefaults(for: clientID).lastUsedAPIVersion
-    }
+    // MARK: - Tests
 
-    private func persistLastUsedAPIVersion(for clientID: String, apiVersion: APIVersion) {
-        logger.info("persisting last used API version (v\(apiVersion.rawValue)) for client (\(clientID))")
-        userDefaults(for: clientID).lastUsedAPIVersion = apiVersion
-    }
-
-    private func userDefaults(for clientID: String) -> UserDefaults {
-        return UserDefaults(suiteName: "com.wire.apiversion.\(clientID)")!
+    func resetLastUsedAPIVersion(for clientID: String) {
+        userDefaults(for: clientID).lastUsedAPIVersion = nil
     }
 
 }

--- a/Source/SessionManager/APIMigration/APIMigrationManager.swift
+++ b/Source/SessionManager/APIMigration/APIMigrationManager.swift
@@ -34,14 +34,9 @@ class APIMigrationManager {
     }
 
     func isMigration(to apiVersion: APIVersion, neededForSessions sessions: [ZMUserSession]) -> Bool {
-
-        for session in sessions {
-            if isMigration(to: apiVersion, neededForSession: session) {
-                return true
-            }
-        }
-
-        return false
+        return sessions.filter {
+            isMigration(to: apiVersion, neededForSession: $0)
+        }.count > 0
     }
 
     func isMigration(to apiVersion: APIVersion, neededForSession session: ZMUserSession) -> Bool {

--- a/Source/SessionManager/APIMigration/AccessTokenMigration.swift
+++ b/Source/SessionManager/APIMigration/AccessTokenMigration.swift
@@ -1,0 +1,72 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+protocol AccessTokenRenewalObserver {
+    func accessTokenRenewalDidSucceed()
+    func accessTokenRenewalDidFail()
+}
+
+class AccessTokenMigration: APIMigration, AccessTokenRenewalObserver {
+
+    let version: APIVersion
+
+    private var continuation: CheckedContinuation<Void, Swift.Error>?
+    private let logger = Logging.apiMigration
+
+    enum Error: Swift.Error {
+        case failedToRenewAccessToken
+    }
+
+    init(version: APIVersion) {
+        self.version = version
+    }
+
+    func perform(with session: ZMUserSession, clientID: String) async throws {
+        logger.info("performing access token migration for clientID \(clientID)")
+
+        session.setAccessTokenRenewalObserver(self)
+
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Swift.Error>) in
+            self.continuation = continuation
+            session.renewAccessToken(with: clientID)
+        }
+    }
+
+    // TODO: David
+    // We may want to tear down the access token renewal observer when it succeeds / fails
+    // to avoid getting callbacks when the token is renewed from elsewhere.
+    // Note that since we tear down the continuation, the only consequence to that is that we will log.
+
+    func accessTokenRenewalDidSucceed() {
+        logger.info("successfully renewed access token")
+        continuation?.resume()
+        teardownContinuation()
+    }
+
+    func accessTokenRenewalDidFail() {
+        logger.warn("failed to renew access token")
+        continuation?.resume(throwing: Self.Error.failedToRenewAccessToken)
+        teardownContinuation()
+    }
+
+    private func teardownContinuation() {
+        continuation = nil
+    }
+}

--- a/Source/SessionManager/APIVersionResolver.swift
+++ b/Source/SessionManager/APIVersionResolver.swift
@@ -102,6 +102,10 @@ final class APIVersionResolver {
         if !wasFederationEnabled && BackendInfo.isFederationEnabled {
             delegate?.apiVersionResolverDetectedFederationHasBeenEnabled()
         }
+
+        if let apiVersion = BackendInfo.apiVersion {
+            delegate?.apiVersionResolverDidResolve(apiVersion: apiVersion)
+        }
     }
 
     private func reportBlacklist(payload: APIVersionResponsePayload) {
@@ -143,6 +147,7 @@ protocol APIVersionResolverDelegate: AnyObject {
 
     func apiVersionResolverDetectedFederationHasBeenEnabled()
     func apiVersionResolverFailedToResolveVersion(reason: BlacklistReason)
+    func apiVersionResolverDidResolve(apiVersion: APIVersion)
 
 }
 

--- a/Source/SessionManager/SessionManager+APIVersionResolver.swift
+++ b/Source/SessionManager/SessionManager+APIVersionResolver.swift
@@ -27,6 +27,7 @@ extension SessionManager: APIVersionResolverDelegate {
             apiVersionResolver = createAPIVersionResolver()
         }
 
+        apiMigrationManager.previousAPIVersion = BackendInfo.apiVersion
         apiVersionResolver!.resolveAPIVersion()
     }
 

--- a/Source/SessionManager/SessionManager+APIVersionResolver.swift
+++ b/Source/SessionManager/SessionManager+APIVersionResolver.swift
@@ -47,16 +47,17 @@ extension SessionManager: APIVersionResolverDelegate {
     }
 
     func apiVersionResolverDidResolve(apiVersion: APIVersion) {
+
         // TODO: David
         // calling `sessionManagerWillMigrateAccount` will transition the app in the
         // migrating state and show a loading screen. it will happen each time the version
         // is resolved i.e each time the app goes in the foreground. This may be too much
         // and could be avoided if we delayed this until after we've checked if migrations
         // are needed. However, there'd be a risk that requests are fired in the meantime.
+
         delegate?.sessionManagerWillMigrateAccount { [weak self] in
             guard let `self` = self else { return }
             Task {
-                // Do we want to migrate all the sessions?
                 await self.apiMigrationManager.migrateIfNeeded(
                     sessions: self.backgroundUserSessions.map(\.value),
                     to: apiVersion

--- a/Source/SessionManager/SessionManager+APIVersionResolver.swift
+++ b/Source/SessionManager/SessionManager+APIVersionResolver.swift
@@ -46,6 +46,26 @@ extension SessionManager: APIVersionResolverDelegate {
         return apiVersionResolver
     }
 
+    func apiVersionResolverDidResolve(apiVersion: APIVersion) {
+        // TODO: David
+        // calling `sessionManagerWillMigrateAccount` will transition the app in the
+        // migrating state and show a loading screen. it will happen each time the version
+        // is resolved i.e each time the app goes in the foreground. This may be too much
+        // and could be avoided if we delayed this until after we've checked if migrations
+        // are needed. However, there'd be a risk that requests are fired in the meantime.
+        delegate?.sessionManagerWillMigrateAccount { [weak self] in
+            guard let `self` = self else { return }
+            Task {
+                // Do we want to migrate all the sessions?
+                await self.apiMigrationManager.migrateIfNeeded(
+                    sessions: self.backgroundUserSessions.map(\.value),
+                    to: apiVersion
+                )
+                self.delegate?.sessionManagerDidPerformAPIMigrations()
+            }
+        }
+    }
+
     func apiVersionResolverFailedToResolveVersion(reason: BlacklistReason) {
         delegate?.sessionManagerDidBlacklistCurrentVersion(reason: reason)
     }

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -58,6 +58,7 @@ public protocol SessionManagerDelegate: SessionActivationObserver {
     func sessionManagerDidBlacklistCurrentVersion(reason: BlacklistReason)
     func sessionManagerDidBlacklistJailbrokenDevice()
     func sessionManagerDidPerformFederationMigration(authenticated: Bool)
+    func sessionManagerDidPerformAPIMigrations()
 
     var isInAuthenticatedAppState: Bool { get }
     var isInUnathenticatedAppState: Bool { get }
@@ -241,6 +242,7 @@ public final class SessionManager: NSObject, SessionManagerType {
     let notificationsTracker: NotificationsTracker?
     let configuration: SessionManagerConfiguration
     var pendingURLAction: URLAction?
+    let apiMigrationManager: APIMigrationManager
 
     var notificationCenter: UserNotificationCenter = UNUserNotificationCenter.current()
 
@@ -443,6 +445,9 @@ public final class SessionManager: NSObject, SessionManagerType {
         self.pushRegistry = pushRegistry
         self.maxNumberAccounts = maxNumberAccounts
         self.isDeveloperModeEnabled = isDeveloperModeEnabled
+        self.apiMigrationManager = APIMigrationManager(
+            migrations: [AccessTokenMigration(version: .v3)]
+        )
 
         // we must set these before initializing the PushDispatcher b/c if the app
         // received a push from terminated state, it requires these properties to be

--- a/Source/SessionManager/SessionManager.swift
+++ b/Source/SessionManager/SessionManager.swift
@@ -446,7 +446,7 @@ public final class SessionManager: NSObject, SessionManagerType {
         self.maxNumberAccounts = maxNumberAccounts
         self.isDeveloperModeEnabled = isDeveloperModeEnabled
         self.apiMigrationManager = APIMigrationManager(
-            migrations: [AccessTokenMigration(version: .v3)]
+            migrations: [AccessTokenMigration()]
         )
 
         // we must set these before initializing the PushDispatcher b/c if the app

--- a/Source/UserSession/ZMUserSession+AccessToken.swift
+++ b/Source/UserSession/ZMUserSession+AccessToken.swift
@@ -1,0 +1,45 @@
+//
+// Wire
+// Copyright (C) 2023 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension ZMUserSession: AccessTokenRenewing {
+
+    func renewAccessToken(with clientID: String) {
+        transportSession.renewAccessToken(with: clientID)
+    }
+
+    func setAccessTokenRenewalObserver(_ observer: AccessTokenRenewalObserver) {
+        accessTokenRenewalObserver = observer
+    }
+
+    func transportSessionAccessTokenDidFail(response: ZMTransportResponse) {
+        managedObjectContext.performGroupedBlock { [weak self] in
+            guard let self = self else { return }
+            let selfUser = ZMUser.selfUser(in: self.managedObjectContext)
+            let error = NSError.userSessionErrorWith(.accessTokenExpired, userInfo: selfUser.loginCredentials.dictionaryRepresentation)
+            self.notifyAuthenticationInvalidated(error)
+        }
+
+        accessTokenRenewalObserver?.accessTokenRenewalDidFail()
+    }
+
+    func transportSessionAccessTokenDidSucceed() {
+        accessTokenRenewalObserver?.accessTokenRenewalDidSucceed()
+    }
+}

--- a/Source/UserSession/ZMUserSession+AccessToken.swift
+++ b/Source/UserSession/ZMUserSession+AccessToken.swift
@@ -37,9 +37,11 @@ extension ZMUserSession: AccessTokenRenewing {
         }
 
         accessTokenRenewalObserver?.accessTokenRenewalDidFail()
+        accessTokenRenewalObserver = nil
     }
 
     func transportSessionAccessTokenDidSucceed() {
         accessTokenRenewalObserver?.accessTokenRenewalDidSucceed()
+        accessTokenRenewalObserver = nil
     }
 }

--- a/Source/UserSession/ZMUserSession.swift
+++ b/Source/UserSession/ZMUserSession.swift
@@ -59,7 +59,6 @@ public class ZMUserSession: NSObject {
     private let appVersion: String
     private var tokens: [Any] = []
     private var tornDown: Bool = false
-    private var accessTokenRenewalObserver: AccessTokenRenewalObserver?
 
     var isNetworkOnline: Bool = true
     var isPerformingSync: Bool = true {
@@ -93,6 +92,7 @@ public class ZMUserSession: NSObject {
     let legacyHotFix: ZMHotFix
     // When we move to the monorepo, uncomment hotFixApplicator
     // let hotFixApplicator = PatchApplicator<HotfixPatch>(lastRunVersionKey: "lastRunHotFixVersion")
+    var accessTokenRenewalObserver: AccessTokenRenewalObserver?
 
     public lazy var featureService = FeatureService(context: syncContext)
 
@@ -297,7 +297,7 @@ public class ZMUserSession: NSObject {
         transportSession.setAccessTokenRenewalFailureHandler { [weak self] (response) in
             self?.transportSessionAccessTokenDidFail(response: response)
         }
-        transportSession.setAccessTokenRenewalSuccessHandler { [weak self]  _,_ in
+        transportSession.setAccessTokenRenewalSuccessHandler { [weak self]  _, _ in
             self?.transportSessionAccessTokenDidSucceed()
         }
     }
@@ -445,10 +445,6 @@ public class ZMUserSession: NSObject {
 
     // MARK: - Access Token
 
-    func renewAccessToken(with clientID: String) {
-        transportSession.renewAccessToken(with: clientID)
-    }
-
     private func renewAccessTokenIfNeeded(for userClient: UserClient) {
         guard
             let apiVersion = BackendInfo.apiVersion,
@@ -457,25 +453,6 @@ public class ZMUserSession: NSObject {
         else { return }
 
         renewAccessToken(with: clientID)
-    }
-
-    func setAccessTokenRenewalObserver(_ observer: AccessTokenRenewalObserver) {
-        accessTokenRenewalObserver = observer
-    }
-
-    private func transportSessionAccessTokenDidFail(response: ZMTransportResponse) {
-        managedObjectContext.performGroupedBlock { [weak self] in
-            guard let strongRef = self else { return }
-            let selfUser = ZMUser.selfUser(in: strongRef.managedObjectContext)
-            let error = NSError.userSessionErrorWith(.accessTokenExpired, userInfo: selfUser.loginCredentials.dictionaryRepresentation)
-            strongRef.notifyAuthenticationInvalidated(error)
-        }
-
-        accessTokenRenewalObserver?.accessTokenRenewalDidFail()
-    }
-
-    private func transportSessionAccessTokenDidSucceed() {
-        accessTokenRenewalObserver?.accessTokenRenewalDidSucceed()
     }
 
     // MARK: - Perform changes
@@ -684,7 +661,7 @@ extension ZMUserSession: ZMSyncStateDelegate {
         }
     }
 
-    private func notifyAuthenticationInvalidated(_ error: Error) {
+    func notifyAuthenticationInvalidated(_ error: Error) {
         managedObjectContext.performGroupedBlock {  [weak self] in
             guard let accountId = self?.managedObjectContext.selfUserId else {
                 return

--- a/Source/Utility/Logging.swift
+++ b/Source/Utility/Logging.swift
@@ -1,0 +1,27 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension Logging {
+
+    /// For logs related to API migrations
+
+    public static let apiMigration = ZMSLog(tag: "API Migration")
+
+}

--- a/Tests/Source/Integration/IntegrationTest.swift
+++ b/Tests/Source/Integration/IntegrationTest.swift
@@ -687,6 +687,9 @@ extension IntegrationTest: SessionManagerDelegate {
         // no op
     }
 
+    public func sessionManagerDidPerformAPIMigrations() {
+        // no op
+    }
 }
 
 @objcMembers

--- a/Tests/Source/RecordingMockTransportSession.swift
+++ b/Tests/Source/RecordingMockTransportSession.swift
@@ -73,6 +73,8 @@ class RecordingMockTransportSession: NSObject, TransportSessionType {
 
     func setAccessTokenRenewalSuccessHandler(_ handler: @escaping ZMAccessTokenHandlerBlock) { }
 
+    func setAccessTokenRenewalSuccessHandler(handler: @escaping ZMAccessTokenHandlerBlock) { }
+
     var didCallSetNetworkStateDelegate: Bool = false
     func setNetworkStateDelegate(_ delegate: ZMNetworkStateDelegate?) {
         didCallSetNetworkStateDelegate = true

--- a/Tests/Source/SessionManager/APIMigrationManagerTests.swift
+++ b/Tests/Source/SessionManager/APIMigrationManagerTests.swift
@@ -46,7 +46,6 @@ class APIMigrationManagerTests: MessagingTest {
 
         let sut = APIMigrationManager(migrations: [])
 
-        sut.resetLastUsedAPIVersion(for: clientID)
         XCTAssertNil(sut.lastUsedAPIVersion(for: clientID))
 
         // When
@@ -56,6 +55,7 @@ class APIMigrationManagerTests: MessagingTest {
         XCTAssertEqual(sut.lastUsedAPIVersion(for: clientID), APIVersion.v3)
 
         userSession.tearDown()
+        sut.removeDefaults(for: clientID)
     }
 
     func test_itPersistsLastUsedAPIVersion_AfterMigrations() async {
@@ -75,6 +75,7 @@ class APIMigrationManagerTests: MessagingTest {
         XCTAssertEqual(sut.lastUsedAPIVersion(for: clientID), .v3)
 
         userSession.tearDown()
+        sut.removeDefaults(for: clientID)
     }
 
     func test_itPerformsMigrationsForVersionsHigherThanLastUsed() async {
@@ -105,6 +106,7 @@ class APIMigrationManagerTests: MessagingTest {
         XCTAssertEqual(migrationV3.performCalls.count, 1)
 
         userSession.tearDown()
+        sut.removeDefaults(for: clientID)
     }
 
     func test_itPerformsMigrationsForMultipleSessions() async {
@@ -138,6 +140,8 @@ class APIMigrationManagerTests: MessagingTest {
 
         userSession1.tearDown()
         userSession2.tearDown()
+        sut.removeDefaults(for: clientID1)
+        sut.removeDefaults(for: clientID2)
     }
 
     func setupClient(_ clientID: String, in userSession: ZMUserSession) {

--- a/Tests/Source/SessionManager/APIMigrationManagerTests.swift
+++ b/Tests/Source/SessionManager/APIMigrationManagerTests.swift
@@ -1,0 +1,188 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import XCTest
+import WireTransport
+@testable import WireSyncEngine
+
+class APIMigrationMock: APIMigration {
+    var version: APIVersion
+
+    init(version: APIVersion) {
+        self.version = version
+    }
+
+    var performCalls = [(session: ZMUserSession, clientID: String)]()
+
+    func perform(with session: ZMUserSession, clientID: String) async throws {
+        performCalls.append((session, clientID))
+    }
+}
+
+class APIMigrationManagerTests: MessagingTest {
+
+    func test_itPersistsLastUsedAPIVersion_WhenThereIsNone() async {
+        // Given
+        let userSession = stubUserSession()
+        let clientID = "1234abcd"
+
+        setupClient(clientID, in: userSession)
+
+        let sut = APIMigrationManager(migrations: [])
+
+        sut.resetLastUsedAPIVersion(for: clientID)
+        XCTAssertNil(sut.lastUsedAPIVersion(for: clientID))
+
+        // When
+        await sut.migrateIfNeeded(sessions: [userSession], to: APIVersion.v3)
+
+        // Then
+        XCTAssertEqual(sut.lastUsedAPIVersion(for: clientID), APIVersion.v3)
+
+        userSession.tearDown()
+    }
+
+    func test_itPersistsLastUsedAPIVersion_AfterMigrations() async {
+        // Given
+        let userSession = stubUserSession()
+        let clientID = "1234abcd"
+
+        setupClient(clientID, in: userSession)
+
+        let sut = APIMigrationManager(migrations: [])
+        sut.persistLastUsedAPIVersion(for: clientID, apiVersion: .v0)
+
+        // When
+        await sut.migrateIfNeeded(sessions: [userSession], to: .v3)
+
+        // Then
+        XCTAssertEqual(sut.lastUsedAPIVersion(for: clientID), .v3)
+
+        userSession.tearDown()
+    }
+
+    func test_itPerformsMigrationsForVersionsHigherThanLastUsed() async {
+        // Given
+        let userSession = stubUserSession()
+        let clientID = "123abcd"
+
+        setupClient(clientID, in: userSession)
+
+        let migrationV1 = APIMigrationMock(version: .v1)
+        let migrationV2 = APIMigrationMock(version: .v2)
+        let migrationV3 = APIMigrationMock(version: .v3)
+
+        let sut = APIMigrationManager(migrations: [
+            migrationV1,
+            migrationV2,
+            migrationV3
+        ])
+
+        sut.persistLastUsedAPIVersion(for: clientID, apiVersion: .v2)
+
+        // When
+        await sut.migrateIfNeeded(sessions: [userSession], to: .v3)
+
+        // Then
+        XCTAssertEqual(migrationV1.performCalls.count, 0)
+        XCTAssertEqual(migrationV2.performCalls.count, 0)
+        XCTAssertEqual(migrationV3.performCalls.count, 1)
+
+        userSession.tearDown()
+    }
+
+    func test_itPerformsMigrationsForMultipleSessions() async {
+        // Given
+        let userSession1 = stubUserSession()
+        let userSession2 = stubUserSession()
+        let clientID1 = "client1"
+        let clientID2 = "client2"
+
+        setupClient(clientID1, in: userSession1)
+        setupClient(clientID2, in: userSession2)
+
+        let migration = APIMigrationMock(version: .v3)
+        let sut = APIMigrationManager(migrations: [migration])
+
+        sut.persistLastUsedAPIVersion(for: clientID1, apiVersion: .v2)
+        sut.persistLastUsedAPIVersion(for: clientID2, apiVersion: .v2)
+
+        // When
+        await sut.migrateIfNeeded(sessions: [userSession1, userSession2], to: .v3)
+
+        // Then
+        guard migration.performCalls.count == 2 else {
+            return XCTFail()
+        }
+
+        XCTAssertEqual(migration.performCalls[0].session, userSession1)
+        XCTAssertEqual(migration.performCalls[0].clientID, clientID1)
+        XCTAssertEqual(migration.performCalls[1].session, userSession2)
+        XCTAssertEqual(migration.performCalls[1].clientID, clientID2)
+
+        userSession1.tearDown()
+        userSession2.tearDown()
+    }
+
+    func setupClient(_ clientID: String, in userSession: ZMUserSession) {
+        userSession.perform {
+            let selfClient = UserClient.insertNewObject(in: userSession.managedObjectContext)
+            selfClient.remoteIdentifier = clientID
+            selfClient.user = ZMUser.selfUser(in: userSession.managedObjectContext)
+
+            userSession.managedObjectContext.setPersistentStoreMetadata(
+                clientID,
+                key: ZMPersistedClientIdKey
+            )
+
+            XCTAssertNotNil(userSession.selfUserClient)
+        }
+    }
+
+    func stubUserSession() -> ZMUserSession {
+        let mockStrategyDirectory = MockStrategyDirectory()
+        let mockUpdateEventProcessor = MockUpdateEventProcessor()
+
+        let cookieStorage = ZMPersistentCookieStorage(
+            forServerName: "test.example.com",
+            userIdentifier: .create()
+        )
+
+        let mockTransportSession = RecordingMockTransportSession(
+            cookieStorage: cookieStorage,
+            pushChannel: MockPushChannel()
+        )
+
+        return ZMUserSession(
+            userId: .create(),
+            transportSession: mockTransportSession,
+            mediaManager: MockMediaManager(),
+            flowManager: FlowManagerMock(),
+            analytics: nil,
+            eventProcessor: mockUpdateEventProcessor,
+            strategyDirectory: mockStrategyDirectory,
+            syncStrategy: nil,
+            operationLoop: nil,
+            application: application,
+            appVersion: "999",
+            coreDataStack: createCoreDataStack(),
+            configuration: .init()
+        )
+    }
+}

--- a/Tests/Source/SessionManager/APIMigrationManagerTests.swift
+++ b/Tests/Source/SessionManager/APIMigrationManagerTests.swift
@@ -37,53 +37,12 @@ class APIMigrationMock: APIMigration {
 
 class APIMigrationManagerTests: MessagingTest {
 
-    func test_itPersistsLastUsedAPIVersion_WhenThereIsNone() async {
+    // MARK: - Verifying if migration is needed
+
+    func test_itReturnsTrue_WhenMigrationIsNeeded() {
         // Given
-        let userSession = stubUserSession()
-        let clientID = "1234abcd"
-
-        setupClient(clientID, in: userSession)
-
-        let sut = APIMigrationManager(migrations: [])
-
-        XCTAssertNil(sut.lastUsedAPIVersion(for: clientID))
-
-        // When
-        await sut.migrateIfNeeded(sessions: [userSession], to: APIVersion.v3)
-
-        // Then
-        XCTAssertEqual(sut.lastUsedAPIVersion(for: clientID), APIVersion.v3)
-
-        userSession.tearDown()
-        sut.removeDefaults(for: clientID)
-    }
-
-    func test_itPersistsLastUsedAPIVersion_AfterMigrations() async {
-        // Given
-        let userSession = stubUserSession()
-        let clientID = "1234abcd"
-
-        setupClient(clientID, in: userSession)
-
-        let sut = APIMigrationManager(migrations: [])
-        sut.persistLastUsedAPIVersion(for: clientID, apiVersion: .v0)
-
-        // When
-        await sut.migrateIfNeeded(sessions: [userSession], to: .v3)
-
-        // Then
-        XCTAssertEqual(sut.lastUsedAPIVersion(for: clientID), .v3)
-
-        userSession.tearDown()
-        sut.removeDefaults(for: clientID)
-    }
-
-    func test_itPerformsMigrationsForVersionsHigherThanLastUsed() async {
-        // Given
-        let userSession = stubUserSession()
-        let clientID = "123abcd"
-
-        setupClient(clientID, in: userSession)
+        let session1 = setupSession(with: "clientID1")
+        let session2 = setupSession(with: "clientID2")
 
         let migrationV1 = APIMigrationMock(version: .v1)
         let migrationV2 = APIMigrationMock(version: .v2)
@@ -95,7 +54,55 @@ class APIMigrationManagerTests: MessagingTest {
             migrationV3
         ])
 
-        sut.persistLastUsedAPIVersion(for: clientID, apiVersion: .v2)
+        sut.persistLastUsedAPIVersion(for: session1, apiVersion: .v3)
+        sut.persistLastUsedAPIVersion(for: session2, apiVersion: .v1)
+
+        // When / Then
+        XCTAssertTrue(sut.isMigration(to: .v3, neededForSessions: [session1, session2]))
+
+        tearDownSessions([session1, session2])
+    }
+
+    func test_itReturnsFalse_WhenMigrationIsNotNeeded() {
+        // Given
+        let session1 = setupSession(with: "clientID1")
+        let session2 = setupSession(with: "clientID2")
+
+        let migrationV1 = APIMigrationMock(version: .v1)
+        let migrationV2 = APIMigrationMock(version: .v2)
+
+        let sut = APIMigrationManager(migrations: [
+            migrationV1,
+            migrationV2
+        ])
+
+        sut.persistLastUsedAPIVersion(for: session1, apiVersion: .v3)
+        sut.persistLastUsedAPIVersion(for: session2, apiVersion: .v2)
+
+        // When / Then
+        XCTAssertFalse(sut.isMigration(to: .v3, neededForSessions: [session1, session2]))
+
+        tearDownSessions([session1, session2])
+    }
+
+    // MARK: - Migrating sessions
+
+    func test_itPerformsMigrationsForVersionsHigherThanLastUsed() async {
+        // Given
+        let clientID = "123abcd"
+        let userSession = setupSession(with: clientID)
+
+        let migrationV1 = APIMigrationMock(version: .v1)
+        let migrationV2 = APIMigrationMock(version: .v2)
+        let migrationV3 = APIMigrationMock(version: .v3)
+
+        let sut = APIMigrationManager(migrations: [
+            migrationV1,
+            migrationV2,
+            migrationV3
+        ])
+
+        sut.persistLastUsedAPIVersion(for: userSession, apiVersion: .v2)
 
         // When
         await sut.migrateIfNeeded(sessions: [userSession], to: .v3)
@@ -105,25 +112,21 @@ class APIMigrationManagerTests: MessagingTest {
         XCTAssertEqual(migrationV2.performCalls.count, 0)
         XCTAssertEqual(migrationV3.performCalls.count, 1)
 
-        userSession.tearDown()
-        sut.removeDefaults(for: clientID)
+        tearDownSession(userSession)
     }
 
     func test_itPerformsMigrationsForMultipleSessions() async {
         // Given
-        let userSession1 = stubUserSession()
-        let userSession2 = stubUserSession()
         let clientID1 = "client1"
         let clientID2 = "client2"
-
-        setupClient(clientID1, in: userSession1)
-        setupClient(clientID2, in: userSession2)
+        let userSession1 = setupSession(with: clientID1)
+        let userSession2 = setupSession(with: clientID2)
 
         let migration = APIMigrationMock(version: .v3)
         let sut = APIMigrationManager(migrations: [migration])
 
-        sut.persistLastUsedAPIVersion(for: clientID1, apiVersion: .v2)
-        sut.persistLastUsedAPIVersion(for: clientID2, apiVersion: .v2)
+        sut.persistLastUsedAPIVersion(for: userSession1, apiVersion: .v2)
+        sut.persistLastUsedAPIVersion(for: userSession2, apiVersion: .v2)
 
         // When
         await sut.migrateIfNeeded(sessions: [userSession1, userSession2], to: .v3)
@@ -138,13 +141,79 @@ class APIMigrationManagerTests: MessagingTest {
         XCTAssertEqual(migration.performCalls[1].session, userSession2)
         XCTAssertEqual(migration.performCalls[1].clientID, clientID2)
 
-        userSession1.tearDown()
-        userSession2.tearDown()
-        sut.removeDefaults(for: clientID1)
-        sut.removeDefaults(for: clientID2)
+        tearDownSessions([userSession1, userSession2])
     }
 
-    func setupClient(_ clientID: String, in userSession: ZMUserSession) {
+    // MARK: - Persisting last used API version
+
+    func test_itPersistsLastUsedAPIVersion_AfterMigrations() async {
+        // Given
+        let userSession = stubUserSession()
+        let clientID = "1234abcd"
+
+        setupClient(clientID, in: userSession)
+
+        let sut = APIMigrationManager(migrations: [])
+        sut.persistLastUsedAPIVersion(for: userSession, apiVersion: .v0)
+
+        // When
+        await sut.migrateIfNeeded(sessions: [userSession], to: .v3)
+
+        // Then
+        XCTAssertEqual(sut.lastUsedAPIVersion(for: clientID), .v3)
+
+        tearDownSession(userSession)
+    }
+
+    func test_itPersistsLastUsedAPIVersion_ForMultipleSessions() {
+        // Given
+        let sut = APIMigrationManager(migrations: [])
+
+        let clientID1 = "client1"
+        let clientID2 = "client2"
+        let userSession1 = setupSession(with: clientID1)
+        let userSession2 = setupSession(with: clientID2)
+
+        sut.persistLastUsedAPIVersion(for: userSession1, apiVersion: .v1)
+        sut.persistLastUsedAPIVersion(for: userSession2, apiVersion: .v1)
+
+        XCTAssertEqual(sut.lastUsedAPIVersion(for: clientID1), APIVersion.v1)
+        XCTAssertEqual(sut.lastUsedAPIVersion(for: clientID2), APIVersion.v1)
+
+        // When
+        sut.persistLastUsedAPIVersion(
+            for: [userSession1, userSession2],
+            apiVersion: .v3
+        )
+
+        // Then
+        XCTAssertEqual(sut.lastUsedAPIVersion(for: clientID1), APIVersion.v3)
+        XCTAssertEqual(sut.lastUsedAPIVersion(for: clientID2), APIVersion.v3)
+
+        // clean up
+        tearDownSessions([userSession1, userSession2])
+    }
+
+    // MARK: - Helpers
+
+    private func setupSession(with clientID: String) -> ZMUserSession {
+        let session = stubUserSession()
+        setupClient(clientID, in: session)
+        return session
+    }
+
+    private func tearDownSessions(_ sessions: [ZMUserSession]) {
+        sessions.forEach(tearDownSession(_:))
+    }
+
+    private func tearDownSession(_ session: ZMUserSession) {
+        if let clientID = session.selfUserClient?.remoteIdentifier {
+            APIMigrationManager.removeDefaults(for: clientID)
+        }
+        session.tearDown()
+    }
+
+    private func setupClient(_ clientID: String, in userSession: ZMUserSession) {
         userSession.perform {
             let selfClient = UserClient.insertNewObject(in: userSession.managedObjectContext)
             selfClient.remoteIdentifier = clientID
@@ -159,7 +228,7 @@ class APIMigrationManagerTests: MessagingTest {
         }
     }
 
-    func stubUserSession() -> ZMUserSession {
+    private func stubUserSession() -> ZMUserSession {
         let mockStrategyDirectory = MockStrategyDirectory()
         let mockUpdateEventProcessor = MockUpdateEventProcessor()
 

--- a/Tests/Source/SessionManager/APIVersionResolverTests.swift
+++ b/Tests/Source/SessionManager/APIVersionResolverTests.swift
@@ -248,6 +248,31 @@ class APIVersionResolverTests: ZMTBaseTest {
         XCTAssertEqual(BackendInfo.isFederationEnabled, true)
     }
 
+    // MARK: - Delegate
+
+    func test_itReportsToDelegateWhenVersionIsResolved() {
+        // Given
+        let sut = createSUT(
+            clientProdVersions: [.v3],
+            clientDevVersions: []
+        )
+
+        mockBackendInfo(
+            productionVersions: 0...3,
+            developmentVersions: nil,
+            domain: "foo.com",
+            isFederationEnabled: false
+        )
+
+        // When
+        let done = expectation(description: "done")
+        sut.resolveAPIVersion(completion: done.fulfill)
+        XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
+
+        // Then
+        XCTAssertTrue(mockDelegate.didReportAPIVersionHasBeenResolved)
+    }
+
     // MARK: - Blacklist
 
     func testThatItReportsBlacklistReasonWhenBackendIsObsolete() throws {
@@ -357,7 +382,8 @@ private class MockAPIVersionResolverDelegate: APIVersionResolverDelegate {
         didReportFederationHasBeenEnabled = true
     }
 
+    var didReportAPIVersionHasBeenResolved: Bool = false
     func apiVersionResolverDidResolve(apiVersion: APIVersion) {
-        
+        didReportAPIVersionHasBeenResolved = true
     }
 }

--- a/Tests/Source/SessionManager/APIVersionResolverTests.swift
+++ b/Tests/Source/SessionManager/APIVersionResolverTests.swift
@@ -356,4 +356,8 @@ private class MockAPIVersionResolverDelegate: APIVersionResolverDelegate {
     func apiVersionResolverDetectedFederationHasBeenEnabled() {
         didReportFederationHasBeenEnabled = true
     }
+
+    func apiVersionResolverDidResolve(apiVersion: APIVersion) {
+        
+    }
 }

--- a/Tests/Source/SessionManager/AccessTokenMigrationTests.swift
+++ b/Tests/Source/SessionManager/AccessTokenMigrationTests.swift
@@ -1,0 +1,87 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import XCTest
+@testable import WireSyncEngine
+
+class AccessTokenRenewerMock: AccessTokenRenewing {
+
+    struct Calls {
+        var setAccessTokenRenewalObserver = [AccessTokenRenewalObserver]()
+        var renewAccessToken = [String]()
+    }
+
+    var calls = Calls()
+
+    func setAccessTokenRenewalObserver(_ observer: AccessTokenRenewalObserver) {
+        calls.setAccessTokenRenewalObserver.append(observer)
+    }
+
+    var shoudFail: Bool = false
+    func renewAccessToken(with clientID: String) {
+        calls.renewAccessToken.append(clientID)
+
+        if shoudFail {
+            calls.setAccessTokenRenewalObserver.last?.accessTokenRenewalDidFail()
+        } else {
+            calls.setAccessTokenRenewalObserver.last?.accessTokenRenewalDidSucceed()
+        }
+    }
+
+}
+
+class AccessTokenMigrationTests: XCTestCase {
+
+    func test_itSetsObserver_AndRenewsAccessToken() async throws {
+        // Given
+        let sut = AccessTokenMigration(version: .v3)
+        let tokenRenewer = AccessTokenRenewerMock()
+        let clientID = "1234abcd"
+
+        tokenRenewer.shoudFail = false
+
+        // When
+        try await sut.perform(with: tokenRenewer, clientID: clientID)
+
+        // Then
+        XCTAssertEqual(tokenRenewer.calls.setAccessTokenRenewalObserver.count, 1)
+        XCTAssertEqual(tokenRenewer.calls.renewAccessToken.count, 1)
+        XCTAssertEqual(tokenRenewer.calls.renewAccessToken.first, clientID)
+    }
+
+    func test_itThrows_FailedToRenewAccessToken() async {
+        // Given
+        let sut = AccessTokenMigration(version: .v3)
+        let tokenRenewer = AccessTokenRenewerMock()
+        let clientID = "1234abcd"
+
+        tokenRenewer.shoudFail = true
+
+        // When / Then
+        do {
+            try await sut.perform(with: tokenRenewer, clientID: clientID)
+            XCTFail("expected an error")
+        } catch let error as AccessTokenMigration.Error {
+            XCTAssertEqual(error, .failedToRenewAccessToken)
+        } catch {
+            XCTFail("error is not the one expected")
+        }
+    }
+
+}

--- a/Tests/Source/SessionManager/AccessTokenMigrationTests.swift
+++ b/Tests/Source/SessionManager/AccessTokenMigrationTests.swift
@@ -50,7 +50,7 @@ class AccessTokenMigrationTests: XCTestCase {
 
     func test_itSetsObserver_AndRenewsAccessToken() async throws {
         // Given
-        let sut = AccessTokenMigration(version: .v3)
+        let sut = AccessTokenMigration()
         let tokenRenewer = AccessTokenRenewerMock()
         let clientID = "1234abcd"
 
@@ -67,7 +67,7 @@ class AccessTokenMigrationTests: XCTestCase {
 
     func test_itThrows_FailedToRenewAccessToken() async {
         // Given
-        let sut = AccessTokenMigration(version: .v3)
+        let sut = AccessTokenMigration()
         let tokenRenewer = AccessTokenRenewerMock()
         let clientID = "1234abcd"
 

--- a/Tests/Source/SessionManager/SessionManagerTests+APIVersionResolver.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests+APIVersionResolver.swift
@@ -130,6 +130,10 @@ private class MockSessionManagerDelegate: SessionManagerDelegate {
         // no op
     }
 
+    func sessionManagerDidPerformAPIMigrations() {
+        // no op
+    }
+
     var isInAuthenticatedAppState: Bool {
         return true
     }

--- a/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -1650,6 +1650,9 @@ class SessionManagerTestDelegate: SessionManagerDelegate {
         // no op
     }
 
+    func sessionManagerDidPerformAPIMigrations() {
+        // no op
+    }
 }
 
 class SessionManagerObserverMock: SessionManagerCreatedSessionObserver, SessionManagerDestroyedSessionObserver {

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -387,8 +387,9 @@
 		63497702268A20EC00824A05 /* AVSParticipantsChange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63497701268A20EC00824A05 /* AVSParticipantsChange.swift */; };
 		6349770A268A250E00824A05 /* Encodable+JSONString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63497709268A250E00824A05 /* Encodable+JSONString.swift */; };
 		6349771E268B7C4300824A05 /* AVSVideoStreamsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6349771D268B7C4300824A05 /* AVSVideoStreamsTest.swift */; };
-		636826F82953465F00D904C2 /* ZMUserSessionTests+AccessToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636826F72953465F00D904C2 /* ZMUserSessionTests+AccessToken.swift */; };
 		636826F62951F7F300D904C2 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636826F52951F7F300D904C2 /* Logging.swift */; };
+		636826F82953465F00D904C2 /* ZMUserSessionTests+AccessToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636826F72953465F00D904C2 /* ZMUserSessionTests+AccessToken.swift */; };
+		636826FC2954550900D904C2 /* APIMigrationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636826FB2954550900D904C2 /* APIMigrationManagerTests.swift */; };
 		639290A4252CA53200046171 /* CallSnapshotTestFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639290A3252CA53100046171 /* CallSnapshotTestFixture.swift */; };
 		639290A7252DEDB500046171 /* WireCallCenterV3+Degradation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639290A6252DEDB400046171 /* WireCallCenterV3+Degradation.swift */; };
 		63A2E19F2770D7E900D8F271 /* AVSIdentifier+Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CF3FFD2768DF8C0079FF2B /* AVSIdentifier+Stub.swift */; };
@@ -1020,8 +1021,9 @@
 		63497701268A20EC00824A05 /* AVSParticipantsChange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVSParticipantsChange.swift; sourceTree = "<group>"; };
 		63497709268A250E00824A05 /* Encodable+JSONString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+JSONString.swift"; sourceTree = "<group>"; };
 		6349771D268B7C4300824A05 /* AVSVideoStreamsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVSVideoStreamsTest.swift; sourceTree = "<group>"; };
-		636826F72953465F00D904C2 /* ZMUserSessionTests+AccessToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSessionTests+AccessToken.swift"; sourceTree = "<group>"; };
 		636826F52951F7F300D904C2 /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
+		636826F72953465F00D904C2 /* ZMUserSessionTests+AccessToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSessionTests+AccessToken.swift"; sourceTree = "<group>"; };
+		636826FB2954550900D904C2 /* APIMigrationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIMigrationManagerTests.swift; sourceTree = "<group>"; };
 		639290A3252CA53100046171 /* CallSnapshotTestFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallSnapshotTestFixture.swift; sourceTree = "<group>"; };
 		639290A6252DEDB400046171 /* WireCallCenterV3+Degradation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WireCallCenterV3+Degradation.swift"; sourceTree = "<group>"; };
 		63A8F575276B7B3100513750 /* AVSClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVSClientTests.swift; sourceTree = "<group>"; };
@@ -2499,6 +2501,7 @@
 				87DF28C61F680495007E1702 /* PushDispatcherTests.swift */,
 				161ACB3923F6BAFE00ABFF33 /* URLActionTests.swift */,
 				EE9CDE9127DA05D100C4DAC8 /* APIVersionResolverTests.swift */,
+				636826FB2954550900D904C2 /* APIMigrationManagerTests.swift */,
 			);
 			path = SessionManager;
 			sourceTree = "<group>";
@@ -3177,6 +3180,7 @@
 				166D18A6230EC418001288CD /* MockMediaManager.swift in Sources */,
 				09914E531BD6613D00C10BF8 /* ZMDecodedAPSMessageTest.m in Sources */,
 				6349771E268B7C4300824A05 /* AVSVideoStreamsTest.swift in Sources */,
+				636826FC2954550900D904C2 /* APIMigrationManagerTests.swift in Sources */,
 				F9F9F5621D75D62100AE6499 /* RequestStrategyTestBase.swift in Sources */,
 				7C419ED821F8D81D00B95770 /* EventProcessingTrackerTests.swift in Sources */,
 				707CEBB727B515B200E080A4 /* ZMUserSessionTests+SecurityClassification.swift in Sources */,

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -388,6 +388,7 @@
 		6349770A268A250E00824A05 /* Encodable+JSONString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63497709268A250E00824A05 /* Encodable+JSONString.swift */; };
 		6349771E268B7C4300824A05 /* AVSVideoStreamsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6349771D268B7C4300824A05 /* AVSVideoStreamsTest.swift */; };
 		636826F82953465F00D904C2 /* ZMUserSessionTests+AccessToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636826F72953465F00D904C2 /* ZMUserSessionTests+AccessToken.swift */; };
+		636826F62951F7F300D904C2 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636826F52951F7F300D904C2 /* Logging.swift */; };
 		639290A4252CA53200046171 /* CallSnapshotTestFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639290A3252CA53100046171 /* CallSnapshotTestFixture.swift */; };
 		639290A7252DEDB500046171 /* WireCallCenterV3+Degradation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639290A6252DEDB400046171 /* WireCallCenterV3+Degradation.swift */; };
 		63A2E19F2770D7E900D8F271 /* AVSIdentifier+Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CF3FFD2768DF8C0079FF2B /* AVSIdentifier+Stub.swift */; };
@@ -400,6 +401,8 @@
 		63E313D627553CA0002EAF1D /* ZMConversation+AVSIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E313D527553CA0002EAF1D /* ZMConversation+AVSIdentifier.swift */; };
 		63E69AEA27EA293900D6CE88 /* ConnectionTests+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E69AE927EA293900D6CE88 /* ConnectionTests+Swift.swift */; };
 		63EB9B2D258131F700B44635 /* AVSActiveSpeakerChange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63EB9B2C258131F700B44635 /* AVSActiveSpeakerChange.swift */; };
+		63F1DF1F294B68380061565E /* APIMigrationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F1DF1E294B68380061565E /* APIMigrationManager.swift */; };
+		63F1DF21294B69B20061565E /* AccessTokenMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F1DF20294B69B20061565E /* AccessTokenMigration.swift */; };
 		63F376E12835644800FE1F05 /* SessionManagerTests+APIVersionResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F376DF283519CC00FE1F05 /* SessionManagerTests+APIVersionResolver.swift */; };
 		63FE4B9E25C1D2EC002878E5 /* VideoGridPresentationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63FE4B9D25C1D2EC002878E5 /* VideoGridPresentationMode.swift */; };
 		70355A7327AAE62E00F02C76 /* ZMUserSession+SecurityClassification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70355A7227AAE62D00F02C76 /* ZMUserSession+SecurityClassification.swift */; };
@@ -1018,6 +1021,7 @@
 		63497709268A250E00824A05 /* Encodable+JSONString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+JSONString.swift"; sourceTree = "<group>"; };
 		6349771D268B7C4300824A05 /* AVSVideoStreamsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVSVideoStreamsTest.swift; sourceTree = "<group>"; };
 		636826F72953465F00D904C2 /* ZMUserSessionTests+AccessToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSessionTests+AccessToken.swift"; sourceTree = "<group>"; };
+		636826F52951F7F300D904C2 /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		639290A3252CA53100046171 /* CallSnapshotTestFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallSnapshotTestFixture.swift; sourceTree = "<group>"; };
 		639290A6252DEDB400046171 /* WireCallCenterV3+Degradation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WireCallCenterV3+Degradation.swift"; sourceTree = "<group>"; };
 		63A8F575276B7B3100513750 /* AVSClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVSClientTests.swift; sourceTree = "<group>"; };
@@ -1029,6 +1033,8 @@
 		63E313D527553CA0002EAF1D /* ZMConversation+AVSIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversation+AVSIdentifier.swift"; sourceTree = "<group>"; };
 		63E69AE927EA293900D6CE88 /* ConnectionTests+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConnectionTests+Swift.swift"; sourceTree = "<group>"; };
 		63EB9B2C258131F700B44635 /* AVSActiveSpeakerChange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVSActiveSpeakerChange.swift; sourceTree = "<group>"; };
+		63F1DF1E294B68380061565E /* APIMigrationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIMigrationManager.swift; sourceTree = "<group>"; };
+		63F1DF20294B69B20061565E /* AccessTokenMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessTokenMigration.swift; sourceTree = "<group>"; };
 		63F376DF283519CC00FE1F05 /* SessionManagerTests+APIVersionResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionManagerTests+APIVersionResolver.swift"; sourceTree = "<group>"; };
 		63F65F02246D5A9600534A69 /* PushChannelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushChannelTests.swift; sourceTree = "<group>"; };
 		63F65F04246D972900534A69 /* ConversationTests+MessageEditing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationTests+MessageEditing.swift"; sourceTree = "<group>"; };
@@ -2253,6 +2259,15 @@
 			path = AVSIdentifier;
 			sourceTree = "<group>";
 		};
+		63F1DF22294B69E10061565E /* APIMigration */ = {
+			isa = PBXGroup;
+			children = (
+				63F1DF1E294B68380061565E /* APIMigrationManager.swift */,
+				63F1DF20294B69B20061565E /* AccessTokenMigration.swift */,
+			);
+			path = APIMigration;
+			sourceTree = "<group>";
+		};
 		85D850FC5E45F9F688A64419 /* Synchronization */ = {
 			isa = PBXGroup;
 			children = (
@@ -2397,6 +2412,7 @@
 				1645ECF72448A0A3007A82D6 /* Decodable+JSON.swift */,
 				7AA7112E286DB6F50098F670 /* OptionalString+NonEmptyValue.swift */,
 				EE2DE5EB29263C5100F42F4C /* Logger.swift */,
+				636826F52951F7F300D904C2 /* Logging.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -2509,6 +2525,7 @@
 		F19F1D361EFBF60A00275E27 /* SessionManager */ = {
 			isa = PBXGroup;
 			children = (
+				63F1DF22294B69E10061565E /* APIMigration */,
 				EE9CDE8D27D9FF5900C4DAC8 /* APIVersionResolver.swift */,
 				A95D0B1123F6B75A0057014F /* AVSLogObserver.swift */,
 				7C5B94F522DC6BC500A6F8BB /* JailbreakDetector.swift */,
@@ -3238,6 +3255,7 @@
 				164EAF9C1F4455FA00B628C4 /* ZMUserSession+Actions.swift in Sources */,
 				5EFE9C17212AB945007932A6 /* RegistrationPhase.swift in Sources */,
 				EE2DE5E8292519EC00F42F4C /* CallKitCallRegister.swift in Sources */,
+				636826F62951F7F300D904C2 /* Logging.swift in Sources */,
 				EECE27C429435FFE00419A8B /* PushTokenService.swift in Sources */,
 				BF2ADA001F41A3DF000980E8 /* SessionFactories.swift in Sources */,
 				EE458B0B27CCD58800F04038 /* ZMOperationLoop+APIVersion.swift in Sources */,
@@ -3327,6 +3345,7 @@
 				A9C02605266F5B4B002E542B /* ZMClientRegistrationStatus.swift in Sources */,
 				BF735CFA1E70003D003BC61F /* SystemMessageCallObserver.swift in Sources */,
 				1645ECF82448A0A3007A82D6 /* Decodable+JSON.swift in Sources */,
+				63F1DF21294B69B20061565E /* AccessTokenMigration.swift in Sources */,
 				165D3A211E1D43870052E654 /* VoiceChannelV3.swift in Sources */,
 				F19F4F3A1E5F1AE400F4D8FF /* UserProfileImageUpdateStatus.swift in Sources */,
 				5498162D1A432BC800A7CE2E /* ZMMissingUpdateEventsTranscoder.m in Sources */,
@@ -3417,6 +3436,7 @@
 				06239126274DB73A0065A72D /* StartLoginURLActionProcessor.swift in Sources */,
 				EEEED9AA23F6BD75008C94CA /* ZMUserSession+SelfUserProvider.swift in Sources */,
 				5498165A1A432BC800A7CE2E /* ZMUpdateEventsBuffer.m in Sources */,
+				63F1DF1F294B68380061565E /* APIMigrationManager.swift in Sources */,
 				F19E55A022B3A2C5005C792D /* UNNotification+SafeLogging.swift in Sources */,
 				161ACB3223F5BBA100ABFF33 /* CompanyLoginURLActionProcessor.swift in Sources */,
 				063AF985264B2DF800DCBCED /* CallClosedReason.swift in Sources */,

--- a/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/WireSyncEngine.xcodeproj/project.pbxproj
@@ -398,6 +398,8 @@
 		63B1FADB2763A636000766F8 /* ZMUser+AVSIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B1FADA2763A636000766F8 /* ZMUser+AVSIdentifier.swift */; };
 		63C5321F27FDB283009DFFF4 /* SyncStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C5321E27FDB283009DFFF4 /* SyncStatus.swift */; };
 		63C5322027FDB4C4009DFFF4 /* BuildType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 063AFA3E264B30C400DCBCED /* BuildType.swift */; };
+		63CD5958296434A700385037 /* ZMUserSession+AccessToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CD59562964346400385037 /* ZMUserSession+AccessToken.swift */; };
+		63CD5959296442D800385037 /* AccessTokenMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CD59542964332B00385037 /* AccessTokenMigrationTests.swift */; };
 		63CF4000276B4D110079FF2B /* AVSIdentifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CF3FFF276B4D110079FF2B /* AVSIdentifierTests.swift */; };
 		63E313D627553CA0002EAF1D /* ZMConversation+AVSIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E313D527553CA0002EAF1D /* ZMConversation+AVSIdentifier.swift */; };
 		63E69AEA27EA293900D6CE88 /* ConnectionTests+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E69AE927EA293900D6CE88 /* ConnectionTests+Swift.swift */; };
@@ -1030,6 +1032,8 @@
 		63B1FAD82763A510000766F8 /* AVSIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVSIdentifier.swift; sourceTree = "<group>"; };
 		63B1FADA2763A636000766F8 /* ZMUser+AVSIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUser+AVSIdentifier.swift"; sourceTree = "<group>"; };
 		63C5321E27FDB283009DFFF4 /* SyncStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncStatus.swift; sourceTree = "<group>"; };
+		63CD59542964332B00385037 /* AccessTokenMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessTokenMigrationTests.swift; sourceTree = "<group>"; };
+		63CD59562964346400385037 /* ZMUserSession+AccessToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSession+AccessToken.swift"; sourceTree = "<group>"; };
 		63CF3FFD2768DF8C0079FF2B /* AVSIdentifier+Stub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVSIdentifier+Stub.swift"; sourceTree = "<group>"; };
 		63CF3FFF276B4D110079FF2B /* AVSIdentifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVSIdentifierTests.swift; sourceTree = "<group>"; };
 		63E313D527553CA0002EAF1D /* ZMConversation+AVSIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversation+AVSIdentifier.swift"; sourceTree = "<group>"; };
@@ -2012,6 +2016,7 @@
 				A9BABE5E19BA1EF300E9E5A3 /* Search */,
 				F9AB00211F0CDAF00037B437 /* FileRelocator.swift */,
 				166B2B5D23E86522003E8581 /* ZMUserSession.swift */,
+				63CD59562964346400385037 /* ZMUserSession+AccessToken.swift */,
 				EEE186B3259CC92D008707CA /* ZMUserSession+AppLock.swift */,
 				EE419B57256FEA3D004618E2 /* ZMUserSession.Configuration.swift */,
 				A93B528A250101AC0061255E /* ZMUserSession+Debugging.swift */,
@@ -2502,6 +2507,7 @@
 				161ACB3923F6BAFE00ABFF33 /* URLActionTests.swift */,
 				EE9CDE9127DA05D100C4DAC8 /* APIVersionResolverTests.swift */,
 				636826FB2954550900D904C2 /* APIMigrationManagerTests.swift */,
+				63CD59542964332B00385037 /* AccessTokenMigrationTests.swift */,
 			);
 			path = SessionManager;
 			sourceTree = "<group>";
@@ -3071,6 +3077,7 @@
 				7CE017152317D07E00144905 /* ZMAuthenticationStatusTests.swift in Sources */,
 				16085B351F719E6D000B9F22 /* NetworkStateRecorder.swift in Sources */,
 				EE1DEBB323D5A6930087EE1F /* TypingTests.swift in Sources */,
+				63CD5959296442D800385037 /* AccessTokenMigrationTests.swift in Sources */,
 				09BA924C1BD55FA5000DC962 /* UserClientRequestStrategyTests.swift in Sources */,
 				A9692F8A1986476900849241 /* NSString_NormalizationTests.m in Sources */,
 				54880E3D194B5845007271AA /* ZMOperationLoopTests.m in Sources */,
@@ -3381,6 +3388,7 @@
 				54DE9BEB1DE74FFB00EFFB9C /* RandomHandleGenerator.swift in Sources */,
 				F1C51FE91FB4A9C7009C2269 /* RegistrationStrategy.swift in Sources */,
 				549816301A432BC800A7CE2E /* ZMSelfStrategy.m in Sources */,
+				63CD5958296434A700385037 /* ZMUserSession+AccessToken.swift in Sources */,
 				63A2E19F2770D7E900D8F271 /* AVSIdentifier+Stub.swift in Sources */,
 				5E8EE1F720FDC6B900DB1F9B /* CompanyLoginRequestDetector.swift in Sources */,
 				16E0FB87232F8933000E3235 /* ZMUserSession+Authentication.swift in Sources */,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1237" title="FS-1237" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />FS-1237</a>  [iOS] Implement API version migrations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This PR introduces the `APIMigrationManager` that enables us to run migrations when we detect that the api version has changed. 
It also adds a migration for v3, `AccessTokenMigration`, which associates the session's client id to the access token.

### Dependencies (Optional)

https://github.com/wireapp/wire-ios-transport/pull/261

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

### Note

I've added 3 TODOs in the code. I plan on removing them before merging and I'll either implement changes in this PR or create tickets for them if needed.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
