### PR TITLE
feat(apiv3): remove deprecated fields - FS-1269 

### DIFF
--- a/Source/Data Model/Conversation+AccessMode.swift
+++ b/Source/Data Model/Conversation+AccessMode.swift
@@ -290,7 +290,7 @@ internal struct WirelessRequestFactory {
         return .init(path: "/conversations/\(identifier)/code", method: .methodDELETE, payload: nil, apiVersion: apiVersion.rawValue)
     }
 
-        static func setAccessRoles(allowGuests: Bool, allowServices: Bool, for conversation: ZMConversation, apiVersion: APIVersion) -> ZMTransportRequest {
+    static func setAccessRoles(allowGuests: Bool, allowServices: Bool, for conversation: ZMConversation, apiVersion: APIVersion) -> ZMTransportRequest {
         guard let identifier = conversation.remoteIdentifier?.transportString() else {
             fatal("conversation is not yet inserted on the backend")
         }
@@ -311,13 +311,23 @@ internal struct WirelessRequestFactory {
             accessRoles.remove(.nonTeamMember)
         }
 
-        let payload = [
-            "access": ConversationAccessMode.value(forAllowGuests: allowGuests).stringValue as Any,
-            "access_role": ConversationAccessRole.fromAccessRoleV2(accessRoles).rawValue,
-            "access_role_v2": accessRoles.map(\.rawValue)
-        ]
+        var payload: [String : Any] = ["access": ConversationAccessMode.value(forAllowGuests: allowGuests).stringValue as Any]
+        let path: String
 
-        return .init(path: "/conversations/\(identifier)/access", method: .methodPUT, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
+        switch apiVersion {
+        case .v3:
+            guard let domain = conversation.domain.nonEmptyValue ?? BackendInfo.domain else {
+                fatal("no domain associated with conversation, can't make the request")
+            }
+            path = "/conversations/\(domain)/\(identifier)/access"
+            payload["access_role"] = accessRoles.map(\.rawValue)
+        case .v2, .v1, .v0:
+            path = "/conversations/\(identifier)/access"
+            payload["access_role"] = ConversationAccessRole.fromAccessRoleV2(accessRoles).rawValue
+            payload["access_role_v2"] = accessRoles.map(\.rawValue)
+        }
+
+        return .init(path: path, method: .methodPUT, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
     }
 
 }

--- a/Source/Data Model/Conversation+AccessMode.swift
+++ b/Source/Data Model/Conversation+AccessMode.swift
@@ -311,7 +311,7 @@ internal struct WirelessRequestFactory {
             accessRoles.remove(.nonTeamMember)
         }
 
-        var payload: [String : Any] = ["access": ConversationAccessMode.value(forAllowGuests: allowGuests).stringValue as Any]
+        var payload: [String: Any] = ["access": ConversationAccessMode.value(forAllowGuests: allowGuests).stringValue as Any]
         let path: String
 
         switch apiVersion {

--- a/Source/SessionManager/SessionFactories.swift
+++ b/Source/SessionManager/SessionFactories.swift
@@ -102,7 +102,7 @@ open class UnauthenticatedSessionFactory {
 
     var environment: BackendEnvironmentProvider
     var reachability: Reachability
-    
+
     var readyForRequests: Bool = false
     let appVersion: String
 

--- a/Tests/Source/Synchronization/ZMConversationAccessModeTests.swift
+++ b/Tests/Source/Synchronization/ZMConversationAccessModeTests.swift
@@ -46,17 +46,62 @@ public class ZMConversationAccessModeTests: MessagingTest {
         super.tearDown()
     }
 
-    func testThatItGeneratesCorrectSetAccessModeRequest() {
+    func testThatItGeneratesCorrectSetAccessModeRequestForApiVersionV0() {
+        internaltestThatItGeneratesCorrectSetAccessModeRequestForPreviousApiVersions(apiVersion: .v0)
+    }
+
+    func testThatItGeneratesCorrectSetAccessModeRequestForApiVersionV1() {
+        internaltestThatItGeneratesCorrectSetAccessModeRequestForPreviousApiVersions(apiVersion: .v1)
+    }
+
+    func testThatItGeneratesCorrectSetAccessModeRequestForApiVersionV2() {
+        internaltestThatItGeneratesCorrectSetAccessModeRequestForPreviousApiVersions(apiVersion: .v2)
+    }
+
+    func testThatItGeneratesCorrectSetAccessModeRequestForApiVersionV3() {
+        // given
+        selfUser(options: SelfUserOptions(team: .teamA))
+        let conversation = self.conversation(options: ConversationOptions(hasRemoteId: true, team: .teamA, isGroup: true))
+        conversation.domain = "example.com"
+        // when
+        let request = WireSyncEngine.WirelessRequestFactory.setAccessRoles(allowGuests: true, allowServices: false, for: conversation, apiVersion: .v3)
+
+        // then
+        XCTAssertEqual(request.method, .methodPUT)
+        XCTAssertEqual(request.path, "/v3/conversations/example.com/\(conversation.remoteIdentifier!.transportString())/access")
+        guard let payload = request.payload as? [String: AnyHashable] else {
+            XCTFail("missing payload")
+            return
+        }
+        XCTAssertNotNil(payload["access"])
+        XCTAssertEqual(Set(payload["access"] as! [String]), Set(["invite", "code"]))
+        XCTAssertNotNil(payload["access_role"])
+        guard let accessRoles = payload["access_role"] as? [String] else {
+            XCTFail("unexpected format")
+            return
+        }
+        XCTAssertEqual(Set(accessRoles), Set(["team_member", "non_team_member", "guest"]))
+
+        XCTAssertNil(payload["access_role_v2"])
+    }
+
+    func internaltestThatItGeneratesCorrectSetAccessModeRequestForPreviousApiVersions(apiVersion: APIVersion) {
         // given
         selfUser(options: SelfUserOptions(team: .teamA))
         let conversation = self.conversation(options: ConversationOptions(hasRemoteId: true, team: .teamA, isGroup: true))
 
         // when
-        let request = WireSyncEngine.WirelessRequestFactory.setAccessRoles(allowGuests: true, allowServices: false, for: conversation, apiVersion: .v0)
+        let request = WireSyncEngine.WirelessRequestFactory.setAccessRoles(allowGuests: true, allowServices: false, for: conversation, apiVersion: apiVersion)
 
         // then
         XCTAssertEqual(request.method, .methodPUT)
-        XCTAssertEqual(request.path, "/conversations/\(conversation.remoteIdentifier!.transportString())/access")
+        switch apiVersion {
+        case .v0:
+            XCTAssertEqual(request.path, "/conversations/\(conversation.remoteIdentifier!.transportString())/access")
+        case .v1, .v2, .v3:
+            XCTAssertEqual(request.path, "/v\(apiVersion.rawValue)/conversations/\(conversation.remoteIdentifier!.transportString())/access")
+        }
+
         let payload = request.payload as! [String: AnyHashable]
         XCTAssertNotNil(payload)
         XCTAssertNotNil(payload["access"])


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Update payload fields for conversation endpoints api version 3
 
### Solutions

_Briefly describe the solutions you have implemented for the issues explained above._

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
